### PR TITLE
Fix quit message being sent before the quit event

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/common/event/MixinSpongeImplEventFactory.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/common/event/MixinSpongeImplEventFactory.java
@@ -31,6 +31,7 @@ import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.entity.player.Player;
 import org.spongepowered.api.event.entity.player.PlayerJoinEvent;
+import org.spongepowered.api.event.entity.player.PlayerQuitEvent;
 import org.spongepowered.api.event.entity.player.PlayerRespawnEvent;
 import org.spongepowered.api.event.world.WorldLoadEvent;
 import org.spongepowered.api.text.Text;
@@ -63,6 +64,14 @@ public abstract class MixinSpongeImplEventFactory {
         final PlayerRespawnEvent event = (PlayerRespawnEvent) new PlayerEvent.PlayerRespawnEvent((EntityPlayer) player);
         ((IMixinPlayerRespawnEvent) event).setIsBedSpawn(isBedSpawn);
         event.setNewRespawnLocation(respawnLocation);
+        return event;
+    }
+
+    @Overwrite
+    public static PlayerQuitEvent createPlayerQuit(Game game, Player player, Text message, MessageSink sink) {
+        final PlayerQuitEvent event = (PlayerQuitEvent) new PlayerEvent.PlayerLoggedOutEvent((EntityPlayer) player);
+        event.setNewMessage(message);
+        event.setSink(sink);
         return event;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/server/MixinIntegratedServerAnonInner3.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/server/MixinIntegratedServerAnonInner3.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.mixin.core.server;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.spongepowered.api.entity.player.Player;
+import org.spongepowered.api.event.entity.player.PlayerQuitEvent;
+import org.spongepowered.api.text.Texts;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.common.Sponge;
+import org.spongepowered.common.event.SpongeImplEventFactory;
+
+@SideOnly(Side.CLIENT)
+@Mixin(targets = "net/minecraft/server/integrated/IntegratedServer$3")
+public class MixinIntegratedServerAnonInner3 {
+
+    /**
+     * @author Simon816
+     *
+     * PlayerQuitEvent must be fired manually just before playerLoggedOut.
+     *
+     * @see MixinServerConfigurationManager#onFirePlayerLoggedOutCall
+     */
+    @ModifyArg(method = "run()V", at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/server/management/ServerConfigurationManager;playerLoggedOut(Lnet/minecraft/entity/player/EntityPlayerMP;)V"))
+    public EntityPlayerMP beforeFirePlayerLoggedOut(EntityPlayerMP playerIn) {
+        PlayerQuitEvent event =
+                SpongeImplEventFactory.createPlayerQuit(Sponge.getGame(), (Player) playerIn, Texts.of(), ((Player) playerIn).getMessageSink());
+        Sponge.getGame().getEventManager().post(event);
+        // Doesn't make sense to send the event's message because all players
+        // are quitting anyway
+        return playerIn;
+    }
+}

--- a/src/main/resources/mixins.forge.core.json
+++ b/src/main/resources/mixins.forge.core.json
@@ -53,9 +53,13 @@
         "network.MixinNetHandlerPlayServer",
         "server.MixinMinecraftServer",
         "server.MixinServerCommandManager",
+        "server.MixinServerConfigurationManager",
         "world.MixinChunk",
         "world.MixinWorld",
         "world.MixinWorldProvider",
         "world.storage.MixinSaveHandler"
+    ],
+    "client": [
+        "server.MixinIntegratedServerAnonInner3"
     ]
 }


### PR DESCRIPTION
~~Pretty bad hack TBH, will break easily if forge/MC change something.~~

~~This moves the call to `sendChatMsg` after the event has fired in order to get the message from the result of the event.~~

Much of the original PR contents has made it's way into SpongeCommon
This just completes the implementation by removing Forge's method call to fire the event due to Common already handling it.