### PR TITLE
Updated link to new docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 We will always have a need for developers to help us improve Sponge. There is no such thing as a perfect project and things can always be improved. If you are a developer and are interested in helping then please do not hesitate. Just make sure you follow our guidelines.
 
-Please check our [Contribution Guidelines in the Sponge Documentation](https://docs.spongepowered.org/en/latest/devs/guidelines/) for more information.
+Please check our [Contribution Guidelines in the Sponge Documentation](https://docs.spongepowered.org/en/devs/guidelines.html) for more information.


### PR DESCRIPTION
The old link went to a 404 page in the docs, this fixes it.