### PR TITLE
Fix MixinEventPlayerPlaceBlock

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerPlaceBlock.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerPlaceBlock.java
@@ -58,6 +58,8 @@ public abstract class MixinEventPlayerPlaceBlock extends BlockEvent implements P
     @Shadow
     public IBlockState placedAgainst;
 
+    private net.minecraftforge.common.util.BlockSnapshot replacementBlock;
+
     public MixinEventPlayerPlaceBlock(World world, BlockPos pos, IBlockState state) {
         super(world, pos, state);
     }
@@ -69,7 +71,10 @@ public abstract class MixinEventPlayerPlaceBlock extends BlockEvent implements P
 
     @Override
     public BlockSnapshot getReplacementBlock() {
-        return (BlockSnapshot) this.blockSnapshot;
+        if (this.replacementBlock == null) {
+            this.replacementBlock = new net.minecraftforge.common.util.BlockSnapshot(world, pos, this.placedBlock);
+        }
+        return (BlockSnapshot) this.replacementBlock;
     }
 
     @Override


### PR DESCRIPTION
As the javadoc states, the [`getReplacementBlock()`](https://github.com/SpongePowered/SpongeAPI/blob/master/src/main/java/org/spongepowered/api/event/block/BlockChangeEvent.java#L38) is supposed to return the snapshot of the block *replacing* the `getBlock` from the event. Currently, the implementation does not actually do this, and further digging, the previously used `blockSnapshot` is actually a snapshot of the block *being* replaced (which for most all block placement events is actually AIR). 

This fixes the mixin to where the block snapshot return is now the actual replaced block.