### PR TITLE
Implement Persistence Services

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeMod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeMod.java
@@ -184,6 +184,8 @@ public class SpongeMod extends DummyModContainer implements PluginContainer {
     @Subscribe
     public void onInitialization(FMLPostInitializationEvent e) {
         this.registry.postInit();
+        SerializationService service = this.game.getServiceManager().provide(SerializationService.class).get();
+        ((SpongeSerializationService) service).completeRegistration();
     }
 
     @Subscribe

--- a/src/main/java/org/spongepowered/mod/SpongeMod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeMod.java
@@ -45,8 +45,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.Type;
 import org.spongepowered.api.Game;
-import org.spongepowered.api.block.data.Banner;
-import org.spongepowered.api.entity.living.animal.DyeColor;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.service.ProviderExistsException;
@@ -66,9 +64,6 @@ import org.spongepowered.mod.service.scheduler.AsyncScheduler;
 import org.spongepowered.mod.service.scheduler.SyncScheduler;
 import org.spongepowered.mod.service.sql.SqlServiceImpl;
 import org.spongepowered.mod.service.persistence.SpongeSerializationService;
-import org.spongepowered.mod.service.persistence.builders.block.data.SpongePatternLayerBuilder;
-import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeBannerBuilder;
-import org.spongepowered.mod.service.persistence.builders.data.SpongeDyeBuilder;
 import org.spongepowered.mod.util.SpongeHooks;
 
 import java.io.File;
@@ -119,17 +114,9 @@ public class SpongeMod extends DummyModContainer implements PluginContainer {
         try {
             SerializationService serializationService = new SpongeSerializationService();
             this.game.getServiceManager().setProvider(this, SerializationService.class, serializationService);
-            setupSerialization();
         } catch (ProviderExistsException e2) {
             logger.warn("Non-Sponge SerializationService already registered: " + e2.getLocalizedMessage());
         }
-    }
-
-    private void setupSerialization() {
-        SerializationService service = this.game.getServiceManager().provide(SerializationService.class).get();
-        service.registerBuilder(Banner.class, new SpongeBannerBuilder(this.game));
-        service.registerBuilder(Banner.PatternLayer.class, new SpongePatternLayerBuilder(this.game));
-        service.registerBuilder(DyeColor.class, new SpongeDyeBuilder());
     }
 
     @Override
@@ -174,6 +161,7 @@ public class SpongeMod extends DummyModContainer implements PluginContainer {
         if (e.getSide() == Side.SERVER) {
             SpongeHooks.enableThreadContentionMonitoring();
         }
+        this.registry.preInit();
     }
 
     @Subscribe

--- a/src/main/java/org/spongepowered/mod/SpongeMod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeMod.java
@@ -45,6 +45,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.Type;
 import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Banner;
+import org.spongepowered.api.entity.living.animal.DyeColor;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.service.ProviderExistsException;
@@ -53,6 +55,7 @@ import org.spongepowered.api.service.command.SimpleCommandService;
 import org.spongepowered.api.service.scheduler.AsynchronousScheduler;
 import org.spongepowered.api.service.scheduler.SynchronousScheduler;
 import org.spongepowered.api.service.sql.SqlService;
+import org.spongepowered.api.service.persistence.SerializationService;
 import org.spongepowered.mod.command.CommandSponge;
 import org.spongepowered.mod.event.SpongeEventBus;
 import org.spongepowered.mod.event.SpongeEventHooks;
@@ -62,6 +65,10 @@ import org.spongepowered.mod.registry.SpongeGameRegistry;
 import org.spongepowered.mod.service.scheduler.AsyncScheduler;
 import org.spongepowered.mod.service.scheduler.SyncScheduler;
 import org.spongepowered.mod.service.sql.SqlServiceImpl;
+import org.spongepowered.mod.service.persistence.SpongeSerializationService;
+import org.spongepowered.mod.service.persistence.builders.block.data.SpongePatternLayerBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeBannerBuilder;
+import org.spongepowered.mod.service.persistence.builders.data.SpongeDyeBuilder;
 import org.spongepowered.mod.util.SpongeHooks;
 
 import java.io.File;
@@ -109,6 +116,20 @@ public class SpongeMod extends DummyModContainer implements PluginContainer {
             logger.error("Non-Sponge scheduler has been registered. Cannot continue!");
             FMLCommonHandler.instance().exitJava(1, false);
         }
+        try {
+            SerializationService serializationService = new SpongeSerializationService();
+            this.game.getServiceManager().setProvider(this, SerializationService.class, serializationService);
+            setupSerialization();
+        } catch (ProviderExistsException e2) {
+            logger.warn("Non-Sponge SerializationService already registered: " + e2.getLocalizedMessage());
+        }
+    }
+
+    private void setupSerialization() {
+        SerializationService service = this.game.getServiceManager().provide(SerializationService.class).get();
+        service.registerBuilder(Banner.class, new SpongeBannerBuilder(this.game));
+        service.registerBuilder(Banner.PatternLayer.class, new SpongePatternLayerBuilder(this.game));
+        service.registerBuilder(DyeColor.class, new SpongeDyeBuilder());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/block/meta/SpongePatternLayer.java
+++ b/src/main/java/org/spongepowered/mod/block/meta/SpongePatternLayer.java
@@ -27,8 +27,9 @@ package org.spongepowered.mod.block.meta;
 import org.spongepowered.api.block.data.Banner.PatternLayer;
 import org.spongepowered.api.block.meta.BannerPatternShape;
 import org.spongepowered.api.entity.living.animal.DyeColor;
-import org.spongepowered.api.service.persistence.DataSource;
 import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.MemoryDataContainer;
 
 public class SpongePatternLayer implements PatternLayer {
 
@@ -52,13 +53,10 @@ public class SpongePatternLayer implements PatternLayer {
 
     @Override
     public DataContainer toContainer() {
-        // TODO
-        return null;
+        DataContainer container = new MemoryDataContainer();
+        container.set(new DataQuery("id"), id.getId());
+        container.set(new DataQuery("color"), color.getName());
+        return container;
     }
-
-    /*@Override
-    public void serialize(DataSource source) {
-        // TODO
-    }*/
 
 }

--- a/src/main/java/org/spongepowered/mod/entity/SpongeEntityMeta.java
+++ b/src/main/java/org/spongepowered/mod/entity/SpongeEntityMeta.java
@@ -27,6 +27,8 @@ package org.spongepowered.mod.entity;
 import com.google.common.base.MoreObjects;
 import org.spongepowered.api.service.persistence.DataSource;
 import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.MemoryDataContainer;
 
 public class SpongeEntityMeta {
 
@@ -53,15 +55,17 @@ public class SpongeEntityMeta {
         SpongeEntityMeta other = (SpongeEntityMeta) obj;
         if (this.type != other.type) {
             return false;
-        } else if (this.name != other.name) {
+        } else if (this.name.equals(other.name)) {
             return false;
         }
         return true;
     }
 
     public DataContainer toContainer() {
-        // TODO
-        return null;
+        DataContainer container = new MemoryDataContainer();
+        container.set(new DataQuery("id"), this.type);
+        container.set(new DataQuery("name"), this.name);
+        return container;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntity.java
@@ -27,6 +27,9 @@ package org.spongepowered.mod.mixin.core.block.data;
 import net.minecraft.util.BlockPos;
 import org.spongepowered.api.block.BlockLoc;
 import org.spongepowered.api.block.data.TileEntity;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.MemoryDataContainer;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -43,6 +46,9 @@ public abstract class MixinTileEntity implements TileEntity {
     @Shadow
     public abstract BlockPos getPos();
 
+    @Shadow
+    public abstract void markDirty();
+
     @Override
     public BlockLoc getBlock() {
         return new BlockWrapper(getWorld(), getPos());
@@ -51,5 +57,16 @@ public abstract class MixinTileEntity implements TileEntity {
     @Override
     public World getWorld() {
         return (World) this.worldObj;
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = new MemoryDataContainer();
+        container.set(new DataQuery("world"), this.getWorld().getName());
+        container.set(new DataQuery("x"), this.getPos().getX());
+        container.set(new DataQuery("y"), this.getPos().getY());
+        container.set(new DataQuery("z"), this.getPos().getZ());
+        container.set(new DataQuery("tileType"), net.minecraft.tileentity.TileEntity.classToNameMap.get(this.getClass()));
+        return container;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBanner.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBanner.java
@@ -127,13 +127,10 @@ public abstract class MixinTileEntityBanner extends MixinTileEntity {
         this.markDirtyAndUpdate();
     }
 
-    public DataContainer banner$toContainer() {
+    @Override
+    public DataContainer toContainer() {
         DataContainer container = super.toContainer();
-        List<DataView> patterns = Lists.newArrayList();
-        for (PatternLayer shape : this.patternLayers) {
-            patterns.add(shape.toContainer());
-        }
-        container.set(new DataQuery("Patterns"), patterns);
+        container.set(new DataQuery("Patterns"), Lists.newArrayList(this.patternLayers));
         container.set(new DataQuery("Base"), this.baseColor);
         return container;
     }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBanner.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBanner.java
@@ -34,6 +34,10 @@ import org.spongepowered.api.GameRegistry;
 import org.spongepowered.api.block.data.Banner.PatternLayer;
 import org.spongepowered.api.block.meta.BannerPatternShape;
 import org.spongepowered.api.entity.living.animal.DyeColor;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.api.service.persistence.data.MemoryDataContainer;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -50,7 +54,7 @@ import java.util.List;
 @NonnullByDefault
 @Mixin(net.minecraft.tileentity.TileEntityBanner.class)
 @Implements(@Interface(iface = org.spongepowered.api.block.data.Banner.class, prefix = "banner$"))
-public abstract class MixinTileEntityBanner extends TileEntity {
+public abstract class MixinTileEntityBanner extends MixinTileEntity {
 
     @Shadow
     private int baseColor;
@@ -71,7 +75,7 @@ public abstract class MixinTileEntityBanner extends TileEntity {
     }
 
     public void markDirtyAndUpdate() {
-        super.markDirty();
+        this.markDirty();
         if (this.worldObj != null) {
             this.worldObj.markBlockForUpdate(this.getPos());
         }
@@ -121,6 +125,17 @@ public abstract class MixinTileEntityBanner extends TileEntity {
         nbtPattern.setString("Pattern", patternShape.getId());
         this.patterns.appendTag(nbtPattern);
         this.markDirtyAndUpdate();
+    }
+
+    public DataContainer banner$toContainer() {
+        DataContainer container = super.toContainer();
+        List<DataView> patterns = Lists.newArrayList();
+        for (PatternLayer shape : this.patternLayers) {
+            patterns.add(shape.toContainer());
+        }
+        container.set(new DataQuery("Patterns"), patterns);
+        container.set(new DataQuery("Base"), this.baseColor);
+        return container;
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBeacon.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBeacon.java
@@ -42,7 +42,7 @@ import org.spongepowered.asm.mixin.Shadow;
 @NonnullByDefault
 @Implements(@Interface(iface = Beacon.class, prefix = "beacon$"))
 @Mixin(net.minecraft.tileentity.TileEntityBeacon.class)
-public abstract class MixinTileEntityBeacon extends MixinTileEntity {
+public abstract class MixinTileEntityBeacon extends MixinTileEntityLockable {
 
     @Shadow
     public abstract int getField(int id);

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBeacon.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBeacon.java
@@ -31,6 +31,8 @@ import net.minecraft.server.gui.IUpdatePlayerListBox;
 import net.minecraft.tileentity.TileEntityLockable;
 import org.spongepowered.api.block.data.Beacon;
 import org.spongepowered.api.potion.PotionEffectType;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -40,13 +42,11 @@ import org.spongepowered.asm.mixin.Shadow;
 @NonnullByDefault
 @Implements(@Interface(iface = Beacon.class, prefix = "beacon$"))
 @Mixin(net.minecraft.tileentity.TileEntityBeacon.class)
-public abstract class MixinTileEntityBeacon extends TileEntityLockable implements IUpdatePlayerListBox, IInventory {
+public abstract class MixinTileEntityBeacon extends MixinTileEntity {
 
-    @Override
     @Shadow
     public abstract int getField(int id);
 
-    @Override
     @Shadow
     public abstract void setField(int id, int value);
 
@@ -75,4 +75,11 @@ public abstract class MixinTileEntityBeacon extends TileEntityLockable implement
         return getField(0);
     }
 
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = super.toContainer();
+        container.set(new DataQuery("effect1"), getField(1));
+        container.set(new DataQuery("effect2"), getField(2));
+        return container;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBrewingStand.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBrewingStand.java
@@ -24,10 +24,9 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.inventory.ISidedInventory;
-import net.minecraft.server.gui.IUpdatePlayerListBox;
-import net.minecraft.tileentity.TileEntityLockable;
 import org.spongepowered.api.block.data.BrewingStand;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -37,13 +36,11 @@ import org.spongepowered.asm.mixin.Shadow;
 @NonnullByDefault
 @Implements(@Interface(iface = BrewingStand.class, prefix = "brewingstand$"))
 @Mixin(net.minecraft.tileentity.TileEntityBrewingStand.class)
-public abstract class MixinTileEntityBrewingStand extends TileEntityLockable implements IUpdatePlayerListBox, ISidedInventory {
+public abstract class MixinTileEntityBrewingStand extends MixinTileEntityLockable {
 
-    @Override
     @Shadow
     public abstract int getField(int id);
 
-    @Override
     @Shadow
     public abstract void setField(int id, int value);
 
@@ -53,5 +50,12 @@ public abstract class MixinTileEntityBrewingStand extends TileEntityLockable imp
 
     public void brewingstand$setRemainingBrewTime(int time) {
         setField(0, time);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = super.toContainer();
+        container.set(new DataQuery("BrewTime"), this.brewingstand$getRemainingBrewTime());
+        return container;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBrewingStand.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBrewingStand.java
@@ -39,6 +39,9 @@ import org.spongepowered.asm.mixin.Shadow;
 public abstract class MixinTileEntityBrewingStand extends MixinTileEntityLockable {
 
     @Shadow
+    private String customName;
+
+    @Shadow
     public abstract int getField(int id);
 
     @Shadow
@@ -56,6 +59,9 @@ public abstract class MixinTileEntityBrewingStand extends MixinTileEntityLockabl
     public DataContainer toContainer() {
         DataContainer container = super.toContainer();
         container.set(new DataQuery("BrewTime"), this.brewingstand$getRemainingBrewTime());
+        if (this.customName != null) {
+            container.set(new DataQuery("CustomName"), this.customName);
+        }
         return container;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityChest.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityChest.java
@@ -25,14 +25,28 @@
 package org.spongepowered.mod.mixin.core.block.data;
 
 import org.spongepowered.api.block.data.Chest;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 
 @NonnullByDefault
 @Implements(@Interface(iface = Chest.class, prefix = "chest$"))
 @Mixin(net.minecraft.tileentity.TileEntityChest.class)
 public abstract class MixinTileEntityChest extends MixinTileEntityLockable {
 
+    @Shadow
+    public String customName;
+
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = super.toContainer();
+        if (this.customName != null) {
+            container.set(new DataQuery("CustomName"), this.customName);
+        }
+        return container;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityChest.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityChest.java
@@ -24,9 +24,6 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.inventory.IInventory;
-import net.minecraft.server.gui.IUpdatePlayerListBox;
-import net.minecraft.tileentity.TileEntityLockable;
 import org.spongepowered.api.block.data.Chest;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
@@ -36,6 +33,6 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Implements(@Interface(iface = Chest.class, prefix = "chest$"))
 @Mixin(net.minecraft.tileentity.TileEntityChest.class)
-public abstract class MixinTileEntityChest extends TileEntityLockable implements IUpdatePlayerListBox, IInventory {
+public abstract class MixinTileEntityChest extends MixinTileEntityLockable {
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityComparator.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityComparator.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.tileentity.TileEntity;
 import org.spongepowered.api.block.data.Comparator;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
@@ -34,6 +33,6 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Implements(@Interface(iface = Comparator.class, prefix = "comparator$"))
 @Mixin(net.minecraft.tileentity.TileEntityComparator.class)
-public abstract class MixinTileEntityComparator extends TileEntity {
+public abstract class MixinTileEntityComparator extends MixinTileEntity {
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityDaylightDetector.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityDaylightDetector.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.server.gui.IUpdatePlayerListBox;
-import net.minecraft.tileentity.TileEntity;
 import org.spongepowered.api.block.data.DaylightDetector;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
@@ -35,6 +33,6 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Implements(@Interface(iface = DaylightDetector.class, prefix = "daylightdetector$"))
 @Mixin(net.minecraft.tileentity.TileEntityDaylightDetector.class)
-public abstract class MixinTileEntityDaylightDetector extends TileEntity implements IUpdatePlayerListBox {
+public abstract class MixinTileEntityDaylightDetector extends MixinTileEntity {
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityDispenser.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityDispenser.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.inventory.IInventory;
-import net.minecraft.tileentity.TileEntityLockable;
 import org.spongepowered.api.block.data.Dispenser;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
@@ -35,6 +33,6 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Implements(@Interface(iface = Dispenser.class, prefix = "dispenser$"))
 @Mixin(net.minecraft.tileentity.TileEntityDispenser.class)
-public abstract class MixinTileEntityDispenser extends TileEntityLockable implements IInventory {
+public abstract class MixinTileEntityDispenser extends MixinTileEntityLockable {
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityDropper.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityDropper.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.tileentity.TileEntityDispenser;
 import org.spongepowered.api.block.data.Dropper;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
@@ -34,6 +33,6 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Implements(@Interface(iface = Dropper.class, prefix = "dropper$"))
 @Mixin(net.minecraft.tileentity.TileEntityDropper.class)
-public abstract class MixinTileEntityDropper extends TileEntityDispenser {
+public abstract class MixinTileEntityDropper extends MixinTileEntityLockable {
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityEnchantmentTable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityEnchantmentTable.java
@@ -28,14 +28,26 @@ import net.minecraft.server.gui.IUpdatePlayerListBox;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IInteractionObject;
 import org.spongepowered.api.block.data.EnchantmentTable;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 
 @NonnullByDefault
 @Implements(@Interface(iface = EnchantmentTable.class, prefix = "enchanting$"))
 @Mixin(net.minecraft.tileentity.TileEntityEnchantmentTable.class)
-public abstract class MixinTileEntityEnchantmentTable extends TileEntity implements IUpdatePlayerListBox, IInteractionObject {
+public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity {
 
+    @Shadow
+    private String customName;
+
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = super.toContainer();
+        container.set(new DataQuery("CustomName"), this.customName);
+        return container;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityEndPortal.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityEndPortal.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.tileentity.TileEntity;
 import org.spongepowered.api.block.data.EndPortal;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
@@ -34,6 +33,6 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Implements(@Interface(iface = EndPortal.class, prefix = "endportal$"))
 @Mixin(net.minecraft.tileentity.TileEntityEndPortal.class)
-public abstract class MixinTileEntityEndPortal extends TileEntity {
+public abstract class MixinTileEntityEndPortal extends MixinTileEntity {
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityEnderChest.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityEnderChest.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.server.gui.IUpdatePlayerListBox;
-import net.minecraft.tileentity.TileEntity;
 import org.spongepowered.api.block.data.EnderChest;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
@@ -35,6 +33,6 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Implements(@Interface(iface = EnderChest.class, prefix = "enderchest$"))
 @Mixin(net.minecraft.tileentity.TileEntityEnderChest.class)
-public abstract class MixinTileEntityEnderChest extends TileEntity implements IUpdatePlayerListBox {
+public abstract class MixinTileEntityEnderChest extends MixinTileEntity {
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityFurnace.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityFurnace.java
@@ -44,6 +44,9 @@ public abstract class MixinTileEntityFurnace extends MixinTileEntityLockable {
     @Shadow
     public abstract void setField(int id, int value);
 
+    @Shadow
+    private String furnaceCustomName;
+
     public int furnace$getRemainingBurnTime() {
         return getField(0);
     }
@@ -66,6 +69,9 @@ public abstract class MixinTileEntityFurnace extends MixinTileEntityLockable {
         container.set(new DataQuery("BurnTime"), this.furnace$getRemainingBurnTime());
         container.set(new DataQuery("CookTime"), this.furnace$getRemainingCookTime());
         container.set(new DataQuery("CookTimeTotal"), this.getField(3));
+        if (this.furnaceCustomName != null) {
+            container.set(new DataQuery("CustomName"), this.furnaceCustomName);
+        }
         return container;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityFurnace.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityFurnace.java
@@ -24,10 +24,9 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.inventory.ISidedInventory;
-import net.minecraft.server.gui.IUpdatePlayerListBox;
-import net.minecraft.tileentity.TileEntityLockable;
 import org.spongepowered.api.block.data.Furnace;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -37,13 +36,11 @@ import org.spongepowered.asm.mixin.Shadow;
 @NonnullByDefault
 @Implements(@Interface(iface = Furnace.class, prefix = "furnace$"))
 @Mixin(net.minecraft.tileentity.TileEntityFurnace.class)
-public abstract class MixinTileEntityFurnace extends TileEntityLockable implements IUpdatePlayerListBox, ISidedInventory {
+public abstract class MixinTileEntityFurnace extends MixinTileEntityLockable {
 
-    @Override
     @Shadow
     public abstract int getField(int id);
 
-    @Override
     @Shadow
     public abstract void setField(int id, int value);
 
@@ -63,4 +60,12 @@ public abstract class MixinTileEntityFurnace extends TileEntityLockable implemen
         setField(2, getField(3) - time);
     }
 
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = super.toContainer();
+        container.set(new DataQuery("BurnTime"), this.furnace$getRemainingBurnTime());
+        container.set(new DataQuery("CookTime"), this.furnace$getRemainingCookTime());
+        container.set(new DataQuery("CookTimeTotal"), this.getField(3));
+        return container;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityHopper.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityHopper.java
@@ -24,10 +24,9 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.server.gui.IUpdatePlayerListBox;
-import net.minecraft.tileentity.IHopper;
-import net.minecraft.tileentity.TileEntityLockable;
 import org.spongepowered.api.block.data.Hopper;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -37,12 +36,23 @@ import org.spongepowered.asm.mixin.Shadow;
 @NonnullByDefault
 @Implements(@Interface(iface = Hopper.class, prefix = "hopper$"))
 @Mixin(net.minecraft.tileentity.TileEntityHopper.class)
-public abstract class MixinTileEntityHopper extends TileEntityLockable implements IHopper, IUpdatePlayerListBox {
+public abstract class MixinTileEntityHopper extends MixinTileEntityLockable {
 
     @Shadow
-    private int transferCooldown = -1;
+    private int transferCooldown;
 
     public int hopper$getTransferCooldown() {
         return this.transferCooldown;
+    }
+
+    public void hopper$setTransferCooldown(int time) {
+        this.transferCooldown = time;
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = super.toContainer();
+        container.set(new DataQuery("TransferCooldown"), this.transferCooldown);
+        return container;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityHopper.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityHopper.java
@@ -41,6 +41,9 @@ public abstract class MixinTileEntityHopper extends MixinTileEntityLockable {
     @Shadow
     private int transferCooldown;
 
+    @Shadow
+    private String customName;
+
     public int hopper$getTransferCooldown() {
         return this.transferCooldown;
     }
@@ -53,6 +56,9 @@ public abstract class MixinTileEntityHopper extends MixinTileEntityLockable {
     public DataContainer toContainer() {
         DataContainer container = super.toContainer();
         container.set(new DataQuery("TransferCooldown"), this.transferCooldown);
+        if (this.customName != null) {
+            container.set(new DataQuery("CustomName"), this.customName);
+        }
         return container;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityLockable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityLockable.java
@@ -24,11 +24,10 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.world.IInteractionObject;
-import net.minecraft.world.ILockableContainer;
 import net.minecraft.world.LockCode;
 import org.spongepowered.api.block.data.Lockable;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -38,7 +37,7 @@ import org.spongepowered.asm.mixin.Shadow;
 @NonnullByDefault
 @Implements(@Interface(iface = Lockable.class, prefix = "lockable$"))
 @Mixin(net.minecraft.tileentity.TileEntityLockable.class)
-public abstract class MixinTileEntityLockable extends TileEntity implements IInteractionObject, ILockableContainer {
+public abstract class MixinTileEntityLockable extends MixinTileEntity {
 
     @Shadow
     private LockCode code;
@@ -49,5 +48,14 @@ public abstract class MixinTileEntityLockable extends TileEntity implements IInt
 
     public void setLockToken(String token) {
         this.code = new LockCode(token);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = super.toContainer();
+        container.set(new DataQuery("Lock"), this.code.getLock());
+        // container.set(new DataQuery("Contents"), this.getInventory().toContainer());
+        // container.set(new DataQuery("CustomName"), this.getInventory().getName());
+        return container;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityLockable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityLockable.java
@@ -24,20 +24,27 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
+import com.google.common.collect.Lists;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
 import net.minecraft.world.LockCode;
 import org.spongepowered.api.block.data.Lockable;
 import org.spongepowered.api.service.persistence.data.DataContainer;
 import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.api.service.persistence.data.MemoryDataContainer;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
+import java.util.List;
+
 @NonnullByDefault
 @Implements(@Interface(iface = Lockable.class, prefix = "lockable$"))
 @Mixin(net.minecraft.tileentity.TileEntityLockable.class)
-public abstract class MixinTileEntityLockable extends MixinTileEntity {
+public abstract class MixinTileEntityLockable extends MixinTileEntity implements IInventory {
 
     @Shadow
     private LockCode code;
@@ -53,9 +60,20 @@ public abstract class MixinTileEntityLockable extends MixinTileEntity {
     @Override
     public DataContainer toContainer() {
         DataContainer container = super.toContainer();
-        container.set(new DataQuery("Lock"), this.code.getLock());
-        // container.set(new DataQuery("Contents"), this.getInventory().toContainer());
-        // container.set(new DataQuery("CustomName"), this.getInventory().getName());
+        if (this.code != null) {
+            container.set(new DataQuery("Lock"), this.code.getLock());
+        }
+        List<DataView> items = Lists.newArrayList();
+        for (int i = 0; i < getSizeInventory(); i++) {
+            ItemStack stack = getStackInSlot(i);
+            if (stack != null) {
+                DataContainer stackView = new MemoryDataContainer();
+                stackView.set(new DataQuery("Slot"), i);
+                stackView.set(new DataQuery("Item"), ((org.spongepowered.api.item.inventory.ItemStack) stack).toContainer());
+                items.add(stackView);
+            }
+        }
+        container.set(new DataQuery("Contents"), items);
         return container;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityMobSpawner.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityMobSpawner.java
@@ -24,12 +24,14 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.server.gui.IUpdatePlayerListBox;
+import com.google.common.collect.Lists;
 import net.minecraft.tileentity.MobSpawnerBaseLogic;
-import net.minecraft.tileentity.TileEntity;
 import org.spongepowered.api.block.data.MobSpawner;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.api.service.persistence.data.MemoryDataContainer;
 import org.spongepowered.api.util.WeightedRandomEntity;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
@@ -38,13 +40,14 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 import java.util.Collection;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
 @NonnullByDefault
 @Implements(@Interface(iface = MobSpawner.class, prefix = "mobspawner$"))
 @Mixin(net.minecraft.tileentity.TileEntityMobSpawner.class)
-public abstract class MixinTileEntityMobSpawner extends TileEntity implements IUpdatePlayerListBox {
+public abstract class MixinTileEntityMobSpawner extends MixinTileEntity {
 
     @Shadow
     public abstract MobSpawnerBaseLogic getSpawnerBaseLogic();
@@ -140,4 +143,24 @@ public abstract class MixinTileEntityMobSpawner extends TileEntity implements IU
         }
     }
 
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = super.toContainer();
+        container.set(new DataQuery("Delay"), this.mobspawner$getRemainingDelay());
+        container.set(new DataQuery("MinimumDelay"), this.mobspawner$getMinimumSpawnDelay());
+        container.set(new DataQuery("MaximumDelay"), this.mobspawner$getMaximumSpawnDelay());
+        container.set(new DataQuery("SpawnCount"), this.mobspawner$getSpawnCount());
+        container.set(new DataQuery("MaxNearbyEntities"), this.mobspawner$getMaximumNearbyEntities());
+        container.set(new DataQuery("RequiredPlayerRange"), this.mobspawner$getRequiredPlayerRange());
+        container.set(new DataQuery("SpawnRange"), this.mobspawner$getSpawnRange());
+        List<DataView> views = Lists.newArrayList();
+        for (WeightedRandomEntity entity : this.mobspawner$getPossibleEntitiesToSpawn()) {
+            DataContainer entityContainer = new MemoryDataContainer();
+            entityContainer.set(new DataQuery("EntityType"), entity.getEntityType().getId());
+            entityContainer.set(new DataQuery("Weight"), entity.getWeight());
+            entityContainer.set(new DataQuery("EntityData"), entity.getAdditionalProperties());
+        }
+        container.set(new DataQuery("WeightedEntities"), views);
+        return container;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityNote.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityNote.java
@@ -24,9 +24,10 @@
  */
 package org.spongepowered.mod.mixin.core.block.data;
 
-import net.minecraft.tileentity.TileEntity;
 import org.spongepowered.api.block.data.Note;
 import org.spongepowered.api.block.meta.NotePitch;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -39,7 +40,7 @@ import java.util.List;
 @NonnullByDefault
 @Implements(@Interface(iface = Note.class, prefix = "note$"))
 @Mixin(net.minecraft.tileentity.TileEntityNote.class)
-public abstract class MixinTileEntityNote extends TileEntity {
+public abstract class MixinTileEntityNote extends MixinTileEntity {
 
     @Shadow
     public byte note;
@@ -52,4 +53,10 @@ public abstract class MixinTileEntityNote extends TileEntity {
         this.note = pitch.getId();
     }
 
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = super.toContainer();
+        container.set(new DataQuery("Note"), this.note);
+        return container;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntitySign.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntitySign.java
@@ -27,9 +27,12 @@ package org.spongepowered.mod.mixin.core.block.data;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 
+import com.google.common.collect.Lists;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IChatComponent;
 import org.spongepowered.api.block.data.Sign;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
 import org.spongepowered.api.text.message.Message;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
@@ -38,10 +41,12 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.mod.text.message.SpongeMessage;
 
+import java.util.List;
+
 @NonnullByDefault
 @Implements(@Interface(iface = Sign.class, prefix = "sign$"))
 @Mixin(net.minecraft.tileentity.TileEntitySign.class)
-public abstract class MixinTileEntitySign extends TileEntity {
+public abstract class MixinTileEntitySign extends MixinTileEntity {
 
     @Shadow
     public IChatComponent[] signText;
@@ -70,4 +75,14 @@ public abstract class MixinTileEntitySign extends TileEntity {
         this.signText[index] = ((SpongeMessage) text).getHandle();
     }
 
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = super.toContainer();
+        List<String> lines = Lists.newArrayListWithExpectedSize(4);
+        for (Message message: this.sign$getLines()) {
+            lines.add(message.toLegacy());
+        }
+        container.set(new DataQuery("Lines"), lines);
+        return container;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntitySkull.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntitySkull.java
@@ -29,6 +29,9 @@ import net.minecraft.tileentity.TileEntity;
 import org.spongepowered.api.GameProfile;
 import org.spongepowered.api.block.data.Skull;
 import org.spongepowered.api.block.meta.SkullType;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
@@ -42,7 +45,7 @@ import java.util.List;
 @NonnullByDefault
 @Implements(@Interface(iface = Skull.class, prefix = "skull$"))
 @Mixin(net.minecraft.tileentity.TileEntitySkull.class)
-public abstract class MixinTileEntitySkull extends TileEntity {
+public abstract class MixinTileEntitySkull extends MixinTileEntity {
 
     @Shadow
     private int skullRotation;
@@ -84,4 +87,16 @@ public abstract class MixinTileEntitySkull extends TileEntity {
         setType(type.getId());
     }
 
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = super.toContainer();
+        container.set(new DataQuery("Type"), this.getSkullType());
+        container.set(new DataQuery("Rotation"), this.skull$getRotation().ordinal());
+        if (this.skull$getPlayer().isPresent()) {
+            DataView ownerView = container.createView(new DataQuery("Owner"));
+            ownerView.set(new DataQuery("UniqueId"), this.skull$getPlayer().get().getUniqueId().toString());
+            ownerView.set(new DataQuery("UserName"), this.skull$getPlayer().get().getName());
+        }
+        return container;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEnumDyeColor.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEnumDyeColor.java
@@ -24,9 +24,11 @@
  */
 package org.spongepowered.mod.mixin.core.entity.living.animal;
 
+import net.minecraft.item.EnumDyeColor;
 import org.spongepowered.api.entity.living.animal.DyeColor;
-import org.spongepowered.api.service.persistence.DataSource;
 import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.MemoryDataContainer;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -45,7 +47,10 @@ public class MixinEnumDyeColor implements DyeColor {
 
     @Override
     public DataContainer toContainer() {
-        // TODO Auto-generated method stub
-        return null;
+        DataContainer container = new MemoryDataContainer();
+        container.set(new DataQuery("name"), this.name);
+        container.set(new DataQuery("id"), ((EnumDyeColor) (Object) this).getDyeDamage());
+        return container;
     }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/inventory/MixinItemStack.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/inventory/MixinItemStack.java
@@ -152,8 +152,4 @@ public abstract class MixinItemStack implements ItemStack {
         throw new UnsupportedOperationException(); // TODO
     }
 
-    /*@Override
-    public void serialize(DataSource source) {
-        throw new UnsupportedOperationException(); // TODO
-    }*/
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/inventory/MixinItemStack.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/inventory/MixinItemStack.java
@@ -29,7 +29,6 @@ import net.minecraft.nbt.NBTTagList;
 import org.spongepowered.api.item.Enchantment;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
-import org.spongepowered.api.service.persistence.DataSource;
 import org.spongepowered.api.service.persistence.data.DataContainer;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
@@ -149,7 +148,7 @@ public abstract class MixinItemStack implements ItemStack {
 
     @Override
     public DataContainer toContainer() {
-        throw new UnsupportedOperationException(); // TODO
+        throw new UnsupportedOperationException(); // TODO Pending Items API merge
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/potion/MixinPotionEffect.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/potion/MixinPotionEffect.java
@@ -27,6 +27,9 @@ package org.spongepowered.mod.mixin.core.potion;
 import net.minecraft.potion.Potion;
 import org.spongepowered.api.potion.PotionEffect;
 import org.spongepowered.api.potion.PotionEffectType;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.MemoryDataContainer;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -93,5 +96,16 @@ public abstract class MixinPotionEffect implements PotionEffect {
     @Override
     public void setShowParticles(boolean showParticles) {
         this.showParticles = showParticles;
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = new MemoryDataContainer();
+        container.set(new DataQuery("PotionType"), Potion.potionTypes[getPotionID()].getName());
+        container.set(new DataQuery("Duration"), this.duration);
+        container.set(new DataQuery("Amplifier"), this.amplifier);
+        container.set(new DataQuery("Ambience"), this.isAmbient);
+        container.set(new DataQuery("ShowsParticles"), this.showParticles);
+        return container;
     }
 }

--- a/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
@@ -57,6 +57,7 @@ import net.minecraft.world.WorldProviderHell;
 import net.minecraft.world.WorldProviderSurface;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraftforge.fml.common.registry.GameData;
+import org.spongepowered.api.Game;
 import org.spongepowered.api.GameDictionary;
 import org.spongepowered.api.GameProfile;
 import org.spongepowered.api.GameRegistry;
@@ -66,6 +67,23 @@ import org.spongepowered.api.attribute.AttributeModifierBuilder;
 import org.spongepowered.api.attribute.Operation;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.block.data.Banner;
+import org.spongepowered.api.block.data.BrewingStand;
+import org.spongepowered.api.block.data.Chest;
+import org.spongepowered.api.block.data.CommandBlock;
+import org.spongepowered.api.block.data.Comparator;
+import org.spongepowered.api.block.data.DaylightDetector;
+import org.spongepowered.api.block.data.Dispenser;
+import org.spongepowered.api.block.data.Dropper;
+import org.spongepowered.api.block.data.EnchantmentTable;
+import org.spongepowered.api.block.data.EndPortal;
+import org.spongepowered.api.block.data.EnderChest;
+import org.spongepowered.api.block.data.Furnace;
+import org.spongepowered.api.block.data.Hopper;
+import org.spongepowered.api.block.data.MobSpawner;
+import org.spongepowered.api.block.data.Note;
+import org.spongepowered.api.block.data.Sign;
+import org.spongepowered.api.block.data.Skull;
 import org.spongepowered.api.block.meta.BannerPatternShape;
 import org.spongepowered.api.block.meta.BannerPatternShapes;
 import org.spongepowered.api.block.meta.NotePitch;
@@ -109,9 +127,11 @@ import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStackBuilder;
 import org.spongepowered.api.item.merchant.TradeOfferBuilder;
 import org.spongepowered.api.item.recipe.RecipeRegistry;
+import org.spongepowered.api.potion.PotionEffect;
 import org.spongepowered.api.potion.PotionEffectBuilder;
 import org.spongepowered.api.potion.PotionEffectType;
 import org.spongepowered.api.potion.PotionEffectTypes;
+import org.spongepowered.api.service.persistence.SerializationService;
 import org.spongepowered.api.status.Favicon;
 import org.spongepowered.api.text.action.SpongeTextActionFactory;
 import org.spongepowered.api.text.action.TextActions;
@@ -143,6 +163,7 @@ import org.spongepowered.api.world.difficulty.Difficulty;
 import org.spongepowered.api.world.gamerule.DefaultGameRules;
 import org.spongepowered.api.world.weather.Weather;
 import org.spongepowered.api.world.weather.Weathers;
+import org.spongepowered.mod.SpongeMod;
 import org.spongepowered.mod.block.meta.SpongeNotePitch;
 import org.spongepowered.mod.block.meta.SpongeSkullType;
 import org.spongepowered.mod.configuration.SpongeConfig;
@@ -159,6 +180,30 @@ import org.spongepowered.mod.item.SpongeItemStackBuilder;
 import org.spongepowered.mod.item.merchant.SpongeTradeOfferBuilder;
 import org.spongepowered.mod.potion.SpongePotionBuilder;
 import org.spongepowered.mod.rotation.SpongeRotation;
+import org.spongepowered.mod.service.persistence.builders.block.data.SpongePatternLayerBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeBannerBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeBrewingStandBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeChestBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeCommandBlockBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeComparatorBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeDaylightBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeDispenserBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeDropperBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeEnchantmentTableBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeEndPortalBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeEnderChestBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeFurnaceBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeHopperBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeMobSpawnerBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeNoteBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeSignBuilder;
+import org.spongepowered.mod.service.persistence.builders.block.tile.SpongeSkullBuilder;
+import org.spongepowered.mod.service.persistence.builders.data.SpongeDyeBuilder;
+import org.spongepowered.mod.service.persistence.builders.data.SpongeHorseColorBuilder;
+import org.spongepowered.mod.service.persistence.builders.data.SpongeHorseStyleBuilder;
+import org.spongepowered.mod.service.persistence.builders.data.SpongeHorseVariantBuilder;
+import org.spongepowered.mod.service.persistence.builders.data.SpongeOcelotTypeBuilder;
+import org.spongepowered.mod.service.persistence.builders.potion.SpongePotionEffectBuilder;
 import org.spongepowered.mod.status.SpongeFavicon;
 import org.spongepowered.mod.text.chat.SpongeChatType;
 import org.spongepowered.mod.text.format.SpongeTextColor;
@@ -1393,6 +1438,45 @@ public class SpongeGameRegistry implements GameRegistry {
 
     private void setDifficulties() {
         RegistryHelper.mapFields(Difficulties.class, difficultyMappings);
+    }
+
+    private void setupSerialization() {
+        Game game = SpongeMod.instance.getGame();
+        SerializationService service = game.getServiceManager().provide(SerializationService.class).get();
+        // TileEntities
+        service.registerBuilder(Banner.class, new SpongeBannerBuilder(game));
+        service.registerBuilder(Banner.PatternLayer.class, new SpongePatternLayerBuilder(game));
+        service.registerBuilder(BrewingStand.class, new SpongeBrewingStandBuilder(game));
+        service.registerBuilder(Chest.class, new SpongeChestBuilder(game));
+        service.registerBuilder(CommandBlock.class, new SpongeCommandBlockBuilder(game));
+        service.registerBuilder(Comparator.class, new SpongeComparatorBuilder(game));
+        service.registerBuilder(DaylightDetector.class, new SpongeDaylightBuilder(game));
+        service.registerBuilder(Dispenser.class, new SpongeDispenserBuilder(game));
+        service.registerBuilder(Dropper.class, new SpongeDropperBuilder(game));
+        service.registerBuilder(EnchantmentTable.class, new SpongeEnchantmentTableBuilder(game));
+        service.registerBuilder(EnderChest.class, new SpongeEnderChestBuilder(game));
+        service.registerBuilder(EndPortal.class, new SpongeEndPortalBuilder(game));
+        service.registerBuilder(Furnace.class, new SpongeFurnaceBuilder(game));
+        service.registerBuilder(Hopper.class, new SpongeHopperBuilder(game));
+        service.registerBuilder(MobSpawner.class, new SpongeMobSpawnerBuilder(game));
+        service.registerBuilder(Note.class, new SpongeNoteBuilder(game));
+        service.registerBuilder(Sign.class, new SpongeSignBuilder(game));
+        service.registerBuilder(Skull.class, new SpongeSkullBuilder(game));
+
+        // Meta
+        service.registerBuilder(DyeColor.class, new SpongeDyeBuilder());
+        service.registerBuilder(HorseColor.class, new SpongeHorseColorBuilder());
+        service.registerBuilder(HorseStyle.class, new SpongeHorseStyleBuilder());
+        service.registerBuilder(HorseVariant.class, new SpongeHorseVariantBuilder());
+        service.registerBuilder(OcelotType.class, new SpongeOcelotTypeBuilder());
+        service.registerBuilder(PotionEffect.class, new SpongePotionEffectBuilder());
+
+        // User
+        // TODO someone needs to write a User implementation...
+    }
+
+    public void preInit() {
+        setupSerialization();
     }
     
     public void init() {

--- a/src/main/java/org/spongepowered/mod/service/persistence/SpongeSerializationService.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/SpongeSerializationService.java
@@ -22,53 +22,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.entity;
 
-import com.google.common.base.MoreObjects;
-import org.spongepowered.api.service.persistence.DataSource;
-import org.spongepowered.api.service.persistence.data.DataContainer;
+package org.spongepowered.mod.service.persistence;
 
-public class SpongeEntityMeta {
+import static com.google.common.base.Preconditions.checkNotNull;
 
-    public final int type;
-    public final String name;
+import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
+import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.SerializationService;
 
-    public SpongeEntityMeta(int type, String name) {
-        this.type = type;
-        this.name = name;
-    }
+import java.util.Map;
 
-    public String getName() {
-        return this.name;
+public class SpongeSerializationService implements SerializationService {
+
+    private final Map<Class<?>, DataSerializableBuilder<?>> builders = Maps.newHashMap();
+
+
+    @Override
+    public <T extends DataSerializable> void registerBuilder(Class<T> clazz, DataSerializableBuilder<T> builder) {
+        checkNotNull(clazz);
+        checkNotNull(builder);
+        if (!this.builders.containsKey(clazz)) {
+            this.builders.put(clazz, builder);
+        }
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
+    @SuppressWarnings("unchecked")
+    public <T extends DataSerializable> Optional<DataSerializableBuilder<T>> getBuilder(Class<T> clazz) {
+        checkNotNull(clazz);
+        if (this.builders.containsKey(clazz)) {
+            return Optional.of((DataSerializableBuilder<T>) this.builders.get(clazz));
+        } else {
+            return Optional.absent();
         }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        SpongeEntityMeta other = (SpongeEntityMeta) obj;
-        if (this.type != other.type) {
-            return false;
-        } else if (this.name != other.name) {
-            return false;
-        }
-        return true;
-    }
-
-    public DataContainer toContainer() {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("type", this.type)
-                .add("name", this.name)
-                .toString();
     }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/SpongeSerializationService.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/SpongeSerializationService.java
@@ -26,24 +26,32 @@
 package org.spongepowered.mod.service.persistence;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import org.spongepowered.api.service.persistence.DataSerializable;
 import org.spongepowered.api.service.persistence.DataSerializableBuilder;
 import org.spongepowered.api.service.persistence.SerializationService;
+import org.spongepowered.mod.SpongeMod;
 
 import java.util.Map;
 
 public class SpongeSerializationService implements SerializationService {
 
     private final Map<Class<?>, DataSerializableBuilder<?>> builders = Maps.newHashMap();
+    private boolean registrationComplete = false;
 
+    public void completeRegistration() {
+        checkState(!registrationComplete);
+        this.registrationComplete = true;
+    }
 
     @Override
     public <T extends DataSerializable> void registerBuilder(Class<T> clazz, DataSerializableBuilder<T> builder) {
         checkNotNull(clazz);
         checkNotNull(builder);
+        checkState(!registrationComplete);
         if (!this.builders.containsKey(clazz)) {
             this.builders.put(clazz, builder);
         }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/data/SpongePatternLayerBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/data/SpongePatternLayerBuilder.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.service.persistence.builders.block.data;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Banner;
+import org.spongepowered.api.block.meta.BannerPatternShape;
+import org.spongepowered.api.entity.living.animal.DyeColor;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.SerializationService;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.mod.block.meta.SpongePatternLayer;
+
+public class SpongePatternLayerBuilder implements DataSerializableBuilder<Banner.PatternLayer> {
+
+    private final Game game;
+
+    public SpongePatternLayerBuilder(Game game) {
+        this.game = game;
+    }
+
+    @Override
+    public Optional<Banner.PatternLayer> build(final DataView container) throws InvalidDataException {
+        checkNotNull(container);
+        if (!container.contains(new DataQuery("id")) || !container.contains(new DataQuery("color"))) {
+            throw new InvalidDataException("The provided container does not contain the data to make a PatternLayer!");
+        }
+        String id = container.getString(new DataQuery("id")).get();
+        Optional<BannerPatternShape> shapeOptional = this.game.getRegistry().getBannerPatternShape(id);
+        if (!shapeOptional.isPresent()) {
+            throw new InvalidDataException("The provided container has an invalid banner pattern shape entry!");
+        }
+        SerializationService service = this.game.getServiceManager().provide(SerializationService.class).get();
+        Optional<DyeColor> colorOptional = container.getSerializable(new DataQuery("color"), DyeColor.class, service);
+        if (!colorOptional.isPresent()) {
+            throw new InvalidDataException("The provided container has an invalid dye color entry!");
+        }
+        return Optional.<Banner.PatternLayer>of(new SpongePatternLayer(shapeOptional.get(), colorOptional.get()));
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/data/package-info.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/data/package-info.java
@@ -22,53 +22,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.entity;
 
-import com.google.common.base.MoreObjects;
-import org.spongepowered.api.service.persistence.DataSource;
-import org.spongepowered.api.service.persistence.data.DataContainer;
-
-public class SpongeEntityMeta {
-
-    public final int type;
-    public final String name;
-
-    public SpongeEntityMeta(int type, String name) {
-        this.type = type;
-        this.name = name;
-    }
-
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        SpongeEntityMeta other = (SpongeEntityMeta) obj;
-        if (this.type != other.type) {
-            return false;
-        } else if (this.name != other.name) {
-            return false;
-        }
-        return true;
-    }
-
-    public DataContainer toContainer() {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("type", this.type)
-                .add("name", this.name)
-                .toString();
-    }
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.mod.service.persistence.builders.block.data;

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/AbstractTileBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/AbstractTileBuilder.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
+import net.minecraft.block.BlockJukebox;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityBanner;
+import net.minecraft.tileentity.TileEntityBeacon;
+import net.minecraft.tileentity.TileEntityBrewingStand;
+import net.minecraft.tileentity.TileEntityChest;
+import net.minecraft.tileentity.TileEntityCommandBlock;
+import net.minecraft.tileentity.TileEntityComparator;
+import net.minecraft.tileentity.TileEntityDaylightDetector;
+import net.minecraft.tileentity.TileEntityDispenser;
+import net.minecraft.tileentity.TileEntityDropper;
+import net.minecraft.tileentity.TileEntityEnchantmentTable;
+import net.minecraft.tileentity.TileEntityEndPortal;
+import net.minecraft.tileentity.TileEntityEnderChest;
+import net.minecraft.tileentity.TileEntityFlowerPot;
+import net.minecraft.tileentity.TileEntityFurnace;
+import net.minecraft.tileentity.TileEntityHopper;
+import net.minecraft.tileentity.TileEntityMobSpawner;
+import net.minecraft.tileentity.TileEntityNote;
+import net.minecraft.tileentity.TileEntityPiston;
+import net.minecraft.tileentity.TileEntitySign;
+import net.minecraft.tileentity.TileEntitySkull;
+import net.minecraft.util.BlockPos;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.service.persistence.DataSerializable;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.api.world.World;
+
+import java.util.Map;
+
+public abstract class AbstractTileBuilder<T extends org.spongepowered.api.block.data.TileEntity & DataSerializable> implements DataSerializableBuilder<T> {
+
+    private static final Map<Class<? extends TileEntity>, BlockType> classToTypeMap = Maps.newHashMap();
+
+    protected final Game game;
+
+    protected AbstractTileBuilder(Game game) {
+        this.game = game;
+    }
+
+    static {
+        // These are our known block types. We need to find a way to support the mod ones
+        addBlockMapping(TileEntityDropper.class, BlockTypes.DROPPER);
+        addBlockMapping(TileEntityChest.class, BlockTypes.CHEST);
+        addBlockMapping(TileEntityEnderChest.class, BlockTypes.ENDER_CHEST);
+        addBlockMapping(BlockJukebox.TileEntityJukebox.class, BlockTypes.JUKEBOX);
+        addBlockMapping(TileEntityDispenser.class, BlockTypes.DISPENSER);
+        addBlockMapping(TileEntityDropper.class, BlockTypes.DROPPER);
+        addBlockMapping(TileEntitySign.class, BlockTypes.STANDING_SIGN);
+        addBlockMapping(TileEntityMobSpawner.class, BlockTypes.MOB_SPAWNER);
+        addBlockMapping(TileEntityNote.class, BlockTypes.NOTEBLOCK);
+        addBlockMapping(TileEntityPiston.class, BlockTypes.PISTON);
+        addBlockMapping(TileEntityFurnace.class, BlockTypes.FURNACE);
+        addBlockMapping(TileEntityBrewingStand.class, BlockTypes.BREWING_STAND);
+        addBlockMapping(TileEntityEnchantmentTable.class, BlockTypes.ENCHANTING_TABLE);
+        addBlockMapping(TileEntityEndPortal.class, BlockTypes.END_PORTAL);
+        addBlockMapping(TileEntityCommandBlock.class, BlockTypes.COMMAND_BLOCK);
+        addBlockMapping(TileEntityBeacon.class, BlockTypes.BEACON);
+        addBlockMapping(TileEntitySkull.class, BlockTypes.SKULL);
+        addBlockMapping(TileEntityDaylightDetector.class, BlockTypes.DAYLIGHT_DETECTOR);
+        addBlockMapping(TileEntityHopper.class, BlockTypes.HOPPER);
+        addBlockMapping(TileEntityComparator.class, BlockTypes.UNPOWERED_COMPARATOR);
+        addBlockMapping(TileEntityFlowerPot.class, BlockTypes.FLOWER_POT);
+        addBlockMapping(TileEntityBanner.class, BlockTypes.STANDING_BANNER);
+    }
+
+    private static void addBlockMapping(Class<? extends TileEntity> tileClass, BlockType blocktype) {
+        classToTypeMap.put(tileClass, blocktype);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<T> build(DataView container) throws InvalidDataException {
+        checkNotNull(container);
+        DataQuery worldQuery = new DataQuery("world");
+        DataQuery xPosQuery = new DataQuery("x");
+        DataQuery yPosQuery = new DataQuery("y");
+        DataQuery zPosQuery = new DataQuery("z");
+        DataQuery tileTypeQuery = new DataQuery("tileType");
+        if (!container.contains(tileTypeQuery) || !container.contains(worldQuery) || !container.contains(xPosQuery) || !container.contains(yPosQuery)
+            || !container.contains(zPosQuery)) {
+            throw new InvalidDataException("The provided container does not contain the data to make a TileEntity!");
+        }
+        String worldName = container.getString(worldQuery).get();
+        Optional<World> worldOptional = this.game.getServer().get().getWorld(worldName);
+        if (!worldOptional.isPresent()) {
+            throw new InvalidDataException("The provided container references a world that does not exist!");
+        }
+        int x = container.getInt(xPosQuery).get();
+        int y = container.getInt(yPosQuery).get();
+        int z = container.getInt(zPosQuery).get();
+        // TODO find a better way to do this... Hopefully with API PR #475
+        Class<? extends TileEntity> clazz = (Class<? extends TileEntity>) TileEntity.nameToClassMap.get(container.getString(tileTypeQuery).get());
+        if (clazz == null) {
+            return Optional.absent(); // TODO throw exception maybe?
+        }
+        BlockType type = classToTypeMap.get(clazz);
+        if (type == null) {
+            return Optional.absent(); // TODO throw exception maybe?
+        }
+        // Now we should be ready to actually deserialize the TileEntity with the right block.
+        worldOptional.get().getFullBlock(x, y, z).replaceWith(type);
+        BlockPos pos = new BlockPos(x, y, z);
+        TileEntity tileEntity = ((net.minecraft.world.World) worldOptional.get()).getTileEntity(pos);
+        if (tileEntity == null) {
+            return Optional.absent(); // TODO throw exception maybe?
+        } else {
+            // We really need to validate only after the implementing class deems it ready...
+            tileEntity.invalidate();
+            return Optional.of((T) tileEntity);
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBannerBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBannerBuilder.java
@@ -25,10 +25,7 @@
 
 package org.spongepowered.mod.service.persistence.builders.block.tile;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.Optional;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityBanner;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.block.data.Banner;
@@ -63,9 +60,9 @@ public class SpongeBannerBuilder extends AbstractTileBuilder<Banner> {
             throw new InvalidDataException("The provided container has an invalid dye color entry!");
         }
         banner.setBaseColor(colorOptional.get());
-        List<DataView> patternsList = (List<DataView>) container.getList(new DataQuery("Patterns")).get();
-        for (DataView pattern : patternsList) {
-            banner.addPatternLayer(service.getBuilder(Banner.PatternLayer.class).get().build(pattern).get());
+        List<Banner.PatternLayer> patternsList = container.getSerializableList(new DataQuery("Patterns"), Banner.PatternLayer.class, service).get();
+        for (Banner.PatternLayer pattern : patternsList) {
+            banner.addPatternLayer(pattern);
         }
         ((TileEntityBanner) banner).validate();
         return Optional.of(banner);

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBannerBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBannerBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityBanner;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Banner;
+import org.spongepowered.api.entity.living.animal.DyeColor;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.SerializationService;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+
+import java.util.List;
+
+public class SpongeBannerBuilder extends AbstractTileBuilder<Banner> {
+
+    public SpongeBannerBuilder(Game game) {
+        super(game);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<Banner> build(DataView container) throws InvalidDataException {
+        Optional<Banner> bannerOptional = super.build(container);
+        if (!bannerOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a Banner tile entity!");
+        }
+        Banner banner = bannerOptional.get();
+        if (!container.contains(new DataQuery("Base")) || !container.contains(new DataQuery("Patterns"))) {
+            throw new InvalidDataException("The provided container does not contain the data to make a Banner!");
+        }
+        SerializationService service = this.game.getServiceManager().provide(SerializationService.class).get();
+        Optional<DyeColor> colorOptional = container.getSerializable(new DataQuery("color"), DyeColor.class, service);
+        if (!colorOptional.isPresent()) {
+            throw new InvalidDataException("The provided container has an invalid dye color entry!");
+        }
+        banner.setBaseColor(colorOptional.get());
+        List<DataView> patternsList = (List<DataView>) container.getList(new DataQuery("Patterns")).get();
+        for (DataView pattern : patternsList) {
+            banner.addPatternLayer(service.getBuilder(Banner.PatternLayer.class).get().build(pattern).get());
+        }
+        ((TileEntityBanner) banner).validate();
+        return Optional.of(banner);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBeaconBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBeaconBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.potion.Potion;
+import net.minecraft.tileentity.TileEntityBeacon;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Beacon;
+import org.spongepowered.api.potion.PotionEffectType;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+
+public class SpongeBeaconBuilder extends SpongeLockableBuilder<Beacon> {
+
+    public SpongeBeaconBuilder(Game game) {
+        super(game);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<Beacon> build(DataView container) throws InvalidDataException {
+        Optional<Beacon> beaconOptional = super.build(container);
+        if (!beaconOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a Banner tile entity!");
+        }
+        Beacon beacon = beaconOptional.get();
+        if (!container.contains(new DataQuery("effect1")) || !container.contains(new DataQuery("effect2"))) {
+            throw new InvalidDataException("The provided container does not contain the data to make a Banner!");
+        }
+        beacon.setPrimaryEffect((PotionEffectType) Potion.potionTypes[container.getInt(new DataQuery("effect1")).get()]);
+        beacon.setSecondaryEffect((PotionEffectType) Potion.potionTypes[container.getInt(new DataQuery("effect2")).get()]);
+        ((TileEntityBeacon) beacon).validate();
+        return Optional.of(beacon);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBrewingStandBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBrewingStandBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityBeacon;
+import net.minecraft.tileentity.TileEntityBrewingStand;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.BrewingStand;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+
+public class SpongeBrewingStandBuilder extends SpongeLockableBuilder<BrewingStand> {
+
+    public SpongeBrewingStandBuilder(Game game) {
+        super(game);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<BrewingStand> build(DataView container) throws InvalidDataException {
+        Optional<BrewingStand> beaconOptional = super.build(container);
+        if (!beaconOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a Banner tile entity!");
+        }
+        BrewingStand beacon = beaconOptional.get();
+        if (!container.contains(new DataQuery("BrewTime"))) {
+            throw new InvalidDataException("The provided container does not contain the data to make a Banner!");
+        }
+        if (container.contains(new DataQuery("CustomName"))) {
+            ((TileEntityBeacon) beacon).setName(container.getString(new DataQuery("CustomName")).get());
+        }
+        beacon.setRemainingBrewTime(container.getInt(new DataQuery("BrewTime")).get());
+        ((TileEntityBrewingStand) beacon).validate();
+        return Optional.of(beacon);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeChestBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeChestBuilder.java
@@ -22,29 +22,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.block.data;
 
-import org.spongepowered.api.block.data.EnchantmentTable;
-import org.spongepowered.api.service.persistence.data.DataContainer;
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityChest;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Chest;
+import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.api.service.persistence.data.DataQuery;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.api.service.persistence.data.DataView;
 
-@NonnullByDefault
-@Implements(@Interface(iface = EnchantmentTable.class, prefix = "enchanting$"))
-@Mixin(net.minecraft.tileentity.TileEntityEnchantmentTable.class)
-public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity {
+public class SpongeChestBuilder extends SpongeLockableBuilder<Chest> {
 
-    @Shadow
-    private String customName;
+    public SpongeChestBuilder(Game game) {
+        super(game);
+    }
 
     @Override
-    public DataContainer toContainer() {
-        DataContainer container = super.toContainer();
-        container.set(new DataQuery("CustomName"), this.customName);
-        return container;
+    @SuppressWarnings("unchecked")
+    public Optional<Chest> build(DataView container) throws InvalidDataException {
+        Optional<Chest> chestOptional = super.build(container);
+        if (!chestOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a Banner tile entity!");
+        }
+        Chest chest = chestOptional.get();
+        if (container.contains(new DataQuery("CustomName"))) {
+            ((TileEntityChest) chest).setCustomName(container.getString(new DataQuery("CustomName")).get());
+        }
+        ((TileEntityChest) chest).validate();
+        return Optional.of(chest);
     }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeCommandBlockBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeCommandBlockBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityCommandBlock;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.CommandBlock;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.api.text.message.Messages;
+
+public class SpongeCommandBlockBuilder extends AbstractTileBuilder<CommandBlock> {
+
+    public SpongeCommandBlockBuilder(Game game) {
+        super(game);
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "deprecation"})
+    public Optional<CommandBlock> build(DataView container) throws InvalidDataException {
+        Optional<CommandBlock> commandblockOptional = super.build(container);
+        if (!commandblockOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a CommandBlock tile entity!");
+        }
+        CommandBlock commandblock = commandblockOptional.get();
+        if (!container.contains(new DataQuery("StoredCommand")) || !container.contains(new DataQuery("SuccessCount")) || !container.contains(new DataQuery("DoesTrackOutput"))) {
+            throw new InvalidDataException("The provided container does not contain the data to make a CommandBlock!");
+        }
+        commandblock.setStoredCommand(container.getString(new DataQuery("StoredCommand")).get());
+        commandblock.setSuccessCount(container.getInt(new DataQuery("SuccessCount")).get());
+        commandblock.shouldTrackOutput(container.getBoolean(new DataQuery("DoesTrackOutput")).get());
+        if (commandblock.doesTrackOutput()) {
+            commandblock.setLastOutput(Messages.fromLegacy(container.getString(new DataQuery("TrackedOutput")).get()));
+        }
+        ((TileEntityCommandBlock) commandblock).validate();
+        return Optional.of(commandblock);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeComparatorBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeComparatorBuilder.java
@@ -22,29 +22,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.block.data;
 
-import org.spongepowered.api.block.data.EnchantmentTable;
-import org.spongepowered.api.service.persistence.data.DataContainer;
-import org.spongepowered.api.service.persistence.data.DataQuery;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+package org.spongepowered.mod.service.persistence.builders.block.tile;
 
-@NonnullByDefault
-@Implements(@Interface(iface = EnchantmentTable.class, prefix = "enchanting$"))
-@Mixin(net.minecraft.tileentity.TileEntityEnchantmentTable.class)
-public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity {
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityComparator;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Comparator;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataView;
 
-    @Shadow
-    private String customName;
+public class SpongeComparatorBuilder extends AbstractTileBuilder<Comparator> {
+
+    public SpongeComparatorBuilder(Game game) {
+        super(game);
+    }
 
     @Override
-    public DataContainer toContainer() {
-        DataContainer container = super.toContainer();
-        container.set(new DataQuery("CustomName"), this.customName);
-        return container;
+    @SuppressWarnings("unchecked")
+    public Optional<Comparator> build(DataView container) throws InvalidDataException {
+        Optional<Comparator> comparatorOptional = super.build(container);
+        if (!comparatorOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a Banner tile entity!");
+        }
+        ((TileEntityComparator) comparatorOptional.get()).validate();
+        return Optional.of(comparatorOptional.get());
     }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeDaylightBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeDaylightBuilder.java
@@ -23,5 +23,29 @@
  * THE SOFTWARE.
  */
 
-@org.spongepowered.api.util.annotation.NonnullByDefault
-package org.spongepowered.mod.service.persistence;
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityDaylightDetector;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.DaylightDetector;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataView;
+
+public class SpongeDaylightBuilder extends AbstractTileBuilder<DaylightDetector> {
+
+    public SpongeDaylightBuilder(Game game) {
+        super(game);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<DaylightDetector> build(DataView container) throws InvalidDataException {
+        Optional<DaylightDetector> daylightdetectorOptional = super.build(container);
+        if (!daylightdetectorOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a DaylightDetector tile entity!");
+        }
+        ((TileEntityDaylightDetector) daylightdetectorOptional.get()).validate();
+        return Optional.of(daylightdetectorOptional.get());
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeDispenserBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeDispenserBuilder.java
@@ -23,5 +23,34 @@
  * THE SOFTWARE.
  */
 
-@org.spongepowered.api.util.annotation.NonnullByDefault
 package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityDispenser;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Dispenser;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+
+public class SpongeDispenserBuilder extends SpongeLockableBuilder<Dispenser> {
+
+    public SpongeDispenserBuilder(Game game) {
+        super(game);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<Dispenser> build(DataView container) throws InvalidDataException {
+        Optional<Dispenser> dispenserOptional = super.build(container);
+        if (!dispenserOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a Dispenser tile entity!");
+        }
+        Dispenser dispenser = dispenserOptional.get();
+        if (container.contains(new DataQuery("CustomName"))) {
+            ((TileEntityDispenser) dispenser).setCustomName(container.getString(new DataQuery("CustomName")).get());
+        }
+        ((TileEntityDispenser) dispenser).validate();
+        return Optional.of(dispenser);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeDropperBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeDropperBuilder.java
@@ -22,29 +22,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.block.data;
 
-import org.spongepowered.api.block.data.EnchantmentTable;
-import org.spongepowered.api.service.persistence.data.DataContainer;
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityDropper;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Dropper;
+import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.api.service.persistence.data.DataQuery;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.api.service.persistence.data.DataView;
 
-@NonnullByDefault
-@Implements(@Interface(iface = EnchantmentTable.class, prefix = "enchanting$"))
-@Mixin(net.minecraft.tileentity.TileEntityEnchantmentTable.class)
-public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity {
+public class SpongeDropperBuilder extends SpongeLockableBuilder<Dropper> {
 
-    @Shadow
-    private String customName;
+    public SpongeDropperBuilder(Game game) {
+        super(game);
+    }
 
     @Override
-    public DataContainer toContainer() {
-        DataContainer container = super.toContainer();
-        container.set(new DataQuery("CustomName"), this.customName);
-        return container;
+    @SuppressWarnings("unchecked")
+    public Optional<Dropper> build(DataView container) throws InvalidDataException {
+        Optional<Dropper> dropperOptional = super.build(container);
+        if (!dropperOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a Dropper tile entity!");
+        }
+        Dropper dropper = dropperOptional.get();
+        if (container.contains(new DataQuery("CustomName"))) {
+            ((TileEntityDropper) dropper).setCustomName(container.getString(new DataQuery("CustomName")).get());
+        }
+        ((TileEntityDropper) dropper).validate();
+        return Optional.of(dropper);
     }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeEnchantmentTableBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeEnchantmentTableBuilder.java
@@ -22,29 +22,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.block.data;
 
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityEnchantmentTable;
+import org.spongepowered.api.Game;
 import org.spongepowered.api.block.data.EnchantmentTable;
-import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.api.service.persistence.data.DataQuery;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.api.service.persistence.data.DataView;
 
-@NonnullByDefault
-@Implements(@Interface(iface = EnchantmentTable.class, prefix = "enchanting$"))
-@Mixin(net.minecraft.tileentity.TileEntityEnchantmentTable.class)
-public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity {
+public class SpongeEnchantmentTableBuilder extends AbstractTileBuilder<EnchantmentTable> {
 
-    @Shadow
-    private String customName;
+    public SpongeEnchantmentTableBuilder(Game game) {
+        super(game);
+    }
 
     @Override
-    public DataContainer toContainer() {
-        DataContainer container = super.toContainer();
-        container.set(new DataQuery("CustomName"), this.customName);
-        return container;
+    @SuppressWarnings("unchecked")
+    public Optional<EnchantmentTable> build(DataView container) throws InvalidDataException {
+        Optional<EnchantmentTable> enchantmenttableOptional = super.build(container);
+        if (!enchantmenttableOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a EnchantmentTable tile entity!");
+        }
+        EnchantmentTable enchantmenttable = enchantmenttableOptional.get();
+        if (container.contains(new DataQuery("CustomName"))) {
+            ((TileEntityEnchantmentTable) enchantmenttable).setCustomName(container.getString(new DataQuery("CustomName")).get());
+        }
+        ((TileEntityEnchantmentTable) enchantmenttable).validate();
+        return Optional.of(enchantmenttable);
     }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeEndPortalBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeEndPortalBuilder.java
@@ -23,5 +23,29 @@
  * THE SOFTWARE.
  */
 
-@org.spongepowered.api.util.annotation.NonnullByDefault
-package org.spongepowered.mod.service.persistence.builders.block.data;
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityEndPortal;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.EndPortal;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataView;
+
+public class SpongeEndPortalBuilder extends AbstractTileBuilder<EndPortal> {
+
+    public SpongeEndPortalBuilder(Game game) {
+        super(game);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<EndPortal> build(DataView container) throws InvalidDataException {
+        Optional<EndPortal> endportalOptional = super.build(container);
+        if (!endportalOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a EndPortal tile entity!");
+        }
+        ((TileEntityEndPortal) endportalOptional.get()).validate();
+        return Optional.of(endportalOptional.get());
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeEnderChestBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeEnderChestBuilder.java
@@ -22,29 +22,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.block.data;
 
-import org.spongepowered.api.block.data.EnchantmentTable;
-import org.spongepowered.api.service.persistence.data.DataContainer;
-import org.spongepowered.api.service.persistence.data.DataQuery;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+package org.spongepowered.mod.service.persistence.builders.block.tile;
 
-@NonnullByDefault
-@Implements(@Interface(iface = EnchantmentTable.class, prefix = "enchanting$"))
-@Mixin(net.minecraft.tileentity.TileEntityEnchantmentTable.class)
-public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity {
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityEnderChest;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.EnderChest;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataView;
 
-    @Shadow
-    private String customName;
+public class SpongeEnderChestBuilder extends AbstractTileBuilder<EnderChest> {
+
+    public SpongeEnderChestBuilder(Game game) {
+        super(game);
+    }
 
     @Override
-    public DataContainer toContainer() {
-        DataContainer container = super.toContainer();
-        container.set(new DataQuery("CustomName"), this.customName);
-        return container;
+    @SuppressWarnings("unchecked")
+    public Optional<EnderChest> build(DataView container) throws InvalidDataException {
+        Optional<EnderChest> enderchestOptional = super.build(container);
+        if (!enderchestOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a EnderChest tile entity!");
+        }
+        ((TileEntityEnderChest) enderchestOptional.get()).validate();
+        return Optional.of(enderchestOptional.get());
     }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeFurnaceBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeFurnaceBuilder.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityFurnace;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Furnace;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+
+public class SpongeFurnaceBuilder extends SpongeLockableBuilder<Furnace> {
+
+    public SpongeFurnaceBuilder(Game game) {
+        super(game);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<Furnace> build(DataView container) throws InvalidDataException {
+        Optional<Furnace> furnaceOptional = super.build(container);
+        if (!furnaceOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a Banner tile entity!");
+        }
+        Furnace furnace = furnaceOptional.get();
+        if (container.contains(new DataQuery("CustomName"))) {
+            ((TileEntityFurnace) furnace).setCustomInventoryName(container.getString(new DataQuery("CustomName")).get());
+        }
+        if (!container.contains(new DataQuery("BurnTime")) || !container.contains(new DataQuery("CookTime")) || !container.contains(new DataQuery("CookTimeTotal"))) {
+            throw new InvalidDataException("The provided container does not contain the data to make a Hopper!");
+        }
+        furnace.setRemainingBurnTime(container.getInt(new DataQuery("BurnTime")).get());
+        furnace.setRemainingCookTime(container.getInt(new DataQuery("CookTime")).get());
+        ((TileEntityFurnace) furnace).setField(3, container.getInt(new DataQuery("CookTimeTotal")).get());
+        ((TileEntityFurnace) furnace).validate();
+        return Optional.of(furnace);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeHopperBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeHopperBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityHopper;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Hopper;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+
+public class SpongeHopperBuilder extends SpongeLockableBuilder<Hopper> {
+
+    public SpongeHopperBuilder(Game game) {
+        super(game);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<Hopper> build(DataView container) throws InvalidDataException {
+        Optional<Hopper> hopperOptional = super.build(container);
+        if (!hopperOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a Hopper tile entity!");
+        }
+        Hopper hopper = hopperOptional.get();
+        if (container.contains(new DataQuery("CustomName"))) {
+            ((TileEntityHopper) hopper).setCustomName(container.getString(new DataQuery("CustomName")).get());
+        }
+        if (!container.contains(new DataQuery("TransferCooldown"))) {
+            throw new InvalidDataException("The provided container does not contain the data to make a Hopper!");
+        }
+        hopper.setTransferCooldown(container.getInt(new DataQuery("TransferCooldown")).get());
+        ((TileEntityHopper) hopper).validate();
+        return Optional.of(hopper);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeLockableBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeLockableBuilder.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.inventory.IInventory;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Lockable;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.SerializationService;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+
+import java.util.List;
+
+public class SpongeLockableBuilder<T extends Lockable> extends AbstractTileBuilder<T> {
+
+    public SpongeLockableBuilder(Game game) {
+        super(game);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<T> build(DataView container) throws InvalidDataException {
+        Optional<T> lockOptional = super.build(container);
+        if (!lockOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a lockable tile entity!");
+        }
+        Lockable lockable = lockOptional.get();
+        if (!container.contains(new DataQuery("Contents"))) {
+            throw new InvalidDataException("The provided container does not contain the data to make a lockable tile entity!");
+        }
+        SerializationService service = this.game.getServiceManager().provide(SerializationService.class).get();
+        List<DataView> contents = container.getViewList(new DataQuery("Contents")).get();
+        for (DataView content: contents) {
+            net.minecraft.item.ItemStack stack = (net.minecraft.item.ItemStack) content.getSerializable(new DataQuery("Item"), ItemStack.class, service).get();
+            ((IInventory) lockable).setInventorySlotContents(content.getInt(new DataQuery("Slot")).get(), stack);
+        }
+        if (container.contains(new DataQuery("Lock"))) {
+            lockable.setLockToken(container.getString(new DataQuery("Lock")).get());
+        }
+        return Optional.of((T) lockable);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeMobSpawnerBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeMobSpawnerBuilder.java
@@ -22,29 +22,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.block.data;
 
-import org.spongepowered.api.block.data.EnchantmentTable;
-import org.spongepowered.api.service.persistence.data.DataContainer;
-import org.spongepowered.api.service.persistence.data.DataQuery;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+package org.spongepowered.mod.service.persistence.builders.block.tile;
 
-@NonnullByDefault
-@Implements(@Interface(iface = EnchantmentTable.class, prefix = "enchanting$"))
-@Mixin(net.minecraft.tileentity.TileEntityEnchantmentTable.class)
-public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity {
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityMobSpawner;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.MobSpawner;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataView;
 
-    @Shadow
-    private String customName;
+public class SpongeMobSpawnerBuilder extends AbstractTileBuilder<MobSpawner> {
+
+    public SpongeMobSpawnerBuilder(Game game) {
+        super(game);
+    }
 
     @Override
-    public DataContainer toContainer() {
-        DataContainer container = super.toContainer();
-        container.set(new DataQuery("CustomName"), this.customName);
-        return container;
+    @SuppressWarnings("unchecked")
+    public Optional<MobSpawner> build(DataView container) throws InvalidDataException {
+        Optional<MobSpawner> mobspawnerOptional = super.build(container);
+        if (!mobspawnerOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a MobSpawner tile entity!");
+        }
+        // TODO Actually figure out how to handle creating weighted entities
+
+        ((TileEntityMobSpawner) mobspawnerOptional.get()).validate();
+        return Optional.of(mobspawnerOptional.get());
     }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeNoteBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeNoteBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntityNote;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Note;
+import org.spongepowered.api.block.meta.NotePitch;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+
+import java.util.List;
+
+public class SpongeNoteBuilder extends AbstractTileBuilder<Note> {
+
+    public SpongeNoteBuilder(Game game) {
+        super(game);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Optional<Note> build(DataView container) throws InvalidDataException {
+        Optional<Note> noteOptional = super.build(container);
+        if (!noteOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a Note tile entity!");
+        }
+        if (!container.contains(new DataQuery("Note"))) {
+            throw new InvalidDataException("The container had insufficient data to create a Note tile entity!");
+        }
+        Note note = noteOptional.get();
+        NotePitch pitch = ((List<NotePitch>) this.game.getRegistry().getNotePitches()).get(container.getInt(new DataQuery("Note")).get());
+        note.setNote(pitch);
+        ((TileEntityNote) note).validate();
+        return Optional.of(note);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeSignBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeSignBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntitySign;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Sign;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.api.text.message.Messages;
+
+public class SpongeSignBuilder extends AbstractTileBuilder<Sign> {
+
+    public SpongeSignBuilder(Game game) {
+        super(game);
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "deprecation"})
+    public Optional<Sign> build(DataView container) throws InvalidDataException {
+        Optional<Sign> signOptional = super.build(container);
+        if (!signOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a Sign tile entity!");
+        }
+        if (!container.contains(new DataQuery("Lines"))) {
+            throw new InvalidDataException("The container had insufficient data to create a Sign tile entity!");
+        }
+        Sign sign = signOptional.get();
+        int i = 0;
+        for (String message : container.getStringList(new DataQuery("Lines")).get()) {
+            sign.setLine(i++, Messages.fromLegacy(message));
+        }
+        ((TileEntitySign) sign).validate();
+        return Optional.of(sign);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeSkullBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeSkullBuilder.java
@@ -22,29 +22,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.block.data;
 
-import org.spongepowered.api.block.data.EnchantmentTable;
-import org.spongepowered.api.service.persistence.data.DataContainer;
+package org.spongepowered.mod.service.persistence.builders.block.tile;
+
+import com.google.common.base.Optional;
+import net.minecraft.tileentity.TileEntitySkull;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.block.data.Skull;
+import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.api.service.persistence.data.DataQuery;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.api.service.persistence.data.DataView;
 
-@NonnullByDefault
-@Implements(@Interface(iface = EnchantmentTable.class, prefix = "enchanting$"))
-@Mixin(net.minecraft.tileentity.TileEntityEnchantmentTable.class)
-public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity {
+public class SpongeSkullBuilder extends AbstractTileBuilder<Skull> {
 
-    @Shadow
-    private String customName;
+    public SpongeSkullBuilder(Game game) {
+        super(game);
+    }
 
     @Override
-    public DataContainer toContainer() {
-        DataContainer container = super.toContainer();
-        container.set(new DataQuery("CustomName"), this.customName);
-        return container;
+    @SuppressWarnings("unchecked")
+    public Optional<Skull> build(DataView container) throws InvalidDataException {
+        Optional<Skull> skullOptional = super.build(container);
+        if (!skullOptional.isPresent()) {
+            throw new InvalidDataException("The container had insufficient data to create a Skull tile entity!");
+        }
+        if (!container.contains(new DataQuery("Type")) || container.contains(new DataQuery("Rotation"))) {
+            throw new InvalidDataException("The container had insufficient data to create a Skull tile entity!");
+        }
+        Skull skull = skullOptional.get();
+        ((TileEntitySkull) skull).validate();
+        return Optional.of(skull);
     }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/package-info.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/package-info.java
@@ -22,53 +22,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.entity;
 
-import com.google.common.base.MoreObjects;
-import org.spongepowered.api.service.persistence.DataSource;
-import org.spongepowered.api.service.persistence.data.DataContainer;
-
-public class SpongeEntityMeta {
-
-    public final int type;
-    public final String name;
-
-    public SpongeEntityMeta(int type, String name) {
-        this.type = type;
-        this.name = name;
-    }
-
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        SpongeEntityMeta other = (SpongeEntityMeta) obj;
-        if (this.type != other.type) {
-            return false;
-        } else if (this.name != other.name) {
-            return false;
-        }
-        return true;
-    }
-
-    public DataContainer toContainer() {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("type", this.type)
-                .add("name", this.name)
-                .toString();
-    }
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.mod.service.persistence.builders.block.tile;

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeDyeBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeDyeBuilder.java
@@ -22,53 +22,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.entity;
 
-import com.google.common.base.MoreObjects;
-import org.spongepowered.api.service.persistence.DataSource;
-import org.spongepowered.api.service.persistence.data.DataContainer;
+package org.spongepowered.mod.service.persistence.builders.data;
 
-public class SpongeEntityMeta {
+import static com.google.common.base.Preconditions.checkNotNull;
 
-    public final int type;
-    public final String name;
+import com.google.common.base.Optional;
+import net.minecraft.item.EnumDyeColor;
+import org.spongepowered.api.entity.living.animal.DyeColor;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
 
-    public SpongeEntityMeta(int type, String name) {
-        this.type = type;
-        this.name = name;
-    }
-
-    public String getName() {
-        return this.name;
-    }
+public class SpongeDyeBuilder implements DataSerializableBuilder<DyeColor> {
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
+    public Optional<DyeColor> build(DataView container) throws InvalidDataException {
+        checkNotNull(container);
+        if (!container.contains(new DataQuery("id")) || !container.contains(new DataQuery("name"))) {
+            throw new InvalidDataException("The container does not have data pertaining to Dyecolor!");
         }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        SpongeEntityMeta other = (SpongeEntityMeta) obj;
-        if (this.type != other.type) {
-            return false;
-        } else if (this.name != other.name) {
-            return false;
-        }
-        return true;
-    }
-
-    public DataContainer toContainer() {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("type", this.type)
-                .add("name", this.name)
-                .toString();
+        int id = container.getInt(new DataQuery("id")).get();
+        return Optional.of((DyeColor) (Object) EnumDyeColor.byDyeDamage(id));
     }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeHorseColorBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeHorseColorBuilder.java
@@ -22,29 +22,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.block.data;
 
-import org.spongepowered.api.block.data.EnchantmentTable;
-import org.spongepowered.api.service.persistence.data.DataContainer;
+package org.spongepowered.mod.service.persistence.builders.data;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.entity.living.animal.HorseColor;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.api.service.persistence.data.DataQuery;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.mod.entity.SpongeEntityConstants;
 
-@NonnullByDefault
-@Implements(@Interface(iface = EnchantmentTable.class, prefix = "enchanting$"))
-@Mixin(net.minecraft.tileentity.TileEntityEnchantmentTable.class)
-public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity {
-
-    @Shadow
-    private String customName;
+public class SpongeHorseColorBuilder implements DataSerializableBuilder<HorseColor> {
 
     @Override
-    public DataContainer toContainer() {
-        DataContainer container = super.toContainer();
-        container.set(new DataQuery("CustomName"), this.customName);
-        return container;
+    public Optional<HorseColor> build(DataView container) throws InvalidDataException {
+        checkNotNull(container);
+        if (!container.contains(new DataQuery("id")) || !container.contains(new DataQuery("name"))) {
+            throw new InvalidDataException("The container does not have data pertaining to HorseColor!");
+        }
+        int id = container.getInt(new DataQuery("id")).get();
+        HorseColor color = SpongeEntityConstants.HORSE_COLOR_IDMAP.get(id);
+        if (color == null) {
+            throw new InvalidDataException("The container has an invalid HorseColor id!");
+        }
+        return Optional.of(color);
     }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeHorseStyleBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeHorseStyleBuilder.java
@@ -22,29 +22,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.block.data;
 
-import org.spongepowered.api.block.data.EnchantmentTable;
-import org.spongepowered.api.service.persistence.data.DataContainer;
+package org.spongepowered.mod.service.persistence.builders.data;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.entity.living.animal.HorseStyle;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.api.service.persistence.data.DataQuery;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.mod.entity.SpongeEntityConstants;
 
-@NonnullByDefault
-@Implements(@Interface(iface = EnchantmentTable.class, prefix = "enchanting$"))
-@Mixin(net.minecraft.tileentity.TileEntityEnchantmentTable.class)
-public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity {
-
-    @Shadow
-    private String customName;
+public class SpongeHorseStyleBuilder implements DataSerializableBuilder<HorseStyle> {
 
     @Override
-    public DataContainer toContainer() {
-        DataContainer container = super.toContainer();
-        container.set(new DataQuery("CustomName"), this.customName);
-        return container;
+    public Optional<HorseStyle> build(DataView container) throws InvalidDataException {
+        checkNotNull(container);
+        if (!container.contains(new DataQuery("id")) || !container.contains(new DataQuery("name"))) {
+            throw new InvalidDataException("The container does not have data pertaining to HorseColor!");
+        }
+        int id = container.getInt(new DataQuery("id")).get();
+        HorseStyle color = SpongeEntityConstants.HORSE_STYLE_IDMAP.get(id);
+        if (color == null) {
+            throw new InvalidDataException("The container has an invalid HorseColor id!");
+        }
+        return Optional.of(color);
     }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeHorseVariantBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeHorseVariantBuilder.java
@@ -23,5 +23,31 @@
  * THE SOFTWARE.
  */
 
-@org.spongepowered.api.util.annotation.NonnullByDefault
 package org.spongepowered.mod.service.persistence.builders.data;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.entity.living.animal.HorseVariant;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.mod.entity.SpongeEntityConstants;
+
+public class SpongeHorseVariantBuilder implements DataSerializableBuilder<HorseVariant> {
+
+    @Override
+    public Optional<HorseVariant> build(DataView container) throws InvalidDataException {
+        checkNotNull(container);
+        if (!container.contains(new DataQuery("id")) || !container.contains(new DataQuery("name"))) {
+            throw new InvalidDataException("The container does not have data pertaining to HorseColor!");
+        }
+        int id = container.getInt(new DataQuery("id")).get();
+        HorseVariant color = SpongeEntityConstants.HORSE_VARIANT_IDMAP.get(id);
+        if (color == null) {
+            throw new InvalidDataException("The container has an invalid HorseColor id!");
+        }
+        return Optional.of(color);
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeOcelotTypeBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeOcelotTypeBuilder.java
@@ -22,29 +22,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.block.data;
 
-import org.spongepowered.api.block.data.EnchantmentTable;
-import org.spongepowered.api.service.persistence.data.DataContainer;
+package org.spongepowered.mod.service.persistence.builders.data;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.entity.living.animal.OcelotType;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.api.service.persistence.data.DataQuery;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.mod.entity.SpongeEntityConstants;
 
-@NonnullByDefault
-@Implements(@Interface(iface = EnchantmentTable.class, prefix = "enchanting$"))
-@Mixin(net.minecraft.tileentity.TileEntityEnchantmentTable.class)
-public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity {
-
-    @Shadow
-    private String customName;
+public class SpongeOcelotTypeBuilder implements DataSerializableBuilder<OcelotType> {
 
     @Override
-    public DataContainer toContainer() {
-        DataContainer container = super.toContainer();
-        container.set(new DataQuery("CustomName"), this.customName);
-        return container;
+    public Optional<OcelotType> build(DataView container) throws InvalidDataException {
+        checkNotNull(container);
+        if (!container.contains(new DataQuery("id")) || !container.contains(new DataQuery("name"))) {
+            throw new InvalidDataException("The container does not have data pertaining to OcelotType!");
+        }
+        int id = container.getInt(new DataQuery("id")).get();
+        OcelotType ocelotType = SpongeEntityConstants.OCELOT_IDMAP.get(id);
+        if (ocelotType == null) {
+            throw new InvalidDataException("The container has an invalid OcelotType id!");
+        }
+        return Optional.of(ocelotType);
     }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/data/package-info.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/data/package-info.java
@@ -22,53 +22,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.entity;
 
-import com.google.common.base.MoreObjects;
-import org.spongepowered.api.service.persistence.DataSource;
-import org.spongepowered.api.service.persistence.data.DataContainer;
-
-public class SpongeEntityMeta {
-
-    public final int type;
-    public final String name;
-
-    public SpongeEntityMeta(int type, String name) {
-        this.type = type;
-        this.name = name;
-    }
-
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        SpongeEntityMeta other = (SpongeEntityMeta) obj;
-        if (this.type != other.type) {
-            return false;
-        } else if (this.name != other.name) {
-            return false;
-        }
-        return true;
-    }
-
-    public DataContainer toContainer() {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("type", this.type)
-                .add("name", this.name)
-                .toString();
-    }
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.mod.service.persistence.builders.data;

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/potion/SpongePotionEffectBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/potion/SpongePotionEffectBuilder.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.mod.service.persistence.builders.potion;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Optional;
+import net.minecraft.potion.Potion;
+import org.spongepowered.api.potion.PotionEffect;
+import org.spongepowered.api.potion.PotionEffectBuilder;
+import org.spongepowered.api.potion.PotionEffectType;
+import org.spongepowered.api.service.persistence.DataSerializableBuilder;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.mod.SpongeMod;
+
+public class SpongePotionEffectBuilder implements DataSerializableBuilder<PotionEffect> {
+
+    @Override
+    public Optional<PotionEffect> build(DataView container) throws InvalidDataException {
+        checkNotNull(container);
+        if (!container.contains(new DataQuery("PotionType")) || !container.contains(new DataQuery("Duration"))
+            || !container.contains(new DataQuery("Amplifier")) || !container.contains(new DataQuery("Ambiance"))
+            || !container.contains(new DataQuery("ShowsParticles"))) {
+            throw new InvalidDataException("The container does not have data pertaining to PotionEffect!");
+        }
+        String effectName = container.getString(new DataQuery("PotionType")).get();
+        PotionEffectType potionType = null;
+        for (Potion potion : Potion.potionTypes) {
+            if (potion.getName().equalsIgnoreCase(effectName)) {
+                potionType = (PotionEffectType) potion;
+            }
+        }
+        if (potionType == null) {
+            throw new InvalidDataException("The container has an invalid potion type name: " + effectName);
+        }
+        int duration = container.getInt(new DataQuery("Duration")).get();
+        int amplifier = container.getInt(new DataQuery("Amplifier")).get();
+        boolean ambience = container.getBoolean(new DataQuery("Ambience")).get();
+        boolean particles = container.getBoolean(new DataQuery("ShowsParticles")).get();
+        PotionEffectBuilder builder = SpongeMod.instance.getGame().getRegistry().getPotionEffectBuilder();
+
+        return Optional.of(builder.potionType(potionType)
+                                  .particles(particles)
+                                  .duration(duration)
+                                  .amplifier(amplifier)
+                                  .ambience(ambience)
+                                  .build());
+    }
+}

--- a/src/main/java/org/spongepowered/mod/service/persistence/package-info.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/package-info.java
@@ -22,53 +22,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.entity;
 
-import com.google.common.base.MoreObjects;
-import org.spongepowered.api.service.persistence.DataSource;
-import org.spongepowered.api.service.persistence.data.DataContainer;
-
-public class SpongeEntityMeta {
-
-    public final int type;
-    public final String name;
-
-    public SpongeEntityMeta(int type, String name) {
-        this.type = type;
-        this.name = name;
-    }
-
-    public String getName() {
-        return this.name;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        SpongeEntityMeta other = (SpongeEntityMeta) obj;
-        if (this.type != other.type) {
-            return false;
-        } else if (this.name != other.name) {
-            return false;
-        }
-        return true;
-    }
-
-    public DataContainer toContainer() {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("type", this.type)
-                .add("name", this.name)
-                .toString();
-    }
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.mod.service.persistence;

--- a/src/main/resources/sponge_at.cfg
+++ b/src/main/resources/sponge_at.cfg
@@ -45,6 +45,9 @@ public net.minecraft.village.MerchantRecipe field_180323_f # rewardsExp
 
 public net.minecraft.block.state.BlockState$StateImplementation
 
+public-f net.minecraft.tileentity.TileEntity field_145855_i # nameToClassMap
+public-f net.minecraft.tileentity.TileEntity field_145853_j # classToNameMap
+
 public net.minecraft.command.server.CommandBlockLogic field_145764_b # successCount
 public net.minecraft.command.server.CommandBlockLogic field_145763_e # commandStored
 


### PR DESCRIPTION
With the Persistence API being merged, it's time for the various `DataSerializable` objects to actually successfully serialize their data to a `DataContainer`.

This has some changes to achieve this including:

- Provide a new service that requires registration before world loading starts
- Using SuperMixins for TileEntities
- Update to latest API for simpler usage of DataViews