### PR TITLE
Add EnderPearl damage methods back

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/entity/projectile/MixinEntityEnderPearl.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entity/projectile/MixinEntityEnderPearl.java
@@ -24,18 +24,45 @@
  */
 package org.spongepowered.mod.mixin.entity.projectile;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityEnderPearl;
 import net.minecraft.entity.projectile.EntityThrowable;
+import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
 import org.spongepowered.api.entity.projectile.EnderPearl;
+import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @NonnullByDefault
 @Mixin(EntityEnderPearl.class)
 public abstract class MixinEntityEnderPearl extends EntityThrowable implements EnderPearl {
 
+    public double damageAmount;
+
+    public ProjectileSource projectileSource;
+
     public MixinEntityEnderPearl(World p_i1776_1_) {
         super(p_i1776_1_);
+    }
+
+    @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V", at =
+    @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"))
+    private float onAttackEntityFrom(float damage) {
+        return (float) this.damageAmount;
+    }
+
+
+    @Override
+    public double getDamage() {
+        return this.damageAmount;
+    }
+
+    @Override
+    public void setDamage(double damage) {
+        this.damageAmount = damage;
     }
 }


### PR DESCRIPTION
Now that `EnderPearl` is a `DamagingProjectile`, it once again has damage getters and setters.

The code in `EnderPearl` is identical to what it was before the methods were removed - I've just updated some other files affected by the commits pulled in by the submodule update.