### PR TITLE
Implement various Entity, Block, Item and more methods

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/block/MixinBlockType.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/MixinBlockType.java
@@ -24,21 +24,27 @@
  */
 package org.spongepowered.mod.mixin.core.block;
 
+import com.google.common.base.Optional;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFalling;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.Item;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.item.ItemBlock;
 import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.mod.util.TranslationHelper;
 
 @NonnullByDefault
 @Mixin(Block.class)
 public abstract class MixinBlockType implements BlockType {
+
+    @Shadow private boolean needsRandomTick;
 
     @Shadow(prefix = "shadow$")
     public abstract IBlockState shadow$getDefaultState();
@@ -105,6 +111,22 @@ public abstract class MixinBlockType implements BlockType {
     @Override
     public float getEmittedLight() {
         return 15F / getLightValue();
+    }
+
+    @Override
+    @Overwrite
+    public boolean getTickRandomly() {
+        return this.needsRandomTick;
+    }
+
+    @Override
+    public void setTickRandomly(boolean tickRandomly) {
+        this.needsRandomTick = tickRandomly;
+    }
+
+    @Override
+    public Optional<ItemBlock> getHeldItem() {
+        return Optional.fromNullable((ItemBlock) Item.getItemFromBlock((Block) (Object) this));
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntity.java
@@ -45,7 +45,7 @@ public abstract class MixinTileEntity implements TileEntity {
 
     @Override
     public BlockLoc getBlock() {
-        return new BlockWrapper(getWorld(), getPos().getX(), getPos().getY(), getPos().getZ());
+        return new BlockWrapper(getWorld(), getPos());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinArmorEquipable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinArmorEquipable.java
@@ -30,7 +30,7 @@ import net.minecraft.entity.item.EntityArmorStand;
 import net.minecraft.entity.monster.EntityGiantZombie;
 import net.minecraft.entity.monster.EntitySkeleton;
 import net.minecraft.entity.monster.EntityZombie;
-import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import org.spongepowered.api.entity.ArmorEquipable;
 import org.spongepowered.api.item.inventory.ItemStack;
@@ -39,7 +39,7 @@ import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
 
 // All implementors of ArmorEquipable
-@Mixin({EntityArmorStand.class, EntityGiantZombie.class, EntitySkeleton.class, EntityPlayerMP.class, EntityZombie.class})
+@Mixin({EntityArmorStand.class, EntityGiantZombie.class, EntityPlayer.class, EntitySkeleton.class, EntityZombie.class})
 @Implements(@Interface(iface = ArmorEquipable.class, prefix = "equipable$"))
 public abstract class MixinArmorEquipable extends EntityLivingBase {
 
@@ -52,7 +52,7 @@ public abstract class MixinArmorEquipable extends EntityLivingBase {
     private static final int SLOT_LEGGINGS = 2;
     private static final int SLOT_CHESTPLATE = 3;
     private static final int SLOT_HELMET = 4;
-    
+
     public Optional<ItemStack> equipable$getHelmet() {
         return Optional.fromNullable((ItemStack) this.getEquipmentInSlot(SLOT_HELMET));
     }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntity.java
@@ -65,6 +65,8 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
     private EntityType entityType;
     private boolean teleporting;
     private net.minecraft.entity.Entity teleportVehicle;
+    private float origWidth;
+    private float origHeight;
 
     @Shadow
     private UUID entityUniqueID;
@@ -123,6 +125,14 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
     @Inject(method = "<init>", at = @At("RETURN"))
     public void onConstructed(net.minecraft.world.World world, CallbackInfo ci) {
         this.entityType = ((SpongeGameRegistry) SpongeMod.instance.getGame().getRegistry()).entityClassToTypeMappings.get(this.getClass());
+    }
+
+    @Inject(method = "setSize", at = @At("RETURN"))
+    public void onSetSize(float width, float height, CallbackInfo ci) {
+        if (this.origWidth == 0 || this.origHeight == 0) {
+            this.origWidth = this.width;
+            this.origHeight = this.height;
+        }
     }
 
     @Inject(method = "moveEntity(DDD)V", at = @At("HEAD"), cancellable = true)
@@ -349,8 +359,13 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
 
     @Override
     public float getScale() {
-        // TODO
-        return 0;
+        if (this.origWidth == 0 || this.origHeight == 0) {
+            this.origWidth = this.width;
+            this.origHeight = this.height;
+        }
+        double scaleW = this.width / this.origWidth;
+        double scaleH = this.height / this.origHeight;
+        return (float) (scaleH + scaleW) / 2;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntityEnderCrystal.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntityEnderCrystal.java
@@ -29,14 +29,11 @@ import net.minecraft.entity.item.EntityEnderCrystal;
 import net.minecraft.world.World;
 import org.spongepowered.api.entity.EnderCrystal;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
 
 @NonnullByDefault
 @Mixin(EntityEnderCrystal.class)
-@Implements(@Interface(iface = EnderCrystal.class, prefix = "endercrystal$"))
-public abstract class MixinEntityEnderCrystal extends Entity {
+public abstract class MixinEntityEnderCrystal extends Entity implements EnderCrystal {
 
     public MixinEntityEnderCrystal(World worldIn) {
         super(worldIn);

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntityItem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntityItem.java
@@ -57,7 +57,7 @@ public abstract class MixinEntityItem extends Entity implements Item {
     @Shadow
     private int age;
 
-    @Shadow
+    @Shadow(remap = false)
     public int lifespan;
 
     @Shadow

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinArmorStand.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinArmorStand.java
@@ -84,6 +84,12 @@ public abstract class MixinArmorStand extends EntityLivingBase {
     @Shadow
     protected abstract void setNoBasePlate(boolean p_175426_1_);
 
+    @Shadow
+    public abstract boolean hasNoGravity();
+
+    @Shadow
+    protected abstract void setNoGravity(boolean p_175425_1_);
+
     public MixinArmorStand(net.minecraft.world.World worldIn) {
         super(worldIn);
     }
@@ -160,5 +166,13 @@ public abstract class MixinArmorStand extends EntityLivingBase {
 
     public void astand$setHasBasePlate(boolean baseplate) {
         this.setNoBasePlate(!baseplate);
+    }
+
+    public boolean astand$hasGravity() {
+        return !this.hasNoGravity();
+    }
+
+    public void astand$setGravity(boolean gravity) {
+        this.setNoGravity(!gravity);
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityLiving.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityLiving.java
@@ -74,6 +74,10 @@ public abstract class MixinEntityLiving extends EntityLivingBase {
         return getLeashedToEntity() != null;
     }
 
+    public void agent$setLeashed(boolean leashed) {
+        // TODO
+    }
+
     public Optional<Entity> agent$getLeashHolder() {
         return Optional.fromNullable((Entity) getLeashedToEntity());
     }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityLivingBase.java
@@ -253,4 +253,12 @@ public abstract class MixinEntityLivingBase extends Entity {
         setAlwaysRenderNameTag(visible);
     }
 
+    public boolean living$isInvisible() {
+        return this.getFlag(5);
+    }
+
+    public void living$setInvisible(boolean invisible) {
+        this.setFlag(5, invisible);
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/MixinEntityBoat.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/MixinEntityBoat.java
@@ -128,6 +128,12 @@ public abstract class MixinEntityBoat extends Entity implements Boat {
     }
 
     @Override
+    public boolean isInWater() {
+        // TODO This only works when the boat is submerged
+        return this.inWater;
+    }
+
+    @Override
     public double getMaxSpeed() {
         return this.maxSpeed;
     }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecart.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecart.java
@@ -41,10 +41,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(EntityMinecart.class)
 public abstract class MixinEntityMinecart extends Entity implements Minecart {
 
-    @Shadow
+    @Shadow(remap = false)
     public abstract double getDragAir();
 
-    @Shadow
+    @Shadow(remap = false)
     public abstract double getMaxSpeed();
 
     private double maxSpeed;

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/weather/MixinEntityLightningBolt.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/weather/MixinEntityLightningBolt.java
@@ -48,6 +48,11 @@ public abstract class MixinEntityLightningBolt extends EntityWeatherEffect imple
         return this.effect;
     }
 
+    @Override
+    public void setEffect(boolean effect) {
+        this.effect = effect;
+    }
+
     @Inject(method = "onUpdate()V", at = {@At(value = "NEW", args = "class=net.minecraft.util.BlockPos"),
             @At(value = "NEW", args = "class=net.minecraft.util.AxisAlignedBB")}, cancellable = true)
     public void onOnUpdate(CallbackInfo ci) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/block/MixinEventBlock.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/block/MixinEventBlock.java
@@ -48,7 +48,7 @@ public abstract class MixinEventBlock extends Event implements BlockEvent {
 
     @Override
     public BlockLoc getBlock() {
-        return new BlockWrapper((World) this.world, this.pos.getX(), this.pos.getY(), this.pos.getZ());
+        return new BlockWrapper((World) this.world, this.pos);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/MixinEnchantment.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/MixinEnchantment.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.mod.mixin.core.item;
 
+import net.minecraft.enchantment.EnumEnchantmentType;
 import net.minecraft.util.ResourceLocation;
 import org.spongepowered.api.item.Enchantment;
 import org.spongepowered.api.item.ItemTypes;
@@ -31,16 +32,18 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-
-import java.util.Map;
-import java.util.Map.Entry;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @NonnullByDefault
 @Mixin(net.minecraft.enchantment.Enchantment.class)
 public abstract class MixinEnchantment implements Enchantment {
 
+    private String id = "";
+
     @Shadow
-    private static Map<ResourceLocation, net.minecraft.enchantment.Enchantment> field_180307_E;
+    private int weight;
 
     @Shadow
     public abstract int getMinLevel();
@@ -64,14 +67,19 @@ public abstract class MixinEnchantment implements Enchantment {
     @Shadow(remap = false)
     public abstract boolean isAllowedOnBooks();
 
+    @Inject(method = "<init>", at = @At("RETURN"))
+    public void onConstructed(int id, ResourceLocation resLoc, int weight, EnumEnchantmentType type, CallbackInfo ci) {
+        this.id = resLoc.toString();
+    }
+
     @Override
     public String getId() {
-        for (Entry<ResourceLocation, net.minecraft.enchantment.Enchantment> entry : field_180307_E.entrySet()) {
-            if (entry.getValue().equals(this)) {
-                return entry.getKey().toString();
-            }
-        }
-        return ""; //Should never be reached
+        return this.id;
+    }
+
+    @Override
+    public int getWeight() {
+        return this.weight;
     }
 
     @Override
@@ -108,4 +116,5 @@ public abstract class MixinEnchantment implements Enchantment {
     public boolean isCompatibleWith(Enchantment ench) {
         return canApplyTogether((net.minecraft.enchantment.Enchantment) ench);
     }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/MixinItemType.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/MixinItemType.java
@@ -29,12 +29,15 @@ import net.minecraft.util.StatCollector;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.mod.util.TranslationHelper;
 
 @NonnullByDefault
 @Mixin(Item.class)
+@Implements(@Interface(iface = ItemType.class, prefix = "item$"))
 public abstract class MixinItemType implements ItemType {
 
     @Shadow
@@ -45,6 +48,9 @@ public abstract class MixinItemType implements ItemType {
 
     @Shadow
     private int maxDamage;
+
+    @Shadow
+    private boolean hasSubtypes;
 
     @Override
     public String getId() {
@@ -67,5 +73,9 @@ public abstract class MixinItemType implements ItemType {
     @Override
     public int getMaxDamage() {
         return this.maxDamage;
+    }
+
+    public boolean item$isDamageable() {
+        return this.maxDamage > 0 && !this.hasSubtypes;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/inventory/MixinItemStack.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/inventory/MixinItemStack.java
@@ -29,6 +29,8 @@ import net.minecraft.nbt.NBTTagList;
 import org.spongepowered.api.item.Enchantment;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.service.persistence.DataSource;
+import org.spongepowered.api.service.persistence.data.DataContainer;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -143,5 +145,15 @@ public abstract class MixinItemStack implements ItemStack {
     @Override
     public int getEnchantment(Enchantment enchant) {
         return getEnchantments().get(enchant);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        throw new UnsupportedOperationException(); // TODO
+    }
+
+    @Override
+    public void serialize(DataSource source) {
+        throw new UnsupportedOperationException(); // TODO
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/potion/MixinPotionEffect.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/potion/MixinPotionEffect.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.mod.mixin.core.potion;
 
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.potion.Potion;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.potion.PotionEffect;
@@ -60,8 +61,8 @@ public abstract class MixinPotionEffect implements PotionEffect {
     }
 
     @Override
-    public void apply(Living ent) {
-        // TODO
+    public void apply(Living entity) {
+        ((EntityLivingBase) entity).addPotionEffect((net.minecraft.potion.PotionEffect) (Object) this);
     }
 
     public int potionEffect$getDuration() {

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorld.java
@@ -412,9 +412,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
 
     @Override
     public Optional<Entity> getEntity(UUID uuid) {
-        World spongeWorld = this;
-        if (spongeWorld instanceof WorldServer) {
-            // TODO Should this be done in an override in a WorldServer mixin?
+        if ((Object) this instanceof WorldServer) {
             return Optional.fromNullable((Entity) ((WorldServer) (Object) this).getEntityFromUuid(uuid));
         }
         for (net.minecraft.entity.Entity entity : this.loadedEntityList) {

--- a/src/main/java/org/spongepowered/mod/registry/SpongeGameDictionary.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeGameDictionary.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.registry;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import net.minecraft.item.Item;
+import net.minecraftforge.oredict.OreDictionary;
+import org.spongepowered.api.GameDictionary;
+import org.spongepowered.api.item.ItemType;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class SpongeGameDictionary implements GameDictionary {
+
+    public static final GameDictionary instance = new SpongeGameDictionary();
+
+    private SpongeGameDictionary() {
+    }
+
+    @Override
+    public void register(String key, ItemType type) {
+        OreDictionary.registerOre(key, (Item) type);
+    }
+
+    @Override
+    public Set<ItemType> get(String key) {
+        HashSet<ItemType> items = Sets.newHashSet();
+        for (net.minecraft.item.ItemStack itemStack : OreDictionary.getOres(key)) {
+            items.add((ItemType) itemStack.getItem());
+        }
+        return items;
+    }
+
+    @Override
+    public Map<String, Set<ItemType>> getAllItems() {
+        HashMap<String, Set<ItemType>> allItems = Maps.newHashMap();
+        for (String key : OreDictionary.getOreNames()) {
+            allItems.put(key, this.get(key));
+        }
+        return allItems;
+    }
+}

--- a/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
@@ -573,7 +573,7 @@ public class SpongeGameRegistry implements GameRegistry {
 
     @Override
     public GameDictionary getGameDictionary() {
-        throw new UnsupportedOperationException(); // TODO
+        return SpongeGameDictionary.instance;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
@@ -493,12 +493,17 @@ public class SpongeGameRegistry implements GameRegistry {
 
     @Override
     public Optional<Rotation> getRotationFromDegree(int degrees) {
-        throw new UnsupportedOperationException(); // TODO
+        for (Rotation rotation : rotationMappings.values()) {
+            if (rotation.getAngle() == degrees) {
+                return Optional.of(rotation);
+            }
+        }
+        return Optional.absent();
     }
 
     @Override
     public List<Rotation> getRotations() {
-        throw new UnsupportedOperationException(); // TODO
+        return ImmutableList.copyOf(rotationMappings.values());
     }
 
     @Override


### PR DESCRIPTION
This PR implements bits 'n' pieces that are missing from various entity/block/item mixins.

Summary:
 * Completed the implementation of `BlockType`
 * Make `EntityPlayer` implement `ArmorEquipable` now that `Human` extends it (was `EntityPlayerMP`)
 * Implement Entity#getScale  - not completely sure how to do this but basically it averages the difference between the original entity width/height and it's current width/height
 * Completed implementation of `ArmorStand` (gravity methods were recently added in the API)
 * Completed implementation of `Living` (invisibility methods were recently added)
 * Tweaks to `MixinEnchantment`  - improved efficiency of `getId` and add missing `getWeight`
 * Completed implementation of `ItemType`
 * Add missing `PotionEffect#apply` method
 * Rotation methods in `SpongeGameRegistry`
 * Some other minor tweaks
 * __New:__ Implement `GameDictionary` using Forge's `OreDictionary`

I have a few other things in my mind that I could add
 - Try to enforce max stack quantity in ItemStack
 - implementation of SpongePowered/SpongeAPI#458 if it gets merged