### PR TITLE
Implement Human interface and remainder of methods in Player interface

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/entity/player/MixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/player/MixinEntityPlayer.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.entity.player;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.util.FoodStats;
+import net.minecraft.world.World;
+import org.spongepowered.api.entity.living.Human;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@NonnullByDefault
+@Mixin(EntityPlayer.class)
+@Implements(@Interface(iface = Human.class, prefix = "human$"))
+public abstract class MixinEntityPlayer extends EntityLivingBase {
+
+    @Shadow
+    public Container inventoryContainer;
+    @Shadow
+    public Container openContainer;
+    @Shadow
+    protected FoodStats foodStats;
+
+    public MixinEntityPlayer(World worldIn) {
+        super(worldIn);
+    }
+
+    float human$getHunger() {
+        return foodStats.getFoodLevel();
+    }
+
+    void human$setHunger(float hunger) {
+        foodStats.setFoodLevel((int)hunger);
+    }
+
+    float human$getSaturation() {
+        return foodStats.getSaturationLevel();
+    }
+
+    void human$setSaturation(float saturation) {
+        foodStats.setFoodSaturationLevel(saturation);
+    }
+
+    boolean human$isViewingInventory() {
+        return this.openContainer == this.inventoryContainer;
+    }
+
+}

--- a/src/main/java/org/spongepowered/mod/mixin/entity/player/MixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/player/MixinEntityPlayer.java
@@ -52,23 +52,23 @@ public abstract class MixinEntityPlayer extends EntityLivingBase {
         super(worldIn);
     }
 
-    float human$getHunger() {
+    public float human$getHunger() {
         return foodStats.getFoodLevel();
     }
 
-    void human$setHunger(float hunger) {
+    public void human$setHunger(float hunger) {
         foodStats.setFoodLevel((int)hunger);
     }
 
-    float human$getSaturation() {
+    public float human$getSaturation() {
         return foodStats.getSaturationLevel();
     }
 
-    void human$setSaturation(float saturation) {
+    public void human$setSaturation(float saturation) {
         foodStats.setFoodSaturationLevel(saturation);
     }
 
-    boolean human$isViewingInventory() {
+    public boolean human$isViewingInventory() {
         return this.openContainer == this.inventoryContainer;
     }
 

--- a/src/main/java/org/spongepowered/mod/mixin/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/player/MixinEntityPlayerMP.java
@@ -26,6 +26,7 @@ package org.spongepowered.mod.mixin.entity.player;
 
 import java.util.Locale;
 
+import com.google.common.base.Optional;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.NetHandlerPlayServer;
@@ -122,10 +123,18 @@ public abstract class MixinEntityPlayerMP extends EntityPlayer implements Comman
     }
 
     public void playermp$resetTitle() {
-        throw new UnsupportedOperationException();
+        SpongeTitle title = new SpongeTitle(false, true, Optional.<Message>absent(), Optional.<Message>absent(),
+                Optional.<Integer>absent(), Optional.<Integer>absent(), Optional.<Integer>absent());
+        for (S45PacketTitle packet : title.getPackets()) {
+            this.playerNetServerHandler.sendPacket(packet);
+        }
     }
 
     public void playermp$clearTitle() {
-        throw new UnsupportedOperationException();
+        SpongeTitle title = new SpongeTitle(true, false, Optional.<Message>absent(), Optional.<Message>absent(),
+                Optional.<Integer>absent(), Optional.<Integer>absent(), Optional.<Integer>absent());
+        for (S45PacketTitle packet : title.getPackets()) {
+            this.playerNetServerHandler.sendPacket(packet);
+        }
     }
 }


### PR DESCRIPTION
This PR adds the MixinEntityPlayer class, which implements methods defined in the Human interface. Additionally, it implements the clearTitle and resetTitle methods defined in the Player interface.