### PR TITLE
Add code for getMinecraftVersion()

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeGame.java
+++ b/src/main/java/org/spongepowered/mod/SpongeGame.java
@@ -25,6 +25,7 @@
 package org.spongepowered.mod;
 
 import com.google.common.base.Optional;
+import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.GameRegistry;
@@ -97,7 +98,7 @@ public final class SpongeGame implements Game {
 
     @Override
     public MinecraftVersion getMinecraftVersion() {
-        throw new UnsupportedOperationException(); // TODO
+        return (MinecraftVersion) MinecraftServer.getServer().getServerStatusResponse().getProtocolVersionInfo();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/SpongeMinecraftVersion.java
+++ b/src/main/java/org/spongepowered/mod/SpongeMinecraftVersion.java
@@ -25,6 +25,7 @@
 package org.spongepowered.mod;
 
 import com.google.common.base.MoreObjects;
+import net.minecraft.network.ServerStatusResponse;
 import org.spongepowered.api.MinecraftVersion;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 
@@ -37,6 +38,11 @@ public class SpongeMinecraftVersion implements ProtocolMinecraftVersion {
     public SpongeMinecraftVersion(String name, int protocol) {
         this.name = name;
         this.protocol = protocol;
+    }
+
+    public SpongeMinecraftVersion(ServerStatusResponse.MinecraftProtocolVersionIdentifier identifier) {
+        this.name = identifier.getName();
+        this.protocol = identifier.getProtocol();
     }
 
     @Override


### PR DESCRIPTION
With the help of Sibomots I wrote some code so getMinecraftVersion() in SpongeGame would work. However, we're not sure if the singleton approach is the best.

~~I also fixed "gradle javadoc" from throwing errors but there is a file that needs to be fixed. I removed a "@see" annotation thinking it was invalid when really the error was caused by the annotation being immediately followed by a "@link" annotation.~~