### PR TITLE
Several improvements to SpongeGameRegistry

### DIFF
--- a/src/main/java/org/spongepowered/mod/registry/RegistryHelper.java
+++ b/src/main/java/org/spongepowered/mod/registry/RegistryHelper.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.registry;
+
+import com.google.common.base.Function;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+class RegistryHelper {
+
+    public static boolean mapFields(Class<?> apiClass, Map<String, ?> mapping, Collection<String> ignoredFields) {
+        boolean mappingSuccess = true;
+        for (Field f : apiClass.getDeclaredFields()) {
+            if (ignoredFields.contains(f.getName())) {
+                continue;
+            }
+            try {
+                f.set(null, mapping.get(f.getName()));
+            } catch (Exception e) {
+                e.printStackTrace();
+                mappingSuccess = false;
+            }
+        }
+        return mappingSuccess;
+    }
+
+    public static boolean mapFields(Class<?> apiClass, Function<String, ?> mapFunction) {
+        boolean mappingSuccess = true;
+        for (Field f : apiClass.getDeclaredFields()) {
+            try {
+                f.set(null, mapFunction.apply(f.getName()));
+            } catch (Exception e) {
+                e.printStackTrace();
+                mappingSuccess = false;
+            }
+        }
+        return mappingSuccess;
+    }
+
+    public static boolean mapFields(Class<?> apiClass, Map<String, ?> mapping) {
+        return mapFields(apiClass, mapping, Collections.<String>emptyList());
+    }
+
+    public static boolean setFactory(Class<?> apiClass, Object factory) {
+        try {
+            apiClass.getDeclaredField("factory").set(null, factory);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
@@ -25,20 +25,13 @@
 
 package org.spongepowered.mod.registry;
 
-import java.awt.Color;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.ImmutableBiMap.Builder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import net.minecraft.entity.Entity;
@@ -125,6 +118,7 @@ import org.spongepowered.api.world.DimensionTypes;
 import org.spongepowered.api.world.biome.BiomeType;
 import org.spongepowered.api.world.biome.BiomeTypes;
 import org.spongepowered.api.world.gamerule.DefaultGameRules;
+import org.spongepowered.api.world.weather.Weather;
 import org.spongepowered.api.world.weather.Weathers;
 import org.spongepowered.mod.effect.particle.SpongeParticleEffectBuilder;
 import org.spongepowered.mod.effect.particle.SpongeParticleType;
@@ -143,13 +137,22 @@ import org.spongepowered.mod.text.selector.SpongeSelectorType;
 import org.spongepowered.mod.weather.SpongeWeather;
 import org.spongepowered.mod.world.SpongeDimensionType;
 
+import java.awt.Color;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
 @SuppressWarnings("unchecked")
 @NonnullByDefault
 public class SpongeGameRegistry implements GameRegistry {
 
-    private Map<String, BiomeType> biomeTypeMappings = Maps.newHashMap();
-    public static Map<String, SpongeTextColor> textColorMappings = Maps.newHashMap();
-    public static Map<TextColor, EnumChatFormatting> textColorToEnumMappings = Maps.newHashMap();
+    private final Map<String, BiomeType> biomeTypeMappings = Maps.newHashMap();
+    public static final Map<String, SpongeTextColor> textColorMappings = Maps.newHashMap();
+    public static final Map<TextColor, EnumChatFormatting> textColorToEnumMappings = Maps.newHashMap();
+
     public static final ImmutableMap<String, TextStyle.Base> textStyleMappings = new ImmutableMap.Builder<String, TextStyle.Base>()
                                                                                 .put("OBFUSCATED", new TextStyle.Base("OBFUSCATED", 'k'))
                                                                                 .put("BOLD", new TextStyle.Base("BOLD", 'l'))
@@ -158,6 +161,7 @@ public class SpongeGameRegistry implements GameRegistry {
                                                                                 .put("ITALIC", new TextStyle.Base("ITALIC", 'o'))
                                                                                 .put("RESET", new TextStyle.Base("RESET", 'r'))
                                                                                 .build();
+
     private static final ImmutableMap<String, ChatType> chatTypeMappings = new ImmutableMap.Builder<String, ChatType>()
                                                                            .put("CHAT", new SpongeChatType("CHAT", (byte) 0))
                                                                            .put("SYSTEM", new SpongeChatType("SYSTEM", (byte) 1))
@@ -174,34 +178,30 @@ public class SpongeGameRegistry implements GameRegistry {
                                                                            .put("TOP_LEFT", new SpongeRotation(315))
                                                                            .build();
 
-    private Map<String, Art> artMappings = Maps.newHashMap();
-    private Map<String, EntityType> entityTypeMappings = Maps.newHashMap();
-    public Map<String, SpongeEntityType> entityIdToTypeMappings = Maps.newHashMap();
-    public Map<Class<? extends Entity>, SpongeEntityType> entityClassToTypeMappings = Maps.newHashMap();
-    public Map<String, Enchantment> enchantmentMappings = Maps.newHashMap();
-    private Map<String, Career> careerMappings = Maps.newHashMap();
-    private Map<String, Profession> professionMappings = Maps.newHashMap();
-    private Map<Integer, List<Career>> professionToCareerMappings = Maps.newHashMap();
-    private Map<String, DimensionType> dimensionTypeMappings = Maps.newHashMap();
-    public Map<Class<? extends Dimension>, DimensionType> dimensionClassMappings = Maps.newHashMap();
-    private Map<String, SpongeParticleType> particleMappings = Maps.newHashMap();
-    private Map<String, ParticleType> particleByName = Maps.newHashMap();
-    private List<BlockType> blockList = new ArrayList<BlockType>();
-    private List<ItemType> itemList = new ArrayList<ItemType>();
-    private List<PotionEffectType> potionList = new ArrayList<PotionEffectType>();
-    private List<BiomeType> biomeTypes = new ArrayList<BiomeType>();
-
-    public static final ImmutableBiMap<Direction, EnumFacing> directionMap;
-    static {
-        Builder<Direction, EnumFacing> directionMapBuilder = ImmutableBiMap.builder();
-        directionMapBuilder.put(Direction.NORTH, EnumFacing.NORTH);
-        directionMapBuilder.put(Direction.EAST, EnumFacing.EAST);
-        directionMapBuilder.put(Direction.SOUTH, EnumFacing.SOUTH);
-        directionMapBuilder.put(Direction.WEST, EnumFacing.WEST);
-        directionMapBuilder.put(Direction.UP, EnumFacing.UP);
-        directionMapBuilder.put(Direction.DOWN, EnumFacing.DOWN);
-        directionMap = directionMapBuilder.build();
-    }
+    public static final ImmutableBiMap<Direction, EnumFacing> directionMap = ImmutableBiMap.<Direction, EnumFacing>builder()
+                                                                            .put(Direction.NORTH, EnumFacing.NORTH)
+                                                                            .put(Direction.EAST, EnumFacing.EAST)
+                                                                            .put(Direction.SOUTH, EnumFacing.SOUTH)
+                                                                            .put(Direction.WEST, EnumFacing.WEST)
+                                                                            .put(Direction.UP, EnumFacing.UP)
+                                                                            .put(Direction.DOWN, EnumFacing.DOWN)
+                                                                            .build();
+    private final Map<String, Art> artMappings = Maps.newHashMap();
+    private final Map<String, EntityType> entityTypeMappings = Maps.newHashMap();
+    public final Map<String, SpongeEntityType> entityIdToTypeMappings = Maps.newHashMap();
+    public final Map<Class<? extends Entity>, SpongeEntityType> entityClassToTypeMappings = Maps.newHashMap();
+    public final Map<String, Enchantment> enchantmentMappings = Maps.newHashMap();
+    private final Map<String, Career> careerMappings = Maps.newHashMap();
+    private final Map<String, Profession> professionMappings = Maps.newHashMap();
+    private final Map<Integer, List<Career>> professionToCareerMappings = Maps.newHashMap();
+    private final Map<String, DimensionType> dimensionTypeMappings = Maps.newHashMap();
+    public final Map<Class<? extends Dimension>, DimensionType> dimensionClassMappings = Maps.newHashMap();
+    private final Map<String, SpongeParticleType> particleMappings = Maps.newHashMap();
+    private final Map<String, ParticleType> particleByName = Maps.newHashMap();
+    private final List<BlockType> blockList = new ArrayList<BlockType>();
+    private final List<ItemType> itemList = new ArrayList<ItemType>();
+    private final List<PotionEffectType> potionList = new ArrayList<PotionEffectType>();
+    private final List<BiomeType> biomeTypes = new ArrayList<BiomeType>();
 
     @Override
     public Optional<BlockType> getBlock(String id) {
@@ -502,13 +502,7 @@ public class SpongeGameRegistry implements GameRegistry {
         this.addParticleType("ITEM_TAKE", new SpongeParticleType(EnumParticleTypes.ITEM_TAKE, false));
         this.addParticleType("MOB_APPEARANCE", new SpongeParticleType(EnumParticleTypes.MOB_APPEARANCE, false));
 
-        for (Field field : ParticleTypes.class.getDeclaredFields()) {
-            try {
-                field.set(null, this.particleMappings.get(field.getName()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
+        RegistryHelper.mapFields(ParticleTypes.class, this.particleMappings);
     }
 
     private void addParticleType(String mapping, SpongeParticleType particle) {
@@ -522,13 +516,12 @@ public class SpongeGameRegistry implements GameRegistry {
             this.blockList.add(getBlock(iter.next().toString()).get());
         }
 
-        for (Field f : BlockTypes.class.getDeclaredFields()) {
-            try {
-                f.set(null, getBlock(f.getName().toLowerCase()).get());
-            } catch (Exception e) {
-                // Ignoring error
+        RegistryHelper.mapFields(BlockTypes.class, new Function<String, BlockType>() {
+            @Override
+            public BlockType apply(String fieldName) {
+                return getBlock(fieldName.toLowerCase()).get();
             }
-        }
+        });
     }
 
     private void setItemTypes() {
@@ -537,13 +530,12 @@ public class SpongeGameRegistry implements GameRegistry {
             this.itemList.add(getItem(iter.next().toString()).get());
         }
 
-        for (Field f : ItemTypes.class.getDeclaredFields()) {
-            try {
-                f.set(null, getItem(f.getName().toLowerCase()).get());
-            } catch (Exception e) {
-                // Ignoring error
+        RegistryHelper.mapFields(ItemTypes.class, new Function<String, ItemType>() {
+            @Override
+            public ItemType apply(String fieldName) {
+                return getItem(fieldName.toLowerCase()).get();
             }
-        }
+        });
     }
 
     private void setEnchantments() {
@@ -572,13 +564,8 @@ public class SpongeGameRegistry implements GameRegistry {
         this.enchantmentMappings.put("INFINITY", (Enchantment) net.minecraft.enchantment.Enchantment.infinity);
         this.enchantmentMappings.put("LUCK_OF_THE_SEA", (Enchantment) net.minecraft.enchantment.Enchantment.luckOfTheSea);
         this.enchantmentMappings.put("LURE", (Enchantment) net.minecraft.enchantment.Enchantment.lure);
-        for (Field f : Enchantments.class.getDeclaredFields()) {
-            try {
-                f.set(null, this.enchantmentMappings.get(f.getName()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
+
+        RegistryHelper.mapFields(Enchantments.class, enchantmentMappings);
     }
     
     // Note: This is probably fairly slow, but only needs to be run rarely.
@@ -589,88 +576,105 @@ public class SpongeGameRegistry implements GameRegistry {
                 this.potionList.add(potionEffectType);
             }
         }
-        for (Field f : PotionEffectTypes.class.getDeclaredFields()) {
-            try {
-                f.set(null, getPotion(f.getName().toLowerCase()).get());
-            } catch (Exception e) {
-                e.printStackTrace();
+        RegistryHelper.mapFields(PotionEffectTypes.class, new Function<String, PotionEffectType>() {
+            @Override
+            public PotionEffectType apply(String fieldName) {
+                return getPotion(fieldName.toLowerCase()).get();
             }
-        }
+        });
     }
 
     private void setArts() {
-        for(Field f : Arts.class.getDeclaredFields()) {
+        RegistryHelper.mapFields(Arts.class, new Function<String, Art>() {
+            @Override
+            public Art apply(String fieldName) {
+                Art art = (Art) (Object) EnumArt.valueOf(fieldName);
+                SpongeGameRegistry.this.artMappings.put(art.getName(), art);
+                return art;
+            }
+        });
+    }
+
+    private Map<String, Integer> mcEntityNameToId = null;
+
+    private SpongeEntityType newEntityTypeFromName(String spongeName, String mcName) {
+        if (mcEntityNameToId == null) {
             try {
-                Art art = (Art) (Object) EnumArt.valueOf(f.getName());
-                f.set(null, art);
-                this.artMappings.put(art.getName(), art);
+                Field field_180126_g = EntityList.class.getDeclaredField("field_180126_g");
+                field_180126_g.setAccessible(true);
+                mcEntityNameToId = (Map<String, Integer>) field_180126_g.get(null);
             } catch (Exception e) {
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
+        return new SpongeEntityType(mcEntityNameToId.get(mcName), spongeName, (Class<? extends Entity>) EntityList.stringToClassMapping.get(mcName));
     }
-    
+
+    private SpongeEntityType newEntityTypeFromName(String name) {
+        return newEntityTypeFromName(name, name);
+    }
+
     private void setEntityTypes() {
         // internal mapping of our EntityTypes to actual MC names
-        this.entityTypeMappings.put("DROPPED_ITEM", new SpongeEntityType(1, "Item", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Item")));
-        this.entityTypeMappings.put("EXPERIENCE_ORB", new SpongeEntityType(2, "XPOrb", (Class<? extends Entity>)EntityList.stringToClassMapping.get("XPOrb")));
-        this.entityTypeMappings.put("LEASH_HITCH", new SpongeEntityType(8, "LeashKnot", (Class<? extends Entity>)EntityList.stringToClassMapping.get("LeashKnot")));
-        this.entityTypeMappings.put("PAINTING", new SpongeEntityType(9, "Painting", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Painting")));
-        this.entityTypeMappings.put("ARROW", new SpongeEntityType(10, "Arrow", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Arrow")));
-        this.entityTypeMappings.put("SNOWBALL", new SpongeEntityType(11, "Snowball", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Snowball")));
-        this.entityTypeMappings.put("FIREBALL", new SpongeEntityType(12, "LargeFireball", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Fireball")));
-        this.entityTypeMappings.put("SMALL_FIREBALL", new SpongeEntityType(13, "SmallFireball", (Class<? extends Entity>)EntityList.stringToClassMapping.get("SmallFireball")));
-        this.entityTypeMappings.put("ENDER_PEARL", new SpongeEntityType(14, "ThrownEnderpearl", (Class<? extends Entity>)EntityList.stringToClassMapping.get("ThrownEnderpearl")));
-        this.entityTypeMappings.put("EYE_OF_ENDER", new SpongeEntityType(15, "EyeOfEnderSignal", (Class<? extends Entity>)EntityList.stringToClassMapping.get("EyeOfEnderSignal")));
-        this.entityTypeMappings.put("SPLASH_POTION", new SpongeEntityType(16, "ThrownPotion", (Class<? extends Entity>)EntityList.stringToClassMapping.get("ThrownPotion")));
-        this.entityTypeMappings.put("THROWN_EXP_BOTTLE", new SpongeEntityType(17, "ThrownExpBottle", (Class<? extends Entity>)EntityList.stringToClassMapping.get("ThrownExpBottle")));
-        this.entityTypeMappings.put("ITEM_FRAME", new SpongeEntityType(18, "ItemFrame", (Class<? extends Entity>)EntityList.stringToClassMapping.get("ItemFrame")));
-        this.entityTypeMappings.put("WITHER_SKULL", new SpongeEntityType(19, "WitherSkull", (Class<? extends Entity>)EntityList.stringToClassMapping.get("WitherSkull")));
-        this.entityTypeMappings.put("PRIMED_TNT", new SpongeEntityType(20, "PrimedTnt", (Class<? extends Entity>)EntityList.stringToClassMapping.get("PrimedTnt")));
-        this.entityTypeMappings.put("FALLING_BLOCK", new SpongeEntityType(21, "FallingSand", (Class<? extends Entity>)EntityList.stringToClassMapping.get("FallingSand")));
-        this.entityTypeMappings.put("FIREWORK", new SpongeEntityType(22, "FireworksRocketEntity", (Class<? extends Entity>)EntityList.stringToClassMapping.get("FireworksRocketEntity")));
-        this.entityTypeMappings.put("ARMOR_STAND", new SpongeEntityType(30, "ArmorStand", (Class<? extends Entity>)EntityList.stringToClassMapping.get("ArmorStand")));;
-        this.entityTypeMappings.put("BOAT", new SpongeEntityType(41, "Boat", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Boat")));
-        this.entityTypeMappings.put("RIDEABLE_MINECART", new SpongeEntityType(42, "MinecartRideable", (Class<? extends Entity>)EntityList.stringToClassMapping.get("MinecartRideable")));
-        this.entityTypeMappings.put("CHESTED_MINECART", new SpongeEntityType(43, "MinecartChest", (Class<? extends Entity>)EntityList.stringToClassMapping.get("MinecartChest")));
-        this.entityTypeMappings.put("FURNACE_MINECART", new SpongeEntityType(44, "MinecartFurnace", (Class<? extends Entity>)EntityList.stringToClassMapping.get("MinecartFurnace")));
-        this.entityTypeMappings.put("TNT_MINECART", new SpongeEntityType(45, "MinecartTnt", (Class<? extends Entity>)EntityList.stringToClassMapping.get("MinecartTNT")));
-        this.entityTypeMappings.put("HOPPER_MINECART", new SpongeEntityType(46, "MinecartHopper", (Class<? extends Entity>)EntityList.stringToClassMapping.get("MinecartHopper")));
-        this.entityTypeMappings.put("MOB_SPAWNER_MINECART", new SpongeEntityType(47, "MinecartSpawner", (Class<? extends Entity>)EntityList.stringToClassMapping.get("MinecartSpawner")));
-        this.entityTypeMappings.put("COMMANDBLOCK_MINECART", new SpongeEntityType(40, "MinecartCommandBlock", (Class<? extends Entity>)EntityList.stringToClassMapping.get("MinecartCommandBlock")));
-        this.entityTypeMappings.put("CREEPER", new SpongeEntityType(50, "Creeper", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Creeper")));
-        this.entityTypeMappings.put("SKELETON", new SpongeEntityType(51, "Skeleton", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Skeleton")));
-        this.entityTypeMappings.put("SPIDER", new SpongeEntityType(52, "Spider", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Spider")));
-        this.entityTypeMappings.put("GIANT", new SpongeEntityType(53, "Giant", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Giant")));
-        this.entityTypeMappings.put("ZOMBIE", new SpongeEntityType(54, "Zombie", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Zombie")));
-        this.entityTypeMappings.put("SLIME", new SpongeEntityType(55, "Slime", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Slime")));
-        this.entityTypeMappings.put("GHAST", new SpongeEntityType(56, "Ghast", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Ghast")));
-        this.entityTypeMappings.put("PIG_ZOMBIE", new SpongeEntityType(57, "PigZombie", (Class<? extends Entity>)EntityList.stringToClassMapping.get("PigZombie")));
-        this.entityTypeMappings.put("ENDERMAN", new SpongeEntityType(58, "Enderman", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Enderman")));
-        this.entityTypeMappings.put("CAVE_SPIDER", new SpongeEntityType(59, "CaveSpider", (Class<? extends Entity>)EntityList.stringToClassMapping.get("CaveSpider")));
-        this.entityTypeMappings.put("SILVERFISH", new SpongeEntityType(60, "Silverfish", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Silverfish")));
-        this.entityTypeMappings.put("BLAZE", new SpongeEntityType(61, "Blaze", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Blaze")));
-        this.entityTypeMappings.put("MAGMA_CUBE", new SpongeEntityType(62, "LavaSlime", (Class<? extends Entity>)EntityList.stringToClassMapping.get("LavaSlime")));
-        this.entityTypeMappings.put("ENDER_DRAGON", new SpongeEntityType(63, "EnderDragon", (Class<? extends Entity>)EntityList.stringToClassMapping.get("EnderDragon")));
-        this.entityTypeMappings.put("WITHER", new SpongeEntityType(64, "WitherBoss", (Class<? extends Entity>)EntityList.stringToClassMapping.get("WitherBoss")));
-        this.entityTypeMappings.put("BAT", new SpongeEntityType(65, "Bat", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Bat")));
-        this.entityTypeMappings.put("WITCH", new SpongeEntityType(66, "Witch", (Class<? extends Entity>)EntityList.stringToClassMapping.get("FallingSand")));
-        this.entityTypeMappings.put("ENDERMITE", new SpongeEntityType(67, "Endermite", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Endermite")));
-        this.entityTypeMappings.put("GUARDIAN", new SpongeEntityType(68, "Guardian", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Guardian")));
-        this.entityTypeMappings.put("PIG", new SpongeEntityType(90, "Pig", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Pig")));
-        this.entityTypeMappings.put("SHEEP", new SpongeEntityType(91, "Sheep", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Sheep")));
-        this.entityTypeMappings.put("COW", new SpongeEntityType(92, "Cow", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Cow")));
-        this.entityTypeMappings.put("CHICKEN", new SpongeEntityType(93, "Chicken", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Chicken")));
-        this.entityTypeMappings.put("SQUID", new SpongeEntityType(94, "Squid", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Squid")));
-        this.entityTypeMappings.put("WOLF", new SpongeEntityType(95, "Wolf", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Wolf")));
-        this.entityTypeMappings.put("MUSHROOM_COW", new SpongeEntityType(96, "MushroomCow", (Class<? extends Entity>)EntityList.stringToClassMapping.get("MushroomCow")));
-        this.entityTypeMappings.put("SNOWMAN", new SpongeEntityType(97, "SnowMan", (Class<? extends Entity>)EntityList.stringToClassMapping.get("SnowMan")));
-        this.entityTypeMappings.put("OCELOT", new SpongeEntityType(98, "Ozelot", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Ozelot")));
-        this.entityTypeMappings.put("IRON_GOLEM", new SpongeEntityType(99, "VillagerGolem", (Class<? extends Entity>)EntityList.stringToClassMapping.get("VillagerGolem")));
-        this.entityTypeMappings.put("HORSE", new SpongeEntityType(100, "EntityHorse", (Class<? extends Entity>)EntityList.stringToClassMapping.get("EntityHorse")));
-        this.entityTypeMappings.put("RABBIT", new SpongeEntityType(101, "Rabbit", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Rabbit")));
-        this.entityTypeMappings.put("VILLAGER", new SpongeEntityType(120, "Villager", (Class<? extends Entity>)EntityList.stringToClassMapping.get("Villager")));
-        this.entityTypeMappings.put("ENDER_CRYSTAL", new SpongeEntityType(200, "EnderCrystal", (Class<? extends Entity>)EntityList.stringToClassMapping.get("EnderCrystal")));
+        this.entityTypeMappings.put("DROPPED_ITEM", newEntityTypeFromName("Item"));
+        this.entityTypeMappings.put("EXPERIENCE_ORB", newEntityTypeFromName("XPOrb"));
+        this.entityTypeMappings.put("LEASH_HITCH", newEntityTypeFromName("LeashKnot"));
+        this.entityTypeMappings.put("PAINTING", newEntityTypeFromName("Painting"));
+        this.entityTypeMappings.put("ARROW", newEntityTypeFromName("Arrow"));
+        this.entityTypeMappings.put("SNOWBALL", newEntityTypeFromName("Snowball"));
+        this.entityTypeMappings.put("FIREBALL", newEntityTypeFromName("LargeFireball", "Fireball"));
+        this.entityTypeMappings.put("SMALL_FIREBALL", newEntityTypeFromName("SmallFireball"));
+        this.entityTypeMappings.put("ENDER_PEARL", newEntityTypeFromName("ThrownEnderpearl"));
+        this.entityTypeMappings.put("EYE_OF_ENDER", newEntityTypeFromName("EyeOfEnderSignal"));
+        this.entityTypeMappings.put("SPLASH_POTION", newEntityTypeFromName("ThrownPotion"));
+        this.entityTypeMappings.put("THROWN_EXP_BOTTLE", newEntityTypeFromName("ThrownExpBottle"));
+        this.entityTypeMappings.put("ITEM_FRAME", newEntityTypeFromName("ItemFrame"));
+        this.entityTypeMappings.put("WITHER_SKULL", newEntityTypeFromName("WitherSkull"));
+        this.entityTypeMappings.put("PRIMED_TNT", newEntityTypeFromName("PrimedTnt"));
+        this.entityTypeMappings.put("FALLING_BLOCK", newEntityTypeFromName("FallingSand"));
+        this.entityTypeMappings.put("FIREWORK", newEntityTypeFromName("FireworksRocketEntity"));
+        this.entityTypeMappings.put("ARMOR_STAND", newEntityTypeFromName("ArmorStand"));
+        this.entityTypeMappings.put("BOAT", newEntityTypeFromName("Boat"));
+        this.entityTypeMappings.put("RIDEABLE_MINECART", newEntityTypeFromName("MinecartRideable"));
+        this.entityTypeMappings.put("CHESTED_MINECART", newEntityTypeFromName("MinecartChest"));
+        this.entityTypeMappings.put("FURNACE_MINECART", newEntityTypeFromName("MinecartFurnace"));
+        this.entityTypeMappings.put("TNT_MINECART", newEntityTypeFromName("MinecartTnt", "MinecartTNT"));
+        this.entityTypeMappings.put("HOPPER_MINECART", newEntityTypeFromName("MinecartHopper"));
+        this.entityTypeMappings.put("MOB_SPAWNER_MINECART", newEntityTypeFromName("MinecartSpawner"));
+        this.entityTypeMappings.put("COMMANDBLOCK_MINECART", newEntityTypeFromName("MinecartCommandBlock"));
+        this.entityTypeMappings.put("CREEPER", newEntityTypeFromName("Creeper"));
+        this.entityTypeMappings.put("SKELETON", newEntityTypeFromName("Skeleton"));
+        this.entityTypeMappings.put("SPIDER", newEntityTypeFromName("Spider"));
+        this.entityTypeMappings.put("GIANT", newEntityTypeFromName("Giant"));
+        this.entityTypeMappings.put("ZOMBIE", newEntityTypeFromName("Zombie"));
+        this.entityTypeMappings.put("SLIME", newEntityTypeFromName("Slime"));
+        this.entityTypeMappings.put("GHAST", newEntityTypeFromName("Ghast"));
+        this.entityTypeMappings.put("PIG_ZOMBIE", newEntityTypeFromName("PigZombie"));
+        this.entityTypeMappings.put("ENDERMAN", newEntityTypeFromName("Enderman"));
+        this.entityTypeMappings.put("CAVE_SPIDER", newEntityTypeFromName("CaveSpider"));
+        this.entityTypeMappings.put("SILVERFISH", newEntityTypeFromName("Silverfish"));
+        this.entityTypeMappings.put("BLAZE", newEntityTypeFromName("Blaze"));
+        this.entityTypeMappings.put("MAGMA_CUBE", newEntityTypeFromName("LavaSlime"));
+        this.entityTypeMappings.put("ENDER_DRAGON", newEntityTypeFromName("EnderDragon"));
+        this.entityTypeMappings.put("WITHER", newEntityTypeFromName("WitherBoss"));
+        this.entityTypeMappings.put("BAT", newEntityTypeFromName("Bat"));
+        this.entityTypeMappings.put("WITCH", newEntityTypeFromName("Witch"));
+        this.entityTypeMappings.put("ENDERMITE", newEntityTypeFromName("Endermite"));
+        this.entityTypeMappings.put("GUARDIAN", newEntityTypeFromName("Guardian"));
+        this.entityTypeMappings.put("PIG", newEntityTypeFromName("Pig"));
+        this.entityTypeMappings.put("SHEEP", newEntityTypeFromName("Sheep"));
+        this.entityTypeMappings.put("COW", newEntityTypeFromName("Cow"));
+        this.entityTypeMappings.put("CHICKEN", newEntityTypeFromName("Chicken"));
+        this.entityTypeMappings.put("SQUID", newEntityTypeFromName("Squid"));
+        this.entityTypeMappings.put("WOLF", newEntityTypeFromName("Wolf"));
+        this.entityTypeMappings.put("MUSHROOM_COW", newEntityTypeFromName("MushroomCow"));
+        this.entityTypeMappings.put("SNOWMAN", newEntityTypeFromName("SnowMan"));
+        this.entityTypeMappings.put("OCELOT", newEntityTypeFromName("Ozelot"));
+        this.entityTypeMappings.put("IRON_GOLEM", newEntityTypeFromName("VillagerGolem"));
+        this.entityTypeMappings.put("HORSE", newEntityTypeFromName("EntityHorse"));
+        this.entityTypeMappings.put("RABBIT", newEntityTypeFromName("Rabbit"));
+        this.entityTypeMappings.put("VILLAGER", newEntityTypeFromName("Villager"));
+        this.entityTypeMappings.put("ENDER_CRYSTAL", newEntityTypeFromName("EnderCrystal"));
         this.entityTypeMappings.put("EGG", new SpongeEntityType(-1, "Egg", EntityEgg.class));
         this.entityTypeMappings.put("FISHING_HOOK", new SpongeEntityType(-2, "FishingHook", EntityFishHook.class));
         this.entityTypeMappings.put("LIGHTNING", new SpongeEntityType(-3, "Lightning", EntityLightningBolt.class));
@@ -678,71 +682,31 @@ public class SpongeGameRegistry implements GameRegistry {
         this.entityTypeMappings.put("PLAYER", new SpongeEntityType(-5, "Player", EntityPlayerMP.class));
         this.entityTypeMappings.put("COMPLEX_PART", new SpongeEntityType(-6, "ComplexPart", EntityDragonPart.class));
 
-        for (Field f : EntityTypes.class.getDeclaredFields()) {
-            try {
-                EntityType entityType = this.entityTypeMappings.get(f.getName());
-                f.set(null, this.entityTypeMappings.get(f.getName()));
-                this.entityClassToTypeMappings.put(((SpongeEntityType)entityType).entityClass, (SpongeEntityType)entityType);
-                this.entityIdToTypeMappings.put(((SpongeEntityType)entityType).modId, ((SpongeEntityType)entityType));
-            } catch (Exception e) {
-                // Ignore errors
+        RegistryHelper.mapFields(EntityTypes.class, new Function<String, EntityType>() {
+            @Override
+            public EntityType apply(String fieldName) {
+                if (fieldName.equals("UNKNOWN")) {
+                    // TODO Something for Unknown?
+                    return null;
+                }
+                EntityType entityType = SpongeGameRegistry.this.entityTypeMappings.get(fieldName);
+                SpongeGameRegistry.this.entityClassToTypeMappings.put(((SpongeEntityType) entityType).entityClass, (SpongeEntityType) entityType);
+                SpongeGameRegistry.this.entityIdToTypeMappings.put(((SpongeEntityType) entityType).getId(), ((SpongeEntityType) entityType));
+                return entityType;
             }
-        }
+        });
 
-        // skeleton types
-        for (Field f : SkeletonTypes.class.getDeclaredFields()) {
-            try {
-                f.set(null, SpongeEntityConstants.SKELETON_TYPES.get(f.getName()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-
-        // horse colors
-        for (Field f : HorseColors.class.getDeclaredFields()) {
-            try {
-                f.set(null, SpongeEntityConstants.HORSE_COLORS.get(f.getName()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-
-        // horse variants
-        for (Field f : HorseVariants.class.getDeclaredFields()) {
-            try {
-                f.set(null, SpongeEntityConstants.HORSE_VARIANTS.get(f.getName()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-
-        for (Field f : HorseStyles.class.getDeclaredFields()) {
-            try {
-                f.set(null, SpongeEntityConstants.HORSE_STYLES.get(f.getName()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-
-        for (Field f : OcelotTypes.class.getDeclaredFields()) {
-            try {
-                f.set(null, SpongeEntityConstants.OCELOT_TYPES.get(f.getName()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-
-        for (Field f : RabbitTypes.class.getDeclaredFields()) {
-            try {
-                f.set(null, SpongeEntityConstants.RABBIT_TYPES.get(f.getName()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
+        RegistryHelper.mapFields(SkeletonTypes.class, SpongeEntityConstants.SKELETON_TYPES);
+        RegistryHelper.mapFields(HorseColors.class, SpongeEntityConstants.HORSE_COLORS);
+        RegistryHelper.mapFields(HorseVariants.class, SpongeEntityConstants.HORSE_VARIANTS);
+        RegistryHelper.mapFields(HorseStyles.class, SpongeEntityConstants.HORSE_STYLES);
+        RegistryHelper.mapFields(OcelotTypes.class, SpongeEntityConstants.OCELOT_TYPES);
+        RegistryHelper.mapFields(RabbitTypes.class, SpongeEntityConstants.RABBIT_TYPES);
     }
 
     private void setBiomeTypes() {
-        for (BiomeGenBase biome : BiomeGenBase.getBiomeGenArray()) {
+        BiomeGenBase[] biomeArray = BiomeGenBase.getBiomeGenArray();
+        for (BiomeGenBase biome : biomeArray) {
             if (biome != null) {
                 this.biomeTypes.add((BiomeType)biome);
             }
@@ -788,35 +752,29 @@ public class SpongeGameRegistry implements GameRegistry {
         this.biomeTypeMappings.put("MESA", (BiomeType)BiomeGenBase.mesa);
         this.biomeTypeMappings.put("MESA_PLATEAU_FOREST", (BiomeType)BiomeGenBase.mesaPlateau_F);
         this.biomeTypeMappings.put("MESA_PLATEAU", (BiomeType)BiomeGenBase.mesaPlateau);
-        this.biomeTypeMappings.put("SUNFLOWER_PLAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.plains.biomeID + 128]);
-        this.biomeTypeMappings.put("DESERT_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.desert.biomeID + 128]);
-        this.biomeTypeMappings.put("FLOWER_FOREST", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.forest.biomeID + 128]);
-        this.biomeTypeMappings.put("TAIGA_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.taiga.biomeID + 128]);
-        this.biomeTypeMappings.put("SWAMPLAND_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.swampland.biomeID + 128]);
-        this.biomeTypeMappings.put("ICE_PLAINS_SPIKES", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.icePlains.biomeID + 128]);
-        this.biomeTypeMappings.put("JUNGLE_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.jungle.biomeID + 128]);
-        this.biomeTypeMappings.put("JUNGLE_EDGE_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.jungleEdge.biomeID + 128]);
-        this.biomeTypeMappings.put("COLD_TAIGA_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.coldTaiga.biomeID + 128]);
-        this.biomeTypeMappings.put("SAVANNA_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.savanna.biomeID + 128]);
-        this.biomeTypeMappings.put("SAVANNA_PLATEAU_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.savannaPlateau.biomeID + 128]);
-        this.biomeTypeMappings.put("MESA_BRYCE", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.mesa.biomeID + 128]);
-        this.biomeTypeMappings.put("MESA_PLATEAU_FOREST_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.mesaPlateau_F.biomeID + 128]);
-        this.biomeTypeMappings.put("MESA_PLATEAU_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.mesaPlateau.biomeID + 128]);
-        this.biomeTypeMappings.put("BIRCH_FOREST_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.birchForest.biomeID + 128]);
-        this.biomeTypeMappings.put("BIRCH_FOREST_HILLS_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.birchForestHills.biomeID + 128]);
-        this.biomeTypeMappings.put("ROOFED_FOREST_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.roofedForest.biomeID + 128]);
-        this.biomeTypeMappings.put("MEGA_SPRUCE_TAIGA", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.megaTaiga.biomeID + 128]);
-        this.biomeTypeMappings.put("EXTREME_HILLS_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.extremeHills.biomeID + 128]);
-        this.biomeTypeMappings.put("EXTREME_HILLS_PLUS_MOUNTAINS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.extremeHillsPlus.biomeID + 128]);
-        this.biomeTypeMappings.put("MEGA_SPRUCE_TAIGA_HILLS", (BiomeType)BiomeGenBase.getBiomeGenArray()[BiomeGenBase.megaTaigaHills.biomeID + 128]);
+        this.biomeTypeMappings.put("SUNFLOWER_PLAINS", (BiomeType) biomeArray[BiomeGenBase.plains.biomeID + 128]);
+        this.biomeTypeMappings.put("DESERT_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.desert.biomeID + 128]);
+        this.biomeTypeMappings.put("FLOWER_FOREST", (BiomeType) biomeArray[BiomeGenBase.forest.biomeID + 128]);
+        this.biomeTypeMappings.put("TAIGA_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.taiga.biomeID + 128]);
+        this.biomeTypeMappings.put("SWAMPLAND_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.swampland.biomeID + 128]);
+        this.biomeTypeMappings.put("ICE_PLAINS_SPIKES", (BiomeType) biomeArray[BiomeGenBase.icePlains.biomeID + 128]);
+        this.biomeTypeMappings.put("JUNGLE_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.jungle.biomeID + 128]);
+        this.biomeTypeMappings.put("JUNGLE_EDGE_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.jungleEdge.biomeID + 128]);
+        this.biomeTypeMappings.put("COLD_TAIGA_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.coldTaiga.biomeID + 128]);
+        this.biomeTypeMappings.put("SAVANNA_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.savanna.biomeID + 128]);
+        this.biomeTypeMappings.put("SAVANNA_PLATEAU_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.savannaPlateau.biomeID + 128]);
+        this.biomeTypeMappings.put("MESA_BRYCE", (BiomeType) biomeArray[BiomeGenBase.mesa.biomeID + 128]);
+        this.biomeTypeMappings.put("MESA_PLATEAU_FOREST_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.mesaPlateau_F.biomeID + 128]);
+        this.biomeTypeMappings.put("MESA_PLATEAU_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.mesaPlateau.biomeID + 128]);
+        this.biomeTypeMappings.put("BIRCH_FOREST_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.birchForest.biomeID + 128]);
+        this.biomeTypeMappings.put("BIRCH_FOREST_HILLS_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.birchForestHills.biomeID + 128]);
+        this.biomeTypeMappings.put("ROOFED_FOREST_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.roofedForest.biomeID + 128]);
+        this.biomeTypeMappings.put("MEGA_SPRUCE_TAIGA", (BiomeType) biomeArray[BiomeGenBase.megaTaiga.biomeID + 128]);
+        this.biomeTypeMappings.put("EXTREME_HILLS_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.extremeHills.biomeID + 128]);
+        this.biomeTypeMappings.put("EXTREME_HILLS_PLUS_MOUNTAINS", (BiomeType) biomeArray[BiomeGenBase.extremeHillsPlus.biomeID + 128]);
+        this.biomeTypeMappings.put("MEGA_SPRUCE_TAIGA_HILLS", (BiomeType) biomeArray[BiomeGenBase.megaTaigaHills.biomeID + 128]);
 
-        for (Field f : BiomeTypes.class.getDeclaredFields()) {
-            try {
-                f.set(null, this.biomeTypeMappings.get(f.getName()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
+        RegistryHelper.mapFields(BiomeTypes.class, biomeTypeMappings);
     }
 
     private void setCareersAndProfessions() {
@@ -903,67 +861,30 @@ public class SpongeGameRegistry implements GameRegistry {
         textColorToEnumMappings.put(textColorMappings.get("RESET"), EnumChatFormatting.RESET);
         textColorToEnumMappings.put(textColorMappings.get("YELLOW"), EnumChatFormatting.YELLOW);
 
-        for (Field f : TextColors.class.getDeclaredFields()) {
-            try {
-                f.set(null, textColorMappings.get(f.getName()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-
-        for (Field f : TextStyles.class.getDeclaredFields()) {
-            try {
-                if (!f.getName().equals("NONE") && !f.getName().equals("ZERO")) { // ignore these as they are already implemented in API
-                    f.set(null, textStyleMappings.get(f.getName()));
-                }
-            } catch (Exception e) {
-                // e.printStackTrace();
-            }
-        }
-
-        for (Field f : ChatTypes.class.getDeclaredFields()) {
-            try {
-                f.set(null, chatTypeMappings.get(f.getName()));
-            } catch (Exception e) {
-                // e.printStackTrace();
-            }
-        }
+        RegistryHelper.mapFields(TextColors.class, textColorMappings);
+        RegistryHelper.mapFields(TextStyles.class, textStyleMappings, Lists.newArrayList("NONE", "ZERO"));
+        RegistryHelper.mapFields(ChatTypes.class, chatTypeMappings);
     }
 
     private void setRotations() {
-        for (Field f : Rotations.class.getDeclaredFields()) {
-            try {
-                f.set(null, rotationMappings.get(f.getName()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
+        RegistryHelper.mapFields(Rotations.class, rotationMappings);
     }
     
     private void setWeathers() {
-        for (Field f : Weathers.class.getDeclaredFields()) {
-            try {
-                f.set(null, new SpongeWeather());
-            } catch (Exception e) {
-                e.printStackTrace();
+        RegistryHelper.mapFields(Weathers.class, new Function<String, Weather>() {
+            @Override
+            public Weather apply(String fieldName) {
+                return new SpongeWeather();
             }
-        }
+        });
     }
 
     private void setTextActionFactory() {
-        try {
-            TextActions.class.getDeclaredField("factory").set(null, new SpongeTextActionFactory());
-        } catch (Exception e) {
-            // e.printStackTrace();
-        }
+        RegistryHelper.setFactory(TextActions.class, new SpongeTextActionFactory());
     }
 
     private void setMessageFactory() {
-        try {
-            Messages.class.getDeclaredField("factory").set(null, new SpongeMessageFactory());
-        } catch (Exception e) {
-            // e.printStackTrace();
-        }
+        RegistryHelper.setFactory(Messages.class, new SpongeMessageFactory());
     }
 
     private void setSelectors() {
@@ -972,19 +893,15 @@ public class SpongeGameRegistry implements GameRegistry {
             SelectorTypes.class.getDeclaredField("ALL_ENTITIES").set(null, new SpongeSelectorType("e"));
             SelectorTypes.class.getDeclaredField("NEAREST_PLAYER").set(null, new SpongeSelectorType("p"));
             SelectorTypes.class.getDeclaredField("RANDOM_PLAYER").set(null, new SpongeSelectorType("r"));
-            SelectorTypes.class.getDeclaredField("factory").set(null, new SpongeSelectorTypeFactory());
-            Selectors.class.getDeclaredField("factory").set(null, new SpongeSelectorFactory());
         } catch (Exception e) {
             e.printStackTrace();
         }
+        RegistryHelper.setFactory(SelectorTypes.class, new SpongeSelectorTypeFactory());
+        RegistryHelper.setFactory(Selectors.class, new SpongeSelectorFactory());
     }
 
     private void setTitleFactory() {
-        try {
-            Titles.class.getDeclaredField("factory").set(null, new SpongeTitleFactory());
-        } catch (Exception e) {
-            // e.printStackTrace();
-        }
+        RegistryHelper.setFactory(Titles.class, new SpongeTitleFactory());
     }
 
     private void setDimensionTypes() {


### PR DESCRIPTION
 * All mapping fields are final
 * directionMap follows other static builder conventions
 * RegistryHelper - makes mapping API classes easier
  * `Map<String, ?>` mapping like before. Optional ignoredFields parameter
  * `Function<String, ?>` mapping, calls a function for every field in the target class
  * `setFactory` convenience method
 * `newEntityTypeFromName` - simplifies entity mapping
  * Looks up entity ID, no need to know it before hand
  * Reduces clutter, can spot mistakes easier. e.g Who spotted `WITCH` => `FallingSand`
 * In `setBiomeTypes`, reduced the amount of calls to `BiomeGenBase.getBiomeGenArray()` by making local variable `biomeArray`

### Registry issues fixed with this PR
 * ~~Entity type mapping `ARMOR_STAND` was named `ARMORSTAND`~~ Has been fixed
 * Entity type mapping `WITCH` was actually mapped to `FallingSand`
 * The `entityIdToTypeMappings` was actually setting `modId` (i.e `'minecraft'`) as the key rather than `getId()`
