### PR TITLE
Nicer build errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,16 @@
 // Utility to catch those who have not initialized git submodules
 if (!file("Mixin/build.gradle").exists()) {
-    throw new RuntimeException(
-        "Error locating the Gradle subprojects. " +
+    println "Error locating the Gradle subprojects. " +
         "You most likely forgot to run 'git submodule update --init'. " +
-        "This usually doesn't happen to people who read the README ;)")
+        "This usually doesn't happen to people who read the README ;)"
+    exec {
+        commandLine 'git', 'submodule', 'update', '--init', '--recursive'
+    }
+    copy {
+        from 'scripts'
+        include 'precommit'
+        into '.git/hooks'
+    }
 }
 
 // Gradle repositories and dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,11 @@
+// Utility to catch those who have not initialized git submodules
+if (!file("Mixin/build.gradle").exists()) {
+    throw new RuntimeException(
+        "Error locating the Gradle subprojects. " +
+        "You most likely forgot to run 'git submodule update --init'. " +
+        "This usually doesn't happen to people who read the README ;)")
+}
+
 // Gradle repositories and dependencies
 buildscript {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ if (!file("Mixin/build.gradle").exists()) {
         include 'precommit'
         into '.git/hooks'
     }
+    throw new RuntimeException("Please run your gradle command again.")
 }
 
 // Gradle repositories and dependencies

--- a/gradlew
+++ b/gradlew
@@ -1,5 +1,8 @@
 if [ ! -f ./SpongeAPI/gradlew ]; then
     echo "Error locating the Gradle subprojects. You most likely forgot to run 'git submodule update --init'. This usually doesn't happen to people who read the README ;)"
-    exit 1
+    # run it for them
+    git submodule update --init --recursive
+    # also assume they didn't run the cp
+    cp scripts/pre-commit .git/hooks
 fi
 ./SpongeAPI/gradlew $@

--- a/gradlew
+++ b/gradlew
@@ -1,1 +1,5 @@
+if [ ! -f ./SpongeAPI/gradlew ]; then
+    echo "Error locating the Gradle subprojects. You most likely forgot to run 'git submodule update --init'. This usually doesn't happen to people who read the README ;)"
+    exit 1
+fi
 ./SpongeAPI/gradlew $@

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,1 +1,6 @@
+@ECHO off
+IF NOT EXIST SpongeAPI\gradlew.bat (
+    echo Error locating the Gradle subprojects. You most likely forgot to run 'git submodule update --init'. This usually doesn't happen to people who read the README ;^)
+    exit 1
+)
 SpongeAPI\gradlew.bat %*

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,6 +1,9 @@
 @ECHO off
 IF NOT EXIST SpongeAPI\gradlew.bat (
     echo Error locating the Gradle subprojects. You most likely forgot to run 'git submodule update --init'. This usually doesn't happen to people who read the README ;^)
-    exit 1
+    REM run it for them
+    git submodule update --init --recursive
+    REM also assume they didn't run the cp
+    cp scripts/pre-commit .git/hooks
 )
 SpongeAPI\gradlew.bat %*


### PR DESCRIPTION
Adds some nicer error logging and forced errors for people who miss common steps.

See #182, #171, #154, #178, #79, (and many others...) for examples.

Some things still to be done:
- [ ] Hooking into gradle finding dependencies to catch the infamous '403 Forbidden' error for people who have not run `gradle setupDecompWorkspace --refresh-dependencies`
- [x] Adding submodule detection to the gradlew scripts (since they refer to the submodules)
- [x] Make @kenzierocks happy by turning this into a todo list