### PR TITLE
Register the human entity as a mod entity

### DIFF
--- a/src/main/java/org/spongepowered/mod/registry/SpongeModGameRegistry.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeModGameRegistry.java
@@ -25,6 +25,7 @@
 package org.spongepowered.mod.registry;
 
 import com.google.common.base.Function;
+import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.fml.common.registry.GameData;
 import org.spongepowered.api.GameDictionary;
 import org.spongepowered.api.block.BlockType;
@@ -32,10 +33,10 @@ import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.common.entity.living.human.EntityHuman;
 import org.spongepowered.common.registry.RegistryHelper;
 import org.spongepowered.common.registry.SpongeGameRegistry;
 
-@SuppressWarnings("unchecked")
 @NonnullByDefault
 public class SpongeModGameRegistry extends SpongeGameRegistry {
 
@@ -78,4 +79,15 @@ public class SpongeModGameRegistry extends SpongeGameRegistry {
             }
         });
     }
+
+    private void registerCustomEntities() {
+        EntityRegistry.registerModEntity(EntityHuman.class, "Human", -7, "Sponge", 512, 2, false);
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        registerCustomEntities();
+    }
+
 }


### PR DESCRIPTION
### Update
The human entity now exists in SpongeCommon as an `EntityCreature`. Therefore this PR is almost not needed.
I have re-purposed this PR to register the human as a mod entity and cleanup `MixinEntityRegistry`.

### Old description
This implements the `Human` entity.

I have done some testing, so far there are no issues when a human and I am in the world. However, it is difficult to properly test how well this works when there are many players on the server + many humans.

The concept is simple, to the server, a human is just another entity, an `EntityLivingBase`.
To the client, a human is another player who is AFK, an `EntityOtherPlayerMP`.

I am looking for feedback on the implementation so far, and whether there are any concerns with it.

Due to `HumanEntity` extending `EntityPlayer`, some things have to be overridden so that it is not seen as a player on the server.