### PR TITLE
Fix CommandBlock sources fixes #161

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/command/MixinCommandBlockLogic.java
+++ b/src/main/java/org/spongepowered/mod/mixin/command/MixinCommandBlockLogic.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.command;
+
+import org.spongepowered.api.text.message.Message;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.util.command.source.CommandBlockSource;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.extent.Extent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.mod.text.message.SpongeMessage;
+
+import com.flowpowered.math.vector.Vector3d;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.server.CommandBlockLogic;
+import net.minecraft.util.ChatComponentText;
+
+@NonnullByDefault
+@Mixin(CommandBlockLogic.class)
+public abstract class MixinCommandBlockLogic implements ICommandSender, CommandBlockSource {
+
+    @Override
+    public void sendMessage(String... messages) {
+        for (String msg : messages) {
+            this.addChatMessage(new ChatComponentText(msg));
+        }
+    }
+
+    @Override
+    public void sendMessage(Message... messages) {
+        for (Message msg : messages) {
+            this.addChatMessage(((SpongeMessage<?>) msg).getHandle());
+        }
+    }
+
+    @Override
+    public void sendMessage(Iterable<Message> messages) {
+        for (Message msg : messages) {
+            this.addChatMessage(((SpongeMessage<?>) msg).getHandle());
+        }
+    }
+
+    @Override
+    public Location getLocation() {
+        return new Location((Extent) getEntityWorld(), new Vector3d(getPositionVector().xCoord, getPositionVector().yCoord,
+                getPositionVector().zCoord));
+    }
+
+    @Override
+    public org.spongepowered.api.world.World getWorld() {
+        return (org.spongepowered.api.world.World) getEntityWorld();
+    }
+
+}

--- a/src/main/java/org/spongepowered/mod/mixin/command/MixinCommandBlockLogic.java
+++ b/src/main/java/org/spongepowered/mod/mixin/command/MixinCommandBlockLogic.java
@@ -31,8 +31,8 @@ import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.mod.text.message.SpongeMessage;
+import org.spongepowered.mod.util.VecHelper;
 
-import com.flowpowered.math.vector.Vector3d;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.server.CommandBlockLogic;
 import net.minecraft.util.ChatComponentText;
@@ -64,8 +64,7 @@ public abstract class MixinCommandBlockLogic implements ICommandSender, CommandB
 
     @Override
     public Location getLocation() {
-        return new Location((Extent) getEntityWorld(), new Vector3d(getPositionVector().xCoord, getPositionVector().yCoord,
-                getPositionVector().zCoord));
+        return new Location((Extent) getEntityWorld(), VecHelper.toVector(getPositionVector()));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/text/selector/FakeCommandSender.java
+++ b/src/main/java/org/spongepowered/mod/text/selector/FakeCommandSender.java
@@ -35,8 +35,7 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
 import org.spongepowered.api.world.Location;
-
-import com.flowpowered.math.vector.Vector3d;
+import org.spongepowered.mod.util.VecHelper;
 
 class FakeCommandSender implements ICommandSender {
 
@@ -46,8 +45,7 @@ class FakeCommandSender implements ICommandSender {
     public FakeCommandSender(@Nullable Location location) {
         this.location = location;
         if (location != null) {
-            Vector3d pos = location.getPosition();
-            this.positionVec3 = new Vec3(pos.getX(), pos.getY(), pos.getZ());
+            this.positionVec3 = VecHelper.toVector(location.getPosition());
         } else {
             this.positionVec3 = null;
         }

--- a/src/main/java/org/spongepowered/mod/util/VecHelper.java
+++ b/src/main/java/org/spongepowered/mod/util/VecHelper.java
@@ -29,18 +29,33 @@ import com.flowpowered.math.vector.Vector3f;
 import com.flowpowered.math.vector.Vector3i;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.Rotations;
+import net.minecraft.util.Vec3;
 import net.minecraft.util.Vec3i;
 
 public final class VecHelper {
 
-    // === Flow Vector --> BlockPos ===
+    // === Flow Vector3d --> BlockPos ===
 
     public static BlockPos toBlockPos(Vector3d vector) {
         return new BlockPos(vector.getX(), vector.getY(), vector.getZ());
     }
 
+    // === Flow Vector3f --> BlockPos ===
+
+    public static BlockPos toBlockPos(Vector3f vector) {
+        return new BlockPos(vector.getX(), vector.getY(), vector.getZ());
+    }
+
+    // === Flow Vector3i --> BlockPos ===
+
     public static BlockPos toBlockPos(Vector3i vector) {
         return new BlockPos(vector.getX(), vector.getY(), vector.getZ());
+    }
+
+    // === MC BlockPos --> flow Vector3i ==
+
+    public static Vector3i toVector(BlockPos pos) {
+        return new Vector3i(pos.getX(), pos.getY(), pos.getZ());
     }
 
     // === Flow Vector --> Rotations ===
@@ -55,9 +70,28 @@ public final class VecHelper {
         return new Vector3f(rotation.func_179415_b(), rotation.func_179416_c(), rotation.func_179413_d());
     }
 
-    // === MC Vector --> Flow Vector ===
+    // === MC Vec3i --> Flow Vector3i ===
 
     public static Vector3i toVector(Vec3i vector) {
         return new Vector3i(vector.getX(), vector.getY(), vector.getZ());
     }
+
+    // === flow Vector3i --> MC Vec3i ===
+
+    public static Vec3i toVector(Vector3i vector) {
+        return new Vec3i(vector.getX(), vector.getY(), vector.getZ());
+    }
+
+    // === MC Vec3 --> flow Vector3d ==
+
+    public static Vector3d toVector(Vec3 vector) {
+        return new Vector3d(vector.xCoord, vector.yCoord, vector.zCoord);
+    }
+
+    // === flow Vector3d --> MC Vec3 ==
+
+    public static Vec3 toVector(Vector3d vector) {
+        return new Vec3(vector.getX(), vector.getY(), vector.getZ());
+    }
+
 }

--- a/src/main/resources/mixins.sponge.json
+++ b/src/main/resources/mixins.sponge.json
@@ -29,6 +29,7 @@
     "block.data.MixinTileEntityNote",
     "block.data.MixinTileEntitySign",
     "block.data.MixinTileEntitySkull",
+    "command.MixinCommandBlockLogic",
     "entity.MixinEntity",
     "entity.MixinArmorEquipable",
     "entity.MixinEntityEnderCrystal",


### PR DESCRIPTION
This PR fixes #161 by mixing the new `CommandBlockSource` into minecraft's `CommandBlockLogic`. This ensures that A) the object passed to the command handler is comparable with sponge's own command handler and B) the CommandSource sent to a plugin's CommandCallable can be checked using `source instanceof CommandBlockSource` to determine its *type* so to speak.

This single mixin will affect both `TileEntityCommandBlock` and `EntityMinecartCommandBlock` as both use `CommandBlockLogic` as the handler for their command internals.
