### PR TITLE
Implement SQL service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,10 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.7'
     compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.0-beta9'
     compile 'com.google.inject:guice:4.0-beta5'
-    
+    compile 'com.zaxxer:HikariCP-java6:2.1.0'
+    compile 'org.mariadb.jdbc:mariadb-java-client:1.1.8'
+    compile 'com.h2database:h2:1.4.186'
+    compile 'org.xerial:sqlite-jdbc:3.8.+'
     compile project('Mixin')
     compile project('SpongeAPI')
     
@@ -105,6 +108,10 @@ shadowJar  {
         include(dependency('ninja.leaping.configurate:configurate-hocon'))
         include(dependency('ninja.leaping.configurate:configurate-core'))
         include(dependency('com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru'))
+        include(dependency('com.zaxxer:HikariCP-java6'))
+        include(dependency('org.mariadb.jdbc:mariadb-java-client'))
+        include(dependency('com.h2database:h2'))
+        include(dependency('org.xerial:sqlite-jdbc'))
         include(project('SpongeAPI'))
         include(project('Mixin'))
     }

--- a/src/main/java/org/spongepowered/mod/SpongeMod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeMod.java
@@ -49,12 +49,14 @@ import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.service.ProviderExistsException;
 import org.spongepowered.api.service.command.CommandService;
 import org.spongepowered.api.service.command.SimpleCommandService;
+import org.spongepowered.api.service.sql.SqlService;
 import org.spongepowered.mod.command.CommandSponge;
 import org.spongepowered.mod.event.SpongeEventBus;
 import org.spongepowered.mod.event.SpongeEventHooks;
 import org.spongepowered.mod.guice.SpongeGuiceModule;
 import org.spongepowered.mod.plugin.SpongePluginContainer;
 import org.spongepowered.mod.registry.SpongeGameRegistry;
+import org.spongepowered.mod.service.sql.SqlServiceImpl;
 import org.spongepowered.mod.util.SpongeHooks;
 
 import java.io.File;
@@ -86,8 +88,13 @@ public class SpongeMod extends DummyModContainer implements PluginContainer {
             SimpleCommandService commandService = new SimpleCommandService(this.game.getPluginManager());
             this.game.getServiceManager().setProvider(this, CommandService.class, commandService);
             ((SpongeEventBus) this.game.getEventManager()).register(this, commandService);
-        } catch (ProviderExistsException e1) {
-            logger.warn("Non-Sponge CommandService already registered: " + e1.getLocalizedMessage());
+        } catch (ProviderExistsException e) {
+            logger.warn("Non-Sponge CommandService already registered: " + e.getLocalizedMessage());
+        }
+        try {
+            game.getServiceManager().setProvider(this, SqlService.class, new SqlServiceImpl());
+        } catch (ProviderExistsException e) {
+            logger.warn("Non-Sponge SqlService already registered: " + e.getLocalizedMessage());
         }
     }
 

