### PR TITLE
Implement ItemStack, TradeOffer and PotionEffect builders

### DIFF
--- a/src/main/java/org/spongepowered/mod/item/SpongeItemStackBuilder.java
+++ b/src/main/java/org/spongepowered/mod/item/SpongeItemStackBuilder.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.item;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import net.minecraft.item.Item;
+
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackBuilder;
+
+public class SpongeItemStackBuilder implements ItemStackBuilder {
+
+    public SpongeItemStackBuilder() {
+        reset();
+    }
+
+    private ItemType type;
+    private int damage;
+    private int quantity;
+    private int maxQuantity;
+
+    @Override
+    public ItemStackBuilder itemType(ItemType itemType) {
+        checkNotNull(itemType, "Item type cannot be null");
+        this.type = itemType;
+        return this;
+    }
+
+    @Override
+    public ItemStackBuilder damage(int damage) {
+        checkArgument(damage >= 0, "Damage cannot be negative");
+        this.damage = damage;
+        return this;
+    }
+
+    @Override
+    public ItemStackBuilder quantity(int quantity) throws IllegalArgumentException {
+        checkArgument(quantity > 0, "Quantity must be greater than 0");
+        this.quantity = quantity;
+        return this;
+    }
+
+    @Override
+    public ItemStackBuilder maxQuantity(int maxQuantity) {
+        checkArgument(maxQuantity > 0, "Max quantity must be greater than 0");
+        this.maxQuantity = maxQuantity;
+        return this;
+    }
+
+    @Override
+    public ItemStackBuilder fromItemStack(ItemStack itemStack) {
+        checkNotNull(itemStack, "Item stack cannot be null");
+        // Assumes the item stack's values don't need to be validated
+        type = itemStack.getItem();
+        damage = itemStack.getDamage();
+        quantity = itemStack.getQuantity();
+        maxQuantity = itemStack.getMaxStackQuantity();
+        return this;
+    }
+
+    @Override
+    public ItemStackBuilder reset() {
+        type = null;
+        damage = 0;
+        quantity = 1;
+        maxQuantity = 64;
+        return this;
+    }
+
+    @Override
+    public ItemStack build() throws IllegalStateException {
+        checkState(type != null, "Item type has not been set");
+        checkState(quantity <= maxQuantity, "Quantity cannot be greater than the max quantity (%s)", maxQuantity);
+        // TODO How to enforce maxQuantity in the returned stack?
+        return (ItemStack) new net.minecraft.item.ItemStack((Item) type, quantity, damage);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/item/merchant/SpongeTradeOfferBuilder.java
+++ b/src/main/java/org/spongepowered/mod/item/merchant/SpongeTradeOfferBuilder.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.item.merchant;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import net.minecraft.village.MerchantRecipe;
+
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.merchant.TradeOffer;
+import org.spongepowered.api.item.merchant.TradeOfferBuilder;
+
+import java.lang.reflect.Field;
+
+public class SpongeTradeOfferBuilder implements TradeOfferBuilder {
+
+    private ItemStack firstItem;
+    private ItemStack secondItem;
+    private ItemStack sellingItem;
+    private int useCount;
+    private int maxUses;
+    private boolean allowsExperience;
+    private static final Field field_180323_f;
+
+    static {
+        try {
+            field_180323_f = MerchantRecipe.class.getDeclaredField("field_180323_f");
+            field_180323_f.setAccessible(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public SpongeTradeOfferBuilder() {
+        reset();
+    }
+
+    @Override
+    public TradeOfferBuilder withFirstBuyingItem(ItemStack item) {
+        checkNotNull(item, "Buying item cannot be null");
+        this.firstItem = item;
+        return this;
+    }
+
+    @Override
+    public TradeOfferBuilder withSeconBuyingItem(ItemStack item) {
+        this.secondItem = item;
+        return this;
+    }
+
+    @Override
+    public TradeOfferBuilder withSellingItem(ItemStack item) {
+        checkNotNull(item, "Selling item cannot be null");
+        this.sellingItem = item;
+        return this;
+    }
+
+    @Override
+    public TradeOfferBuilder withUses(int uses) {
+        checkArgument(uses >= 0, "Usage count cannot be negative");
+        this.useCount = uses;
+        return this;
+    }
+
+    @Override
+    public TradeOfferBuilder withMaxUses(int maxUses) {
+        checkArgument(maxUses > 0, "Max usage count must be greater than 0");
+        this.maxUses = maxUses;
+        return this;
+    }
+
+    @Override
+    public TradeOfferBuilder setCanGrantExperience(boolean experience) {
+        this.allowsExperience = experience;
+        return this;
+    }
+
+    @Override
+    public TradeOffer build() throws IllegalStateException {
+        checkState(firstItem != null, "Trading item has not been set");
+        checkState(sellingItem != null, "Selling item has not been set");
+        checkState(useCount <= maxUses, "Usage count cannot be greater than the max usage count (%s)", maxUses);
+        MerchantRecipe recipe =
+                new MerchantRecipe((net.minecraft.item.ItemStack) firstItem, (net.minecraft.item.ItemStack) secondItem,
+                        (net.minecraft.item.ItemStack) sellingItem, useCount, maxUses);
+        try {
+            field_180323_f.setBoolean(recipe, allowsExperience);
+        } catch (Exception ignored) {
+            // No can do
+        }
+        return (TradeOffer) recipe;
+    }
+
+    @Override
+    public TradeOfferBuilder fromTradeOffer(TradeOffer offer) {
+        checkNotNull(offer, "Trade offer cannot be null");
+        // Assumes the offer's values don't need to be validated
+        firstItem = offer.getFirstBuyingItem();
+        secondItem = offer.getSecondBuyingItem().orNull();
+        sellingItem = offer.getSellingItem();
+        useCount = offer.getUses();
+        maxUses = offer.getMaxUses();
+        allowsExperience = offer.doesGrantExperience();
+        return this;
+    }
+
+    @Override
+    public TradeOfferBuilder reset() {
+        firstItem = null;
+        secondItem = null;
+        sellingItem = null;
+        useCount = 0;
+        maxUses = 7;
+        allowsExperience = true;
+        return this;
+    }
+}

--- a/src/main/java/org/spongepowered/mod/potion/SpongePotionBuilder.java
+++ b/src/main/java/org/spongepowered/mod/potion/SpongePotionBuilder.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.potion;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import org.spongepowered.api.potion.PotionEffect;
+import org.spongepowered.api.potion.PotionEffectBuilder;
+import org.spongepowered.api.potion.PotionEffectType;
+
+public class SpongePotionBuilder implements PotionEffectBuilder {
+
+    private PotionEffectType potionType;
+    private int duration;
+    private int amplifier;
+    private boolean isAmbient;
+    private boolean showParticles;
+
+    public SpongePotionBuilder() {
+        reset();
+    }
+
+    @Override
+    public PotionEffectBuilder potionType(PotionEffectType potionEffectType) {
+        checkNotNull(potionEffectType, "Potion effect type cannot be null");
+        this.potionType = potionEffectType;
+        return this;
+    }
+
+    @Override
+    public PotionEffectBuilder duration(int duration) {
+        checkArgument(duration > 0, "Duration must be greater than 0");
+        this.duration = duration;
+        return this;
+    }
+
+    @Override
+    public PotionEffectBuilder amplifier(int amplifier) throws IllegalArgumentException {
+        checkArgument(amplifier >= 0, "Amplifier must not be negative");
+        this.amplifier = amplifier;
+        return this;
+    }
+
+    @Override
+    public PotionEffectBuilder ambience(boolean ambience) {
+        this.isAmbient = ambience;
+        return this;
+    }
+
+    @Override
+    public PotionEffectBuilder particles(boolean showsParticles) {
+        this.showParticles = showsParticles;
+        return this;
+    }
+
+    @Override
+    public PotionEffectBuilder reset() {
+        potionType = null;
+        duration = 0;
+        amplifier = 0;
+        isAmbient = false;
+        showParticles = true;
+        return this;
+    }
+
+    @Override
+    public PotionEffect build() throws IllegalStateException {
+        checkState(potionType != null, "Potion type has not been set");
+        checkState(duration > 0, "Duration has not been set");
+        return (PotionEffect) new net.minecraft.potion.PotionEffect(((net.minecraft.potion.Potion) potionType).id, duration, amplifier, isAmbient,
+                showParticles);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
@@ -25,13 +25,12 @@
 
 package org.spongepowered.mod.registry;
 
-import java.awt.Color;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableBiMap.Builder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
@@ -114,18 +113,22 @@ import org.spongepowered.mod.entity.SpongeEntityConstants;
 import org.spongepowered.mod.entity.SpongeEntityMeta;
 import org.spongepowered.mod.entity.SpongeEntityType;
 import org.spongepowered.mod.entity.SpongeProfession;
+import org.spongepowered.mod.item.SpongeItemStackBuilder;
+import org.spongepowered.mod.item.merchant.SpongeTradeOfferBuilder;
+import org.spongepowered.mod.potion.SpongePotionBuilder;
 import org.spongepowered.mod.rotation.SpongeRotation;
 import org.spongepowered.mod.text.chat.SpongeChatType;
 import org.spongepowered.mod.text.format.SpongeTextColor;
 import org.spongepowered.mod.weather.SpongeWeather;
 import org.spongepowered.mod.world.SpongeDimensionType;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.ImmutableBiMap.Builder;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
+import java.awt.Color;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 @SuppressWarnings("unchecked")
 @NonnullByDefault
@@ -201,16 +204,12 @@ public class SpongeGameRegistry implements GameRegistry {
 
     @Override
     public ItemStackBuilder getItemBuilder() {
-
-        //TODO implement.
-        return null;
+        return new SpongeItemStackBuilder();
     }
 
     @Override
     public TradeOfferBuilder getTradeOfferBuilder() {
-
-        //TODO implement.
-        return null;
+        return new SpongeTradeOfferBuilder();
     }
 
     @Override
@@ -408,9 +407,7 @@ public class SpongeGameRegistry implements GameRegistry {
 
     @Override
     public PotionEffectBuilder getPotionEffectBuilder() {
-
-        //TODO implement.
-        return null;
+        return new SpongePotionBuilder();
     }
 
     @Override


### PR DESCRIPTION
The required mixins for ItemStack, TradeOffer and PotionEffect are implemented, but there was no builders for them.
This PR implements the 3 builders.