### PR TITLE
Implement PlayerDropItemEvent

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerDropItem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerDropItem.java
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.event.entity.item;
+package org.spongepowered.mod.mixin.core.event.player;
 
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -41,7 +41,7 @@ import java.util.Collections;
 
 @NonnullByDefault
 @Mixin(ItemTossEvent.class)
-public abstract class MixinEventItemToss implements PlayerDropItemEvent {
+public abstract class MixinEventPlayerDropItem implements PlayerDropItemEvent {
 
     @Shadow
     public EntityPlayer player;

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerDropItem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerDropItem.java
@@ -26,6 +26,7 @@ package org.spongepowered.mod.mixin.core.event.player;
 
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.entity.item.ItemEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import org.spongepowered.api.entity.Item;
 import org.spongepowered.api.entity.living.Human;
@@ -41,17 +42,18 @@ import java.util.Collections;
 
 @NonnullByDefault
 @Mixin(ItemTossEvent.class)
-public abstract class MixinEventPlayerDropItem implements PlayerDropItemEvent {
+public abstract class MixinEventPlayerDropItem extends ItemEvent implements PlayerDropItemEvent {
+
+    public MixinEventPlayerDropItem(EntityItem itemEntity) {
+        super(itemEntity);
+    }
 
     @Shadow
     public EntityPlayer player;
 
-    @Shadow
-    public EntityItem entityItem;
-
     @Override
     public Collection<Item> getDroppedItems() {
-        return Collections.nCopies(1, (Item) entityItem);
+        return Collections.nCopies(1, (Item) this.entityItem);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/event/entity/item/MixinEventItemToss.java
+++ b/src/main/java/org/spongepowered/mod/mixin/event/entity/item/MixinEventItemToss.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.event.entity.item;
+
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.entity.item.ItemTossEvent;
+import org.spongepowered.api.entity.Item;
+import org.spongepowered.api.entity.living.Human;
+import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.api.entity.player.Player;
+import org.spongepowered.api.event.entity.living.player.PlayerDropItemEvent;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@NonnullByDefault
+@Mixin(ItemTossEvent.class)
+public abstract class MixinEventItemToss implements PlayerDropItemEvent {
+
+    @Shadow
+    public EntityPlayer player;
+
+    @Shadow
+    public EntityItem entityItem;
+
+    @Override
+    public Collection<Item> getDroppedItems() {
+        return Collections.nCopies(1, (Item) entityItem);
+    }
+
+    @Override
+    public Player getPlayer() {
+        return (Player) this.player;
+    }
+
+    @Override
+    public Player getHuman() {
+        return (Player) this.player;
+    }
+
+    @Override
+    public Player getLiving() {
+        return (Player) this.player;
+    }
+
+}

--- a/src/main/resources/mixins.sponge.core.json
+++ b/src/main/resources/mixins.sponge.core.json
@@ -122,7 +122,6 @@
         "event.entity.MixinEventEntity",
         "event.entity.MixinEventEntityConstructing",
         "event.entity.MixinEventEntityJoinWorld",
-        "event.entity.item.MixinEntityItem",
         "event.player.MixinEventPlayer",
         "event.player.MixinEventPlayerBreakBlock",
         "event.player.MixinEventPlayerDropItem",

--- a/src/main/resources/mixins.sponge.core.json
+++ b/src/main/resources/mixins.sponge.core.json
@@ -122,6 +122,7 @@
         "event.entity.MixinEventEntity",
         "event.entity.MixinEventEntityConstructing",
         "event.entity.MixinEventEntityJoinWorld",
+        "event.entity.item.MixinEntityItem",
         "event.player.MixinEventPlayer",
         "event.player.MixinEventPlayerBreakBlock",
         "event.player.MixinEventPlayerChat",

--- a/src/main/resources/mixins.sponge.core.json
+++ b/src/main/resources/mixins.sponge.core.json
@@ -125,6 +125,7 @@
         "event.entity.item.MixinEntityItem",
         "event.player.MixinEventPlayer",
         "event.player.MixinEventPlayerBreakBlock",
+        "event.player.MixinEventPlayerDropItem",
         "event.player.MixinEventPlayerChat",
         "event.player.MixinEventPlayerFML",
         "event.player.MixinEventPlayerInteractBlock",


### PR DESCRIPTION
Due to the fact that `ItemTossEvent` extends `ItemEvent` and not `PlayerEvent`, it's necessary to implement `getPlayer`, `getHuman`, and `getLiving`, as they won't be mixed into a superclass.