### PR TITLE
Fix some entity mixins not storing their state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ ext.ciSystem = project.hasProperty("ciSystem") ? ciSystem : 'unknown'
 ext.commit = project.hasProperty("commit") ? commit : 'unknown'
 
 // Version -> Minecraft-MinecraftForge-Ours(If any?)
-version = '1.8-1334-1.1DEV-' + buildNumber
+version = '1.8-1341-1.1DEV-' + buildNumber
 
 // mixin variables
 ext.mixinSrg = new File(project.buildDir, "tmp/mixins/mixins.srg")
@@ -62,7 +62,7 @@ repositories {
 
 // MinecraftForge version
 minecraft {
-    version = "1.8-11.14.1.1334"
+    version = "1.8-11.14.1.1341"
     mappings = "snapshot_20150301"
 }
 

--- a/src/main/java/org/spongepowered/mod/entity/projectile/ProjectileSourceSerializer.java
+++ b/src/main/java/org/spongepowered/mod/entity/projectile/ProjectileSourceSerializer.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.entity.projectile;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagLong;
+import net.minecraft.nbt.NBTTagString;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.projectile.Projectile;
+import org.spongepowered.api.entity.projectile.source.BlockProjectileSource;
+import org.spongepowered.api.entity.projectile.source.ProjectileSource;
+import org.spongepowered.api.entity.projectile.source.UnknownProjectileSource;
+import org.spongepowered.mod.util.VecHelper;
+
+import java.util.UUID;
+
+public class ProjectileSourceSerializer {
+
+    // TODO Revisit when persistent containers are implemented.
+    // Note: ProjectileSource itself does not extend DataContainer
+
+    public static NBTBase toNbt(ProjectileSource projectileSource) {
+        if (projectileSource instanceof Entity) {
+            return new NBTTagString(((Entity) projectileSource).getUniqueId().toString());
+        }
+        if (projectileSource instanceof BlockProjectileSource) {
+            return new NBTTagLong(VecHelper.toBlockPos(((BlockProjectileSource) projectileSource).getBlock().getPosition()).toLong());
+        }
+        return null;
+    }
+
+    public static ProjectileSource fromNbt(World worldObj, NBTBase tag) {
+        if (tag instanceof NBTTagString) {
+            Entity entity =
+                    ((org.spongepowered.api.world.World) worldObj).getEntity(UUID.fromString(((NBTTagString) tag).getString())).orNull();
+            if (entity instanceof ProjectileSource) {
+                return (ProjectileSource) entity;
+            }
+        }
+        if (tag instanceof NBTTagLong) {
+            TileEntity tileEntity = worldObj.getTileEntity(BlockPos.fromLong(((NBTTagLong) tag).getLong()));
+            if (tileEntity instanceof ProjectileSource) {
+                return (ProjectileSource) tileEntity;
+            }
+        }
+        return new UnknownProjectileSource();
+    }
+
+    public static void writeSourceToNbt(NBTTagCompound compound, ProjectileSource projectileSource, net.minecraft.entity.Entity potentalEntitySource) {
+        if (projectileSource == null && potentalEntitySource instanceof ProjectileSource) {
+            projectileSource = (ProjectileSource) potentalEntitySource;
+        }
+        NBTBase projectileNbt = toNbt(projectileSource);
+        if (projectileNbt != null) {
+            compound.setTag("projectileSource", projectileNbt);
+        }
+    }
+
+    public static void readSourceFromNbt(NBTTagCompound compound, Projectile projectile) {
+        if (compound.hasKey("projectileSource")) {
+            projectile.setShooter(fromNbt((World) projectile.getWorld(), compound.getTag("projectileSource")));
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBanner.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBanner.java
@@ -70,8 +70,9 @@ public abstract class MixinTileEntityBanner extends MixinTileEntity {
         updatePatterns();
     }
 
-    @Inject(method = "readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("RETURN"))
-    private void onReadFromNBT(NBTTagCompound tagCompound, CallbackInfo ci) {
+    @Override
+    public void readFromNbt(NBTTagCompound compound) {
+        super.readFromNbt(compound);
         updatePatterns();
     }
 

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/hanging/MixinEntityHanging.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/hanging/MixinEntityHanging.java
@@ -25,6 +25,7 @@
 package org.spongepowered.mod.mixin.core.entity.hanging;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
 import org.spongepowered.api.entity.hanging.Hanging;
@@ -33,11 +34,14 @@ import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.SoftOverride;
 import org.spongepowered.mod.registry.SpongeGameRegistry;
 
 @NonnullByDefault
 @Mixin(net.minecraft.entity.EntityHanging.class)
 public abstract class MixinEntityHanging extends Entity implements Hanging {
+
+    private MixinEntityHanging super$;
 
     @Shadow
     public EnumFacing facingDirection;
@@ -88,4 +92,19 @@ public abstract class MixinEntityHanging extends Entity implements Hanging {
         this.facingDirection =
                 SpongeGameRegistry.directionMap.get(direction) == null ? EnumFacing.NORTH : SpongeGameRegistry.directionMap.get(direction);
     }
+
+    @SoftOverride
+    public void writeToNbt(NBTTagCompound compound) {
+        super$.writeToNbt(compound);
+        compound.setBoolean("ignorePhysics", this.ignorePhysics);
+    }
+
+    @SoftOverride
+    public void readFromNbt(NBTTagCompound compound) {
+        super$.readFromNbt(compound);
+        if (compound.hasKey("ignorePhysics")) {
+            this.ignorePhysics = compound.getBoolean("ignorePhysics");
+        }
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityLivingBase.java
@@ -32,6 +32,7 @@ import net.minecraft.entity.ai.attributes.IAttribute;
 import net.minecraft.entity.ai.attributes.IAttributeInstance;
 import net.minecraft.entity.boss.EntityDragon;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
@@ -44,6 +45,7 @@ import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.SoftOverride;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,6 +57,8 @@ import javax.annotation.Nullable;
 @Mixin(EntityLivingBase.class)
 @Implements(@Interface(iface = Living.class, prefix = "living$"))
 public abstract class MixinEntityLivingBase extends Entity {
+
+    private MixinEntityLivingBase super$;
 
     private int maxAir = 300;
 
@@ -259,6 +263,20 @@ public abstract class MixinEntityLivingBase extends Entity {
 
     public void living$setInvisible(boolean invisible) {
         this.setFlag(5, invisible);
+    }
+
+    @SoftOverride
+    public void readFromNbt(NBTTagCompound compound) {
+        super$.readFromNbt(compound);
+        if (compound.hasKey("maxAir")) {
+            this.maxAir = compound.getInteger("maxAir");
+        }
+    }
+
+    @SoftOverride
+    public void writeToNbt(NBTTagCompound compound) {
+        super$.writeToNbt(compound);
+        compound.setInteger("maxAir", this.maxAir);
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityArrow.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityArrow.java
@@ -26,7 +26,7 @@ package org.spongepowered.mod.mixin.core.entity.projectile;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.projectile.EntityArrow;
-import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.api.entity.projectile.Arrow;
 import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.entity.projectile.source.UnknownProjectileSource;
@@ -35,13 +35,15 @@ import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.entity.projectile.ProjectileSourceSerializer;
+import org.spongepowered.mod.mixin.core.entity.MixinEntity;
 
 import javax.annotation.Nullable;
 
 @NonnullByDefault
 @Mixin(EntityArrow.class)
 @Implements(@Interface(iface = Arrow.class, prefix = "arrow$"))
-public abstract class MixinEntityArrow extends Entity implements Arrow {
+public abstract class MixinEntityArrow extends MixinEntity implements Arrow {
 
     @Shadow
     public double damage;
@@ -65,9 +67,9 @@ public abstract class MixinEntityArrow extends Entity implements Arrow {
 
     @Override
     public ProjectileSource getShooter() {
-        if (this.projectileSource != null && this.projectileSource instanceof ProjectileSource) {
+        if (this.projectileSource instanceof ProjectileSource) {
             return this.projectileSource;
-        } else if (this.shootingEntity != null && this.shootingEntity instanceof ProjectileSource) {
+        } else if (this.shootingEntity instanceof ProjectileSource) {
             return (ProjectileSource) this.shootingEntity;
         }
         return new UnknownProjectileSource();
@@ -111,7 +113,15 @@ public abstract class MixinEntityArrow extends Entity implements Arrow {
         this.setIsCritical(critical);
     }
 
-    public MixinEntityArrow(World worldIn) {
-        super(worldIn);
+    @Override
+    public void readFromNbt(NBTTagCompound compound) {
+        super.readFromNbt(compound);
+        ProjectileSourceSerializer.readSourceFromNbt(compound, this);
+    }
+
+    @Override
+    public void writeToNbt(NBTTagCompound compound) {
+        super.writeToNbt(compound);
+        ProjectileSourceSerializer.writeSourceToNbt(compound, this.projectileSource, this.shootingEntity);
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityEgg.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityEgg.java
@@ -25,8 +25,7 @@
 package org.spongepowered.mod.mixin.core.entity.projectile;
 
 import net.minecraft.entity.projectile.EntityEgg;
-import net.minecraft.entity.projectile.EntityThrowable;
-import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -37,13 +36,9 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 @NonnullByDefault
 @Mixin(EntityEgg.class)
 @Implements(@Interface(iface = org.spongepowered.api.entity.projectile.Egg.class, prefix = "egg$"))
-public abstract class MixinEntityEgg extends EntityThrowable {
+public abstract class MixinEntityEgg extends MixinEntityThrowable {
 
     public double damageAmount;
-
-    public MixinEntityEgg(World worldIn) {
-        super(worldIn);
-    }
 
     @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V", at =
             @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"))
@@ -57,5 +52,19 @@ public abstract class MixinEntityEgg extends EntityThrowable {
 
     public void egg$setDamage(double damage) {
         this.damageAmount = damage;
+    }
+
+    @Override
+    public void readFromNbt(NBTTagCompound compound) {
+        super.readFromNbt(compound);
+        if (compound.hasKey("damageAmount")) {
+            this.damageAmount = compound.getDouble("damageAmount");
+        }
+    }
+
+    @Override
+    public void writeToNbt(NBTTagCompound compound) {
+        super.writeToNbt(compound);
+        compound.setDouble("damageAmount", this.damageAmount);
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityEnderEye.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityEnderEye.java
@@ -25,22 +25,19 @@
 package org.spongepowered.mod.mixin.core.entity.projectile;
 
 import com.flowpowered.math.vector.Vector3d;
-import net.minecraft.entity.Entity;
-import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.api.entity.projectile.EyeOfEnder;
 import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.entity.projectile.source.UnknownProjectileSource;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.entity.projectile.ProjectileSourceSerializer;
+import org.spongepowered.mod.mixin.core.entity.MixinEntity;
 
 @NonnullByDefault
 @Mixin(net.minecraft.entity.item.EntityEnderEye.class)
-public abstract class MixinEntityEnderEye extends Entity implements EyeOfEnder {
-
-    public MixinEntityEnderEye(World worldIn) {
-        super(worldIn);
-    }
+public abstract class MixinEntityEnderEye extends MixinEntity implements EyeOfEnder {
 
     @Shadow
     private double targetX;
@@ -86,6 +83,18 @@ public abstract class MixinEntityEnderEye extends Entity implements EyeOfEnder {
     @Override
     public void setShooter(ProjectileSource shooter) {
         this.projectileSource = shooter;
+    }
+
+    @Override
+    public void readFromNbt(NBTTagCompound compound) {
+        super.readFromNbt(compound);
+        ProjectileSourceSerializer.readSourceFromNbt(compound, this);
+    }
+
+    @Override
+    public void writeToNbt(NBTTagCompound compound) {
+        super.writeToNbt(compound);
+        ProjectileSourceSerializer.writeSourceToNbt(compound, this.projectileSource, null);
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityEnderPearl.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityEnderPearl.java
@@ -25,10 +25,8 @@
 package org.spongepowered.mod.mixin.core.entity.projectile;
 
 import net.minecraft.entity.item.EntityEnderPearl;
-import net.minecraft.entity.projectile.EntityThrowable;
-import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.api.entity.projectile.EnderPearl;
-import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -39,15 +37,9 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 @NonnullByDefault
 @Mixin(EntityEnderPearl.class)
 @Implements(@Interface(iface = EnderPearl.class, prefix = "enderpearl$"))
-public abstract class MixinEntityEnderPearl extends EntityThrowable {
+public abstract class MixinEntityEnderPearl extends MixinEntityThrowable {
 
     public double damageAmount;
-
-    public ProjectileSource projectileSource;
-
-    public MixinEntityEnderPearl(World p_i1776_1_) {
-        super(p_i1776_1_);
-    }
 
     @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V", at =
             @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"))
@@ -62,4 +54,19 @@ public abstract class MixinEntityEnderPearl extends EntityThrowable {
     public void enderpearl$setDamage(double damage) {
         this.damageAmount = damage;
     }
+
+    @Override
+    public void readFromNbt(NBTTagCompound compound) {
+        super.readFromNbt(compound);
+        if (compound.hasKey("damageAmount")) {
+            this.damageAmount = compound.getDouble("damageAmount");
+        }
+    }
+
+    @Override
+    public void writeToNbt(NBTTagCompound compound) {
+        super.writeToNbt(compound);
+        compound.setDouble("damageAmount", this.damageAmount);
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityFireworkRocket.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityFireworkRocket.java
@@ -24,22 +24,19 @@
  */
 package org.spongepowered.mod.mixin.core.entity.projectile;
 
-import net.minecraft.entity.Entity;
-import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.api.entity.projectile.Firework;
 import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.entity.projectile.source.UnknownProjectileSource;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.entity.projectile.ProjectileSourceSerializer;
+import org.spongepowered.mod.mixin.core.entity.MixinEntity;
 
 @NonnullByDefault
 @Mixin(net.minecraft.entity.item.EntityFireworkRocket.class)
-public abstract class MixinEntityFireworkRocket extends Entity implements Firework {
-
-    public MixinEntityFireworkRocket(World worldIn) {
-        super(worldIn);
-    }
+public abstract class MixinEntityFireworkRocket extends MixinEntity implements Firework {
 
     @Shadow
     private int lifetime;
@@ -72,6 +69,18 @@ public abstract class MixinEntityFireworkRocket extends Entity implements Firewo
     @Override
     public void setShooter(ProjectileSource shooter) {
         this.projectileSource = shooter;
+    }
+
+    @Override
+    public void readFromNbt(NBTTagCompound compound) {
+        super.readFromNbt(compound);
+        ProjectileSourceSerializer.readSourceFromNbt(compound, this);
+    }
+
+    @Override
+    public void writeToNbt(NBTTagCompound compound) {
+        super.writeToNbt(compound);
+        ProjectileSourceSerializer.writeSourceToNbt(compound, this.projectileSource, null);
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityFishHook.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityFishHook.java
@@ -31,6 +31,7 @@ import net.minecraft.entity.item.EntityXPOrb;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityFishHook;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
@@ -45,9 +46,11 @@ import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.SoftOverride;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.mod.SpongeMod;
+import org.spongepowered.mod.entity.projectile.ProjectileSourceSerializer;
 import org.spongepowered.mod.interfaces.IMixinEntityFishHook;
 
 import javax.annotation.Nullable;
@@ -55,6 +58,8 @@ import javax.annotation.Nullable;
 @NonnullByDefault
 @Mixin(EntityFishHook.class)
 public abstract class MixinEntityFishHook extends Entity implements FishHook, IMixinEntityFishHook {
+
+    private MixinEntityFishHook super$;
 
     private double damageAmount;
 
@@ -206,4 +211,19 @@ public abstract class MixinEntityFishHook extends Entity implements FishHook, IM
         this.fishingRod = fishingRod;
     }
 
+    @SoftOverride
+    public void readFromNbt(NBTTagCompound compound) {
+        super$.readFromNbt(compound);
+        if (compound.hasKey("damageAmount")) {
+            this.damageAmount = compound.getDouble("damageAmount");
+        }
+        ProjectileSourceSerializer.readSourceFromNbt(compound, this);
+    }
+
+    @SoftOverride
+    public void writeToNbt(NBTTagCompound compound) {
+        super$.writeToNbt(compound);
+        compound.setDouble("damageAmount", this.damageAmount);
+        ProjectileSourceSerializer.writeSourceToNbt(compound, this.projectileSource, this.angler);
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntitySnowball.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntitySnowball.java
@@ -24,8 +24,7 @@
  */
 package org.spongepowered.mod.mixin.core.entity.projectile;
 
-import net.minecraft.entity.projectile.EntityThrowable;
-import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.api.entity.projectile.Snowball;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
@@ -37,11 +36,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 @NonnullByDefault
 @Mixin(net.minecraft.entity.projectile.EntitySnowball.class)
 @Implements(@Interface(iface = Snowball.class, prefix = "snowball$"))
-public abstract class MixinEntitySnowball extends EntityThrowable {
-
-    public MixinEntitySnowball(World worldIn) {
-        super(worldIn);
-    }
+public abstract class MixinEntitySnowball extends MixinEntityThrowable {
 
     private double damageAmount = 0;
     private boolean damageSet = false;
@@ -60,4 +55,24 @@ public abstract class MixinEntitySnowball extends EntityThrowable {
         this.damageSet = true;
         this.damageAmount = damage;
     }
+
+    @Override
+    public void readFromNbt(NBTTagCompound compound) {
+        super.readFromNbt(compound);
+        if (compound.hasKey("damageAmount")) {
+            this.damageAmount = compound.getDouble("damageAmount");
+            this.damageSet = true;
+        }
+    }
+
+    @Override
+    public void writeToNbt(NBTTagCompound compound) {
+        super.writeToNbt(compound);
+        if (this.damageSet) {
+            compound.setDouble("damageAmount", this.damageAmount);
+        } else {
+            compound.removeTag("damageAmount");
+        }
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityThrowable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityThrowable.java
@@ -24,22 +24,23 @@
  */
 package org.spongepowered.mod.mixin.core.entity.projectile;
 
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.projectile.EntityThrowable;
-import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.api.entity.projectile.Projectile;
 import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.entity.projectile.source.UnknownProjectileSource;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.entity.projectile.ProjectileSourceSerializer;
+import org.spongepowered.mod.mixin.core.entity.MixinEntity;
 
 import javax.annotation.Nullable;
 
 @NonnullByDefault
 @Mixin(EntityThrowable.class)
-public abstract class MixinEntityThrowable extends Entity implements Projectile {
+public abstract class MixinEntityThrowable extends MixinEntity implements Projectile {
 
     @Nullable
     public ProjectileSource projectileSource;
@@ -78,7 +79,15 @@ public abstract class MixinEntityThrowable extends Entity implements Projectile 
         this.projectileSource = shooter;
     }
 
-    public MixinEntityThrowable(World worldIn) {
-        super(worldIn);
+    @Override
+    public void readFromNbt(NBTTagCompound compound) {
+        super.readFromNbt(compound);
+        ProjectileSourceSerializer.readSourceFromNbt(compound, this);
+    }
+
+    @Override
+    public void writeToNbt(NBTTagCompound compound) {
+        super.writeToNbt(compound);
+        ProjectileSourceSerializer.writeSourceToNbt(compound, this.projectileSource, this.thrower);
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntityFireball.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntityFireball.java
@@ -24,20 +24,22 @@
  */
 package org.spongepowered.mod.mixin.core.entity.projectile.fireball;
 
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.MovingObjectPosition;
-import net.minecraft.world.World;
 import org.spongepowered.api.entity.projectile.explosive.fireball.Fireball;
 import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.entity.projectile.source.UnknownProjectileSource;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.SoftOverride;
+import org.spongepowered.mod.entity.projectile.ProjectileSourceSerializer;
+import org.spongepowered.mod.mixin.core.entity.MixinEntity;
 
 @NonnullByDefault
 @Mixin(net.minecraft.entity.projectile.EntityFireball.class)
-public abstract class MixinEntityFireball extends Entity implements Fireball {
+public abstract class MixinEntityFireball extends MixinEntity implements Fireball {
 
     @Shadow
     public EntityLivingBase shootingEntity;
@@ -46,10 +48,6 @@ public abstract class MixinEntityFireball extends Entity implements Fireball {
     protected abstract void onImpact(MovingObjectPosition p_70227_1_);
 
     private ProjectileSource projectileSource = null;
-
-    public MixinEntityFireball(World worldIn) {
-        super(worldIn);
-    }
 
     @Override
     public ProjectileSource getShooter() {
@@ -76,6 +74,19 @@ public abstract class MixinEntityFireball extends Entity implements Fireball {
     @Override
     public void detonate() {
         this.onImpact(new MovingObjectPosition(null));
+    }
+
+    @Override
+    @SoftOverride
+    public void readFromNbt(NBTTagCompound compound) {
+        super.readFromNbt(compound);
+        ProjectileSourceSerializer.readSourceFromNbt(compound, this);
+    }
+
+    @Override
+    public void writeToNbt(NBTTagCompound compound) {
+        super.writeToNbt(compound);
+        ProjectileSourceSerializer.writeSourceToNbt(compound, this.projectileSource, this.shootingEntity);
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntityLargeFireball.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntityLargeFireball.java
@@ -24,8 +24,7 @@
  */
 package org.spongepowered.mod.mixin.core.entity.projectile.fireball;
 
-import net.minecraft.entity.projectile.EntityFireball;
-import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.api.entity.projectile.explosive.fireball.LargeFireball;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
@@ -35,16 +34,12 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @NonnullByDefault
 @Mixin(net.minecraft.entity.projectile.EntityLargeFireball.class)
-public abstract class MixinEntityLargeFireball extends EntityFireball implements LargeFireball {
+public abstract class MixinEntityLargeFireball extends MixinEntityFireball implements LargeFireball {
 
     @Shadow
-    public int explosionPower = 1;
+    public int explosionPower;
 
     private float damage = 6.0f;
-
-    public MixinEntityLargeFireball(World worldIn) {
-        super(worldIn);
-    }
 
     @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"))
@@ -70,5 +65,19 @@ public abstract class MixinEntityLargeFireball extends EntityFireball implements
     @Override
     public void setExplosionPower(int explosionPower) {
         this.explosionPower = explosionPower;
+    }
+
+    @Override
+    public void readFromNbt(NBTTagCompound compound) {
+        super.readFromNbt(compound);
+        if (compound.hasKey("damageAmount")) {
+            this.damage = compound.getFloat("damageAmount");
+        }
+    }
+
+    @Override
+    public void writeToNbt(NBTTagCompound compound) {
+        super.writeToNbt(compound);
+        compound.setFloat("damageAmount", this.damage);
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntitySmallFireball.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntitySmallFireball.java
@@ -24,8 +24,7 @@
  */
 package org.spongepowered.mod.mixin.core.entity.projectile.fireball;
 
-import net.minecraft.entity.projectile.EntityFireball;
-import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.api.entity.projectile.explosive.fireball.SmallFireball;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
@@ -34,13 +33,9 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @NonnullByDefault
 @Mixin(net.minecraft.entity.projectile.EntitySmallFireball.class)
-public abstract class MixinEntitySmallFireball extends EntityFireball implements SmallFireball {
+public abstract class MixinEntitySmallFireball extends MixinEntityFireball implements SmallFireball {
 
     private float damage = 5.0f;
-
-    public MixinEntitySmallFireball(World worldIn) {
-        super(worldIn);
-    }
 
     @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"))
@@ -56,5 +51,19 @@ public abstract class MixinEntitySmallFireball extends EntityFireball implements
     @Override
     public void setDamage(double damage) {
         this.damage = (float) damage;
+    }
+
+    @Override
+    public void readFromNbt(NBTTagCompound compound) {
+        super.readFromNbt(compound);
+        if (compound.hasKey("damageAmount")) {
+            this.damage = compound.getFloat("damageAmount");
+        }
+    }
+
+    @Override
+    public void writeToNbt(NBTTagCompound compound) {
+        super.writeToNbt(compound);
+        compound.setFloat("damageAmount", this.damage);
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntityWitherSkull.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntityWitherSkull.java
@@ -24,8 +24,7 @@
  */
 package org.spongepowered.mod.mixin.core.entity.projectile.fireball;
 
-import net.minecraft.entity.projectile.EntityFireball;
-import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.api.entity.projectile.explosive.WitherSkull;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
@@ -34,14 +33,10 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @NonnullByDefault
 @Mixin(net.minecraft.entity.projectile.EntityWitherSkull.class)
-public abstract class MixinEntityWitherSkull extends EntityFireball implements WitherSkull {
+public abstract class MixinEntityWitherSkull extends MixinEntityFireball implements WitherSkull {
 
     private float damage = 0.0f;
     private boolean damageSet = false;
-
-    public MixinEntityWitherSkull(World worldIn) {
-        super(worldIn);
-    }
 
     @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"))
@@ -66,6 +61,25 @@ public abstract class MixinEntityWitherSkull extends EntityFireball implements W
     public void setDamage(double damage) {
         this.damageSet = true;
         this.damage = (float) damage;
+    }
+
+    @Override
+    public void readFromNbt(NBTTagCompound compound) {
+        super.readFromNbt(compound);
+        if (compound.hasKey("damageAmount")) {
+            this.damage = compound.getFloat("damageAmount");
+            this.damageSet = true;
+        }
+    }
+
+    @Override
+    public void writeToNbt(NBTTagCompound compound) {
+        super.writeToNbt(compound);
+        if (this.damageSet) {
+            compound.setFloat("damageAmount", this.damage);
+        } else {
+            compound.removeTag("damageAmount");
+        }
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/MixinEntityBoat.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/MixinEntityBoat.java
@@ -27,11 +27,13 @@ package org.spongepowered.mod.mixin.core.entity.vehicle;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityBoat;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import org.spongepowered.api.entity.vehicle.Boat;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.SoftOverride;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -40,26 +42,20 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(EntityBoat.class)
 public abstract class MixinEntityBoat extends Entity implements Boat {
 
+    private MixinEntityBoat super$;
+
     @Shadow
     private double speedMultiplier;
 
-    private double maxSpeed;
-    private boolean moveOnLand;
-    private double occupiedDecelerationSpeed;
-    private double unoccupiedDecelerationSpeed;
+    private double maxSpeed = 0.35D;
+    private boolean moveOnLand = false;
+    private double occupiedDecelerationSpeed = 0D;
+    private double unoccupiedDecelerationSpeed = 0.8D;
 
     private double tempMotionX;
     private double tempMotionZ;
     private double tempSpeedMultiplier;
     private double initialDisplacement;
-
-    @Inject(method = "<init>", at = @At("RETURN"))
-    public void onConstructed(World world, CallbackInfo ci) {
-        this.maxSpeed = 0.35;
-        this.moveOnLand = false;
-        this.occupiedDecelerationSpeed = 0f;
-        this.unoccupiedDecelerationSpeed = 0.8f;
-    }
 
     @Inject(method = "onUpdate()V", at = @At(value = "INVOKE", target = "net.minecraft.entity.Entity.moveEntity(DDD)V"))
     public void implementLandBoats(CallbackInfo ci) {
@@ -171,5 +167,31 @@ public abstract class MixinEntityBoat extends Entity implements Boat {
     @Override
     public void setUnoccupiedDeceleration(double unoccupiedDeceleration) {
         this.unoccupiedDecelerationSpeed = unoccupiedDeceleration;
+    }
+
+    @SoftOverride
+    public void readFromNbt(NBTTagCompound compound) {
+        super$.readFromNbt(compound);
+        if (compound.hasKey("maxSpeed")) {
+            this.maxSpeed = compound.getDouble("maxSpeed");
+        }
+        if (compound.hasKey("moveOnLand")) {
+            this.moveOnLand = compound.getBoolean("moveOnLand");
+        }
+        if (compound.hasKey("occupiedDecelerationSpeed")) {
+            this.occupiedDecelerationSpeed = compound.getDouble("occupiedDecelerationSpeed");
+        }
+        if (compound.hasKey("unoccupiedDecelerationSpeed")) {
+            this.unoccupiedDecelerationSpeed = compound.getDouble("unoccupiedDecelerationSpeed");
+        }
+    }
+
+    @SoftOverride
+    public void writeToNbt(NBTTagCompound compound) {
+        super$.writeToNbt(compound);
+        compound.setDouble("maxSpeed", this.maxSpeed);
+        compound.setBoolean("moveOnLand", this.moveOnLand);
+        compound.setDouble("occupiedDecelerationSpeed", this.occupiedDecelerationSpeed);
+        compound.setDouble("unoccupiedDecelerationSpeed", this.unoccupiedDecelerationSpeed);
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecart.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecart.java
@@ -27,19 +27,24 @@ package org.spongepowered.mod.mixin.core.entity.vehicle.minecart;
 import com.flowpowered.math.vector.Vector3d;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityMinecart;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import org.spongepowered.api.entity.vehicle.minecart.Minecart;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.SoftOverride;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.mod.util.VectorSerializer;
 
 @NonnullByDefault
 @Mixin(EntityMinecart.class)
 public abstract class MixinEntityMinecart extends Entity implements Minecart {
+
+    private MixinEntityMinecart super$;
 
     @Shadow(remap = false)
     public abstract double getDragAir();
@@ -47,18 +52,10 @@ public abstract class MixinEntityMinecart extends Entity implements Minecart {
     @Shadow(remap = false)
     public abstract double getMaxSpeed();
 
-    private double maxSpeed;
-    private boolean slowWhenEmpty;
-    private Vector3d airborneMod;
-    private Vector3d derailedMod;
-
-    @Inject(method = "<init>", at = @At("RETURN"))
-    public void onConstructed(World world, CallbackInfo ci) {
-        this.maxSpeed = 0.4D;
-        this.slowWhenEmpty = true;
-        this.airborneMod = new Vector3d(0.5D, 0.5D, 0.5D);
-        this.derailedMod = new Vector3d(0.5D, 0.5D, 0.5D);
-    }
+    private double maxSpeed = 0.4D;
+    private boolean slowWhenEmpty = true;
+    private Vector3d airborneMod = new Vector3d(0.5D, 0.5D, 0.5D);
+    private Vector3d derailedMod = new Vector3d(0.5D, 0.5D, 0.5D);
 
     // this method overwrites the vanilla accessor for maximum speed
     @Overwrite
@@ -155,4 +152,31 @@ public abstract class MixinEntityMinecart extends Entity implements Minecart {
     public void setDerailedVelocityMod(Vector3d derailedVelocityMod) {
         this.derailedMod = derailedVelocityMod;
     }
+
+    @SoftOverride
+    public void readFromNbt(NBTTagCompound compound) {
+        super$.readFromNbt(compound);
+        if (compound.hasKey("maxSpeed")) {
+            this.maxSpeed = compound.getDouble("maxSpeed");
+        }
+        if (compound.hasKey("slowWhenEmpty")) {
+            this.slowWhenEmpty = compound.getBoolean("slowWhenEmpty");
+        }
+        if (compound.hasKey("airborneModifier")) {
+            this.airborneMod = VectorSerializer.fromNbt(compound.getCompoundTag("airborneModifier"));
+        }
+        if (compound.hasKey("derailedModifier")) {
+            this.derailedMod = VectorSerializer.fromNbt(compound.getCompoundTag("derailedModifier"));
+        }
+    }
+
+    @SoftOverride
+    public void writeToNbt(NBTTagCompound compound) {
+        super$.writeToNbt(compound);
+        compound.setDouble("maxSpeed", this.maxSpeed);
+        compound.setBoolean("slowWhenEmpty", this.slowWhenEmpty);
+        compound.setTag("airborneModifier", VectorSerializer.toNbt(this.airborneMod));
+        compound.setTag("derailedModifier", VectorSerializer.toNbt(this.derailedMod));
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/weather/MixinEntityLightningBolt.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/weather/MixinEntityLightningBolt.java
@@ -25,10 +25,12 @@
 package org.spongepowered.mod.mixin.core.entity.weather;
 
 import net.minecraft.entity.effect.EntityWeatherEffect;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import org.spongepowered.api.entity.weather.Lightning;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.SoftOverride;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -36,6 +38,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @NonnullByDefault
 @Mixin(net.minecraft.entity.effect.EntityLightningBolt.class)
 public abstract class MixinEntityLightningBolt extends EntityWeatherEffect implements Lightning {
+
+    private MixinEntityLightningBolt super$;
 
     private boolean effect = false;
 
@@ -59,5 +63,19 @@ public abstract class MixinEntityLightningBolt extends EntityWeatherEffect imple
         if (this.effect) {
             ci.cancel();
         }
+    }
+
+    @SoftOverride
+    public void readFromNbt(NBTTagCompound compound) {
+        super$.readFromNbt(compound);
+        if (compound.hasKey("effect")) {
+            this.effect = compound.getBoolean("effect");
+        }
+    }
+
+    @SoftOverride
+    public void writeToNbt(NBTTagCompound compound) {
+        super$.writeToNbt(compound);
+        compound.setBoolean("effect", this.effect);
     }
 }

--- a/src/main/java/org/spongepowered/mod/util/VectorSerializer.java
+++ b/src/main/java/org/spongepowered/mod/util/VectorSerializer.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.util;
+
+import com.flowpowered.math.vector.Vector3d;
+import net.minecraft.nbt.NBTTagCompound;
+
+
+public class VectorSerializer {
+
+    public static NBTTagCompound toNbt(Vector3d vector) {
+        NBTTagCompound compound = new NBTTagCompound();
+        compound.setDouble("x", vector.getX());
+        compound.setDouble("y", vector.getY());
+        compound.setDouble("z", vector.getZ());
+        return compound;
+    }
+
+    public static Vector3d fromNbt(NBTTagCompound compound) {
+        return new Vector3d(compound.getDouble("x"), compound.getDouble("y"), compound.getDouble("z"));
+    }
+
+}


### PR DESCRIPTION
Initially discovered in https://github.com/SpongePowered/Sponge/pull/165#discussion_r24569829.

Entity mixins that define additional data do not save this data to the disk since vanilla is not aware it.
I have gone through every entity mixin to find any data that will not persist.
It is unlikely for a lightning bolt to need to be persistent but I have added it anyway.

The following pull requests may have some data that should be made persistent.
~~#126~~, ~~#165~~, ~~#166~~, #167, ~~#169~~ 
I can either wait for the PRs to be pulled, then update this one to fix the issues. Or pull this and I can suggest changes needed for the other PRs.