### PR TITLE
Add getUniqueId to MixinEntity.

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/MixinEntity.java
@@ -25,6 +25,8 @@
 package org.spongepowered.mod.mixin.entity;
 
 import java.util.ArrayDeque;
+import java.util.UUID;
+
 import javax.annotation.Nullable;
 
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -88,6 +90,13 @@ public abstract class MixinEntity implements Entity, ISpongeEntity {
     protected abstract void shadow$setRotation(float yaw, float pitch);
     @Shadow
     public abstract void mountEntity(net.minecraft.entity.Entity entityIn);
+    @Shadow
+    public abstract UUID getUniqueID();
+
+    @Override
+    public UUID getUniqueId() {
+        return this.getUniqueID();
+    }
 
     @Override
     public World getWorld() {


### PR DESCRIPTION
Implements `getUniqueId()` for players. I'm assuming that `getGameProfile().getId()` is the best way to get this unique identifier based on the information at http://www.minecraftforge.net/forum/index.php?topic=22491.0