--- a/src/main/java/org/spongepowered/mod/command/CommandSponge.java
+++ b/src/main/java/org/spongepowered/mod/command/CommandSponge.java
@@ -90,7 +90,7 @@ public class CommandSponge extends CommandBase {
     public void processCommand(ICommandSender sender, String[] args) {
         if (args.length > 0) {
             String command = args[0];
-            SpongeConfig config = CoreMixinPlugin.getGlobalConfig();
+            SpongeConfig<?> config = CoreMixinPlugin.getGlobalConfig();
 
             if (COMMANDS.contains(command)) {
                 if (FLAG_COMMANDS.contains(command)) {
@@ -198,7 +198,7 @@ public class CommandSponge extends CommandBase {
                             }
                             configName = "ALL";
                         } else if (name.equals("*") && config.getType() == SpongeConfig.Type.DIMENSION) {
-                            for (SpongeConfig dimensionConfig : SpongeGameRegistry.dimensionConfigs.values()) {
+                            for (SpongeConfig<?> dimensionConfig : SpongeGameRegistry.dimensionConfigs.values()) {
                                 dimensionConfig.save();
                             }
                             configName = "ALL";
@@ -213,12 +213,12 @@ public class CommandSponge extends CommandBase {
                             config.reload();
                         } else if (name.equals("*") && config.getType() == SpongeConfig.Type.WORLD) {
                             for (WorldServer worldserver : DimensionManager.getWorlds()) {
-                                SpongeConfig worldConfig = ((IMixinWorld) worldserver).getWorldConfig();
+                                SpongeConfig<?> worldConfig = ((IMixinWorld) worldserver).getWorldConfig();
                                 worldConfig.reload();
                             }
                             configName = "ALL";
                         } else if (name.equals("*") && config.getType() == SpongeConfig.Type.DIMENSION) {
-                            for (SpongeConfig dimensionConfig : SpongeGameRegistry.dimensionConfigs.values()) {
+                            for (SpongeConfig<?> dimensionConfig : SpongeGameRegistry.dimensionConfigs.values()) {
                                 dimensionConfig.reload();
                             }
                             configName = "ALL";
@@ -342,7 +342,7 @@ public class CommandSponge extends CommandBase {
         sender.addChatMessage(new ChatComponentText("Chunk info complete"));
     }
 
-    private boolean getToggle(SpongeConfig config, ICommandSender sender, String key) {
+    private boolean getToggle(SpongeConfig<?> config, ICommandSender sender, String key) {
         try {
             if (config.getSetting(key).isVirtual()) {
                 sender.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "Could not find option: " + key));
@@ -359,7 +359,7 @@ public class CommandSponge extends CommandBase {
         return true;
     }
 
-    private boolean setToggle(SpongeConfig config, ICommandSender sender, String key, String value) {
+    private boolean setToggle(SpongeConfig<?> config, ICommandSender sender, String key, String value) {
         try {
             if (config.getSetting(key).isVirtual()) {
                 sender.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "Could not find option: " + key));

--- a/src/main/java/org/spongepowered/mod/configuration/SpongeConfig.java
+++ b/src/main/java/org/spongepowered/mod/configuration/SpongeConfig.java
@@ -200,8 +200,15 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
 
     public static class GlobalConfig extends ConfigBase {
 
+        @Setting
+        private SqlCategory sql = new SqlCategory();
+
         @Setting(value = "modules")
         private ModuleCategory mixins = new ModuleCategory();
+
+        public SqlCategory getSql() {
+            return sql;
+        }
 
         public ModuleCategory getModules() {
             return mixins;
@@ -271,6 +278,16 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
 
         public WorldCategory getWorld() {
             return world;
+        }
+    }
+
+    @ConfigSerializable
+    public static class SqlCategory extends Category {
+        @Setting
+        private Map<String, String> aliases = new HashMap<String, String>();
+
+        public Map<String, String> getAliases() {
+            return aliases;
         }
     }
 

--- a/src/main/java/org/spongepowered/mod/configuration/SpongeConfig.java
+++ b/src/main/java/org/spongepowered/mod/configuration/SpongeConfig.java
@@ -24,10 +24,12 @@
  */
 package org.spongepowered.mod.configuration;
 
+import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMapper;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -35,13 +37,21 @@ import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
-public class SpongeConfig {
+public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
 
     public enum Type {
-        GLOBAL,
-        DIMENSION,
-        WORLD
+        GLOBAL(GlobalConfig.class),
+        DIMENSION(DimensionConfig.class),
+        WORLD(WorldConfig.class);
+
+        private final Class<? extends ConfigBase> type;
+
+        Type(Class<? extends ConfigBase> type) {
+            this.type = type;
+        }
     }
 
     public static final String CONFIG_ENABLED = "config-enabled";
@@ -95,14 +105,16 @@ public class SpongeConfig {
 
     private Type type;
     private HoconConfigurationLoader loader;
-    private CommentedConfigurationNode root = SimpleCommentedConfigurationNode.root();
-    private ObjectMapper<ConfigBase>.BoundInstance configMapper;
-    private ConfigBase configBase;
+    private CommentedConfigurationNode root = SimpleCommentedConfigurationNode.root(ConfigurationOptions.defaults()
+            .setHeader(HEADER));
+    private ObjectMapper<T>.BoundInstance configMapper;
+    private T configBase;
     private String modId;
     private String configName;
     @SuppressWarnings("unused")
     private File file;
 
+    @SuppressWarnings("unchecked")
     public SpongeConfig(Type type, File file, String modId) {
 
         this.type = type;
@@ -113,44 +125,50 @@ public class SpongeConfig {
             if (!file.getParentFile().exists()) {
                 file.getParentFile().mkdirs();
             }
+
             if (!file.exists()) {
                 file.createNewFile();
-
-                this.loader = HoconConfigurationLoader.builder().setFile(file).build();
-                if (type == Type.GLOBAL) {
-                    this.configBase = new GlobalConfig();
-                    this.configName = "GLOBAL";
-                } else if (type == Type.DIMENSION) {
-                    this.configBase = new DimensionConfig();
-                    this.configName = file.getParentFile().getName().toUpperCase();
-                } else {
-                    this.configBase = new WorldConfig();
-                    this.configName = file.getParentFile().getName().toUpperCase();
-                }
-                this.configMapper = ObjectMapper.forObject(this.configBase);
-                this.configMapper.serialize(this.root.getNode(this.modId));
-                this.loader.save(this.root);
-            } else {
-                this.loader = HoconConfigurationLoader.builder().setFile(file).build();
-                this.root = this.loader.load();
             }
+
+            this.loader = HoconConfigurationLoader.builder().setFile(file).build();
+            if (type == Type.GLOBAL) {
+                this.configName = "GLOBAL";
+            } else {
+                this.configName = file.getParentFile().getName().toUpperCase();
+            }
+
+            this.configMapper = (ObjectMapper.BoundInstance) ObjectMapper.forClass(this.type.type).bindToNew();
+
+            reload();
+            this.loader.save(this.root);
         } catch (Throwable t) {
             LogManager.getLogger().error(ExceptionUtils.getStackTrace(t));
         }
     }
 
+    public T getConfig() {
+        return configBase;
+    }
+
     public void save() {
         try {
+            this.configMapper.serialize(this.root.getNode(this.modId));
             this.loader.save(this.root);
         } catch (IOException e) {
+            LogManager.getLogger().error(ExceptionUtils.getStackTrace(e));
+        } catch (ObjectMappingException e) {
             LogManager.getLogger().error(ExceptionUtils.getStackTrace(e));
         }
     }
 
     public void reload() {
         try {
-            this.root = this.loader.load();
+            this.root = this.loader.load(ConfigurationOptions.defaults()
+                    .setHeader(HEADER));
+            this.configBase = this.configMapper.populate(this.root.getNode(this.modId));
         } catch (IOException e) {
+            LogManager.getLogger().error(ExceptionUtils.getStackTrace(e));
+        } catch (ObjectMappingException e) {
             LogManager.getLogger().error(ExceptionUtils.getStackTrace(e));
         }
     }
@@ -180,139 +198,391 @@ public class SpongeConfig {
         return this.type;
     }
 
-    private class GlobalConfig extends ConfigBase {
+    public static class GlobalConfig extends ConfigBase {
 
         @Setting(value = "modules")
-        public ModuleCategory mixins = new ModuleCategory();
+        private ModuleCategory mixins = new ModuleCategory();
+
+        public ModuleCategory getModules() {
+            return mixins;
+        }
     }
 
-    private class DimensionConfig extends ConfigBase {
+    public static class DimensionConfig extends ConfigBase {
 
         public DimensionConfig() {
             this.configEnabled = false;
         }
     }
 
-    private class WorldConfig extends ConfigBase {
+    public static class WorldConfig extends ConfigBase {
 
         public WorldConfig() {
             this.configEnabled = false;
         }
     }
 
-    private class ConfigBase {
+    public static class ConfigBase {
 
         @Setting(
                 value = CONFIG_ENABLED,
                 comment = "Controls whether or not this config is enabled.\nNote: If enabled, World configs override Dimension and Global, Dimension configs override Global.")
-        public boolean configEnabled = true;
+        protected boolean configEnabled = true;
         @Setting
-        public DebugCategory debug = new DebugCategory();
+        private DebugCategory debug = new DebugCategory();
         @Setting
-        public EntityCategory entity = new EntityCategory();
+        private EntityCategory entity = new EntityCategory();
         @Setting(value = MODULE_ENTITY_ACTIVATION_RANGE)
-        public EntityActivationRangeCategory entityActivationRange = new EntityActivationRangeCategory();
+        private EntityActivationRangeCategory entityActivationRange = new EntityActivationRangeCategory();
         @Setting
-        public GeneralCategory general = new GeneralCategory();
+        private GeneralCategory general = new GeneralCategory();
         @Setting
-        public LoggingCategory logging = new LoggingCategory();
+        private LoggingCategory logging = new LoggingCategory();
         @Setting
-        public WorldCategory world = new WorldCategory();
+        private WorldCategory world = new WorldCategory();
 
-        @ConfigSerializable
-        private class DebugCategory extends Category {
-
-            @Setting(value = DEBUG_THREAD_CONTENTION_MONITORING, comment = "Enable Java's thread contention monitoring for thread dumps")
-            public boolean enableThreadContentionMonitoring = false;
-            @Setting(value = DEBUG_DUMP_CHUNKS_ON_DEADLOCK, comment = "Dump chunks in the event of a deadlock")
-            public boolean dumpChunksOnDeadlock = false;
-            @Setting(value = DEBUG_DUMP_HEAP_ON_DEADLOCK, comment = "Dump the heap in the event of a deadlock")
-            public boolean dumpHeapOnDeadlock = false;
-            @Setting(value = DEBUG_DUMP_THREADS_ON_WARN, comment = "Dump the server thread on deadlock warning")
-            public boolean dumpThreadsOnWarn = false;
+        public boolean isConfigEnabled() {
+            return configEnabled;
         }
 
-        @ConfigSerializable
-        private class GeneralCategory extends Category {
-
-            @Setting(value = GENERAL_DISABLE_WARNINGS, comment = "Disable warning messages to server admins")
-            public boolean disableWarnings = false;
-            @Setting(value = GENERAL_CHUNK_LOAD_OVERRIDE,
-                    comment = "Forces Chunk Loading on provide requests (speedup for mods that don't check if a chunk is loaded)")
-            public boolean chunkLoadOverride = false;
+        public void setConfigEnabled(boolean configEnabled) {
+            this.configEnabled = configEnabled;
         }
 
-        @ConfigSerializable
-        private class EntityCategory extends Category {
-
-            @Setting(value = ENTITY_MAX_BOUNDING_BOX_SIZE, comment = "Max size of an entity's bounding box before removing it. Set to 0 to disable")
-            public int maxBoundingBoxSize = 1000;
-            @Setting(value = SpongeConfig.ENTITY_MAX_SPEED, comment = "Square of the max speed of an entity before removing it. Set to 0 to disable")
-            public int maxSpeed = 100;
-            @Setting(value = ENTITY_COLLISION_WARN_SIZE,
-                    comment = "Number of colliding entities in one spot before logging a warning. Set to 0 to disable")
-            public int maxCollisionSize = 200;
-            @Setting(value = ENTITY_COUNT_WARN_SIZE,
-                    comment = "Number of entities in one dimension before logging a warning. Set to 0 to disable")
-            public int maxCountWarnSize = 0;
-            @Setting(value = ENTITY_ITEM_DESPAWN_RATE, comment = "Controls the time in ticks for when an item despawns.")
-            public int itemDespawnRate = 6000;
+        public DebugCategory getDebug() {
+            return debug;
         }
 
-        @ConfigSerializable
-        private class EntityActivationRangeCategory extends Category {
-
-            @Setting(value = ENTITY_ACTIVATION_RANGE_CREATURE)
-            public int creatureActivationRange = 32;
-            @Setting(value = ENTITY_ACTIVATION_RANGE_MONSTER)
-            public int monsterActivationRange = 32;
-            @Setting(value = ENTITY_ACTIVATION_RANGE_AQUATIC)
-            public int aquaticActivationRange = 32;
-            @Setting(value = ENTITY_ACTIVATION_RANGE_AMBIENT)
-            public int ambientActivationRange = 32;
-            @Setting(value = ENTITY_ACTIVATION_RANGE_MISC)
-            public int miscActivationRange = 16;
+        public EntityCategory getEntity() {
+            return entity;
         }
 
-        @ConfigSerializable
-        private class LoggingCategory extends Category {
-
-            @Setting(value = LOGGING_CHUNK_LOAD, comment = "Log when chunks are loaded")
-            public boolean chunkLoadLogging = false;
-            @Setting(value = LOGGING_CHUNK_UNLOAD, comment = "Log when chunks are unloaded")
-            public boolean chunkUnloadLogging = false;
-            @Setting(value = LOGGING_ENTITY_SPAWN, comment = "Log when living entities are spawned")
-            public boolean entitySpawnLogging = false;
-            @Setting(value = LOGGING_ENTITY_DESPAWN, comment = "Log when living entities are despawned")
-            public boolean entityDespawnLogging = false;
-            @Setting(value = LOGGING_ENTITY_DEATH, comment = "Log when living entities are destroyed")
-            public boolean entityDeathLogging = false;
-            @Setting(value = LOGGING_STACKTRACES, comment = "Add stack traces to dev logging")
-            public boolean logWithStackTraces = false;
-            @Setting(value = LOGGING_ENTITY_COLLISION_CHECKS, comment = "Whether to log entity collision/count checks")
-            public boolean logEntityCollisionChecks = false;
-            @Setting(value = LOGGING_ENTITY_SPEED_REMOVAL, comment = "Whether to log entity removals due to speed")
-            public boolean logEntitySpeedRemoval = false;
+        public EntityActivationRangeCategory getEntityActivationRange() {
+            return entityActivationRange;
         }
 
-        @ConfigSerializable
-        protected class ModuleCategory extends Category {
-
-            @Setting(value = MODULE_ENTITY_ACTIVATION_RANGE)
-            public boolean pluginEntityActivation = true;
+        public GeneralCategory getGeneral() {
+            return general;
         }
 
-        @ConfigSerializable
-        private class WorldCategory extends Category {
-
-            @Setting(value = WORLD_INFINITE_WATER_SOURCE, comment = "Vanilla water source behavior - is infinite")
-            public boolean infiniteWaterSource = false;
-            @Setting(value = WORLD_FLOWING_LAVA_DECAY, comment = "Lava behaves like vanilla water when source block is removed")
-            public boolean flowingLavaDecay = false;
+        public LoggingCategory getLogging() {
+            return logging;
         }
 
-        @ConfigSerializable
-        private class Category {
+        public WorldCategory getWorld() {
+            return world;
         }
+    }
+
+    @ConfigSerializable
+    public static class DebugCategory extends Category {
+
+        @Setting(value = DEBUG_THREAD_CONTENTION_MONITORING, comment = "Enable Java's thread contention monitoring for thread dumps")
+        private boolean enableThreadContentionMonitoring = false;
+        @Setting(value = DEBUG_DUMP_CHUNKS_ON_DEADLOCK, comment = "Dump chunks in the event of a deadlock")
+        private boolean dumpChunksOnDeadlock = false;
+        @Setting(value = DEBUG_DUMP_HEAP_ON_DEADLOCK, comment = "Dump the heap in the event of a deadlock")
+        private boolean dumpHeapOnDeadlock = false;
+        @Setting(value = DEBUG_DUMP_THREADS_ON_WARN, comment = "Dump the server thread on deadlock warning")
+        private boolean dumpThreadsOnWarn = false;
+
+        public boolean isEnableThreadContentionMonitoring() {
+            return enableThreadContentionMonitoring;
+        }
+
+        public void setEnableThreadContentionMonitoring(boolean enableThreadContentionMonitoring) {
+            this.enableThreadContentionMonitoring = enableThreadContentionMonitoring;
+        }
+
+        public boolean dumpChunksOnDeadlock() {
+            return dumpChunksOnDeadlock;
+        }
+
+        public void setDumpChunksOnDeadlock(boolean dumpChunksOnDeadlock) {
+            this.dumpChunksOnDeadlock = dumpChunksOnDeadlock;
+        }
+
+        public boolean dumpHeapOnDeadlock() {
+            return dumpHeapOnDeadlock;
+        }
+
+        public void setDumpHeapOnDeadlock(boolean dumpHeapOnDeadlock) {
+            this.dumpHeapOnDeadlock = dumpHeapOnDeadlock;
+        }
+
+        public boolean dumpThreadsOnWarn() {
+            return dumpThreadsOnWarn;
+        }
+
+        public void setDumpThreadsOnWarn(boolean dumpThreadsOnWarn) {
+            this.dumpThreadsOnWarn = dumpThreadsOnWarn;
+        }
+    }
+
+    @ConfigSerializable
+    public static class GeneralCategory extends Category {
+
+        @Setting(value = GENERAL_DISABLE_WARNINGS, comment = "Disable warning messages to server admins")
+        private boolean disableWarnings = false;
+        @Setting(value = GENERAL_CHUNK_LOAD_OVERRIDE,
+                comment = "Forces Chunk Loading on provide requests (speedup for mods that don't check if a chunk is loaded)")
+        private boolean chunkLoadOverride = false;
+
+        public boolean disableWarnings() {
+            return disableWarnings;
+        }
+
+        public void setDisableWarnings(boolean disableWarnings) {
+            this.disableWarnings = disableWarnings;
+        }
+
+        public boolean chunkLoadOverride() {
+            return chunkLoadOverride;
+        }
+
+        public void setChunkLoadOverride(boolean chunkLoadOverride) {
+            this.chunkLoadOverride = chunkLoadOverride;
+        }
+    }
+
+    @ConfigSerializable
+    public static class EntityCategory extends Category {
+
+        @Setting(value = ENTITY_MAX_BOUNDING_BOX_SIZE, comment = "Max size of an entity's bounding box before removing it. Set to 0 to disable")
+        private int maxBoundingBoxSize = 1000;
+        @Setting(value = SpongeConfig.ENTITY_MAX_SPEED, comment = "Square of the max speed of an entity before removing it. Set to 0 to disable")
+        private int maxSpeed = 100;
+        @Setting(value = ENTITY_COLLISION_WARN_SIZE,
+                comment = "Number of colliding entities in one spot before logging a warning. Set to 0 to disable")
+        private int maxCollisionSize = 200;
+        @Setting(value = ENTITY_COUNT_WARN_SIZE,
+                comment = "Number of entities in one dimension before logging a warning. Set to 0 to disable")
+        private int maxCountWarnSize = 0;
+        @Setting(value = ENTITY_ITEM_DESPAWN_RATE, comment = "Controls the time in ticks for when an item despawns.")
+        private int itemDespawnRate = 6000;
+
+        public int getMaxBoundingBoxSize() {
+            return maxBoundingBoxSize;
+        }
+
+        public void setMaxBoundingBoxSize(int maxBoundingBoxSize) {
+            this.maxBoundingBoxSize = maxBoundingBoxSize;
+        }
+
+        public int getMaxSpeed() {
+            return maxSpeed;
+        }
+
+        public void setMaxSpeed(int maxSpeed) {
+            this.maxSpeed = maxSpeed;
+        }
+
+        public int getMaxCollisionSize() {
+            return maxCollisionSize;
+        }
+
+        public void setMaxCollisionSize(int maxCollisionSize) {
+            this.maxCollisionSize = maxCollisionSize;
+        }
+
+        public int getMaxCountWarnSize() {
+            return maxCountWarnSize;
+        }
+
+        public void setMaxCountWarnSize(int maxCountWarnSize) {
+            this.maxCountWarnSize = maxCountWarnSize;
+        }
+
+        public int getItemDespawnRate() {
+            return itemDespawnRate;
+        }
+
+        public void setItemDespawnRate(int itemDespawnRate) {
+            this.itemDespawnRate = itemDespawnRate;
+        }
+    }
+
+    @ConfigSerializable
+    public static class EntityActivationRangeCategory extends Category {
+
+        @Setting(value = ENTITY_ACTIVATION_RANGE_CREATURE)
+        private int creatureActivationRange = 32;
+        @Setting(value = ENTITY_ACTIVATION_RANGE_MONSTER)
+        private int monsterActivationRange = 32;
+        @Setting(value = ENTITY_ACTIVATION_RANGE_AQUATIC)
+        private int aquaticActivationRange = 32;
+        @Setting(value = ENTITY_ACTIVATION_RANGE_AMBIENT)
+        private int ambientActivationRange = 32;
+        @Setting(value = ENTITY_ACTIVATION_RANGE_MISC)
+        private int miscActivationRange = 16;
+
+        public int getCreatureActivationRange() {
+            return creatureActivationRange;
+        }
+
+        public void setCreatureActivationRange(int creatureActivationRange) {
+            this.creatureActivationRange = creatureActivationRange;
+        }
+
+        public int getMonsterActivationRange() {
+            return monsterActivationRange;
+        }
+
+        public void setMonsterActivationRange(int monsterActivationRange) {
+            this.monsterActivationRange = monsterActivationRange;
+        }
+
+        public int getAquaticActivationRange() {
+            return aquaticActivationRange;
+        }
+
+        public void setAquaticActivationRange(int aquaticActivationRange) {
+            this.aquaticActivationRange = aquaticActivationRange;
+        }
+
+        public int getAmbientActivationRange() {
+            return ambientActivationRange;
+        }
+
+        public void setAmbientActivationRange(int ambientActivationRange) {
+            this.ambientActivationRange = ambientActivationRange;
+        }
+
+        public int getMiscActivationRange() {
+            return miscActivationRange;
+        }
+
+        public void setMiscActivationRange(int miscActivationRange) {
+            this.miscActivationRange = miscActivationRange;
+        }
+    }
+
+    @ConfigSerializable
+    public static class LoggingCategory extends Category {
+
+        @Setting(value = LOGGING_CHUNK_LOAD, comment = "Log when chunks are loaded")
+        private boolean chunkLoadLogging = false;
+        @Setting(value = LOGGING_CHUNK_UNLOAD, comment = "Log when chunks are unloaded")
+        private boolean chunkUnloadLogging = false;
+        @Setting(value = LOGGING_ENTITY_SPAWN, comment = "Log when living entities are spawned")
+        private boolean entitySpawnLogging = false;
+        @Setting(value = LOGGING_ENTITY_DESPAWN, comment = "Log when living entities are despawned")
+        private boolean entityDespawnLogging = false;
+        @Setting(value = LOGGING_ENTITY_DEATH, comment = "Log when living entities are destroyed")
+        private boolean entityDeathLogging = false;
+        @Setting(value = LOGGING_STACKTRACES, comment = "Add stack traces to dev logging")
+        private boolean logWithStackTraces = false;
+        @Setting(value = LOGGING_ENTITY_COLLISION_CHECKS, comment = "Whether to log entity collision/count checks")
+        private boolean logEntityCollisionChecks = false;
+        @Setting(value = LOGGING_ENTITY_SPEED_REMOVAL, comment = "Whether to log entity removals due to speed")
+        private boolean logEntitySpeedRemoval = false;
+
+        public boolean chunkLoadLogging() {
+            return chunkLoadLogging;
+        }
+
+        public void setChunkLoadLogging(boolean chunkLoadLogging) {
+            this.chunkLoadLogging = chunkLoadLogging;
+        }
+
+        public boolean chunkUnloadLogging() {
+            return chunkUnloadLogging;
+        }
+
+        public void setChunkUnloadLogging(boolean chunkUnloadLogging) {
+            this.chunkUnloadLogging = chunkUnloadLogging;
+        }
+
+        public boolean entitySpawnLogging() {
+            return entitySpawnLogging;
+        }
+
+        public void setEntitySpawnLogging(boolean entitySpawnLogging) {
+            this.entitySpawnLogging = entitySpawnLogging;
+        }
+
+        public boolean entityDespawnLogging() {
+            return entityDespawnLogging;
+        }
+
+        public void setEntityDespawnLogging(boolean entityDespawnLogging) {
+            this.entityDespawnLogging = entityDespawnLogging;
+        }
+
+        public boolean entityDeathLogging() {
+            return entityDeathLogging;
+        }
+
+        public void setEntityDeathLogging(boolean entityDeathLogging) {
+            this.entityDeathLogging = entityDeathLogging;
+        }
+
+        public boolean logWithStackTraces() {
+            return logWithStackTraces;
+        }
+
+        public void setLogWithStackTraces(boolean logWithStackTraces) {
+            this.logWithStackTraces = logWithStackTraces;
+        }
+
+        public boolean logEntityCollisionChecks() {
+            return logEntityCollisionChecks;
+        }
+
+        public void setLogEntityCollisionChecks(boolean logEntityCollisionChecks) {
+            this.logEntityCollisionChecks = logEntityCollisionChecks;
+        }
+
+        public boolean logEntitySpeedRemoval() {
+            return logEntitySpeedRemoval;
+        }
+
+        public void setLogEntitySpeedRemoval(boolean logEntitySpeedRemoval) {
+            this.logEntitySpeedRemoval = logEntitySpeedRemoval;
+        }
+    }
+
+    @ConfigSerializable
+    public static class ModuleCategory extends Category {
+
+        @Setting(value = MODULE_ENTITY_ACTIVATION_RANGE)
+        private boolean pluginEntityActivation = true;
+
+        public boolean usePluginEntityActivation() {
+            return pluginEntityActivation;
+        }
+
+        public void setPluginEntityActivation(boolean pluginEntityActivation) {
+            this.pluginEntityActivation = pluginEntityActivation;
+        }
+    }
+
+    @ConfigSerializable
+    public static class WorldCategory extends Category {
+
+        @Setting(value = WORLD_INFINITE_WATER_SOURCE, comment = "Vanilla water source behavior - is infinite")
+        private boolean infiniteWaterSource = false;
+        @Setting(value = WORLD_FLOWING_LAVA_DECAY, comment = "Lava behaves like vanilla water when source block is removed")
+        private boolean flowingLavaDecay = false;
+
+        public boolean hasInfiniteWaterSource() {
+            return infiniteWaterSource;
+        }
+
+        public void setInfiniteWaterSource(boolean infiniteWaterSource) {
+            this.infiniteWaterSource = infiniteWaterSource;
+        }
+
+        public boolean hasFlowingLavaDecay() {
+            return flowingLavaDecay;
+        }
+
+        public void setFlowingLavaDecay(boolean flowingLavaDecay) {
+            this.flowingLavaDecay = flowingLavaDecay;
+        }
+    }
+
+    @ConfigSerializable
+    private static class Category {
     }
 }

--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinWorld.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinWorld.java
@@ -28,5 +28,5 @@ import org.spongepowered.mod.configuration.SpongeConfig;
 
 public interface IMixinWorld {
 
-    SpongeConfig getWorldConfig();
+    SpongeConfig<SpongeConfig.WorldConfig> getWorldConfig();
 }

--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinWorldProvider.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinWorldProvider.java
@@ -28,7 +28,7 @@ import org.spongepowered.mod.configuration.SpongeConfig;
 
 public interface IMixinWorldProvider {
 
-    void setDimensionConfig(SpongeConfig config);
+    void setDimensionConfig(SpongeConfig<SpongeConfig.DimensionConfig> config);
 
-    SpongeConfig getDimensionConfig();
+    SpongeConfig<SpongeConfig.DimensionConfig> getDimensionConfig();
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorld.java
@@ -92,7 +92,7 @@ import java.util.UUID;
 public abstract class MixinWorld implements World, IMixinWorld {
 
     private boolean keepSpawnLoaded;
-    public SpongeConfig worldConfig;
+    public SpongeConfig<SpongeConfig.WorldConfig> worldConfig;
 
     @Shadow
     public WorldProvider provider;
@@ -137,7 +137,9 @@ public abstract class MixinWorld implements World, IMixinWorld {
         if (!client) {
             String providerName = providerIn.getDimensionName().toLowerCase().replace(" ", "_").replace("[^A-Za-z0-9_]", "");
             this.worldConfig =
-                    new SpongeConfig(SpongeConfig.Type.WORLD, new File(SpongeMod.instance.getConfigDir() + File.separator + providerName
+                    new SpongeConfig<SpongeConfig.WorldConfig>(SpongeConfig.Type.WORLD, new File(SpongeMod.instance.getConfigDir() +
+                            File
+                            .separator + providerName
                             + File.separator + (providerIn.getDimensionId() == 0 ? "dim0" : providerIn.getSaveFolder().toLowerCase()), "world.conf"),
                             "sponge");
         }
@@ -423,7 +425,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
     }
 
     @Override
-    public SpongeConfig getWorldConfig() {
+    public SpongeConfig<SpongeConfig.WorldConfig> getWorldConfig() {
         return this.worldConfig;
     }
 

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldProvider.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldProvider.java
@@ -44,7 +44,7 @@ import java.io.File;
 public abstract class MixinWorldProvider implements Dimension, IMixinWorldProvider {
 
     private boolean allowPlayerRespawns;
-    private SpongeConfig dimensionConfig;
+    private SpongeConfig<SpongeConfig.DimensionConfig> dimensionConfig;
 
     @Shadow
     protected int dimensionId;
@@ -68,8 +68,10 @@ public abstract class MixinWorldProvider implements Dimension, IMixinWorldProvid
         WorldProvider provider = net.minecraftforge.common.DimensionManager.createProviderFor(dimension);
         if (!SpongeGameRegistry.dimensionConfigs.containsKey(provider.getClass())) {
             String providerName = provider.getDimensionName().toLowerCase().replace(" ", "_").replace("[^A-Za-z0-9_]", "");
-            SpongeConfig dimConfig =
-                    new SpongeConfig(SpongeConfig.Type.DIMENSION, new File(SpongeMod.instance.getConfigDir() + File.separator + providerName
+            SpongeConfig<SpongeConfig.DimensionConfig> dimConfig =
+                    new SpongeConfig<SpongeConfig.DimensionConfig>(SpongeConfig.Type.DIMENSION, new File(SpongeMod.instance.getConfigDir
+                            () + File
+                            .separator + providerName
                             + File.separator, "dimension.conf"), "sponge");
             SpongeGameRegistry.dimensionConfigs.put(provider.getClass(), dimConfig);
             ((IMixinWorldProvider) provider).setDimensionConfig(dimConfig);
@@ -126,12 +128,12 @@ public abstract class MixinWorldProvider implements Dimension, IMixinWorldProvid
     }
 
     @Override
-    public void setDimensionConfig(SpongeConfig config) {
+    public void setDimensionConfig(SpongeConfig<SpongeConfig.DimensionConfig> config) {
         this.dimensionConfig = config;
     }
 
     @Override
-    public SpongeConfig getDimensionConfig() {
+    public SpongeConfig<SpongeConfig.DimensionConfig> getDimensionConfig() {
         return this.dimensionConfig;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityItem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityItem.java
@@ -60,7 +60,7 @@ public abstract class MixinEntityItem extends Entity implements Item {
         }
 
         if (!this.worldObj.isRemote
-                && this.age >= ((IMixinWorld) this.worldObj).getWorldConfig().getRootNode().getNode("entity", "item-despawn-rate").getInt()) {
+                && this.age >= ((IMixinWorld) this.worldObj).getWorldConfig().getConfig().getEntity().getItemDespawnRate()) {
             this.setDead();
         }
     }

--- a/src/main/java/org/spongepowered/mod/mixin/plugin/CoreMixinPlugin.java
+++ b/src/main/java/org/spongepowered/mod/mixin/plugin/CoreMixinPlugin.java
@@ -39,13 +39,15 @@ import java.util.Set;
 public class CoreMixinPlugin implements IMixinConfigPlugin {
 
     private List<String> mixins = new ArrayList<String>();
-    private static SpongeConfig GLOBAL_CONFIG;
+    private static SpongeConfig<SpongeConfig.GlobalConfig> GLOBAL_CONFIG;
     private static File SPONGE_CONFIG_DIR = new File("." + File.separator + "config" + File.separator + "sponge" + File.separator);
 
     @Override
     public void onLoad(String mixinPackage) {
         try {
-            GLOBAL_CONFIG = new SpongeConfig(SpongeConfig.Type.GLOBAL, new File(SPONGE_CONFIG_DIR, "global.conf"), "sponge");
+            GLOBAL_CONFIG = new SpongeConfig<SpongeConfig.GlobalConfig>(SpongeConfig.Type.GLOBAL, new File(SPONGE_CONFIG_DIR, "global" +
+                    ".conf"),
+                    "sponge");
         } catch (Throwable t) {
             LogManager.getLogger().error(ExceptionUtils.getStackTrace(t));
         }
@@ -81,7 +83,7 @@ public class CoreMixinPlugin implements IMixinConfigPlugin {
             String mixinClassName, IMixinInfo mixinInfo) {
     }
 
-    public static SpongeConfig getGlobalConfig() {
+    public static SpongeConfig<SpongeConfig.GlobalConfig> getGlobalConfig() {
         return GLOBAL_CONFIG;
     }
 

--- a/src/main/java/org/spongepowered/mod/mixin/plugin/entityactivation/EntityActivationRangePlugin.java
+++ b/src/main/java/org/spongepowered/mod/mixin/plugin/entityactivation/EntityActivationRangePlugin.java
@@ -27,7 +27,6 @@ package org.spongepowered.mod.mixin.plugin.entityactivation;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
-import org.spongepowered.mod.configuration.SpongeConfig;
 import org.spongepowered.mod.mixin.plugin.CoreMixinPlugin;
 
 import java.util.ArrayList;
@@ -49,7 +48,7 @@ public class EntityActivationRangePlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        if (!CoreMixinPlugin.getGlobalConfig().getRootNode().getNode("modules", SpongeConfig.MODULE_ENTITY_ACTIVATION_RANGE).getBoolean()
+        if (!CoreMixinPlugin.getGlobalConfig().getConfig().getModules().usePluginEntityActivation()
                 && mixinClassName.contains("mixin.entityactivation")) {
             return false;
         }

--- a/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
@@ -182,7 +182,8 @@ public class SpongeGameRegistry implements GameRegistry {
     private final Map<String, BiomeType> biomeTypeMappings = Maps.newHashMap();
     public static final Map<String, SpongeTextColor> textColorMappings = Maps.newHashMap();
     public static final Map<TextColor, EnumChatFormatting> textColorToEnumMappings = Maps.newHashMap();
-    public static final Map<Class<? extends WorldProvider>, SpongeConfig> dimensionConfigs = Maps.newHashMap();
+    public static final Map<Class<? extends WorldProvider>, SpongeConfig<SpongeConfig.DimensionConfig>> dimensionConfigs = Maps
+            .newHashMap();
     public static final ImmutableMap<String, TextStyle.Base> textStyleMappings = new ImmutableMap.Builder<String, TextStyle.Base>()
             .put("OBFUSCATED", new TextStyle.Base("OBFUSCATED", 'k'))
             .put("BOLD", new TextStyle.Base("BOLD", 'l'))

--- a/src/main/java/org/spongepowered/mod/service/sql/SqlServiceImpl.java
+++ b/src/main/java/org/spongepowered/mod/service/sql/SqlServiceImpl.java
@@ -1,0 +1,167 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.service.sql;
+
+import com.google.common.base.Optional;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.spongepowered.api.service.sql.SqlService;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.mod.mixin.plugin.CoreMixinPlugin;
+
+import javax.annotation.Nonnull;
+import javax.sql.DataSource;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/**
+ * Implementation of a SQL-using service.
+ * <p>
+ * This implementation does a few interesting things<br>
+ *     - It's thread-safe
+ *     - It allows applying additional driver-specific connection
+ *     properties -- this allows us to do some light performance tuning in
+ *     cases where we don't want to be as conservative as the driver developers
+ *     - Caches DataSources. This cache is currently never cleared of stale entries
+ *     -- if some plugin makes database connections to a ton of different databases
+ *     we may want to implement this, but it is kinda unimportant.
+ */
+@NonnullByDefault
+public class SqlServiceImpl implements SqlService {
+
+    private static final Map<String, Properties> PROTOCOL_SPECIFIC_PROPS;
+
+    static {
+        ImmutableMap.Builder<String, Properties> build = ImmutableMap.builder();
+        final Properties mySqlProps = new Properties();
+        mySqlProps.setProperty("useConfigs",
+                "maxPerformance"); // Config options based on http://assets.en.oreilly
+                // .com/1/event/21/Connector_J%20Performance%20Gems%20Presentation.pdf
+        build.put("com.mysql.jdbc.Driver", mySqlProps);
+        build.put("org.mariadb.jdbc.Driver", mySqlProps);
+
+        PROTOCOL_SPECIFIC_PROPS = build.build();
+    }
+
+    private final LoadingCache<ConnectionInfo, DataSource> connectionCache =
+            CacheBuilder.newBuilder().build(new CacheLoader<ConnectionInfo, DataSource>() {
+                @Override
+                public DataSource load(@Nonnull ConnectionInfo key) throws Exception {
+                    HikariConfig config = new HikariConfig();
+                    config.setUsername(key.getUser());
+                    config.setPassword(key.getPassword());
+                    config.setDriverClassName(key.getDriverClassName());
+                    // https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing for info on pool sizing
+                    config.setMaximumPoolSize((Runtime.getRuntime().availableProcessors() * 2) + 1);
+                    Properties driverSpecificProperties = PROTOCOL_SPECIFIC_PROPS.get(key.getDriverClassName());
+                    if (driverSpecificProperties != null) {
+                        config.setDataSourceProperties(driverSpecificProperties);
+                    }
+                    config.setJdbcUrl(key.getAuthlessUrl());
+                    return new HikariDataSource(config);
+                }
+            });
+
+    @Override
+    public DataSource getDataSource(String jdbcConnection) throws SQLException {
+        jdbcConnection = getConnectionUrlFromAlias(jdbcConnection).or(jdbcConnection);
+        ConnectionInfo info = ConnectionInfo.fromUrl(jdbcConnection);
+        try {
+            return this.connectionCache.get(info);
+        } catch (ExecutionException e) {
+            throw new SQLException(e);
+        }
+    }
+
+    public static class ConnectionInfo {
+
+        private static final Pattern URL_REGEX = Pattern.compile("(?:jdbc:)?([^:]+):(//)?(?:([^:]+)(?::([^@]+))?@)?(.*)");
+        private final String user;
+        private final String password;
+        private final String driverClassName;
+        private final String authlessUrl;
+        private final String fullUrl;
+
+        public ConnectionInfo(String user, String password, String driverClassName, String authlessUrl, String fullUrl) {
+            this.user = user;
+            this.password = password;
+            this.driverClassName = driverClassName;
+            this.authlessUrl = authlessUrl;
+            this.fullUrl = fullUrl;
+        }
+
+        public String getUser() {
+            return this.user;
+        }
+
+        public String getPassword() {
+            return this.password;
+        }
+
+        public String getDriverClassName() {
+            return this.driverClassName;
+        }
+
+        public String getAuthlessUrl() {
+            return this.authlessUrl;
+        }
+
+        public String getFullUrl() {
+            return this.fullUrl;
+        }
+
+        public static ConnectionInfo fromUrl(String fullUrl) throws SQLException {
+            Matcher match = URL_REGEX.matcher(fullUrl);
+            if (!match.matches()) {
+                throw new IllegalArgumentException("URL " + fullUrl + " is not a valid JDBC URL");
+            }
+
+            final String protocol = match.group(1);
+            final boolean hasSlashes = match.group(2) != null;
+            final String user = match.group(3);
+            final String pass = match.group(4);
+            final String serverDatabaseSpecifier = match.group(5);
+            final String unauthedUrl = "jdbc:" + protocol + (hasSlashes ? "://" : ":") + serverDatabaseSpecifier;
+            final String driverClass = DriverManager.getDriver(unauthedUrl).getClass().getCanonicalName();
+            return new ConnectionInfo(user, pass, driverClass, unauthedUrl, fullUrl);
+        }
+    }
+
+    @Override
+    public Optional<String> getConnectionUrlFromAlias(String alias) {
+        return Optional.fromNullable(CoreMixinPlugin.getGlobalConfig().getConfig().getSql().getAliases().get(alias));
+    }
+}

--- a/src/main/java/org/spongepowered/mod/util/SpongeHooks.java
+++ b/src/main/java/org/spongepowered/mod/util/SpongeHooks.java
@@ -82,8 +82,8 @@ public class SpongeHooks {
         MinecraftServer.getServer().logSevere(MessageFormat.format(msg, args));
     }
 
-    public static void logStack(SpongeConfig config) {
-        if (config.getRootNode().getNode("logging", SpongeConfig.LOGGING_STACKTRACES).getBoolean()) {
+    public static void logStack(SpongeConfig<?> config) {
+        if (config.getConfig().getLogging().logWithStackTraces()) {
             Throwable ex = new Throwable();
             ex.fillInStackTrace();
             ex.printStackTrace();
@@ -91,8 +91,8 @@ public class SpongeHooks {
     }
 
     public static void logEntityDeath(Entity entity) {
-        SpongeConfig config = getActiveConfig(entity.worldObj);
-        if (config.getRootNode().getNode("logging", SpongeConfig.LOGGING_ENTITY_DEATH).getBoolean()) {
+        SpongeConfig<?> config = getActiveConfig(entity.worldObj);
+        if (config.getConfig().getLogging().entityDeathLogging()) {
             logInfo("[" + config.getConfigName() + "] [" + config.getConfigName() + "] Dim: {0} setDead(): {1}",
                     entity.worldObj.provider.getDimensionId(), entity);
             logStack(config);
@@ -100,24 +100,24 @@ public class SpongeHooks {
     }
 
     public static void logEntityDespawn(Entity entity, String reason) {
-        SpongeConfig config = getActiveConfig(entity.worldObj);
-        if (config.getRootNode().getNode("logging", SpongeConfig.LOGGING_ENTITY_DESPAWN).getBoolean()) {
+        SpongeConfig<?> config = getActiveConfig(entity.worldObj);
+        if (config.getConfig().getLogging().entityDespawnLogging()) {
             logInfo("[" + config.getConfigName() + "] Dim: {0} Despawning ({1}): {2}", entity.worldObj.provider.getDimensionId(), reason, entity);
             logStack(config);
         }
     }
 
     public static void logEntitySpawn(Entity entity) {
-        SpongeConfig config = getActiveConfig(entity.worldObj);
-        if (config.getRootNode().getNode("logging", SpongeConfig.LOGGING_ENTITY_SPAWN).getBoolean()) {
+        SpongeConfig<?> config = getActiveConfig(entity.worldObj);
+        if (config.getConfig().getLogging().entitySpawnLogging()) {
             logInfo("[" + config.getConfigName() + "] Dim: {0} Spawning: {1}", entity.worldObj.provider.getDimensionId(), entity);
             logStack(config);
         }
     }
 
     public static void logChunkLoad(World world, Vector3i chunkPos) {
-        SpongeConfig config = getActiveConfig(world);
-        if (config.getRootNode().getNode("logging", SpongeConfig.LOGGING_CHUNK_LOAD).getBoolean()) {
+        SpongeConfig<?> config = getActiveConfig(world);
+        if (config.getConfig().getLogging().chunkLoadLogging()) {
             logInfo("[" + config.getConfigName() + "] Load Chunk At [{0}] ({1}, {2})", world.provider.getDimensionId(), chunkPos.getX(),
                     chunkPos.getZ());
             logStack(config);
@@ -125,8 +125,8 @@ public class SpongeHooks {
     }
 
     public static void logChunkUnload(World world, Vector3i chunkPos) {
-        SpongeConfig config = getActiveConfig(world);
-        if (config.getRootNode().getNode("logging", SpongeConfig.LOGGING_CHUNK_UNLOAD).getBoolean()) {
+        SpongeConfig<?> config = getActiveConfig(world);
+        if (config.getConfig().getLogging().chunkUnloadLogging()) {
             logInfo("[" + config.getConfigName() + "] Unload Chunk At [{0}] ({1}, {2})", world.provider.getDimensionId(), chunkPos.getX(),
                     chunkPos.getZ());
             logStack(config);
@@ -135,18 +135,18 @@ public class SpongeHooks {
 
     @SuppressWarnings("unused")
     private static void logChunkLoadOverride(ChunkProviderServer provider, int x, int z) {
-        SpongeConfig config = getActiveConfig(provider.worldObj);
+        SpongeConfig<?> config = getActiveConfig(provider.worldObj);
         logInfo("[" + config.getConfigName() + "]  Chunk Load Override: {0}, Dimension ID: {1}", provider.chunkLoadOverride,
                 provider.worldObj.provider.getDimensionId());
     }
 
     public static boolean checkBoundingBoxSize(Entity entity, AxisAlignedBB aabb) {
-        SpongeConfig config = getActiveConfig(entity.worldObj);
+        SpongeConfig<?> config = getActiveConfig(entity.worldObj);
         if (!(entity instanceof EntityLivingBase) || entity instanceof EntityPlayer) {
             return false; // only check living entities that are not players
         }
 
-        int maxBoundingBoxSize = config.getRootNode().getNode("entity", SpongeConfig.ENTITY_MAX_BOUNDING_BOX_SIZE).getInt();
+        int maxBoundingBoxSize = config.getConfig().getEntity().getMaxBoundingBoxSize();
         if (maxBoundingBoxSize <= 0) {
             return false;
         }
@@ -176,12 +176,12 @@ public class SpongeHooks {
     }
 
     public static boolean checkEntitySpeed(Entity entity, double x, double y, double z) {
-        SpongeConfig config = getActiveConfig(entity.worldObj);
-        int maxSpeed = config.getRootNode().getNode("entity", SpongeConfig.ENTITY_MAX_SPEED).getInt();
+        SpongeConfig<?> config = getActiveConfig(entity.worldObj);
+        int maxSpeed = config.getConfig().getEntity().getMaxSpeed();
         if (maxSpeed > 0) {
             double distance = x * x + z * z;
             if (distance > maxSpeed) {
-                if (config.getRootNode().getNode("logging", SpongeConfig.LOGGING_ENTITY_SPEED_REMOVAL).getBoolean()) {
+                if (config.getConfig().getLogging().logEntitySpeedRemoval()) {
                     logInfo("[" + config.getConfigName() + "] Speed violation: {0} was over {1} - Removing Entity: {2}", distance, maxSpeed, entity);
                     if (entity instanceof EntityLivingBase) {
                         EntityLivingBase livingBase = (EntityLivingBase) entity;
@@ -191,7 +191,7 @@ public class SpongeHooks {
                                 livingBase.moveStrafing, livingBase.moveForward);
                     }
 
-                    if (config.getRootNode().getNode("logging", SpongeConfig.LOGGING_STACKTRACES).getBoolean()) {
+                    if (config.getConfig().getLogging().logWithStackTraces()) {
                         logInfo("[" + config.getConfigName() + "] Move offset: ({0}, {1}, {2})", x, y, z);
                         logInfo("[" + config.getConfigName() + "] Motion: ({0}, {1}, {2})", entity.motionX, entity.motionY, entity.motionZ);
                         logInfo("[" + config.getConfigName() + "] Entity: {0}", entity);
@@ -218,11 +218,11 @@ public class SpongeHooks {
     // TODO - needs to be hooked
     @SuppressWarnings("rawtypes")
     public static void logEntitySize(Entity entity, List list) {
-        SpongeConfig config = getActiveConfig(entity.worldObj);
-        if (!config.getRootNode().getNode("logging", SpongeConfig.LOGGING_ENTITY_COLLISION_CHECKS).getBoolean()) {
+        SpongeConfig<?> config = getActiveConfig(entity.worldObj);
+        if (!config.getConfig().getLogging().logEntityCollisionChecks()) {
             return;
         }
-        int collisionWarnSize = config.getRootNode().getNode(SpongeConfig.ENTITY_COLLISION_WARN_SIZE).getInt();
+        int collisionWarnSize = config.getConfig().getEntity().getMaxCollisionSize();
 
         if (list == null) {
             return;
@@ -401,19 +401,19 @@ public class SpongeHooks {
     }
 
     public static void enableThreadContentionMonitoring() {
-        if (!CoreMixinPlugin.getGlobalConfig().getRootNode().getNode("debug", SpongeConfig.DEBUG_THREAD_CONTENTION_MONITORING).getBoolean()) {
+        if (!CoreMixinPlugin.getGlobalConfig().getConfig().getDebug().isEnableThreadContentionMonitoring()) {
             return;
         }
         java.lang.management.ThreadMXBean mbean = java.lang.management.ManagementFactory.getThreadMXBean();
         mbean.setThreadContentionMonitoringEnabled(true);
     }
 
-    public static SpongeConfig getActiveConfig(World world) {
-        SpongeConfig config = ((IMixinWorld) world).getWorldConfig();
-        if (config.getRootNode().getNode(SpongeConfig.CONFIG_ENABLED).getBoolean()) {
+    public static SpongeConfig<?> getActiveConfig(World world) {
+        SpongeConfig<?> config = ((IMixinWorld) world).getWorldConfig();
+        if (config.getConfig().isConfigEnabled()) {
             return config;
         } else if (((IMixinWorldProvider) world.provider).getDimensionConfig() != null && ((IMixinWorldProvider) world.provider)
-                .getDimensionConfig().getRootNode().getNode(SpongeConfig.CONFIG_ENABLED).getBoolean()) {
+                .getDimensionConfig().getConfig().isConfigEnabled()) {
             return ((IMixinWorldProvider) world.provider).getDimensionConfig();
         } else {
             return CoreMixinPlugin.getGlobalConfig();

--- a/src/test/java/org/spongepowered/mod/service/sql/SqlServiceImplTest.java
+++ b/src/test/java/org/spongepowered/mod/service/sql/SqlServiceImplTest.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.service.sql;
+
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+import static org.junit.Assert.*;
+
+public class SqlServiceImplTest {
+    @Test
+    public void testMysqlConnectionInfo() throws SQLException {
+        final String jdbcUrl = "jdbc:mysql://zml:totallymypassword@localhost/sponge";
+        final SqlServiceImpl.ConnectionInfo subject = SqlServiceImpl.ConnectionInfo.fromUrl(jdbcUrl);
+
+        assertEquals("zml", subject.getUser());
+        assertEquals("totallymypassword", subject.getPassword());
+        assertEquals("jdbc:mysql://localhost/sponge", subject.getAuthlessUrl());
+        assertEquals("org.mariadb.jdbc.Driver", subject.getDriverClassName());
+    }
+
+    @Test
+    public void testH2ConnectionInfo() throws SQLException {
+        final String jdbcUrl = "jdbc:h2:sparkles.db";
+        final SqlServiceImpl.ConnectionInfo subject = SqlServiceImpl.ConnectionInfo.fromUrl(jdbcUrl);
+
+        assertNull(subject.getUser());
+        assertNull(subject.getPassword());
+        assertEquals(jdbcUrl, subject.getAuthlessUrl());
+        assertEquals("org.h2.Driver", subject.getDriverClassName());
+    }
+
+    @Test
+    public void testSqliteConnectionInfo() throws SQLException {
+        final String jdbcUrl = "jdbc:sqlite:glitter.db";
+        final SqlServiceImpl.ConnectionInfo subject = SqlServiceImpl.ConnectionInfo.fromUrl(jdbcUrl);
+
+        assertNull(subject.getUser());
+        assertNull(subject.getPassword());
+        assertEquals(jdbcUrl, subject.getAuthlessUrl());
+        assertEquals("org.sqlite.JDBC", subject.getDriverClassName());
+    }
+}


### PR DESCRIPTION
Just want to PR this for some comments on the supported database platforms.
This differs from Bukkit in a few ways

1. Mariadb rather than MySQL connector: I chose the MariaDB one over the MySQL one because to me it seems like there has been a switch away from oracle MySQl based on the fact that Oracle sucks. (they should be protocol-compatible anyways)

2. H2 rather than sqlite: SQLite has a ton of limitations in a lot of areas (like modifying tables) that make working with it hard. H2 has a richer feature set, and as a bonus is pure-java. A few bukkit plugins have used this database engine in the past, so I think it is worth including instead of sqlite.

(and yeah, I dumped another slightly unrelated commit in because I had to work with the config while implementing this API)