### PR TITLE
Add a vector helper to simplify vector conversions

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/block/MixinPropertyDirection.java
+++ b/src/main/java/org/spongepowered/mod/mixin/block/MixinPropertyDirection.java
@@ -35,6 +35,7 @@ import org.spongepowered.api.block.BlockProperty;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.mod.registry.SpongeGameRegistry;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -87,43 +88,20 @@ public abstract class MixinPropertyDirection extends PropertyEnum implements Blo
         return ImmutableSet.copyOf(converted);
     }
 
-    // TODO: These are probably generally useful and should be in a helper class somewhere.
     private Direction getDirection(EnumFacing facing) {
-        switch (facing) {
-            case DOWN:
-                return Direction.DOWN;
-            case UP:
-                return Direction.UP;
-            case NORTH:
-                return Direction.NORTH;
-            case SOUTH:
-                return Direction.SOUTH;
-            case WEST:
-                return Direction.WEST;
-            case EAST:
-                return Direction.EAST;
-            default:
-                throw new IllegalArgumentException(String.format("Invalid EnumFacing '%s'", facing.toString()));
+        Direction direction = SpongeGameRegistry.directionMap.inverse().get(facing);
+        if (direction == null) {
+            throw new IllegalArgumentException(String.format("Invalid EnumFacing '%s'", facing.toString()));
         }
+        return direction;
     }
 
     private EnumFacing getFacing(Direction direction) {
-        switch (direction) {
-            case NORTH:
-                return EnumFacing.NORTH;
-            case EAST:
-                return EnumFacing.EAST;
-            case SOUTH:
-                return EnumFacing.SOUTH;
-            case WEST:
-                return EnumFacing.WEST;
-            case UP:
-                return EnumFacing.UP;
-            case DOWN:
-                return EnumFacing.DOWN;
-            default:
-                throw new IllegalArgumentException(
-                        String.format("Invalid Direction '%s', only cardinal and upright directions are supported", direction.toString()));
+        EnumFacing facing = SpongeGameRegistry.directionMap.get(direction);
+        if (facing == null) {
+            throw new IllegalArgumentException(String.format("Invalid Direction '%s', only cardinal and upright directions are supported",
+                    direction.toString()));
         }
+        return facing;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/entity/living/MixinArmorStand.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/living/MixinArmorStand.java
@@ -35,6 +35,7 @@ import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.util.VecHelper;
 
 @Mixin(EntityArmorStand.class)
 @Implements(@Interface(iface = ArmorStand.class, prefix = "astand$"))
@@ -84,51 +85,51 @@ public abstract class MixinArmorStand extends EntityLivingBase {
     }
 
     public Vector3f astand$getHeadDirection() {
-        return new Vector3f(this.headRotation.func_179415_b(), this.headRotation.func_179416_c(), this.headRotation.func_179413_d());
+        return VecHelper.toVector(this.headRotation);
     }
 
     public void astand$setHeadDirection(Vector3f direction) {
-        setHeadRotation(new Rotations(direction.getX(), direction.getY(), direction.getZ()));
+        setHeadRotation(VecHelper.toRotation(direction));
     }
 
     public Vector3f astand$getBodyRotation() {
-        return new Vector3f(this.bodyRotation.func_179415_b(), this.bodyRotation.func_179416_c(), this.bodyRotation.func_179413_d());
+        return VecHelper.toVector(this.bodyRotation);
     }
 
     public void astand$setBodyDirection(Vector3f direction) {
-        setBodyRotation(new Rotations(direction.getX(), direction.getY(), direction.getZ()));
+        setBodyRotation(VecHelper.toRotation(direction));
     }
 
     public Vector3f astand$getLeftArmDirection() {
-        return new Vector3f(this.leftArmRotation.func_179415_b(), this.leftArmRotation.func_179416_c(), this.leftArmRotation.func_179413_d());
+        return VecHelper.toVector(this.leftArmRotation);
     }
 
     public void astand$setLeftArmDirection(Vector3f direction) {
-        setLeftArmRotation(new Rotations(direction.getX(), direction.getY(), direction.getZ()));
+        setLeftArmRotation(VecHelper.toRotation(direction));
     }
 
     public Vector3f astand$getRightArmDirection() {
-        return new Vector3f(this.rightArmRotation.func_179415_b(), this.rightArmRotation.func_179416_c(), this.rightArmRotation.func_179413_d());
+        return VecHelper.toVector(this.rightArmRotation);
     }
 
     public void astand$setRightArmDirection(Vector3f direction) {
-        setRightArmRotation(new Rotations(direction.getX(), direction.getY(), direction.getZ()));
+        setRightArmRotation(VecHelper.toRotation(direction));
     }
 
     public Vector3f astand$getLeftLegDirection() {
-        return new Vector3f(this.leftLegRotation.func_179415_b(), this.leftLegRotation.func_179416_c(), this.leftLegRotation.func_179413_d());
+        return VecHelper.toVector(this.leftLegRotation);
     }
 
     public void astand$setLeftLegDirection(Vector3f direction) {
-        setLeftLegRotation(new Rotations(direction.getX(), direction.getY(), direction.getZ()));
+        setLeftLegRotation(VecHelper.toRotation(direction));
     }
 
     public Vector3f astand$getRightLegDirection() {
-        return new Vector3f(this.rightLegRotation.func_179415_b(), this.rightLegRotation.func_179416_c(), this.rightLegRotation.func_179413_d());
+        return VecHelper.toVector(this.rightLegRotation);
     }
 
     public void astand$setRightLegDirection(Vector3f direction) {
-        setRightLegRotation(new Rotations(direction.getX(), direction.getY(), direction.getZ()));
+        setRightLegRotation(VecHelper.toRotation(direction));
     }
 
     public boolean astand$isSmall() {

--- a/src/main/java/org/spongepowered/mod/mixin/entity/living/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/living/MixinEntityLivingBase.java
@@ -50,7 +50,6 @@ import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
-import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3f;
 import com.google.common.base.Optional;
 
@@ -177,8 +176,7 @@ public abstract class MixinEntityLivingBase extends Entity {
     }
 
     public Vector3f living$getEyeLocation() {
-        Vector3d vec = ((Living)this).getLocation().getPosition();
-        return new Vector3f(vec.getX(), vec.getY() + getEyeHeight(), vec.getZ());
+        return ((Living) this).getLocation().getPosition().add(0, getEyeHeight(), 0).toFloat();
     }
 
     public int living$getRemainingAir() {

--- a/src/main/java/org/spongepowered/mod/mixin/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/mod/mixin/world/MixinWorld.java
@@ -63,6 +63,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.mod.effect.particle.SpongeParticleEffect;
 import org.spongepowered.mod.effect.particle.SpongeParticleHelper;
+import org.spongepowered.mod.util.VecHelper;
 import org.spongepowered.mod.wrapper.BlockWrapper;
 
 @NonnullByDefault
@@ -115,9 +116,7 @@ public abstract class MixinWorld implements World {
 
     @Override
     public BlockLoc getBlock(Vector3d position) {
-        // TODO: MC's BlockPos does some sort of special rounding on double
-        // positions -- do we want to do that too?
-        return new BlockWrapper(this, (int) position.getX(), (int) position.getY(), (int) position.getZ());
+        return new BlockWrapper(this, VecHelper.toBlockPos(position));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/util/VecHelper.java
+++ b/src/main/java/org/spongepowered/mod/util/VecHelper.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.util;
+
+import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3f;
+import com.flowpowered.math.vector.Vector3i;
+
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.Rotations;
+import net.minecraft.util.Vec3i;
+
+public final class VecHelper {
+
+    // === Flow Vector --> BlockPos ===
+
+    public static BlockPos toBlockPos(Vector3d vector) {
+        return new BlockPos(vector.getX(), vector.getY(), vector.getZ());
+    }
+
+    // === Flow Vector --> Rotations ===
+
+    public static Rotations toRotation(Vector3f vector) {
+        return new Rotations(vector.getX(), vector.getY(), vector.getZ());
+    }
+
+    // === Rotations --> Flow Vector ===
+
+    public static Vector3f toVector(Rotations rotation) {
+        return new Vector3f(rotation.func_179415_b(), rotation.func_179416_c(), rotation.func_179413_d());
+    }
+
+    // === MC Vector --> Flow Vector ===
+
+    public static Vector3i toVector(Vec3i vector) {
+        return new Vector3i(vector.getX(), vector.getY(), vector.getZ());
+    }
+}

--- a/src/main/java/org/spongepowered/mod/wrapper/BlockWrapper.java
+++ b/src/main/java/org/spongepowered/mod/wrapper/BlockWrapper.java
@@ -24,13 +24,14 @@
  */
 package org.spongepowered.mod.wrapper;
 
-import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3i;
 import com.google.common.base.Optional;
+
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.EnumSkyBlock;
+
 import org.spongepowered.api.block.BlockLoc;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.BlockState;
@@ -40,6 +41,8 @@ import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.Extent;
+import org.spongepowered.mod.registry.SpongeGameRegistry;
+import org.spongepowered.mod.util.VecHelper;
 
 import java.util.Collection;
 
@@ -51,6 +54,10 @@ public class BlockWrapper implements BlockLoc {
     private BlockPos pos;
 
     public BlockWrapper(World world, int x, int y, int z) {
+        this(world, new BlockPos(x, y, z));
+    }
+
+    public BlockWrapper(World world, BlockPos blockPos) {
         // This is a NOT check, be careful of that
         if (!(world instanceof net.minecraft.world.World)) {
             System.err.println("World passed to BlockWrapper wasn't a mixin for net.minecraft.world.World! Serious issue!");
@@ -58,28 +65,16 @@ public class BlockWrapper implements BlockLoc {
         }
         this.handle = (net.minecraft.world.World) world;
         this.extent = world;
-        this.pos = new BlockPos(x, y, z);
+        this.pos = blockPos;
     }
 
-    //TODO: Move this to Direction
     private static EnumFacing getNotchDirection(Direction dir) {
-        switch (dir) {
-            case DOWN:
-                return EnumFacing.DOWN;
-            case UP:
-                return EnumFacing.UP;
-            case NORTH:
-                return EnumFacing.NORTH;
-            case SOUTH:
-                return EnumFacing.SOUTH;
-            case WEST:
-                return EnumFacing.WEST;
-            case EAST:
-                return EnumFacing.EAST;
-            default:
-                // TODO: EnumFacing doesn't have an 'invalid/default' value.
-                return EnumFacing.DOWN;
+        EnumFacing facing = SpongeGameRegistry.directionMap.get(dir);
+        if (facing == null) {
+            // TODO: EnumFacing doesn't have an 'invalid/default' value.
+            return EnumFacing.DOWN;
         }
+        return facing;
     }
 
     @Override
@@ -87,15 +82,14 @@ public class BlockWrapper implements BlockLoc {
         return this.extent;
     }
 
-    // TODO: Can we mixin Vector3i with BlockPos?
     @Override
     public Vector3i getPosition() {
-        return new Vector3i(this.pos.getX(), this.pos.getY(), this.pos.getZ());
+        return VecHelper.toVector(this.pos);
     }
 
     @Override
     public Location getLocation() {
-        return new Location(this.extent, new Vector3d(this.pos.getX(), this.pos.getY(), this.pos.getZ()));
+        return new Location(this.extent, VecHelper.toVector(this.pos).toDouble());
     }
 
     @Override


### PR DESCRIPTION
Makes it easier and neater
I also removed the switch statement for Direction <-> EnumFacing since it's no longer needed.

There's some use cases for this in #107 so if this gets merged first I'll update #107 to utilize VecHelper