### PR TITLE
Places imports in order to satisfy checkStyle

### DIFF
--- a/src/main/java/org/spongepowered/api/text/action/SpongeTextActionFactory.java
+++ b/src/main/java/org/spongepowered/api/text/action/SpongeTextActionFactory.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.api.text.action;
 
-import java.net.URL;
-
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.text.action.ClickAction.ChangePage;
@@ -42,6 +40,8 @@ import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.mod.text.action.SpongeClickAction;
 import org.spongepowered.mod.text.action.SpongeHoverAction;
 import org.spongepowered.mod.text.action.SpongeShiftClickAction;
+
+import java.net.URL;
 
 @NonnullByDefault
 public class SpongeTextActionFactory implements TextActionFactory {

--- a/src/main/java/org/spongepowered/api/text/selector/SpongeSelectorTypeFactory.java
+++ b/src/main/java/org/spongepowered/api/text/selector/SpongeSelectorTypeFactory.java
@@ -24,12 +24,12 @@
  */
 package org.spongepowered.api.text.selector;
 
-import java.util.List;
-
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
 
 @NonnullByDefault
 public class SpongeSelectorTypeFactory implements SelectorTypeFactory {

--- a/src/main/java/org/spongepowered/mod/SpongeCoremod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeCoremod.java
@@ -24,12 +24,12 @@
  */
 package org.spongepowered.mod;
 
-import java.util.Map;
+import org.spongepowered.asm.launch.MixinBootstrap;
+import org.spongepowered.asm.mixin.MixinEnvironment;
 
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
 
-import org.spongepowered.asm.launch.MixinBootstrap;
-import org.spongepowered.asm.mixin.MixinEnvironment;
+import java.util.Map;
 
 public class SpongeCoremod implements IFMLLoadingPlugin {
 

--- a/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleEffect.java
+++ b/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleEffect.java
@@ -24,12 +24,12 @@
  */
 package org.spongepowered.mod.effect.particle;
 
-import java.awt.Color;
-
 import org.spongepowered.api.effect.particle.ParticleEffect;
 import org.spongepowered.api.item.inventory.ItemStack;
 
 import com.flowpowered.math.vector.Vector3f;
+
+import java.awt.Color;
 
 public class SpongeParticleEffect implements ParticleEffect {
     private SpongeParticleType type;

--- a/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleEffectBuilder.java
+++ b/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleEffectBuilder.java
@@ -24,18 +24,17 @@
  */
 package org.spongepowered.mod.effect.particle;
 
-import java.awt.Color;
-
-import net.minecraft.item.Item;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.spongepowered.api.effect.particle.ParticleEffectBuilder;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
 
 import com.flowpowered.math.vector.Vector3f;
+import net.minecraft.item.Item;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkArgument;
+import java.awt.Color;
 
 public class SpongeParticleEffectBuilder implements ParticleEffectBuilder {
     protected final SpongeParticleType type;

--- a/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleHelper.java
+++ b/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleHelper.java
@@ -24,17 +24,6 @@
  */
 package org.spongepowered.mod.effect.particle;
 
-import java.awt.Color;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
-
-import net.minecraft.block.Block;
-import net.minecraft.item.Item;
-import net.minecraft.network.Packet;
-import net.minecraft.network.play.server.S2APacketParticles;
-import net.minecraft.util.EnumParticleTypes;
-
 import org.spongepowered.api.item.ItemBlock;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
@@ -42,6 +31,16 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3f;
 import com.google.common.collect.Lists;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S2APacketParticles;
+import net.minecraft.util.EnumParticleTypes;
+
+import java.awt.Color;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 
 public final class SpongeParticleHelper {
 

--- a/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleType.java
+++ b/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleType.java
@@ -24,12 +24,12 @@
  */
 package org.spongepowered.mod.effect.particle;
 
-import java.awt.Color;
-
 import org.spongepowered.api.effect.particle.ParticleType;
 import org.spongepowered.api.item.inventory.ItemStack;
 
 import net.minecraft.util.EnumParticleTypes;
+
+import java.awt.Color;
 
 public class SpongeParticleType implements ParticleType {
     private EnumParticleTypes type;

--- a/src/main/java/org/spongepowered/mod/entity/SpongeEntityConstants.java
+++ b/src/main/java/org/spongepowered/mod/entity/SpongeEntityConstants.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.mod.entity;
 
-import java.util.Map;
-
 import org.spongepowered.api.entity.living.meta.HorseColor;
 import org.spongepowered.api.entity.living.meta.HorseStyle;
 import org.spongepowered.api.entity.living.meta.HorseVariant;
@@ -35,6 +33,7 @@ import org.spongepowered.api.entity.living.meta.SkeletonType;
 
 import com.google.common.collect.Maps;
 
+import java.util.Map;
 
 public class SpongeEntityConstants {
 

--- a/src/main/java/org/spongepowered/mod/event/SpongeEventBus.java
+++ b/src/main/java/org/spongepowered/mod/event/SpongeEventBus.java
@@ -25,15 +25,16 @@
 
 package org.spongepowered.mod.event;
 
-import javax.annotation.Nullable;
-
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
 import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.plugin.PluginManager;
+import org.spongepowered.api.service.event.EventManager;
+import org.spongepowered.api.util.event.Cancellable;
+import org.spongepowered.api.util.event.Event;
+import org.spongepowered.api.util.event.Order;
+import org.spongepowered.api.util.event.Subscribe;
+import org.spongepowered.mod.SpongeMod;
 
 import com.google.common.base.Optional;
 import com.google.common.cache.CacheBuilder;
@@ -45,18 +46,15 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.Inject;
-
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.IEventListener;
 
-import org.spongepowered.api.plugin.PluginContainer;
-import org.spongepowered.api.plugin.PluginManager;
-import org.spongepowered.api.service.event.EventManager;
-import org.spongepowered.api.util.event.Cancellable;
-import org.spongepowered.api.util.event.Event;
-import org.spongepowered.api.util.event.Order;
-import org.spongepowered.api.util.event.Subscribe;
-import org.spongepowered.mod.SpongeMod;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 public class SpongeEventBus implements EventManager {
 

--- a/src/main/java/org/spongepowered/mod/mixin/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/MixinEntity.java
@@ -24,32 +24,30 @@
  */
 package org.spongepowered.mod.mixin.entity;
 
-import java.util.ArrayDeque;
-import java.util.UUID;
-
-import javax.annotation.Nullable;
-
-import com.flowpowered.math.vector.Vector3f;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.network.play.server.S07PacketRespawn;
-import net.minecraft.network.play.server.S1FPacketSetExperience;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.WorldServer;
-
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.mod.entity.ISpongeEntity;
 
 import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3f;
 import com.google.common.base.Optional;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.play.server.S07PacketRespawn;
+import net.minecraft.network.play.server.S1FPacketSetExperience;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.WorldServer;
+
+import java.util.ArrayDeque;
+import java.util.UUID;
+import javax.annotation.Nullable;
 
 @NonnullByDefault
 @Mixin(net.minecraft.entity.Entity.class)

--- a/src/main/java/org/spongepowered/mod/mixin/entity/hanging/MixinEntityItemFrame.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/hanging/MixinEntityItemFrame.java
@@ -24,11 +24,6 @@
  */
 package org.spongepowered.mod.mixin.entity.hanging;
 
-import javax.annotation.Nullable;
-
-import net.minecraft.entity.EntityHanging;
-import net.minecraft.world.World;
-
 import org.spongepowered.api.entity.hanging.ItemFrame;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -36,9 +31,13 @@ import org.spongepowered.api.util.rotation.Rotation;
 import org.spongepowered.api.util.rotation.Rotations;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.SpongeMod;
 
 import com.google.common.base.Optional;
-import org.spongepowered.mod.SpongeMod;
+import net.minecraft.entity.EntityHanging;
+import net.minecraft.world.World;
+
+import javax.annotation.Nullable;
 
 @NonnullByDefault
 @Mixin(net.minecraft.entity.item.EntityItemFrame.class)

--- a/src/main/java/org/spongepowered/mod/mixin/entity/living/MixinEntityLiving.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/living/MixinEntityLiving.java
@@ -24,14 +24,6 @@
  */
 package org.spongepowered.mod.mixin.entity.living;
 
-import javax.annotation.Nullable;
-
-import com.google.common.base.Optional;
-
-import net.minecraft.entity.EntityLiving;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.world.World;
-
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.Agent;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -39,6 +31,13 @@ import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+
+import com.google.common.base.Optional;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.world.World;
+
+import javax.annotation.Nullable;
 
 @NonnullByDefault
 @Mixin(EntityLiving.class)

--- a/src/main/java/org/spongepowered/mod/mixin/entity/living/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/living/MixinEntityLivingBase.java
@@ -24,22 +24,6 @@
  */
 package org.spongepowered.mod.mixin.entity.living;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import javax.annotation.Nullable;
-
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.ai.attributes.IAttribute;
-import net.minecraft.entity.ai.attributes.IAttributeInstance;
-import net.minecraft.entity.boss.EntityDragon;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.potion.Potion;
-import net.minecraft.util.DamageSource;
-import net.minecraft.world.World;
-
 import org.spongepowered.api.entity.living.Human;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.potion.PotionEffect;
@@ -52,6 +36,20 @@ import org.spongepowered.asm.mixin.Shadow;
 
 import com.flowpowered.math.vector.Vector3f;
 import com.google.common.base.Optional;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.ai.attributes.IAttribute;
+import net.minecraft.entity.ai.attributes.IAttributeInstance;
+import net.minecraft.entity.boss.EntityDragon;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.potion.Potion;
+import net.minecraft.util.DamageSource;
+import net.minecraft.world.World;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nullable;
 
 @NonnullByDefault
 @Mixin(EntityLivingBase.class)

--- a/src/main/java/org/spongepowered/mod/mixin/entity/living/animal/MixinEntityHorse.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/living/animal/MixinEntityHorse.java
@@ -24,14 +24,6 @@
  */
 package org.spongepowered.mod.mixin.entity.living.animal;
 
-import javax.annotation.Nullable;
-
-import net.minecraft.entity.passive.EntityAnimal;
-import net.minecraft.entity.passive.EntityHorse;
-import net.minecraft.init.Items;
-import net.minecraft.inventory.AnimalChest;
-import net.minecraft.world.World;
-
 import org.spongepowered.api.entity.living.animal.Horse;
 import org.spongepowered.api.entity.living.meta.HorseColor;
 import org.spongepowered.api.entity.living.meta.HorseStyle;
@@ -46,6 +38,13 @@ import org.spongepowered.mod.entity.SpongeEntityConstants;
 import org.spongepowered.mod.entity.SpongeEntityMeta;
 
 import com.google.common.base.Optional;
+import net.minecraft.entity.passive.EntityAnimal;
+import net.minecraft.entity.passive.EntityHorse;
+import net.minecraft.init.Items;
+import net.minecraft.inventory.AnimalChest;
+import net.minecraft.world.World;
+
+import javax.annotation.Nullable;
 
 @NonnullByDefault
 @Mixin(EntityHorse.class)

--- a/src/main/java/org/spongepowered/mod/mixin/entity/living/complex/MixinEntityDragon.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/living/complex/MixinEntityDragon.java
@@ -24,16 +24,6 @@
  */
 package org.spongepowered.mod.mixin.entity.living.complex;
 
-import java.util.Set;
-
-import javax.annotation.Nullable;
-
-import net.minecraft.entity.EntityLiving;
-import net.minecraft.entity.boss.EntityDragon;
-import net.minecraft.entity.boss.EntityDragonPart;
-import net.minecraft.entity.item.EntityEnderCrystal;
-import net.minecraft.world.World;
-
 import org.spongepowered.api.entity.EnderCrystal;
 import org.spongepowered.api.entity.living.complex.EnderDragon;
 import org.spongepowered.api.entity.living.complex.EnderDragonPart;
@@ -44,8 +34,16 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.boss.EntityDragon;
+import net.minecraft.entity.boss.EntityDragonPart;
+import net.minecraft.entity.item.EntityEnderCrystal;
+import net.minecraft.world.World;
+
+import java.util.Set;
+import javax.annotation.Nullable;
 
 @NonnullByDefault
 @Mixin(EntityDragon.class)

--- a/src/main/java/org/spongepowered/mod/mixin/entity/living/monster/MixinEntityWither.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/living/monster/MixinEntityWither.java
@@ -24,9 +24,6 @@
  */
 package org.spongepowered.mod.mixin.entity.living.monster;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.monster.Wither;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -39,6 +36,9 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.boss.EntityWither;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.world.World;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @NonnullByDefault
 @Mixin(EntityWither.class)

--- a/src/main/java/org/spongepowered/mod/mixin/entity/living/villager/MixinEntityVillager.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/living/villager/MixinEntityVillager.java
@@ -24,15 +24,6 @@
  */
 package org.spongepowered.mod.mixin.entity.living.villager;
 
-import java.util.List;
-
-import javax.annotation.Nullable;
-
-import net.minecraft.entity.EntityAgeable;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.village.MerchantRecipeList;
-import net.minecraft.world.World;
-
 import org.spongepowered.api.entity.living.Human;
 import org.spongepowered.api.entity.living.villager.Career;
 import org.spongepowered.api.entity.living.villager.Profession;
@@ -51,6 +42,13 @@ import org.spongepowered.mod.SpongeMod;
 import org.spongepowered.mod.entity.SpongeEntityMeta;
 
 import com.google.common.base.Optional;
+import net.minecraft.entity.EntityAgeable;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.village.MerchantRecipeList;
+import net.minecraft.world.World;
+
+import java.util.List;
+import javax.annotation.Nullable;
 
 @NonnullByDefault
 @Mixin(net.minecraft.entity.passive.EntityVillager.class)

--- a/src/main/java/org/spongepowered/mod/mixin/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/player/MixinEntityPlayerMP.java
@@ -24,23 +24,8 @@
  */
 package org.spongepowered.mod.mixin.entity.player;
 
-import java.util.List;
-import java.util.Locale;
-
-import com.flowpowered.math.vector.Vector3d;
-import com.google.common.base.Optional;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkArgument;
-
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.network.NetHandlerPlayServer;
-import net.minecraft.network.Packet;
-import net.minecraft.network.play.server.S02PacketChat;
-import net.minecraft.network.play.server.S45PacketTitle;
-import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.world.World;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.spongepowered.api.GameProfile;
 import org.spongepowered.api.effect.particle.ParticleEffect;
@@ -62,6 +47,20 @@ import org.spongepowered.mod.text.chat.SpongeChatType;
 import org.spongepowered.mod.text.message.SpongeMessage;
 import org.spongepowered.mod.text.message.SpongeMessageText;
 import org.spongepowered.mod.text.title.SpongeTitle;
+
+import com.flowpowered.math.vector.Vector3d;
+import com.google.common.base.Optional;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S02PacketChat;
+import net.minecraft.network.play.server.S45PacketTitle;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.world.World;
+
+import java.util.List;
+import java.util.Locale;
 
 @NonnullByDefault
 @Mixin(EntityPlayerMP.class)

--- a/src/main/java/org/spongepowered/mod/mixin/entity/projectile/MixinEntityThrowable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/projectile/MixinEntityThrowable.java
@@ -24,19 +24,19 @@
  */
 package org.spongepowered.mod.mixin.entity.projectile;
 
-import javax.annotation.Nullable;
-
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.projectile.EntityThrowable;
-import net.minecraft.world.World;
-
 import org.spongepowered.api.entity.projectile.Projectile;
 import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.entity.projectile.source.UnknownProjectileSource;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.projectile.EntityThrowable;
+import net.minecraft.world.World;
+
+import javax.annotation.Nullable;
 
 @NonnullByDefault
 @Mixin(EntityThrowable.class)

--- a/src/main/java/org/spongepowered/mod/mixin/event/player/MixinEventPlayerBreakBlock.java
+++ b/src/main/java/org/spongepowered/mod/mixin/event/player/MixinEventPlayerBreakBlock.java
@@ -24,19 +24,6 @@
  */
 package org.spongepowered.mod.mixin.event.player;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.BlockPos;
-import net.minecraft.world.World;
-import net.minecraftforge.event.world.BlockEvent;
-
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.entity.Item;
 import org.spongepowered.api.entity.player.Player;
@@ -45,6 +32,18 @@ import org.spongepowered.api.event.entity.living.player.PlayerBreakBlockEvent;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.event.world.BlockEvent;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 @NonnullByDefault
 @Mixin(value = BlockEvent.BreakEvent.class, remap = false)

--- a/src/main/java/org/spongepowered/mod/mixin/fml/MixinEntityRegistry.java
+++ b/src/main/java/org/spongepowered/mod/mixin/fml/MixinEntityRegistry.java
@@ -24,18 +24,6 @@
  */
 package org.spongepowered.mod.mixin.fml;
 
-import java.util.Map;
-
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityList;
-import net.minecraftforge.fml.common.FMLCommonHandler;
-import net.minecraftforge.fml.common.FMLLog;
-import net.minecraftforge.fml.common.Loader;
-import net.minecraftforge.fml.common.ModContainer;
-import net.minecraftforge.fml.common.registry.EntityRegistry;
-import net.minecraftforge.fml.common.registry.EntityRegistry.EntityRegistration;
-
-import org.apache.logging.log4j.Level;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -46,6 +34,17 @@ import org.spongepowered.mod.registry.SpongeGameRegistry;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ListMultimap;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.common.registry.EntityRegistry.EntityRegistration;
+import net.minecraftforge.fml.common.registry.EntityRegistry;
+import org.apache.logging.log4j.Level;
+
+import java.util.Map;
 
 @NonnullByDefault
 @Mixin(value = EntityRegistry.class, remap = false)

--- a/src/main/java/org/spongepowered/mod/mixin/forge/MixinDimensionManager.java
+++ b/src/main/java/org/spongepowered/mod/mixin/forge/MixinDimensionManager.java
@@ -24,11 +24,6 @@
  */
 package org.spongepowered.mod.mixin.forge;
 
-import java.util.Hashtable;
-
-import net.minecraft.world.WorldProvider;
-import net.minecraftforge.common.DimensionManager;
-
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
@@ -36,6 +31,11 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.mod.SpongeMod;
 import org.spongepowered.mod.registry.SpongeGameRegistry;
 import org.spongepowered.mod.world.SpongeDimensionType;
+
+import net.minecraft.world.WorldProvider;
+import net.minecraftforge.common.DimensionManager;
+
+import java.util.Hashtable;
 
 @NonnullByDefault
 @Mixin(value = DimensionManager.class, remap = false)

--- a/src/main/java/org/spongepowered/mod/mixin/inventory/MixinContainer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/inventory/MixinContainer.java
@@ -24,17 +24,16 @@
  */
 package org.spongepowered.mod.mixin.inventory;
 
-import java.util.List;
-
-import net.minecraft.inventory.Container;
-import net.minecraft.inventory.ICrafting;
-
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 
 import com.google.common.collect.Lists;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.ICrafting;
+
+import java.util.List;
 
 @NonnullByDefault
 @Mixin(Container.class)

--- a/src/main/java/org/spongepowered/mod/mixin/item/MixinEnchantment.java
+++ b/src/main/java/org/spongepowered/mod/mixin/item/MixinEnchantment.java
@@ -24,17 +24,17 @@
  */
 package org.spongepowered.mod.mixin.item;
 
-import java.util.Map;
-import java.util.Map.Entry;
-
-import net.minecraft.util.ResourceLocation;
-
 import org.spongepowered.api.item.Enchantment;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.util.ResourceLocation;
+
+import java.util.Map.Entry;
+import java.util.Map;
 
 @NonnullByDefault
 @Mixin(net.minecraft.enchantment.Enchantment.class)

--- a/src/main/java/org/spongepowered/mod/mixin/item/inventory/MixinItemStack.java
+++ b/src/main/java/org/spongepowered/mod/mixin/item/inventory/MixinItemStack.java
@@ -24,18 +24,18 @@
  */
 package org.spongepowered.mod.mixin.item.inventory;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import net.minecraft.item.Item;
-import net.minecraft.nbt.NBTTagList;
-
 import org.spongepowered.api.item.Enchantment;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.item.Item;
+import net.minecraft.nbt.NBTTagList;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @SuppressWarnings("serial")
 @NonnullByDefault

--- a/src/main/java/org/spongepowered/mod/mixin/server/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/server/MixinMinecraftServer.java
@@ -24,21 +24,6 @@
  */
 package org.spongepowered.mod.mixin.server;
 
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
-
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.management.ServerConfigurationManager;
-import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.IChatComponent;
-import net.minecraft.world.WorldServer;
-import net.minecraftforge.common.DimensionManager;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
-
 import org.spongepowered.api.Server;
 import org.spongepowered.api.entity.player.Player;
 import org.spongepowered.api.text.message.Message;
@@ -50,10 +35,24 @@ import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.text.message.SpongeMessage;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import org.spongepowered.mod.text.message.SpongeMessage;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.ServerConfigurationManager;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
 
 @NonnullByDefault
 @Mixin(MinecraftServer.class)

--- a/src/main/java/org/spongepowered/mod/mixin/server/MixinServerCommandManager.java
+++ b/src/main/java/org/spongepowered/mod/mixin/server/MixinServerCommandManager.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.mod.mixin.server;
 
-import java.util.ArrayList;
-
 import org.spongepowered.api.service.command.SimpleCommandService;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.util.command.CommandException;
@@ -36,9 +34,10 @@ import org.spongepowered.mod.SpongeMod;
 
 import net.minecraft.command.CommandHandler;
 import net.minecraft.command.ICommandSender;
-
 import net.minecraft.command.ServerCommandManager;
 import net.minecraft.server.MinecraftServer;
+
+import java.util.ArrayList;
 
 @NonnullByDefault
 @Mixin(ServerCommandManager.class)

--- a/src/main/java/org/spongepowered/mod/mixin/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/mod/mixin/world/MixinWorld.java
@@ -24,25 +24,8 @@
  */
 package org.spongepowered.mod.mixin.world;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Random;
-import java.util.UUID;
-
-import com.flowpowered.math.vector.Vector3d;
-import com.flowpowered.math.vector.Vector3i;
-import com.google.common.base.Optional;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkArgument;
-
-import net.minecraft.network.Packet;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.management.ServerConfigurationManager;
-import net.minecraft.world.WorldProvider;
-import net.minecraft.world.WorldServer;
-import net.minecraft.world.storage.WorldInfo;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.spongepowered.api.block.BlockLoc;
 import org.spongepowered.api.effect.particle.ParticleEffect;
@@ -65,6 +48,22 @@ import org.spongepowered.mod.effect.particle.SpongeParticleEffect;
 import org.spongepowered.mod.effect.particle.SpongeParticleHelper;
 import org.spongepowered.mod.util.VecHelper;
 import org.spongepowered.mod.wrapper.BlockWrapper;
+
+import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3i;
+import com.google.common.base.Optional;
+import net.minecraft.network.Packet;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.ServerConfigurationManager;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.storage.WorldInfo;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
 
 @NonnullByDefault
 @Mixin(net.minecraft.world.World.class)

--- a/src/main/java/org/spongepowered/mod/mixin/world/MixinWorldBorder.java
+++ b/src/main/java/org/spongepowered/mod/mixin/world/MixinWorldBorder.java
@@ -24,20 +24,19 @@
  */
 package org.spongepowered.mod.mixin.world;
 
-import java.util.List;
-import java.util.Iterator;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.WorldBorder;
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 
 import com.flowpowered.math.vector.Vector3d;
-
 import net.minecraft.world.border.EnumBorderStatus;
 import net.minecraft.world.border.IBorderListener;
 
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.api.world.WorldBorder;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
+import java.util.Iterator;
+import java.util.List;
 
 @NonnullByDefault
 @Mixin(net.minecraft.world.border.WorldBorder.class)

--- a/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
@@ -25,50 +25,6 @@
 
 package org.spongepowered.mod.registry;
 
-import java.awt.Color;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityList;
-import net.minecraft.entity.boss.EntityDragonPart;
-import net.minecraft.entity.effect.EntityLightningBolt;
-import net.minecraft.entity.effect.EntityWeatherEffect;
-import net.minecraft.entity.item.EntityPainting.EnumArt;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.entity.projectile.EntityEgg;
-import net.minecraft.entity.projectile.EntityFishHook;
-import net.minecraft.init.Blocks;
-import net.minecraft.potion.Potion;
-import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumParticleTypes;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.world.WorldProviderEnd;
-import net.minecraft.world.WorldProviderHell;
-import net.minecraft.world.WorldProviderSurface;
-import net.minecraft.world.biome.BiomeGenBase;
-import net.minecraftforge.fml.common.registry.GameData;
-
 import org.spongepowered.api.GameProfile;
 import org.spongepowered.api.GameRegistry;
 import org.spongepowered.api.block.BlockType;
@@ -163,6 +119,49 @@ import org.spongepowered.mod.text.format.SpongeTextColor;
 import org.spongepowered.mod.text.selector.SpongeSelectorType;
 import org.spongepowered.mod.weather.SpongeWeather;
 import org.spongepowered.mod.world.SpongeDimensionType;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
+import net.minecraft.entity.boss.EntityDragonPart;
+import net.minecraft.entity.effect.EntityLightningBolt;
+import net.minecraft.entity.effect.EntityWeatherEffect;
+import net.minecraft.entity.item.EntityPainting.EnumArt;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.entity.projectile.EntityEgg;
+import net.minecraft.entity.projectile.EntityFishHook;
+import net.minecraft.init.Blocks;
+import net.minecraft.potion.Potion;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumParticleTypes;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.WorldProviderEnd;
+import net.minecraft.world.WorldProviderHell;
+import net.minecraft.world.WorldProviderSurface;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.fml.common.registry.GameData;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @SuppressWarnings("unchecked")
 @NonnullByDefault

--- a/src/main/java/org/spongepowered/mod/text/action/SpongeClickAction.java
+++ b/src/main/java/org/spongepowered/mod/text/action/SpongeClickAction.java
@@ -24,10 +24,10 @@
  */
 package org.spongepowered.mod.text.action;
 
-import java.net.URL;
-
 import org.spongepowered.api.text.action.ClickAction;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
+
+import java.net.URL;
 
 @NonnullByDefault
 public class SpongeClickAction<R> implements ClickAction<R> {

--- a/src/main/java/org/spongepowered/mod/text/format/SpongeTextColor.java
+++ b/src/main/java/org/spongepowered/mod/text/format/SpongeTextColor.java
@@ -24,11 +24,11 @@
  */
 package org.spongepowered.mod.text.format;
 
-import java.awt.Color;
+import org.spongepowered.api.text.format.TextColor;
 
 import net.minecraft.util.EnumChatFormatting;
 
-import org.spongepowered.api.text.format.TextColor;
+import java.awt.Color;
 
 public class SpongeTextColor implements TextColor.Base {
 

--- a/src/main/java/org/spongepowered/mod/text/message/SpongeMessage.java
+++ b/src/main/java/org/spongepowered/mod/text/message/SpongeMessage.java
@@ -24,12 +24,6 @@
  */
 package org.spongepowered.mod.text.message;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.List;
-
-import net.minecraft.util.IChatComponent;
-
 import org.spongepowered.api.text.action.ClickAction;
 import org.spongepowered.api.text.action.HoverAction;
 import org.spongepowered.api.text.action.ShiftClickAction;
@@ -39,6 +33,11 @@ import org.spongepowered.api.text.message.Message;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import net.minecraft.util.IChatComponent;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
 
 public abstract class SpongeMessage<T> implements Message {
 

--- a/src/main/java/org/spongepowered/mod/text/message/SpongeMessageBuilder.java
+++ b/src/main/java/org/spongepowered/mod/text/message/SpongeMessageBuilder.java
@@ -24,22 +24,21 @@
  */
 package org.spongepowered.mod.text.message;
 
-import java.util.Deque;
-
-import net.minecraft.util.IChatComponent;
-
 import org.spongepowered.api.text.action.ClickAction;
 import org.spongepowered.api.text.action.HoverAction;
 import org.spongepowered.api.text.action.ShiftClickAction;
 import org.spongepowered.api.text.format.TextColor;
+import org.spongepowered.api.text.format.TextStyle.TextStyleComponent;
 import org.spongepowered.api.text.format.TextStyle;
 import org.spongepowered.api.text.format.TextStyles;
-import org.spongepowered.api.text.format.TextStyle.TextStyleComponent;
 import org.spongepowered.api.text.message.Message;
 import org.spongepowered.api.text.message.MessageBuilder;
 import org.spongepowered.mod.registry.SpongeGameRegistry;
 
 import com.google.common.base.Optional;
+import net.minecraft.util.IChatComponent;
+
+import java.util.Deque;
 
 public abstract class SpongeMessageBuilder<T extends MessageBuilder> implements MessageBuilder {
 

--- a/src/main/java/org/spongepowered/mod/text/message/SpongeMessageSelector.java
+++ b/src/main/java/org/spongepowered/mod/text/message/SpongeMessageSelector.java
@@ -24,17 +24,16 @@
  */
 package org.spongepowered.mod.text.message;
 
-import java.util.ArrayDeque;
-import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
-
-import net.minecraft.util.ChatComponentSelector;
-
 import org.spongepowered.api.text.message.Message;
 import org.spongepowered.api.text.message.MessageBuilder;
 import org.spongepowered.mod.text.selector.SpongeSelector;
 import org.spongepowered.mod.text.selector.SpongeSelectorType;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.util.ChatComponentSelector;
+
+import java.util.ArrayDeque;
+import java.util.Map;
 
 public class SpongeMessageSelector extends SpongeMessage<org.spongepowered.api.text.selector.Selector> implements Message.Selector {
 

--- a/src/main/java/org/spongepowered/mod/text/message/SpongeMessageText.java
+++ b/src/main/java/org/spongepowered/mod/text/message/SpongeMessageText.java
@@ -24,12 +24,12 @@
  */
 package org.spongepowered.mod.text.message;
 
-import java.util.ArrayDeque;
+import org.spongepowered.api.text.message.Message;
+import org.spongepowered.api.text.message.MessageBuilder;
 
 import net.minecraft.util.ChatComponentText;
 
-import org.spongepowered.api.text.message.Message;
-import org.spongepowered.api.text.message.MessageBuilder;
+import java.util.ArrayDeque;
 
 public class SpongeMessageText extends SpongeMessage<String> implements Message.Text {
 

--- a/src/main/java/org/spongepowered/mod/text/message/SpongeMessageTranslatable.java
+++ b/src/main/java/org/spongepowered/mod/text/message/SpongeMessageTranslatable.java
@@ -24,17 +24,16 @@
  */
 package org.spongepowered.mod.text.message;
 
-import java.util.ArrayDeque;
-import java.util.List;
-
-import com.google.common.collect.ImmutableList;
-
-import net.minecraft.util.ChatComponentTranslation;
-
 import org.spongepowered.api.text.message.Message;
 import org.spongepowered.api.text.message.MessageBuilder;
 import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.mod.text.translation.SpongeTranslation;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.util.ChatComponentTranslation;
+
+import java.util.ArrayDeque;
+import java.util.List;
 
 public class SpongeMessageTranslatable extends SpongeMessage<Translation> implements Message.Translatable {
 

--- a/src/main/java/org/spongepowered/mod/text/selector/FakeCommandSender.java
+++ b/src/main/java/org/spongepowered/mod/text/selector/FakeCommandSender.java
@@ -24,8 +24,9 @@
  */
 package org.spongepowered.mod.text.selector;
 
-import javax.annotation.Nullable;
+import org.spongepowered.api.world.Location;
 
+import com.flowpowered.math.vector.Vector3d;
 import net.minecraft.command.CommandResultStats.Type;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.Entity;
@@ -34,9 +35,7 @@ import net.minecraft.util.IChatComponent;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
-import org.spongepowered.api.world.Location;
-
-import com.flowpowered.math.vector.Vector3d;
+import javax.annotation.Nullable;
 
 class FakeCommandSender implements ICommandSender {
 

--- a/src/main/java/org/spongepowered/mod/text/selector/SpongeSelectorBuilder.java
+++ b/src/main/java/org/spongepowered/mod/text/selector/SpongeSelectorBuilder.java
@@ -24,9 +24,6 @@
  */
 package org.spongepowered.mod.text.selector;
 
-import java.util.Collections;
-import java.util.Map;
-
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.text.selector.Selector;
 import org.spongepowered.api.text.selector.SelectorBuilder;
@@ -38,6 +35,9 @@ import com.flowpowered.math.vector.Vector3i;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+
+import java.util.Collections;
+import java.util.Map;
 
 @NonnullByDefault
 public class SpongeSelectorBuilder implements SelectorBuilder {


### PR DESCRIPTION
This PR will address one section of the compiler checkstyle warnings.

It re-orders imports according to the checkstyle predicates.

Don't use "IDE" formatting to handle it.  

The order for new code must be:

import static

import org.spongepowered.*

import third party

import java*

Each of the four sections, the imports are alphabetized.



