### PR TITLE
[WIP] Implement world creation.

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeGame.java
+++ b/src/main/java/org/spongepowered/mod/SpongeGame.java
@@ -59,13 +59,15 @@ public final class SpongeGame implements Game {
     private final EventManager eventManager;
     private final GameRegistry gameRegistry;
     private final ServiceManager serviceManager;
+    private final TeleportHelper teleportHelper;
 
     @Inject
-    public SpongeGame(PluginManager plugin, EventManager event, GameRegistry registry, ServiceManager service) {
+    public SpongeGame(PluginManager plugin, EventManager event, GameRegistry registry, ServiceManager service, TeleportHelper teleportHelper) {
         this.pluginManager = plugin;
         this.eventManager = event;
         this.gameRegistry = registry;
         this.serviceManager = service;
+        this.teleportHelper = teleportHelper;
     }
 
     @Override
@@ -135,6 +137,6 @@ public final class SpongeGame implements Game {
 
     @Override
     public TeleportHelper getTeleportHelper() {
-        return null;
+        return this.teleportHelper;
     }
 }

--- a/src/main/java/org/spongepowered/mod/SpongeMod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeMod.java
@@ -29,7 +29,10 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.DummyModContainer;
 import net.minecraftforge.fml.common.FMLCommonHandler;
@@ -40,6 +43,7 @@ import net.minecraftforge.fml.common.ModMetadata;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerAboutToStartEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartedEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
@@ -59,6 +63,8 @@ import org.spongepowered.api.service.scheduler.AsynchronousScheduler;
 import org.spongepowered.api.service.scheduler.SynchronousScheduler;
 import org.spongepowered.api.service.sql.SqlService;
 import org.spongepowered.api.util.command.CommandMapping;
+import org.spongepowered.api.world.Dimension;
+import org.spongepowered.api.world.DimensionType;
 import org.spongepowered.mod.command.CommandSponge;
 import org.spongepowered.mod.command.MinecraftCommandWrapper;
 import org.spongepowered.mod.event.SpongeEventBus;
@@ -74,9 +80,13 @@ import org.spongepowered.mod.service.scheduler.AsyncScheduler;
 import org.spongepowered.mod.service.scheduler.SyncScheduler;
 import org.spongepowered.mod.service.sql.SqlServiceImpl;
 import org.spongepowered.mod.util.SpongeHooks;
+import org.spongepowered.mod.world.SpongeDimensionType;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
 
 public class SpongeMod extends DummyModContainer implements PluginContainer {
 
@@ -214,6 +224,11 @@ public class SpongeMod extends DummyModContainer implements PluginContainer {
     }
 
     @Subscribe
+    public void onServerAboutToStart(FMLServerAboutToStartEvent e) {
+        registerAllEnabledWorlds();
+    }
+
+    @Subscribe
     public void onServerStarting(FMLServerStartingEvent e) {
         try {
             // Register vanilla-style commands (if necessary -- not necessary on client)
@@ -257,5 +272,64 @@ public class SpongeMod extends DummyModContainer implements PluginContainer {
     @Override
     public Object getInstance() {
         return getMod();
+    }
+
+    public SpongeGameRegistry getSpongeRegistry() {
+        return this.registry;
+    }
+
+    public void registerAllEnabledWorlds() {
+        File[] directoryListing = DimensionManager.getCurrentSaveRootDirectory().listFiles();
+        if (directoryListing == null) {
+            return;
+        }
+
+        for (File child : directoryListing) {
+            File levelData = new File(child, "level_sponge.dat");
+            if (!child.isDirectory() || !levelData.exists()) {
+                continue;
+            }
+
+            try {
+                NBTTagCompound nbt = CompressedStreamTools.readCompressed(new FileInputStream(levelData));
+                if (nbt.hasKey(getModId())) {
+                    NBTTagCompound spongeData = nbt.getCompoundTag(getModId());
+                    boolean enabled = spongeData.getBoolean("enabled");
+                    boolean loadOnStartup = spongeData.getBoolean("loadOnStartup");
+                    int dimensionId = spongeData.getInteger("dimensionId");
+                    if (!(dimensionId == -1) && !(dimensionId == 0) && !(dimensionId == 1)) {
+                        if (!enabled) {
+                            getLogger().info("World "+ child.getName() + " is currently disabled. Skipping world load...");
+                            continue;
+                        }
+                        if (!loadOnStartup) {
+                            getLogger().info("World "+ child.getName() + " 'loadOnStartup' is disabled.. Skipping world load...");
+                            continue;
+                        }
+                    }
+                    if (spongeData.hasKey("uuid_most") && spongeData.hasKey("uuid_least")) {
+                        UUID uuid = new UUID(spongeData.getLong("uuid_most"), spongeData.getLong("uuid_least"));
+                        this.registry.registerWorldUniqueId(uuid, child.getName());
+                    }
+                    if (spongeData.hasKey("dimensionId") && spongeData.getBoolean("enabled")) {
+                        int dimension = spongeData.getInteger("dimensionId");
+                        for (Map.Entry<Class<? extends Dimension>, DimensionType> mapEntry : getSpongeRegistry().dimensionClassMappings
+                                .entrySet()) {
+                            if (mapEntry.getKey().getCanonicalName().equalsIgnoreCase(spongeData.getString("dimensionType"))) {
+                                this.registry.registerWorldDimensionId(dimension, child.getName());
+                                if (!DimensionManager.isDimensionRegistered(dimension)) {
+                                    DimensionManager.registerDimension(dimension,
+                                            ((SpongeDimensionType) mapEntry.getValue()).getDimensionTypeId());
+                                }
+                            }
+                        }
+                    } else {
+                        logger.info("World " + child.getName() + " is disabled! Skipping world registration...");
+                    }
+                }
+            } catch (Throwable t) {
+                logger.error("Error during world registration.", t);
+            }
+        }
     }
 }

--- a/src/main/java/org/spongepowered/mod/guice/SpongeGuiceModule.java
+++ b/src/main/java/org/spongepowered/mod/guice/SpongeGuiceModule.java
@@ -34,10 +34,12 @@ import org.spongepowered.api.plugin.PluginManager;
 import org.spongepowered.api.service.ServiceManager;
 import org.spongepowered.api.service.SimpleServiceManager;
 import org.spongepowered.api.service.event.EventManager;
+import org.spongepowered.api.world.TeleportHelper;
 import org.spongepowered.mod.SpongeGame;
 import org.spongepowered.mod.event.SpongeEventBus;
 import org.spongepowered.mod.plugin.SpongePluginManager;
 import org.spongepowered.mod.registry.SpongeGameRegistry;
+import org.spongepowered.mod.world.SpongeTeleportHelper;
 
 import java.io.File;
 
@@ -50,6 +52,7 @@ public class SpongeGuiceModule extends AbstractModule {
         bind(ServiceManager.class).to(SimpleServiceManager.class).in(Scopes.SINGLETON);
         bind(EventManager.class).to(SpongeEventBus.class).in(Scopes.SINGLETON);
         bind(GameRegistry.class).to(SpongeGameRegistry.class).in(Scopes.SINGLETON);
+        bind(TeleportHelper.class).to(SpongeTeleportHelper.class).in(Scopes.SINGLETON);
         bind(File.class).annotatedWith(new ConfigDirAnnotation(true)).toInstance(Loader.instance().getConfigDir());
     }
 }

--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinEntityPlayerMP.java
@@ -24,19 +24,8 @@
  */
 package org.spongepowered.mod.interfaces;
 
-import com.google.common.collect.ImmutableList;
-import org.spongepowered.api.world.gen.GeneratorPopulator;
-import org.spongepowered.api.world.gen.Populator;
-import net.minecraft.world.storage.WorldInfo;
-import org.spongepowered.mod.configuration.SpongeConfig;
 
-public interface IMixinWorld {
+public interface IMixinEntityPlayerMP {
 
-    SpongeConfig<SpongeConfig.WorldConfig> getWorldConfig();
-
-    ImmutableList<Populator> getPopulators();
-
-    ImmutableList<GeneratorPopulator> getGeneratorPopulators();
-
-    void setWorldInfo(WorldInfo worldInfo);
+    void reset();
 }

--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinServerConfigurationManager.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinServerConfigurationManager.java
@@ -24,19 +24,10 @@
  */
 package org.spongepowered.mod.interfaces;
 
-import com.google.common.collect.ImmutableList;
-import org.spongepowered.api.world.gen.GeneratorPopulator;
-import org.spongepowered.api.world.gen.Populator;
-import net.minecraft.world.storage.WorldInfo;
-import org.spongepowered.mod.configuration.SpongeConfig;
+import net.minecraft.entity.player.EntityPlayerMP;
+import org.spongepowered.api.world.Location;
 
-public interface IMixinWorld {
+public interface IMixinServerConfigurationManager {
 
-    SpongeConfig<SpongeConfig.WorldConfig> getWorldConfig();
-
-    ImmutableList<Populator> getPopulators();
-
-    ImmutableList<GeneratorPopulator> getGeneratorPopulators();
-
-    void setWorldInfo(WorldInfo worldInfo);
+    EntityPlayerMP respawnPlayer(EntityPlayerMP playerIn, int targetDimension, boolean conqueredEnd, Location location);
 }

--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinWorldInfo.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinWorldInfo.java
@@ -24,19 +24,33 @@
  */
 package org.spongepowered.mod.interfaces;
 
-import com.google.common.collect.ImmutableList;
-import org.spongepowered.api.world.gen.GeneratorPopulator;
-import org.spongepowered.api.world.gen.Populator;
-import net.minecraft.world.storage.WorldInfo;
-import org.spongepowered.mod.configuration.SpongeConfig;
+import net.minecraft.nbt.NBTTagCompound;
+import org.spongepowered.api.world.DimensionType;
+import org.spongepowered.api.world.GeneratorType;
 
-public interface IMixinWorld {
+import java.util.UUID;
 
-    SpongeConfig<SpongeConfig.WorldConfig> getWorldConfig();
+public interface IMixinWorldInfo {
 
-    ImmutableList<Populator> getPopulators();
+    NBTTagCompound getSpongeRootLevelNbt();
 
-    ImmutableList<GeneratorPopulator> getGeneratorPopulators();
+    NBTTagCompound getSpongeNbt();
 
-    void setWorldInfo(WorldInfo worldInfo);
+    int getDimensionId();
+
+    void setDimensionId(int id);;
+
+    void setSpongeRootLevelNBT(NBTTagCompound nbt);
+
+    void setUUID(UUID uuid);
+
+    void setDimensionType(DimensionType type);
+
+    void setType(GeneratorType type);
+
+    void setSeed(long seed);
+
+    void setWorldName(String name);
+
+    void readSpongeNbt(NBTTagCompound spongeNbt);
 }

--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinWorldSettings.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinWorldSettings.java
@@ -24,19 +24,18 @@
  */
 package org.spongepowered.mod.interfaces;
 
-import com.google.common.collect.ImmutableList;
-import org.spongepowered.api.world.gen.GeneratorPopulator;
-import org.spongepowered.api.world.gen.Populator;
-import net.minecraft.world.storage.WorldInfo;
-import org.spongepowered.mod.configuration.SpongeConfig;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.world.DimensionType;
 
-public interface IMixinWorld {
+public interface IMixinWorldSettings {
 
-    SpongeConfig<SpongeConfig.WorldConfig> getWorldConfig();
+    void setDimensionType(DimensionType type);
 
-    ImmutableList<Populator> getPopulators();
+    void setEnabled(boolean isWorldEnabled);
 
-    ImmutableList<GeneratorPopulator> getGeneratorPopulators();
+    void setGeneratorSettings(DataContainer generatorSettings);
 
-    void setWorldInfo(WorldInfo worldInfo);
+    void setLoadOnStartup(boolean loadOnStartup);
+
+    void setKeepSpawnLoaded(boolean keepSpawnLoaded);
 }

--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinWorldType.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinWorldType.java
@@ -24,19 +24,14 @@
  */
 package org.spongepowered.mod.interfaces;
 
-import com.google.common.collect.ImmutableList;
-import org.spongepowered.api.world.gen.GeneratorPopulator;
-import org.spongepowered.api.world.gen.Populator;
-import net.minecraft.world.storage.WorldInfo;
-import org.spongepowered.mod.configuration.SpongeConfig;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.world.gen.WorldGenerator;
 
-public interface IMixinWorld {
+import java.util.concurrent.Callable;
 
-    SpongeConfig<SpongeConfig.WorldConfig> getWorldConfig();
+public interface IMixinWorldType {
 
-    ImmutableList<Populator> getPopulators();
+    void setWorldGenerator(Callable<WorldGenerator> generator);
 
-    ImmutableList<GeneratorPopulator> getGeneratorPopulators();
-
-    void setWorldInfo(WorldInfo worldInfo);
+    void setGeneratorSettings(DataContainer settings);
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/server/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/server/MixinMinecraftServer.java
@@ -26,32 +26,54 @@ package org.spongepowered.mod.mixin.core.server;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import net.minecraft.profiler.Profiler;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.management.ServerConfigurationManager;
 import net.minecraft.util.IChatComponent;
+import net.minecraft.world.EnumDifficulty;
+import net.minecraft.world.WorldManager;
+import net.minecraft.world.WorldProvider;
 import net.minecraft.world.WorldServer;
+import net.minecraft.world.WorldSettings;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.chunk.storage.AnvilSaveHandler;
+import net.minecraft.world.storage.ISaveHandler;
+import net.minecraft.world.storage.SaveHandler;
+import net.minecraft.world.storage.WorldInfo;
 import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.entity.player.Player;
+import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.service.permission.PermissionService;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.Tristate;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.util.command.source.ConsoleSource;
+import org.spongepowered.api.world.Dimension;
 import org.spongepowered.api.world.World;
-import org.spongepowered.api.world.gen.WorldGenerator;
+import org.spongepowered.api.world.WorldCreationSettings;
+import org.spongepowered.api.world.storage.WorldProperties;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.SpongeMod;
+import org.spongepowered.mod.interfaces.IMixinWorldInfo;
 import org.spongepowered.mod.interfaces.Subjectable;
 import org.spongepowered.mod.text.SpongeText;
+import org.spongepowered.mod.world.SpongeDimensionType;
 
+import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
@@ -59,6 +81,60 @@ import java.util.UUID;
 @Mixin(MinecraftServer.class)
 @Implements(@Interface(iface = Server.class, prefix = "server$"))
 public abstract class MixinMinecraftServer implements Server, ConsoleSource, Subjectable {
+
+    @Shadow
+    public WorldServer[] worldServers;
+
+    @Shadow
+    private ServerConfigurationManager serverConfigManager;
+
+    @Shadow
+    public Profiler theProfiler;
+
+    @Shadow
+    private boolean enableBonusChest;
+
+    @Shadow
+    private boolean worldIsBeingDeleted;
+
+    @Shadow
+    private int tickCounter;
+
+    @Shadow
+    protected abstract void convertMapIfNeeded(String worldNameIn);
+
+    @Shadow
+    protected abstract void setUserMessage(String message);
+
+    @Shadow
+    protected abstract void initialWorldChunkLoad();
+
+    @Shadow
+    protected abstract void setResourcePackFromWorld(String worldNameIn, ISaveHandler saveHandlerIn);
+
+    @Shadow
+    public abstract boolean canStructuresSpawn();
+
+    @Shadow
+    public abstract WorldSettings.GameType getGameType();
+
+    @Shadow
+    public abstract EnumDifficulty getDifficulty();
+
+    @Shadow
+    public abstract boolean isHardcore();
+
+    @Shadow
+    public abstract boolean isSinglePlayer();
+
+    @Shadow
+    public abstract boolean isDemo();
+
+    @Shadow
+    public abstract String getFolderName();
+
+    @Shadow
+    public abstract void setDifficultyForAllWorlds(EnumDifficulty difficulty);
 
     @Shadow
     public abstract ServerConfigurationManager getConfigurationManager();
@@ -72,12 +148,6 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, Sub
     public abstract int getPort();
 
     @Shadow
-    private int tickCounter;
-
-    @Shadow
-    private ServerConfigurationManager serverConfigManager;
-
-    @Shadow
     public abstract void addChatMessage(IChatComponent message);
 
     @Shadow
@@ -85,6 +155,191 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, Sub
 
     @Shadow
     public abstract void initiateShutdown();
+
+    @Overwrite
+    protected void loadAllWorlds(String overworldFolder, String unused, long seed, WorldType type, String generator) {
+        this.convertMapIfNeeded(overworldFolder);
+        this.setUserMessage("menu.loadingLevel");
+
+        List<Integer> idList = new LinkedList<Integer>(Arrays.asList(DimensionManager.getStaticDimensionIDs()));
+        idList.remove(Integer.valueOf(0));
+        idList.add(0, 0); // load overworld first
+        for (int dim : idList) {
+            WorldProvider provider = WorldProvider.getProviderForDimension(dim);
+            String worldFolder = "";
+            if (dim == 0) {
+                worldFolder = overworldFolder;
+            } else {
+                worldFolder = SpongeMod.instance.getSpongeRegistry().getWorldFolder(dim);
+                if (worldFolder == null) {
+                    worldFolder = provider.getSaveFolder();
+                }
+            }
+
+            WorldInfo worldInfo = null;
+            WorldSettings newWorldSettings = null;
+            AnvilSaveHandler worldsavehandler = null;
+
+            worldsavehandler = new AnvilSaveHandler(getWorldContainer(), worldFolder, true);
+            worldInfo = worldsavehandler.loadWorldInfo();
+            if (worldInfo == null) {
+                newWorldSettings = new WorldSettings(seed, this.getGameType(), this.canStructuresSpawn(), this.isHardcore(), type);
+                newWorldSettings.setWorldName(generator);
+
+                if (this.enableBonusChest) {
+                    newWorldSettings.enableBonusChest();
+                }
+
+                worldInfo = new WorldInfo(newWorldSettings, worldFolder);
+                ((IMixinWorldInfo) worldInfo).setUUID(UUID.randomUUID());
+            } else {
+                worldInfo.setWorldName(worldFolder);
+                newWorldSettings = new WorldSettings(worldInfo);
+            }
+
+            if (dim == 0) {
+                this.setResourcePackFromWorld(this.getFolderName(), worldsavehandler);
+            }
+
+            ((IMixinWorldInfo) worldInfo).setDimensionId(dim);
+            ((IMixinWorldInfo) worldInfo).setDimensionType(((Dimension) provider).getType());
+            UUID uuid = ((WorldProperties) worldInfo).getUniqueId();
+            SpongeMod.instance.getSpongeRegistry().registerWorldUniqueId(uuid, worldFolder);
+
+            WorldServer world = (WorldServer) new WorldServer((MinecraftServer) (Object) this, worldsavehandler, worldInfo, dim,
+                    this.theProfiler).init();
+
+            world.initialize(newWorldSettings);
+            world.addWorldAccess(new WorldManager((MinecraftServer) (Object) this, world));
+
+            if (!this.isSinglePlayer()) {
+                world.getWorldInfo().setGameType(this.getGameType());
+            }
+            SpongeMod.instance.getSpongeRegistry().registerWorldProperties((WorldProperties) worldInfo);
+            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WorldEvent.Load(world));
+        }
+
+        this.serverConfigManager.setPlayerManager(new WorldServer[] {DimensionManager.getWorld(0)});
+        this.setDifficultyForAllWorlds(this.getDifficulty());
+        this.initialWorldChunkLoad();
+    }
+
+    @Override
+    public Optional<World> loadWorld(UUID uuid) {
+        String worldFolder = SpongeMod.instance.getSpongeRegistry().getWorldFolder(uuid);
+        if (worldFolder != null) {
+            return loadWorld(worldFolder);
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<World> loadWorld(String worldName) {
+        File file = new File(getWorldContainer(), worldName);
+
+        if ((file.exists()) && (!file.isDirectory())) {
+            throw new IllegalArgumentException("File exists with the name '" + worldName + "' and isn't a folder");
+        }
+
+        AnvilSaveHandler savehandler = new AnvilSaveHandler(getWorldContainer(), worldName, true);
+        int dim = 0;
+        WorldInfo worldInfo = savehandler.loadWorldInfo();
+        if (worldInfo != null) {
+            // check if enabled
+            if (!((WorldProperties) worldInfo).isEnabled()) {
+                SpongeMod.instance.getLogger().error("Unable to load world " + worldName + ". World is disabled!");
+                return Optional.absent();
+            }
+            if (!SpongeMod.instance.getSpongeRegistry().getWorldProperties(((WorldProperties) worldInfo).getUniqueId()).isPresent()) {
+                SpongeMod.instance.getSpongeRegistry().registerWorldProperties((WorldProperties) worldInfo);
+            } else {
+                worldInfo = (WorldInfo) SpongeMod.instance.getSpongeRegistry().getWorldProperties(((WorldProperties) worldInfo).getUniqueId()).get();
+            }
+            dim = ((IMixinWorldInfo) worldInfo).getDimensionId();
+        } else {
+            return Optional.absent(); // no world data found
+        }
+
+        WorldSettings settings = new WorldSettings(worldInfo);
+
+        if (!DimensionManager.isDimensionRegistered(dim)) { // handle reloads properly
+            DimensionManager.registerDimension(dim, ((SpongeDimensionType) ((WorldProperties) worldInfo).getDimensionType()).getDimensionTypeId());
+        }
+
+        // TODO - handle custom generators
+        //ChunkGenerator gen = settings.getGeneratorType().createGenerator();
+
+        WorldServer world = (WorldServer) new WorldServer((MinecraftServer) (Object) this, savehandler, worldInfo, dim, this.theProfiler).init();
+
+        world.initialize(settings);
+        world.provider.setDimension(dim);
+
+        world.addWorldAccess(new WorldManager((MinecraftServer) (Object) this, world));
+        MinecraftForge.EVENT_BUS.post(new WorldEvent.Load(world));
+        if (!isSinglePlayer())
+        {
+            world.getWorldInfo().setGameType(getGameType());
+        }
+        this.setDifficultyForAllWorlds(this.getDifficulty());
+
+        return Optional.of((World) world);
+    }
+
+    @Override
+    public Optional<WorldProperties> createWorld(WorldCreationSettings settings) {
+        String name = settings.getWorldName();
+        int dim = 0;
+        AnvilSaveHandler savehandler = new AnvilSaveHandler(getWorldContainer(), name, true);
+        WorldInfo worldInfo = savehandler.loadWorldInfo();
+
+        if (worldInfo != null)
+        {
+            if (!SpongeMod.instance.getSpongeRegistry().getWorldProperties(((WorldProperties) worldInfo).getUniqueId()).isPresent()) {
+                SpongeMod.instance.getSpongeRegistry().registerWorldProperties((WorldProperties) worldInfo);
+                return Optional.of((WorldProperties) worldInfo);
+            } else {
+                return SpongeMod.instance.getSpongeRegistry().getWorldProperties(((WorldProperties) worldInfo).getUniqueId());
+            }
+        } else {
+            dim = DimensionManager.getNextFreeDimId();
+            worldInfo = new WorldInfo((WorldSettings) (Object) settings, settings.getWorldName());
+            ((WorldProperties) worldInfo).setKeepSpawnLoaded(settings.doesKeepSpawnLoaded());
+            ((WorldProperties) worldInfo).setLoadOnStartup(settings.loadOnStartup());
+            ((WorldProperties) worldInfo).setEnabled(settings.isEnabled());
+            SpongeMod.instance.getSpongeRegistry().registerWorldProperties((WorldProperties) worldInfo);
+        }
+
+        ((IMixinWorldInfo) worldInfo).setDimensionId(dim);
+        ((IMixinWorldInfo) worldInfo).setDimensionType(settings.getDimensionType());
+        UUID uuid = UUID.randomUUID();
+        ((IMixinWorldInfo) worldInfo).setUUID(uuid);
+        SpongeMod.instance.getSpongeRegistry().registerWorldUniqueId(uuid, name);
+
+        if (!DimensionManager.isDimensionRegistered(dim)) { // handle reloads properly
+            DimensionManager.registerDimension(dim, ((SpongeDimensionType) ((WorldProperties) worldInfo).getDimensionType()).getDimensionTypeId());
+        }
+        savehandler.saveWorldInfoWithPlayer(worldInfo, getConfigurationManager().getHostPlayerData());
+
+        SpongeEventFactory.createWorldCreate(SpongeMod.instance.getGame(), (WorldProperties) worldInfo, settings);
+        return Optional.of((WorldProperties) worldInfo);
+    }
+
+    @Override
+    public boolean unloadWorld(World world) {
+        int dim = ((net.minecraft.world.World) world).provider.getDimensionId();
+        if (DimensionManager.getWorld(dim) != null) {
+            DimensionManager.unloadWorld(((net.minecraft.world.World) world).provider.getDimensionId());
+            return true;
+        }
+        return false;
+    }
+
+    public File getWorldContainer() {
+        if (DimensionManager.getWorld(0) != null) {
+            return ((SaveHandler) DimensionManager.getWorld(0).getSaveHandler()).getWorldDirectory();
+        }
+        return null;
+    }
 
     @Override
     public Collection<World> getWorlds() {
@@ -97,31 +352,24 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, Sub
 
     @Override
     public Optional<World> getWorld(UUID uniqueId) {
-        // TODO: This needs to map to world id's somehow
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<World> getWorld(String worldName) {
-        for (World world : getWorlds()) {
-            if (world.getName().equals(worldName)) {
-                return Optional.fromNullable(world);
+        for (WorldServer worldserver : DimensionManager.getWorlds()) {
+            if (((World) worldserver).getUniqueId().equals(uniqueId)) {
+                return Optional.of((World) worldserver);
             }
         }
         return Optional.absent();
     }
 
     @Override
-    public Optional<World> loadWorld(String worldName) {
-        throw new UnsupportedOperationException(); // TODO
+    public Optional<World> getWorld(String worldName) {
+        for (World world : getWorlds()) {
+            if (world.getName().equals(worldName)) {
+                return Optional.of(world);
+            }
+        }
+        return Optional.absent();
     }
 
-    @Override
-    public boolean unloadWorld(World world) {
-        throw new UnsupportedOperationException(); // TODO
-    }
-
-    @SuppressWarnings("rawtypes")
     @Override
     public void broadcastMessage(Text message) {
         getConfigurationManager().sendChatMsg(((SpongeText) message).toComponent());
@@ -219,9 +467,12 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, Sub
 
     @Override
     public void shutdown(Text kickMessage) {
-        /*for (Player player : getOnlinePlayers()) {
-            ((EntityPlayerMP) player).playerNetServerHandler.kickPlayerFromServer(kickMessage.toLegacy()); //TODO update with the new Text API
-        }*/
+        /*
+         * for (Player player : getOnlinePlayers()) { ((EntityPlayerMP)
+         * player).playerNetServerHandler
+         * .kickPlayerFromServer(kickMessage.toLegacy()); //TODO update with the
+         * new Text API }
+         */
 
         initiateShutdown();
     }

--- a/src/main/java/org/spongepowered/mod/mixin/core/server/MixinServerConfigurationManager.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/server/MixinServerConfigurationManager.java
@@ -1,0 +1,386 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.core.server;
+
+import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3i;
+import com.google.common.base.Optional;
+import com.mojang.authlib.GameProfile;
+import io.netty.buffer.Unpooled;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S01PacketJoinGame;
+import net.minecraft.network.play.server.S03PacketTimeUpdate;
+import net.minecraft.network.play.server.S05PacketSpawnPosition;
+import net.minecraft.network.play.server.S07PacketRespawn;
+import net.minecraft.network.play.server.S09PacketHeldItemChange;
+import net.minecraft.network.play.server.S1DPacketEntityEffect;
+import net.minecraft.network.play.server.S1FPacketSetExperience;
+import net.minecraft.network.play.server.S2BPacketChangeGameState;
+import net.minecraft.network.play.server.S39PacketPlayerAbilities;
+import net.minecraft.network.play.server.S3FPacketCustomPayload;
+import net.minecraft.network.play.server.S41PacketServerDifficulty;
+import net.minecraft.network.play.server.S44PacketWorldBorder;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.scoreboard.ServerScoreboard;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerProfileCache;
+import net.minecraft.server.management.ServerConfigurationManager;
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.storage.IPlayerFileData;
+import net.minecraft.world.storage.WorldInfo;
+import net.minecraftforge.common.network.ForgeMessage;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.network.FMLEmbeddedChannel;
+import net.minecraftforge.fml.common.network.FMLOutboundHandler;
+import net.minecraftforge.fml.common.network.NetworkRegistry;
+import net.minecraftforge.fml.relauncher.Side;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.api.entity.player.Player;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.Dimension;
+import org.spongepowered.api.world.DimensionTypes;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.interfaces.IMixinEntityPlayerMP;
+import org.spongepowered.mod.interfaces.IMixinServerConfigurationManager;
+import org.spongepowered.mod.world.SpongeDimensionType;
+import org.spongepowered.mod.world.border.PlayerBorderListener;
+
+import java.util.Iterator;
+import java.util.List;
+
+@NonnullByDefault
+@Mixin(ServerConfigurationManager.class)
+public abstract class MixinServerConfigurationManager implements IMixinServerConfigurationManager {
+
+    @Shadow
+    private static Logger logger;
+
+    @Shadow
+    private MinecraftServer mcServer;
+
+    @Shadow
+    private IPlayerFileData playerNBTManagerObj;
+
+    @SuppressWarnings("rawtypes")
+    @Shadow
+    public List playerEntityList;
+
+    @Shadow
+    public abstract NBTTagCompound readPlayerDataFromFile(EntityPlayerMP playerIn);
+
+    @Shadow
+    public abstract void setPlayerGameTypeBasedOnOther(EntityPlayerMP p_72381_1_, EntityPlayerMP p_72381_2_, net.minecraft.world.World worldIn);
+
+    @Shadow
+    protected abstract void func_96456_a(ServerScoreboard scoreboardIn, EntityPlayerMP playerIn);
+
+    @Shadow
+    public abstract MinecraftServer getServerInstance();
+
+    @Shadow
+    public abstract int getMaxPlayers();
+
+    @Shadow
+    public abstract void sendChatMsg(IChatComponent component);
+
+    @Shadow
+    public abstract void playerLoggedIn(EntityPlayerMP playerIn);
+
+    @SuppressWarnings("rawtypes")
+    @Overwrite
+    public void initializeConnectionToPlayer(NetworkManager netManager, EntityPlayerMP playerIn, NetHandlerPlayServer nethandlerplayserver) {
+        GameProfile gameprofile = playerIn.getGameProfile();
+        PlayerProfileCache playerprofilecache = this.mcServer.getPlayerProfileCache();
+        GameProfile gameprofile1 = playerprofilecache.getProfileByUUID(gameprofile.getId());
+        String s = gameprofile1 == null ? gameprofile.getName() : gameprofile1.getName();
+        playerprofilecache.addEntry(gameprofile);
+        NBTTagCompound nbttagcompound = this.readPlayerDataFromFile(playerIn);
+        playerIn.setWorld(this.mcServer.worldServerForDimension(playerIn.dimension));
+
+        net.minecraft.world.World playerWorld = this.mcServer.worldServerForDimension(playerIn.dimension);
+        if (playerWorld == null) {
+            playerIn.dimension = 0;
+            playerWorld = this.mcServer.worldServerForDimension(0);
+            BlockPos spawnPoint = playerWorld.provider.getRandomizedSpawnPoint();
+            playerIn.setPosition(spawnPoint.getX(), spawnPoint.getY(), spawnPoint.getZ());
+        }
+
+        playerIn.setWorld(playerWorld);
+        playerIn.theItemInWorldManager.setWorld((WorldServer) playerIn.worldObj);
+        String s1 = "local";
+
+        if (netManager.getRemoteAddress() != null) {
+            s1 = netManager.getRemoteAddress().toString();
+        }
+
+        logger.info(playerIn.getCommandSenderName() + "[" + s1 + "] logged in with entity id " + playerIn.getEntityId() + " at (" + playerIn.posX
+                + ", " + playerIn.posY + ", " + playerIn.posZ + ")");
+        WorldServer worldserver = this.mcServer.worldServerForDimension(playerIn.dimension);
+        WorldInfo worldinfo = worldserver.getWorldInfo();
+        BlockPos blockpos = worldserver.getSpawnPoint();
+        this.setPlayerGameTypeBasedOnOther(playerIn, (EntityPlayerMP) null, worldserver);
+        playerIn.playerNetServerHandler = nethandlerplayserver;
+        // Support vanilla clients logging into custom dimensions
+        int dimension = worldserver.provider.getDimensionId();
+        boolean fmlClient = playerIn.playerNetServerHandler.getNetworkManager().channel().attr(NetworkRegistry.FML_MARKER).get();
+        if (!fmlClient) {
+            if (((Dimension) worldserver.provider).getType().equals(DimensionTypes.NETHER)) {
+                dimension = -1;
+            } else if (((Dimension) worldserver.provider).getType().equals(DimensionTypes.END)) {
+                dimension = 1;
+            } else {
+                dimension = 0;
+            }
+        } else {
+            // register dimension on client-side
+            FMLEmbeddedChannel serverChannel = NetworkRegistry.INSTANCE.getChannel("FORGE", Side.SERVER);
+            serverChannel.attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.PLAYER);
+            serverChannel.attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(playerIn);
+            serverChannel.writeOutbound(new ForgeMessage.DimensionRegisterMessage(dimension,
+                    ((SpongeDimensionType) ((Dimension) worldserver.provider).getType()).getDimensionTypeId()));
+        }
+
+        nethandlerplayserver.sendPacket(new S01PacketJoinGame(playerIn.getEntityId(), playerIn.theItemInWorldManager.getGameType(), worldinfo
+                .isHardcoreModeEnabled(), dimension, worldserver.getDifficulty(), this.getMaxPlayers(), worldinfo
+                .getTerrainType(), worldserver.getGameRules().getGameRuleBooleanValue("reducedDebugInfo")));
+        nethandlerplayserver.sendPacket(new S3FPacketCustomPayload("MC|Brand", (new PacketBuffer(Unpooled.buffer())).writeString(this
+                .getServerInstance().getServerModName())));
+        nethandlerplayserver.sendPacket(new S41PacketServerDifficulty(worldinfo.getDifficulty(), worldinfo.isDifficultyLocked()));
+        nethandlerplayserver.sendPacket(new S05PacketSpawnPosition(blockpos));
+        nethandlerplayserver.sendPacket(new S39PacketPlayerAbilities(playerIn.capabilities));
+        nethandlerplayserver.sendPacket(new S09PacketHeldItemChange(playerIn.inventory.currentItem));
+        playerIn.getStatFile().func_150877_d();
+        playerIn.getStatFile().func_150884_b(playerIn);
+        this.func_96456_a((ServerScoreboard) worldserver.getScoreboard(), playerIn);
+        this.mcServer.refreshStatusNextTick();
+        ChatComponentTranslation chatcomponenttranslation;
+
+        if (!playerIn.getCommandSenderName().equalsIgnoreCase(s)) {
+            chatcomponenttranslation = new ChatComponentTranslation("multiplayer.player.joined.renamed", new Object[] {playerIn.getDisplayName(), s});
+        } else {
+            chatcomponenttranslation = new ChatComponentTranslation("multiplayer.player.joined", new Object[] {playerIn.getDisplayName()});
+        }
+
+        chatcomponenttranslation.getChatStyle().setColor(EnumChatFormatting.YELLOW);
+        this.sendChatMsg(chatcomponenttranslation);
+        this.playerLoggedIn(playerIn);
+        nethandlerplayserver.setPlayerLocation(playerIn.posX, playerIn.posY, playerIn.posZ, playerIn.rotationYaw, playerIn.rotationPitch);
+        this.updateTimeAndWeatherForPlayer(playerIn, worldserver);
+
+        if (this.mcServer.getResourcePackUrl().length() > 0) {
+            playerIn.loadResourcePack(this.mcServer.getResourcePackUrl(), this.mcServer.getResourcePackHash());
+        }
+
+        Iterator iterator = playerIn.getActivePotionEffects().iterator();
+
+        while (iterator.hasNext()) {
+            PotionEffect potioneffect = (PotionEffect) iterator.next();
+            nethandlerplayserver.sendPacket(new S1DPacketEntityEffect(playerIn.getEntityId(), potioneffect));
+        }
+
+        playerIn.addSelfToInternalCraftingInventory();
+
+        net.minecraftforge.fml.common.FMLCommonHandler.instance().firePlayerLoggedIn(playerIn);
+        if (nbttagcompound != null && nbttagcompound.hasKey("Riding", 10)) {
+            Entity entity = EntityList.createEntityFromNBT(nbttagcompound.getCompoundTag("Riding"), worldserver);
+
+            if (entity != null) {
+                entity.forceSpawn = true;
+                worldserver.spawnEntityInWorld(entity);
+                playerIn.mountEntity(entity);
+                entity.forceSpawn = false;
+            }
+        }
+    }
+
+    @SuppressWarnings({"unused", "unchecked"})
+    @Overwrite
+    public EntityPlayerMP recreatePlayerEntity(EntityPlayerMP playerIn, int targetDimension, boolean conqueredEnd) {
+        // Phase 1 - check if the player is allowed to respawn in same dimension
+        net.minecraft.world.World world = this.mcServer.worldServerForDimension(targetDimension);
+        World fromWorld = (World) playerIn.worldObj;
+
+        if (!world.provider.canRespawnHere()) {
+            targetDimension = world.provider.getRespawnDimension(playerIn);
+        }
+
+        // Phase 2 - handle return from End
+        if (conqueredEnd) {
+            WorldServer exitWorld = this.mcServer.worldServerForDimension(targetDimension);
+            Location enter = ((Player) playerIn).getLocation();
+            Optional<Location> exit = null;
+            // use bed if available, otherwise default spawn
+            exit = ((Player) playerIn).getBedLocation();
+
+            if (!exit.isPresent() || ((net.minecraft.world.World) ((World) exit.get().getExtent())).provider.getDimensionId() != 0) {
+                Vector3i pos = ((World) exitWorld).getProperties().getSpawnPosition();
+                exit = Optional.of(new Location((World) exitWorld, new Vector3d(pos.getX(), pos.getY(), pos.getZ())));
+            }
+        }
+
+        // Phase 3 - remove current player from current dimension
+        playerIn.getServerForPlayer().getEntityTracker().removePlayerFromTrackers(playerIn);
+        // par1EntityPlayerMP.getServerForPlayer().getEntityTracker().removeEntityFromAllTrackingPlayers(par1EntityPlayerMP);
+        playerIn.getServerForPlayer().getPlayerManager().removePlayer(playerIn);
+        this.playerEntityList.remove(playerIn);
+        this.mcServer.worldServerForDimension(playerIn.dimension).removePlayerEntityDangerously(playerIn);
+
+        // Phase 4 - handle bed spawn
+        BlockPos bedSpawnChunkCoords = playerIn.getBedLocation(targetDimension);
+        boolean spawnForced = playerIn.isSpawnForced(targetDimension);
+        playerIn.dimension = targetDimension;
+        EntityPlayerMP entityplayermp1 = playerIn;
+        // make sure to update reference for bed spawn logic
+        entityplayermp1.setWorld(this.mcServer.worldServerForDimension(playerIn.dimension));
+        entityplayermp1.playerConqueredTheEnd = false;
+        BlockPos bedSpawnLocation;
+        boolean isBedSpawn = false;
+        World toWorld = ((World) entityplayermp1.worldObj);
+        Location location = null;
+
+        if (bedSpawnChunkCoords != null) { // if player has a bed
+            bedSpawnLocation =
+                    EntityPlayer.getBedSpawnLocation(this.mcServer.worldServerForDimension(playerIn.dimension), bedSpawnChunkCoords, spawnForced);
+
+            if (bedSpawnLocation != null) {
+                isBedSpawn = true;
+                entityplayermp1.setLocationAndAngles(bedSpawnLocation.getX() + 0.5F,
+                        bedSpawnLocation.getY() + 0.1F, bedSpawnLocation.getZ() + 0.5F, 0.0F, 0.0F);
+                entityplayermp1.setSpawnPoint(bedSpawnChunkCoords, spawnForced);
+                location =
+                        new Location(toWorld, new Vector3d(bedSpawnChunkCoords.getX() + 0.5, bedSpawnChunkCoords.getY(),
+                                bedSpawnChunkCoords.getZ() + 0.5));
+            } else { // bed was not found (broken)
+                entityplayermp1.playerNetServerHandler.sendPacket(new S2BPacketChangeGameState(0, 0));
+                // use the spawnpoint as location
+                location =
+                        new Location(toWorld, new Vector3d(toWorld.getProperties().getSpawnPosition().getX(), toWorld.getProperties()
+                                .getSpawnPosition().getY(), toWorld.getProperties().getSpawnPosition().getZ()));
+            }
+        }
+
+        if (location == null) {
+            // use the world spawnpoint as default location
+            location =
+                    new Location(toWorld, new Vector3d(toWorld.getProperties().getSpawnPosition().getX(), toWorld.getProperties().getSpawnPosition()
+                            .getY(), toWorld.getProperties().getSpawnPosition().getZ()));
+        }
+
+        if (!conqueredEnd) { // don't reset player if returning from end
+            // TODO - add respawn event
+            ((IMixinEntityPlayerMP) playerIn).reset();
+        }
+
+        WorldServer targetWorld = (WorldServer) location.getExtent();
+        entityplayermp1.setPositionAndRotation(location.getX(), location.getY(), location.getZ(), 0, 0);//, location.getYaw(), location.getPitch());
+        targetWorld.theChunkProviderServer.loadChunk((int) entityplayermp1.posX >> 4, (int) entityplayermp1.posZ >> 4);
+
+        while (!targetWorld.getCollidingBoundingBoxes(entityplayermp1, entityplayermp1.getEntityBoundingBox()).isEmpty()) {
+            entityplayermp1.setPosition(entityplayermp1.posX, entityplayermp1.posY + 1.0D, entityplayermp1.posZ);
+        }
+
+        // Phase 5 - Respawn player in new world
+        int actualDimension = targetWorld.provider.getDimensionId();
+        // inform client of custom dimensions
+        FMLEmbeddedChannel serverChannel = NetworkRegistry.INSTANCE.getChannel("FORGE", Side.SERVER);
+        serverChannel.attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.PLAYER);
+        serverChannel.attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(entityplayermp1);
+        serverChannel.writeOutbound(new ForgeMessage.DimensionRegisterMessage(actualDimension,
+                ((SpongeDimensionType) ((Dimension) targetWorld.provider).getType()).getDimensionTypeId()));
+
+        boolean fmlClient = entityplayermp1.playerNetServerHandler.getNetworkManager().channel().attr(NetworkRegistry.FML_MARKER).get();
+        // Support vanilla clients teleporting to custom dimensions
+        if (!fmlClient) {
+            if (toWorld.getDimension().getType().equals(DimensionTypes.NETHER)) {
+                actualDimension = -1;
+            } else if (toWorld.getDimension().getType().equals(DimensionTypes.END)) {
+                actualDimension = 1;
+            } else {
+                actualDimension = 0;
+            }
+        }
+
+        entityplayermp1.playerNetServerHandler.sendPacket(new S07PacketRespawn(actualDimension, targetWorld.getDifficulty(), targetWorld
+                .getWorldInfo().getTerrainType(), entityplayermp1.theItemInWorldManager.getGameType()));
+        entityplayermp1.setWorld(targetWorld); // in case plugin changed it
+        entityplayermp1.isDead = false;
+        BlockPos blockpos1 = targetWorld.getSpawnPoint();
+        entityplayermp1.playerNetServerHandler.setPlayerLocation(entityplayermp1.posX, entityplayermp1.posY, entityplayermp1.posZ,
+                entityplayermp1.rotationYaw, entityplayermp1.rotationPitch);
+        entityplayermp1.setSneaking(false);
+        BlockPos spawnLocation = targetWorld.getSpawnPoint();
+        entityplayermp1.playerNetServerHandler.sendPacket(new S05PacketSpawnPosition(spawnLocation));
+        entityplayermp1.playerNetServerHandler.sendPacket(new S1FPacketSetExperience(entityplayermp1.experience, entityplayermp1.experienceTotal,
+                entityplayermp1.experienceLevel));
+        this.updateTimeAndWeatherForPlayer(entityplayermp1, targetWorld);
+        targetWorld.getPlayerManager().addPlayer(entityplayermp1);
+        targetWorld.spawnEntityInWorld(entityplayermp1);
+        this.playerEntityList.add(entityplayermp1);
+        entityplayermp1.addSelfToInternalCraftingInventory();
+        entityplayermp1.setHealth(entityplayermp1.getHealth());
+
+        FMLCommonHandler.instance().firePlayerRespawnEvent(entityplayermp1);
+
+        return entityplayermp1;
+    }
+
+    @Overwrite
+    public void setPlayerManager(WorldServer[] worldServers) {
+        if (this.playerNBTManagerObj != null) {
+            return;
+        }
+        this.playerNBTManagerObj = worldServers[0].getSaveHandler().getPlayerNBTManager();
+        worldServers[0].getWorldBorder().addListener(new PlayerBorderListener());
+    }
+
+    @Overwrite
+    public void updateTimeAndWeatherForPlayer(EntityPlayerMP playerIn, WorldServer worldIn) {
+        net.minecraft.world.border.WorldBorder worldborder = worldIn.getWorldBorder();
+        playerIn.playerNetServerHandler.sendPacket(new S44PacketWorldBorder(worldborder, S44PacketWorldBorder.Action.INITIALIZE));
+        playerIn.playerNetServerHandler.sendPacket(new S03PacketTimeUpdate(worldIn.getTotalWorldTime(), worldIn.getWorldTime(), worldIn
+                .getGameRules().getGameRuleBooleanValue("doDaylightCycle")));
+
+        if (worldIn.isRaining()) {
+            playerIn.playerNetServerHandler.sendPacket(new S2BPacketChangeGameState(1, 0.0F));
+            playerIn.playerNetServerHandler.sendPacket(new S2BPacketChangeGameState(7, worldIn.getRainStrength(1.0F)));
+            playerIn.playerNetServerHandler.sendPacket(new S2BPacketChangeGameState(8, worldIn.getThunderStrength(1.0F)));
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinAnvilSaveHandler.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinAnvilSaveHandler.java
@@ -22,21 +22,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.interfaces;
+package org.spongepowered.mod.mixin.core.world;
 
-import com.google.common.collect.ImmutableList;
-import org.spongepowered.api.world.gen.GeneratorPopulator;
-import org.spongepowered.api.world.gen.Populator;
-import net.minecraft.world.storage.WorldInfo;
-import org.spongepowered.mod.configuration.SpongeConfig;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.chunk.storage.AnvilChunkLoader;
+import net.minecraft.world.chunk.storage.IChunkLoader;
+import net.minecraft.world.storage.SaveHandler;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
 
-public interface IMixinWorld {
+import java.io.File;
 
-    SpongeConfig<SpongeConfig.WorldConfig> getWorldConfig();
+@NonnullByDefault
+@Mixin(net.minecraft.world.chunk.storage.AnvilSaveHandler.class)
+public class MixinAnvilSaveHandler extends SaveHandler {
 
-    ImmutableList<Populator> getPopulators();
+    public MixinAnvilSaveHandler(File savesDirectory, String directoryName, boolean playersDirectoryIn) {
+        super(savesDirectory, directoryName, playersDirectoryIn);
+    }
 
-    ImmutableList<GeneratorPopulator> getGeneratorPopulators();
-
-    void setWorldInfo(WorldInfo worldInfo);
+    @Override
+    @Overwrite
+    public IChunkLoader getChunkLoader(WorldProvider provider) {
+        // To workaround the issue of every world having a seperate savehandler
+        // we won't be generating a DIMXX folder for chunk loaders since this name is already generated
+        // for the world container with provider.getSaveFolder().
+        // This allows users to remove our mod and maintain world compatibility.
+        return new AnvilChunkLoader(this.getWorldDirectory());
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinSaveHandler.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinSaveHandler.java
@@ -1,0 +1,219 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.core.world;
+
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.storage.SaveHandler;
+import net.minecraft.world.storage.WorldInfo;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.SpongeMod;
+import org.spongepowered.mod.interfaces.IMixinWorldInfo;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+
+@NonnullByDefault
+@Mixin(net.minecraft.world.storage.SaveHandler.class)
+public abstract class MixinSaveHandler {
+
+    @Shadow
+    private File worldDirectory;
+
+    @Overwrite
+    public WorldInfo loadWorldInfo() {
+        File file1 = new File(this.worldDirectory, "level.dat");
+        File file2 = new File(this.worldDirectory, "level.dat_old");
+        File spongeFile = new File(this.worldDirectory, "level_sponge.dat");
+        File spongeOldFile = new File(this.worldDirectory, "level_sponge.dat_old");
+        NBTTagCompound nbttagcompound;
+        NBTTagCompound nbttagcompound1;
+
+        WorldInfo worldInfo = null;
+
+        if (!file1.exists() && file2.exists()) {
+            net.minecraftforge.fml.common.FMLCommonHandler.instance().confirmBackupLevelDatUse((SaveHandler) (Object) this);
+        }
+
+        if (file1.exists() || file2.exists()) {
+            try {
+                nbttagcompound = CompressedStreamTools.readCompressed(new FileInputStream(file1.exists() ? file1 : file2));
+                nbttagcompound1 = nbttagcompound.getCompoundTag("Data");
+                worldInfo = new WorldInfo(nbttagcompound1);
+                // Forge and FML data are only loaded from main world
+                if (nbttagcompound1.hasKey("dimension") && nbttagcompound1.getInteger("dimension") == 0) {
+                    net.minecraftforge.fml.common.FMLCommonHandler.instance().handleWorldDataLoad((SaveHandler) (Object) this, worldInfo,
+                            nbttagcompound);
+                }
+
+                // check for sponge data
+                if (spongeFile.exists() || spongeOldFile.exists()) {
+                    nbttagcompound = CompressedStreamTools.readCompressed(new FileInputStream(spongeFile.exists() ? spongeFile : spongeOldFile));
+                    ((IMixinWorldInfo) worldInfo).setSpongeRootLevelNBT(nbttagcompound);
+                    if (nbttagcompound.hasKey(SpongeMod.instance.getModId())) {
+                        NBTTagCompound spongeNbt = nbttagcompound.getCompoundTag(SpongeMod.instance.getModId());
+                        ((IMixinWorldInfo) worldInfo).readSpongeNbt(spongeNbt);
+                    }
+                }
+
+                return worldInfo;
+            } catch (net.minecraftforge.fml.common.StartupQuery.AbortedException e) {
+                throw e;
+            } catch (Exception exception1) {
+                exception1.printStackTrace();
+            }
+        }
+
+        return null;
+    }
+
+    @Overwrite
+    public void saveWorldInfoWithPlayer(WorldInfo worldInformation, NBTTagCompound tagCompound) {
+        NBTTagCompound nbttagcompound1 = worldInformation.cloneNBTCompound(tagCompound);
+        NBTTagCompound nbttagcompound2 = new NBTTagCompound();
+        nbttagcompound2.setTag("Data", nbttagcompound1);
+
+        // Forge and FML data are only saved to main world
+        if (nbttagcompound1.hasKey("dimension") && nbttagcompound1.getInteger("dimension") == 0) {
+            net.minecraftforge.fml.common.FMLCommonHandler.instance().handleWorldDataSave((SaveHandler) (Object) this, worldInformation, nbttagcompound2);
+        }
+
+        try {
+            File file1 = new File(this.worldDirectory, "level.dat_new");
+            File file2 = new File(this.worldDirectory, "level.dat_old");
+            File file3 = new File(this.worldDirectory, "level.dat");
+            CompressedStreamTools.writeCompressed(nbttagcompound2, new FileOutputStream(file1));
+
+            if (file2.exists()) {
+                file2.delete();
+            }
+
+            file3.renameTo(file2);
+
+            if (file3.exists()) {
+                file3.delete();
+            }
+
+            file1.renameTo(file3);
+
+            if (file1.exists()) {
+                file1.delete();
+            }
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+
+        try {
+            File spongeFile1 = new File(this.worldDirectory, "level_sponge.dat_new");
+            File spongeFile2 = new File(this.worldDirectory, "level_sponge.dat_old");
+            File spongeFile3 = new File(this.worldDirectory, "level_sponge.dat");
+            CompressedStreamTools.writeCompressed(((IMixinWorldInfo) worldInformation).getSpongeRootLevelNbt(), new FileOutputStream(spongeFile1));
+
+            if (spongeFile2.exists()) {
+                spongeFile2.delete();
+            }
+
+            spongeFile3.renameTo(spongeFile2);
+
+            if (spongeFile3.exists()) {
+                spongeFile3.delete();
+            }
+
+            spongeFile1.renameTo(spongeFile3);
+
+            if (spongeFile1.exists()) {
+                spongeFile1.delete();
+            }
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+    }
+
+    @Overwrite
+    public void saveWorldInfo(WorldInfo worldInformation) {
+        NBTTagCompound nbttagcompound = worldInformation.getNBTTagCompound();
+        NBTTagCompound nbttagcompound1 = new NBTTagCompound();
+        nbttagcompound1.setTag("Data", nbttagcompound);
+
+        // Forge and FML data are only saved to main world
+        if (nbttagcompound.hasKey("dimension") && nbttagcompound.getInteger("dimension") == 0) {
+            net.minecraftforge.fml.common.FMLCommonHandler.instance().handleWorldDataSave((SaveHandler) (Object) this, worldInformation, nbttagcompound1);
+        }
+
+        try {
+            File file1 = new File(this.worldDirectory, "level.dat_new");
+            File file2 = new File(this.worldDirectory, "level.dat_old");
+            File file3 = new File(this.worldDirectory, "level.dat");
+            CompressedStreamTools.writeCompressed(nbttagcompound1, new FileOutputStream(file1));
+
+            if (file2.exists()) {
+                file2.delete();
+            }
+
+            file3.renameTo(file2);
+
+            if (file3.exists()) {
+                file3.delete();
+            }
+
+            file1.renameTo(file3);
+
+            if (file1.exists()) {
+                file1.delete();
+            }
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+
+        try {
+            File spongeFile1 = new File(this.worldDirectory, "level_sponge.dat_new");
+            File spongeFile2 = new File(this.worldDirectory, "level_sponge.dat_old");
+            File spongeFile3 = new File(this.worldDirectory, "level_sponge.dat");
+            CompressedStreamTools.writeCompressed(((IMixinWorldInfo) worldInformation).getSpongeRootLevelNbt(), new FileOutputStream(spongeFile1));
+
+            if (spongeFile2.exists()) {
+                spongeFile2.delete();
+            }
+
+            spongeFile3.renameTo(spongeFile2);
+
+            if (spongeFile3.exists()) {
+                spongeFile3.delete();
+            }
+
+            spongeFile1.renameTo(spongeFile3);
+
+            if (spongeFile1.exists()) {
+                spongeFile1.delete();
+            }
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldServerMulti.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldServerMulti.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.core.world;
+
+import net.minecraft.profiler.Profiler;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.MinecraftException;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.storage.ISaveHandler;
+import net.minecraft.world.storage.WorldInfo;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@NonnullByDefault
+@Mixin(net.minecraft.world.WorldServerMulti.class)
+public abstract class MixinWorldServerMulti extends WorldServer {
+
+    public MixinWorldServerMulti(MinecraftServer server, ISaveHandler saveHandlerIn, WorldInfo info, int dimensionId, Profiler profilerIn) {
+        super(server, saveHandlerIn, info, dimensionId, profilerIn);
+    }
+
+    @Override
+    @Overwrite
+    protected void saveLevel() throws MinecraftException {
+        // this.perWorldStorage.saveAllData();
+        // we handle all saving including perWorldStorage in WorldServer.saveLevel. This needs to be disabled since we
+        // use a seperate save handler for each world. Each world folder needs to generate a corresponding
+        // level.dat for plugins that require it such as MultiVerse.
+        super.saveLevel();
+    }
+
+    @Override
+    @Overwrite
+    public net.minecraft.world.World init() {
+        return super.init();
+    }
+}

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldSettings.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldSettings.java
@@ -1,0 +1,172 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.core.world;
+
+import net.minecraft.world.WorldSettings;
+import net.minecraft.world.WorldType;
+import org.spongepowered.api.entity.player.gamemode.GameMode;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.DimensionType;
+import org.spongepowered.api.world.GeneratorType;
+import org.spongepowered.api.world.WorldCreationSettings;
+import org.spongepowered.api.world.gen.WorldGeneratorModifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.entity.player.gamemode.SpongeGameMode;
+import org.spongepowered.mod.interfaces.IMixinWorldSettings;
+
+import java.util.Collection;
+
+@NonnullByDefault
+@Mixin(WorldSettings.class)
+public class MixinWorldSettings implements WorldCreationSettings, IMixinWorldSettings {
+
+    private DimensionType dimensionType;
+    private DataContainer generatorSettings;
+    private boolean worldEnabled;
+    private boolean loadOnStartup;
+    private boolean keepSpawnLoaded;
+
+    @Shadow
+    private long seed;
+
+    @Shadow
+    private WorldSettings.GameType theGameType;
+
+    @Shadow
+    private boolean mapFeaturesEnabled;
+
+    @Shadow
+    private boolean hardcoreEnabled;
+
+    @Shadow
+    private WorldType terrainType;
+
+    @Shadow
+    private boolean commandsAllowed;
+
+    @Shadow
+    private boolean bonusChestEnabled;
+
+    @Shadow
+    private String worldName;
+
+    @Override
+    public String getWorldName() {
+        return this.worldName;
+    }
+
+    @Override
+    public long getSeed() {
+        return this.seed;
+    }
+
+    @Override
+    public GameMode getGameMode() {
+        return new SpongeGameMode(this.theGameType.getName());
+    }
+
+    @Override
+    public GeneratorType getGeneratorType() {
+        return (GeneratorType) this.terrainType;
+    }
+
+    @Override
+    public boolean usesMapFeatures() {
+        return this.mapFeaturesEnabled;
+    }
+
+    @Override
+    public boolean isHardcore() {
+        return this.hardcoreEnabled;
+    }
+
+    @Override
+    public boolean commandsAllowed() {
+        return this.commandsAllowed;
+    }
+
+    @Override
+    public boolean bonusChestEnabled() {
+        return this.bonusChestEnabled;
+    }
+
+    @Override
+    public DimensionType getDimensionType() {
+        return this.dimensionType;
+    }
+
+    @Override
+    public void setDimensionType(DimensionType type) {
+        this.dimensionType = type;
+    }
+
+    @Override
+    public DataContainer getGeneratorSettings() {
+        return this.generatorSettings;
+    }
+
+    @Override
+    public void setGeneratorSettings(DataContainer settings) {
+        this.generatorSettings = settings;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return this.worldEnabled;
+    }
+
+    @Override
+    public void setEnabled(boolean isWorldEnabled) {
+        this.worldEnabled = isWorldEnabled;
+    }
+
+    @Override
+    public boolean loadOnStartup() {
+        return this.loadOnStartup;
+    }
+
+    @Override
+    public void setLoadOnStartup(boolean loadOnStartup) {
+        this.loadOnStartup = loadOnStartup;
+    }
+
+    @Override
+    public boolean doesKeepSpawnLoaded() {
+        return this.keepSpawnLoaded;
+    }
+
+    @Override
+    public void setKeepSpawnLoaded(boolean keepSpawnLoaded) {
+        this.keepSpawnLoaded = keepSpawnLoaded;
+    }
+
+    @Override
+    public Collection<WorldGeneratorModifier> getGeneratorModifiers() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+}

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldType.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldType.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.core.world;
+
+import net.minecraft.world.WorldType;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.GeneratorType;
+import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.gen.WorldGenerator;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.interfaces.IMixinWorldType;
+
+import java.util.concurrent.Callable;
+
+@NonnullByDefault
+@Mixin(WorldType.class)
+public class MixinWorldType implements GeneratorType, IMixinWorldType {
+
+    private Callable<WorldGenerator> generator;
+    private DataContainer generatorSettings;
+
+    @Shadow
+    private String worldType;
+
+    @Override
+    public String getName() {
+        return this.worldType;
+    }
+
+    @Override
+    public WorldGenerator createGenerator(World world) {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public void setWorldGenerator(Callable<WorldGenerator> generator) {
+        this.generator = generator;
+    }
+
+    @Override
+    public void setGeneratorSettings(DataContainer settings) {
+        this.generatorSettings = settings;
+    }
+
+    @Override
+    public DataContainer getGeneratorSettings() {
+        return this.generatorSettings;
+    }
+
+}

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/storage/MixinWorldInfo.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/storage/MixinWorldInfo.java
@@ -1,0 +1,524 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.mixin.core.world.storage;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.flowpowered.math.vector.Vector3i;
+import com.google.common.base.Optional;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.EnumDifficulty;
+import net.minecraft.world.GameRules;
+import net.minecraft.world.WorldSettings;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.storage.WorldInfo;
+import org.spongepowered.api.entity.player.gamemode.GameMode;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.service.persistence.data.DataQuery;
+import org.spongepowered.api.service.persistence.data.DataView;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.DimensionType;
+import org.spongepowered.api.world.GeneratorType;
+import org.spongepowered.api.world.WorldBorder;
+import org.spongepowered.api.world.WorldCreationSettings;
+import org.spongepowered.api.world.difficulty.Difficulty;
+import org.spongepowered.api.world.storage.WorldProperties;
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.mod.SpongeMod;
+import org.spongepowered.mod.entity.player.gamemode.SpongeGameMode;
+import org.spongepowered.mod.interfaces.IMixinWorldInfo;
+import org.spongepowered.mod.service.persistence.NbtTranslator;
+
+import java.util.Map;
+import java.util.UUID;
+
+@NonnullByDefault
+@Mixin(WorldInfo.class)
+@Implements(@Interface(iface = WorldProperties.class, prefix = "worldproperties$"))
+public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo {
+
+    private UUID uuid;
+    private boolean worldEnabled;
+    private DimensionType dimensionType;
+    @SuppressWarnings("unused")
+    private boolean loadOnStartup;
+    private boolean keepSpawnLoaded;
+    private NBTTagCompound spongeRootLevelNbt;
+    private NBTTagCompound spongeNbt;
+
+    @Shadow
+    public long randomSeed;
+
+    @Shadow
+    private net.minecraft.world.WorldType terrainType;
+
+    @Shadow
+    private String generatorOptions;
+
+    @Shadow
+    private int spawnX;
+
+    @Shadow
+    private int spawnY;
+
+    @Shadow
+    private int spawnZ;
+
+    @Shadow
+    private long totalTime;
+
+    @Shadow
+    private long worldTime;
+
+    @Shadow
+    private long lastTimePlayed;
+
+    @Shadow
+    private long sizeOnDisk;
+
+    @Shadow
+    private NBTTagCompound playerTag;
+
+    @Shadow
+    private int dimension;
+
+    @Shadow
+    private String levelName;
+
+    @Shadow
+    private int saveVersion;
+
+    @Shadow
+    private int cleanWeatherTime;
+
+    @Shadow
+    private boolean raining;
+
+    @Shadow
+    private int rainTime;
+
+    @Shadow
+    private boolean thundering;
+
+    @Shadow
+    private int thunderTime;
+
+    @Shadow
+    private WorldSettings.GameType theGameType;
+
+    @Shadow
+    private boolean mapFeaturesEnabled;
+
+    @Shadow
+    private boolean hardcore;
+
+    @Shadow
+    private boolean allowCommands;
+
+    @Shadow
+    private boolean initialized;
+
+    @Shadow
+    private EnumDifficulty difficulty;
+
+    @Shadow
+    private boolean difficultyLocked;
+
+    @Shadow
+    private double borderCenterX;
+
+    @Shadow
+    private double borderCenterZ;
+
+    @Shadow
+    private double borderSize;
+
+    @Shadow
+    private long borderSizeLerpTime;
+
+    @Shadow
+    private double borderSizeLerpTarget;
+
+    @Shadow
+    private double borderSafeZone;
+
+    @Shadow
+    private double borderDamagePerBlock;
+
+    @Shadow
+    private int borderWarningDistance;
+
+    @Shadow
+    private int borderWarningTime;
+
+    @Shadow
+    private GameRules theGameRules;
+
+    @Shadow
+    public abstract NBTTagCompound getNBTTagCompound();
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    public void onConstruction(CallbackInfo ci) {
+        this.worldEnabled = true;
+        this.spongeRootLevelNbt = new NBTTagCompound();
+        this.spongeNbt = new NBTTagCompound();
+        this.spongeRootLevelNbt.setTag(SpongeMod.instance.getModId(), this.spongeNbt);
+    }
+
+    @Inject(method = "<init>*", at = @At("RETURN"))
+    public void onConstruction(WorldSettings settings, String name, CallbackInfo ci) {
+        this.worldEnabled = true;
+        this.spongeRootLevelNbt = new NBTTagCompound();
+        this.spongeNbt = new NBTTagCompound();
+        this.spongeRootLevelNbt.setTag(SpongeMod.instance.getModId(), this.spongeNbt);
+        this.dimensionType = ((WorldCreationSettings) (Object) settings).getDimensionType();
+    }
+
+    @Inject(method = "<init>*", at = @At("RETURN"))
+    public void onConstruction(NBTTagCompound nbt, CallbackInfo ci) {
+        this.worldEnabled = true;
+        this.spongeRootLevelNbt = new NBTTagCompound();
+        this.spongeNbt = new NBTTagCompound();
+        this.spongeRootLevelNbt.setTag(SpongeMod.instance.getModId(), this.spongeNbt);
+    }
+
+    private void updateSpongeNbt() {
+        this.spongeNbt.setString("LevelName", this.levelName); // for reference
+        this.spongeNbt.setInteger("dimensionId", this.dimension);
+        if (this.dimensionType != null) {
+            this.spongeNbt.setString("dimensionType", this.dimensionType.getDimensionClass().getName());
+        }
+        if (this.uuid != null) {
+            this.spongeNbt.setLong("uuid_most", this.uuid.getMostSignificantBits());
+            this.spongeNbt.setLong("uuid_least", this.uuid.getLeastSignificantBits());
+        }
+        this.spongeNbt.setBoolean("enabled", this.worldEnabled);
+        this.spongeNbt.setBoolean("keepSpawnLoaded", this.keepSpawnLoaded);
+        this.spongeNbt.setBoolean("loadOnStartup", this.loadOnStartup);
+    }
+
+    @Override
+    public void readSpongeNbt(NBTTagCompound nbt) {
+        this.dimension = nbt.getInteger("dimensionId");
+        long uuid_most = nbt.getLong("uuid_most");
+        long uuid_least = nbt.getLong("uuid_least");
+        this.uuid = new UUID(uuid_most, uuid_least);
+        this.worldEnabled = nbt.getBoolean("enabled");
+        this.keepSpawnLoaded = nbt.getBoolean("keepSpawnLoaded");
+        this.loadOnStartup = nbt.getBoolean("loadOnStartup");
+        for (DimensionType type : SpongeMod.instance.getSpongeRegistry().dimensionClassMappings.values()) {
+            if (type.getDimensionClass().getCanonicalName().equalsIgnoreCase(nbt.getString("dimensionType"))) {
+                this.dimensionType = type;
+            }
+        }
+    }
+
+    @Override
+    public Vector3i getSpawnPosition() {
+        return new Vector3i(this.spawnX, this.spawnY, this.spawnZ);
+    }
+
+    @Override
+    public void setSpawnPosition(Vector3i position) {
+        checkNotNull(position);
+        this.spawnX = position.getX();
+        this.spawnY = position.getY();
+        this.spawnZ = position.getZ();
+    }
+
+    @Override
+    public GeneratorType getGeneratorType() {
+        return (GeneratorType) this.terrainType;
+    }
+
+    @Override
+    public void setType(GeneratorType type) {
+        this.terrainType = (WorldType) type;
+    }
+
+    public long worldproperties$getSeed() {
+        return this.randomSeed;
+    }
+
+    @Override
+    public void setSeed(long seed) {
+        this.randomSeed = seed;
+    }
+
+    @Override
+    public long getTotalTime() {
+        return this.totalTime;
+    }
+
+    public long worldproperties$getWorldTime() {
+        return this.worldTime;
+    }
+
+    @Override
+    public void setWorldTime(long time) {
+        this.worldTime = time;
+    }
+
+    @Override
+    public DimensionType getDimensionType() {
+        return this.dimensionType;
+    }
+
+    @Override
+    public void setDimensionType(DimensionType type) {
+        this.dimensionType = type;
+    }
+
+    public String worldproperties$getWorldName() {
+        return this.levelName;
+    }
+
+    @Override
+    public void setWorldName(String name) {
+        this.levelName = name;
+    }
+
+    public boolean worldproperties$isRaining() {
+        return this.raining;
+    }
+
+    @Override
+    public void setRaining(boolean state) {
+        this.raining = state;
+    }
+
+    public int worldproperties$getRainTime() {
+        return this.rainTime;
+    }
+
+    public void worldproperties$setRainTime(int time) {
+        this.rainTime = time;
+    }
+
+    public boolean worldproperties$isThundering() {
+        return this.thundering;
+    }
+
+    public void worldproperties$setThundering(boolean state) {
+        this.thundering = state;
+    }
+
+    @Override
+    public int getThunderTime() {
+        return this.thunderTime;
+    }
+
+    @Override
+    public void setThunderTime(int time) {
+        this.thunderTime = time;
+    }
+
+    @Override
+    public GameMode getGameMode() {
+        return new SpongeGameMode(this.theGameType.getName());
+    }
+
+    @Override
+    public void setGameMode(GameMode gamemode) {
+        this.theGameType = SpongeMod.instance.getSpongeRegistry().getGameType(gamemode);
+    }
+
+    @Override
+    public boolean usesMapFeatures() {
+        return this.mapFeaturesEnabled;
+    }
+
+    @Override
+    public void setMapFeaturesEnabled(boolean state) {
+        this.mapFeaturesEnabled = state;
+    }
+
+    @Override
+    public boolean isHardcore() {
+        return this.hardcore;
+    }
+
+    @Override
+    public void setHardcore(boolean state) {
+        this.hardcore = state;
+    }
+
+    @Override
+    public boolean areCommandsAllowed() {
+        return this.allowCommands;
+    }
+
+    @Override
+    public void setCommandsAllowed(boolean state) {
+        this.allowCommands = state;
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return this.initialized;
+    }
+
+    @Override
+    public Difficulty getDifficulty() {
+        return (Difficulty) (Object) this.difficulty;
+    }
+
+    @Override
+    public void setDifficulty(Difficulty difficulty) {
+        this.difficulty = (EnumDifficulty) (Object) difficulty;
+    }
+
+    @Override
+    public WorldBorder getWorldBorder() {
+        net.minecraft.world.border.WorldBorder border = new net.minecraft.world.border.WorldBorder();
+        border.setCenter(this.borderCenterX, this.borderCenterZ);
+        border.setDamageAmount(this.borderDamagePerBlock);
+        border.setDamageBuffer(this.borderSafeZone);
+        border.setWarningDistance(this.borderWarningDistance);
+        border.setWarningTime(this.borderWarningTime);
+        return (WorldBorder) border;
+    }
+
+    @Override
+    public Optional<String> getGameRule(String gameRule) {
+        return Optional.fromNullable(this.theGameRules.getGameRuleStringValue(gameRule));
+    }
+
+    @Override
+    public Map<String, String> getGameRules() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void setGameRule(String gameRule, String value) {
+        this.theGameRules.setOrCreateGameRule(gameRule, value);
+    }
+
+    @Override
+    public void setDimensionId(int id) {
+        this.dimension = id;
+    }
+
+    @Override
+    public int getDimensionId() {
+        return this.dimension;
+    }
+
+    @Override
+    public UUID getUniqueId() {
+        return this.uuid;
+    }
+
+    @Override
+    public DataContainer getAdditionalProperties() {
+        NBTTagCompound additionalProperties = (NBTTagCompound) this.spongeRootLevelNbt.copy();
+        additionalProperties.removeTag(SpongeMod.instance.getModId());
+        return (DataContainer) NbtTranslator.getInstance().translateFrom(additionalProperties);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return (DataContainer) NbtTranslator.getInstance().translateFrom(getNBTTagCompound());
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return this.worldEnabled;
+    }
+
+    @Override
+    public void setEnabled(boolean state) {
+        this.worldEnabled = state;
+    }
+
+    @Override
+    public boolean loadOnStartup() {
+        return this.loadOnStartup;
+    }
+
+    @Override
+    public void setLoadOnStartup(boolean state) {
+        this.loadOnStartup = state;
+    }
+
+    @Override
+    public boolean doesKeepSpawnLoaded() {
+        return this.keepSpawnLoaded;
+    }
+
+    @Override
+    public void setKeepSpawnLoaded(boolean state) {
+        this.keepSpawnLoaded = state;
+    }
+
+    @Override
+    public void setUUID(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    @Override
+    public Optional<DataView> getPropertySection(DataQuery path) {
+        if (this.spongeRootLevelNbt.hasKey(path.toString())) {
+            return Optional.of(NbtTranslator.getInstance().translateFrom(this.spongeRootLevelNbt.getCompoundTag(path.toString())));
+        } else {
+            return Optional.absent();
+        }
+    }
+
+    @Override
+    public void setPropertySection(DataQuery path, DataView data) {
+        NBTTagCompound nbt = NbtTranslator.getInstance().translateData(data);
+        this.spongeRootLevelNbt.setTag(path.toString(), nbt);
+    }
+
+    @Override
+    public NBTTagCompound getSpongeRootLevelNbt() {
+        updateSpongeNbt();
+        return this.spongeRootLevelNbt;
+    }
+
+    @Override
+    public NBTTagCompound getSpongeNbt() {
+        updateSpongeNbt();
+        return this.spongeNbt;
+    }
+
+    @Override
+    public void setSpongeRootLevelNBT(NBTTagCompound nbt) {
+        this.spongeRootLevelNbt = nbt;
+        if (nbt.hasKey(SpongeMod.instance.getModId())) {
+            this.spongeNbt = nbt.getCompoundTag(SpongeMod.instance.getModId());
+        } else {
+            this.spongeRootLevelNbt.setTag(SpongeMod.instance.getModId(), this.spongeNbt);
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/mod/mixin/plugin/entityactivation/ActivationRange.java
+++ b/src/main/java/org/spongepowered/mod/mixin/plugin/entityactivation/ActivationRange.java
@@ -210,6 +210,8 @@ public class ActivationRange {
             for (Object o : chunk.getEntityLists()[i]) {
                 Entity entity = (Entity) o;
                 SpongeConfig<?> config = getActiveConfig(entity.worldObj);
+                // TODO
+                if (config == null) continue;
                 SpongeEntityType type = (SpongeEntityType) ((org.spongepowered.api.entity.Entity) entity).getType();
                 if (entity.worldObj.getWorldInfo().getWorldTotalTime() > ((IMixinEntity) entity).getActivatedTick()) {
                     if (((IMixinEntity) entity).getDefaultActivationState()) {
@@ -328,6 +330,8 @@ public class ActivationRange {
         }
 
         for (SpongeConfig<?> config : configs) {
+            // TODO
+            if (config == null) continue;
             if (config.getRootNode().getNode(SpongeConfig.MODULE_ENTITY_ACTIVATION_RANGE, type.getModId()).isVirtual()) {
                 config.getRootNode().getNode(SpongeConfig.MODULE_ENTITY_ACTIVATION_RANGE, type.getModId(), "enabled").setValue(true);
             }

--- a/src/main/java/org/spongepowered/mod/util/VecHelper.java
+++ b/src/main/java/org/spongepowered/mod/util/VecHelper.java
@@ -51,6 +51,11 @@ public final class VecHelper {
         return new Vector3i(pos.getX(), pos.getY(), pos.getZ());
     }
 
+    // === MC BlockPos --> Flow Vector3d ==
+
+    public static Vector3d toVector3d(BlockPos pos) {
+        return new Vector3d(pos.getX(), pos.getY(), pos.getZ());
+    }
 
     // === Rotations --> Flow Vector ===
 

--- a/src/main/java/org/spongepowered/mod/world/SpongeDimensionType.java
+++ b/src/main/java/org/spongepowered/mod/world/SpongeDimensionType.java
@@ -32,13 +32,15 @@ import org.spongepowered.api.world.DimensionType;
 public class SpongeDimensionType implements DimensionType {
 
     private String name;
+    private int dimensionTypeId;
     private boolean keepLoaded;
     private Class<? extends WorldProvider> dimensionClass;
 
-    public SpongeDimensionType(String name, boolean keepLoaded, Class<? extends WorldProvider> dimensionClass) {
+    public SpongeDimensionType(String name, boolean keepLoaded, Class<? extends WorldProvider> dimensionClass, int id) {
         this.name = name;
         this.keepLoaded = keepLoaded;
         this.dimensionClass = dimensionClass;
+        this.dimensionTypeId = id;
     }
 
     @Override
@@ -57,6 +59,10 @@ public class SpongeDimensionType implements DimensionType {
         return (Class<? extends Dimension>) this.dimensionClass;
     }
 
+    public int getDimensionTypeId() {
+        return this.dimensionTypeId;
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
@@ -64,5 +70,22 @@ public class SpongeDimensionType implements DimensionType {
                 .add("keepLoaded", this.keepLoaded)
                 .add("class", this.dimensionClass.getName())
                 .toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof DimensionType)) {
+            return false;
+        }
+
+        DimensionType other = (DimensionType) obj;
+        if (!this.name.equals(other.getName())) {
+            return false;
+        }
+        if (!this.dimensionClass.equals(other.getDimensionClass())) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/org/spongepowered/mod/world/SpongeTeleportHelper.java
+++ b/src/main/java/org/spongepowered/mod/world/SpongeTeleportHelper.java
@@ -1,0 +1,209 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.world;
+
+import com.flowpowered.math.vector.Vector3i;
+import com.google.common.base.Optional;
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.TeleportHelper;
+import org.spongepowered.api.world.World;
+
+public class SpongeTeleportHelper implements TeleportHelper {
+
+    /** The default height radius to scan for safe locations */
+    static int DEFAULT_HEIGHT = 3;
+    /** The default width radius to scan for safe locations */
+    static int DEFAULT_WIDTH = 9;
+
+    @Override
+    public Optional<Location> getSafeLocation(Location location) {
+        return getSafeLocation(location, DEFAULT_HEIGHT, DEFAULT_WIDTH);
+    }
+
+    @Override
+    public Optional<Location> getSafeLocation(Location location, final int height, final int width) {
+        // Check around the player first in a configurable radius:
+        Optional<Location> safe = checkAboveAndBelowLocation(location, height, width);
+        if (safe.isPresent()) {
+            return safe;
+        } else {
+            return Optional.absent();
+        }
+    }
+
+    private Optional<Location> checkAboveAndBelowLocation(Location location, final int height, final int width) {
+        // For now this will just do a straight up block.
+        // Check the main level
+        Optional<Location> safe = checkAroundLocation(location, width);
+
+        if (safe.isPresent()) {
+            return safe;
+        }
+
+        // We've already checked zero right above this.
+        for (int currentLevel = 1; currentLevel <= height; currentLevel++) {
+            // Check above
+            safe = checkAroundLocation(new Location(location.getExtent(), location.getPosition().add(0, currentLevel, 0)), width);
+            if (safe.isPresent()) {
+                return safe;
+            }
+
+            // Check below
+            safe = checkAroundLocation(new Location(location.getExtent(), location.getPosition().sub(0, currentLevel, 0)), width);
+            if (safe.isPresent()) {
+                return safe;
+            }
+        }
+
+        return Optional.absent();
+    }
+
+    private Optional<Location> checkAroundLocation(Location location, final int radius) {
+        // Let's check the center of the 'circle' first...
+        Vector3i blockPos = new Vector3i(location.getBlockPosition());
+        if (isSafeLocation((World) location.getExtent(), blockPos)) {
+            return Optional.of(new Location(location.getExtent(), blockPos));
+        }
+
+        // Now we're going to search in expanding concentric circles...
+        for (int currentRadius = 0; currentRadius <= radius; currentRadius++) {
+            Optional<Vector3i> safePosition = checkAroundSpecificDiameter(location, currentRadius);
+            if (safePosition.isPresent()) {
+                // If a safe area was found: Return the checkLoc, it is the safe location.
+                return Optional.of(new Location(location.getExtent(), safePosition.get()));
+            }
+        }
+
+        return Optional.absent();
+    }
+
+    private Optional<Vector3i> checkAroundSpecificDiameter(Location checkLoc, final int radius) {
+        World world = (World) checkLoc.getExtent();
+        Vector3i blockPos = checkLoc.getBlockPosition();
+        // Check out at the radius provided.
+        blockPos = blockPos.add(radius, 0, 0);
+        if (isSafeLocation(world, blockPos)) {
+            return Optional.of(blockPos);
+        }
+
+        // Move up to the first corner..
+        for (int i = 0; i < radius; i++) {
+            blockPos = blockPos.add(radius, 0, 0);
+            if (isSafeLocation(world, blockPos)) {
+                return Optional.of(blockPos);
+            }
+        }
+
+        // Move to the second corner..
+        for (int i = 0; i < radius * 2; i++) {
+            blockPos = blockPos.add(radius, 0, 0);
+            if (isSafeLocation(world, blockPos)) {
+                return Optional.of(blockPos);
+            }
+        }
+
+        // Move to the third corner..
+        for (int i = 0; i < radius * 2; i++) {
+            blockPos = blockPos.add(radius, 0, 0);
+            if (isSafeLocation(world, blockPos)) {
+                return Optional.of(blockPos);
+            }
+        }
+
+        // Move to the last corner..
+        for (int i = 0; i < radius * 2; i++) {
+            blockPos = blockPos.add(radius, 0, 0);
+            if (isSafeLocation(world, blockPos)) {
+                return Optional.of(blockPos);
+            }
+        }
+
+        // Move back to just before the starting point.
+        for (int i = 0; i < radius - 1; i++) {
+            blockPos = blockPos.add(radius, 0, 0);
+            if (isSafeLocation(world, blockPos)) {
+                return Optional.of(blockPos);
+            }
+        }
+        return Optional.absent();
+    }
+
+    public boolean isSafeLocation(World world, Vector3i blockPos) {
+        Vector3i up = new Vector3i(blockPos.add(Vector3i.UP));
+        Vector3i down = new Vector3i(blockPos.sub(0, 1, 0));
+
+        if (!isBlockSafe(world, blockPos) || !isBlockSafe(world, up) || !isBlockSafe(world, down)) {
+            return false;
+        }
+
+        if (world.getBlock(down).getType() == BlockTypes.AIR) {
+            final boolean blocksBelowSafe = areTwoBlocksBelowSafe(world, down);
+            return blocksBelowSafe;
+        }
+        return true;
+    }
+
+    protected boolean isBlockSafe(World world, Vector3i blockPos) {
+        BlockType block = world.getBlockType(blockPos);
+        if (block.isSolidCube()) {
+            return false;
+        }
+        if (blockPos.getY() < 0) {
+            return false;
+        }
+
+        if (blockPos.getY() >= world.getDimension().getHeight()) {
+            return false;
+        }
+
+        BlockType type = world.getBlockType(blockPos);
+        if (type == BlockTypes.LAVA) {
+            return false;
+        }
+        if (type == BlockTypes.FIRE) {
+            return false;
+        }
+        return true;
+    }
+
+    protected boolean areTwoBlocksBelowSafe(World world, Vector3i blockPos) {
+
+        Vector3i blockBelowPos = new Vector3i(blockPos).sub(0, 1, 0);
+        Vector3i blockBelowPos2 = new Vector3i(blockPos).sub(0, 2, 0);
+        BlockType blockBelow = world.getBlockType(blockBelowPos);
+        BlockType blockBelow2 = world.getBlockType(blockBelowPos2);
+        if (blockBelow == BlockTypes.AIR && blockBelow2 == BlockTypes.AIR) {
+            return false; // prevent fall damage
+        }
+
+        if ((blockBelow == BlockTypes.AIR && (blockBelow2 == BlockTypes.LAVA || blockBelow2 == BlockTypes.FLOWING_LAVA))) {
+            return false; // prevent damage;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/org/spongepowered/mod/world/SpongeWorldBuilder.java
+++ b/src/main/java/org/spongepowered/mod/world/SpongeWorldBuilder.java
@@ -1,0 +1,202 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.world;
+
+import com.google.common.base.Optional;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.WorldSettings;
+import net.minecraft.world.WorldSettings.GameType;
+import net.minecraft.world.WorldType;
+import org.spongepowered.api.Server;
+import org.spongepowered.api.entity.player.gamemode.GameMode;
+import org.spongepowered.api.entity.player.gamemode.GameModes;
+import org.spongepowered.api.service.persistence.data.DataContainer;
+import org.spongepowered.api.world.DimensionType;
+import org.spongepowered.api.world.DimensionTypes;
+import org.spongepowered.api.world.GeneratorType;
+import org.spongepowered.api.world.GeneratorTypes;
+import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.WorldBuilder;
+import org.spongepowered.api.world.WorldCreationSettings;
+import org.spongepowered.api.world.gen.WorldGeneratorModifier;
+import org.spongepowered.api.world.storage.WorldProperties;
+import org.spongepowered.mod.interfaces.IMixinWorldSettings;
+import org.spongepowered.mod.service.persistence.NbtTranslator;
+
+public class SpongeWorldBuilder implements WorldBuilder {
+
+    private String name;
+    private long seed;
+    private GameMode gameMode;
+    private GeneratorType generatorType;
+    private DimensionType dimensionType;
+    private boolean mapFeaturesEnabled;
+    private boolean hardcore;
+    private boolean worldEnabled;
+    private boolean loadOnStartup;
+    private boolean keepSpawnLoaded;
+    private DataContainer generatorSettings;
+
+    public SpongeWorldBuilder() {
+        reset();
+    }
+
+    public SpongeWorldBuilder(WorldCreationSettings settings) {
+        this.name = settings.getWorldName();
+        this.seed = settings.getSeed();
+        this.gameMode = settings.getGameMode();
+        this.generatorType = settings.getGeneratorType();
+        this.dimensionType = settings.getDimensionType();
+        this.mapFeaturesEnabled = settings.usesMapFeatures();
+        this.hardcore = settings.isHardcore();
+        this.worldEnabled = settings.isEnabled();
+        this.loadOnStartup = settings.loadOnStartup();
+        this.keepSpawnLoaded = settings.doesKeepSpawnLoaded();
+    }
+
+    public SpongeWorldBuilder(WorldProperties properties) {
+        this.name = properties.getWorldName();
+        this.seed = properties.getSeed();
+        this.gameMode = properties.getGameMode();
+        this.generatorType = properties.getGeneratorType();
+        this.dimensionType = properties.getDimensionType();
+        this.mapFeaturesEnabled = properties.usesMapFeatures();
+        this.hardcore = properties.isHardcore();
+        this.worldEnabled = properties.isEnabled();
+        this.loadOnStartup = properties.loadOnStartup();
+        this.keepSpawnLoaded = properties.doesKeepSpawnLoaded();
+    }
+
+    @Override
+    public WorldBuilder name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public WorldBuilder seed(long seed) {
+        this.seed = seed;
+        return this;
+    }
+
+    @Override
+    public WorldBuilder gameMode(GameMode gameMode) {
+        this.gameMode = gameMode;
+        return this;
+    }
+
+    @Override
+    public WorldBuilder generator(GeneratorType type) {
+        this.generatorType = type;
+        return this;
+    }
+
+    @Override
+    public WorldBuilder dimensionType(DimensionType type) {
+        this.dimensionType = type;
+        return this;
+    }
+
+    @Override
+    public WorldBuilder usesMapFeatures(boolean enabled) {
+        this.mapFeaturesEnabled = enabled;
+        return this;
+    }
+
+    @Override
+    public WorldBuilder hardcore(boolean enabled) {
+        this.hardcore = enabled;
+        return this;
+    }
+
+    @Override
+    public WorldBuilder enabled(boolean state) {
+        this.worldEnabled = state;
+        return this;
+    }
+
+    @Override
+    public WorldBuilder loadsOnStartup(boolean state) {
+        this.loadOnStartup = state;
+        return this;
+    }
+
+    @Override
+    public WorldBuilder keepsSpawnLoaded(boolean state) {
+        this.keepSpawnLoaded = state;
+        return this;
+    }
+
+    @Override
+    public WorldBuilder generatorSettings(DataContainer settings) {
+        this.generatorSettings = settings;
+        return this;
+    }
+
+    @Override
+    public WorldBuilder generatorModifiers(WorldGeneratorModifier... modifier) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Optional<World> build() throws IllegalStateException {
+        WorldCreationSettings settings = buildSettings();
+        ((Server) MinecraftServer.getServer()).createWorld(buildSettings());
+        return ((Server) MinecraftServer.getServer()).loadWorld(settings.getWorldName());
+    }
+
+    @Override
+    public WorldCreationSettings buildSettings() throws IllegalStateException {
+        WorldSettings settings =
+                new WorldSettings(this.seed, GameType.valueOf(this.gameMode.getTranslation().get()), this.mapFeaturesEnabled, this.hardcore,
+                        (WorldType) this.generatorType);
+        settings.setWorldName(this.name);
+        ((IMixinWorldSettings) (Object) settings).setDimensionType(this.dimensionType);
+        ((IMixinWorldSettings) (Object) settings).setGeneratorSettings(this.generatorSettings);
+        ((IMixinWorldSettings) (Object) settings).setEnabled(this.worldEnabled);
+        ((IMixinWorldSettings) (Object) settings).setKeepSpawnLoaded(this.keepSpawnLoaded);
+        ((IMixinWorldSettings) (Object) settings).setLoadOnStartup(this.loadOnStartup);
+        return (WorldCreationSettings) (Object) settings;
+    }
+
+    @Override
+    public WorldBuilder reset() {
+        this.name = "spongeworld";
+        this.seed = 1234567890;
+        this.gameMode = GameModes.SURVIVAL;
+        this.generatorType = GeneratorTypes.DEFAULT;
+        this.dimensionType = DimensionTypes.OVERWORLD;
+        this.mapFeaturesEnabled = true;
+        this.hardcore = false;
+        this.worldEnabled = true;
+        this.loadOnStartup = true;
+        this.keepSpawnLoaded = false;
+        this.generatorSettings = (DataContainer) NbtTranslator.getInstance().translateFrom(new NBTTagCompound());
+        return this;
+    }
+
+}

--- a/src/main/java/org/spongepowered/mod/world/border/PlayerBorderListener.java
+++ b/src/main/java/org/spongepowered/mod/world/border/PlayerBorderListener.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.mod.world.border;
+
+import net.minecraft.network.play.server.S44PacketWorldBorder;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.border.IBorderListener;
+import net.minecraft.world.border.WorldBorder;
+
+public class PlayerBorderListener implements IBorderListener {
+
+    @Override
+    public void onSizeChanged(WorldBorder border, double newSize) {
+        MinecraftServer.getServer().getConfigurationManager()
+                .sendPacketToAllPlayers(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.SET_SIZE));
+    }
+
+    @Override
+    public void onTransitionStarted(WorldBorder border, double oldSize, double newSize, long time) {
+        MinecraftServer.getServer().getConfigurationManager()
+                .sendPacketToAllPlayers(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.LERP_SIZE));
+    }
+
+    @Override
+    public void onCenterChanged(WorldBorder border, double x, double z) {
+        MinecraftServer.getServer().getConfigurationManager()
+                .sendPacketToAllPlayers(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.SET_CENTER));
+    }
+
+    @Override
+    public void onWarningTimeChanged(WorldBorder border, int newTime) {
+        MinecraftServer.getServer().getConfigurationManager()
+                .sendPacketToAllPlayers(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.SET_WARNING_TIME));
+    }
+
+    @Override
+    public void onWarningDistanceChanged(WorldBorder border, int newDistance) {
+        MinecraftServer.getServer().getConfigurationManager()
+                .sendPacketToAllPlayers(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.SET_WARNING_BLOCKS));
+    }
+
+    @Override
+    public void onDamageAmountChanged(WorldBorder border, double newAmount) {
+    }
+
+    @Override
+    public void onDamageBufferChanged(WorldBorder border, double newSize) {
+    }
+}

--- a/src/main/resources/mixins.sponge.core.json
+++ b/src/main/resources/mixins.sponge.core.json
@@ -177,12 +177,12 @@
         "server.MixinNetHandlerPlayServer",
         "server.MixinNetworkManager",
         "server.MixinServerCommandManager",
+        "server.MixinServerConfigurationManager",
         "status.MixinMinecraftProtocolVersionIdentifier",
         "status.MixinNetHandlerStatusServer",
         "status.MixinPingResponseHandler",
         "status.MixinPlayerCountData",
         "status.MixinServerStatusResponse",
-
         "text.MixinChatComponentScore",
         "text.MixinChatComponentSelector",
         "text.MixinChatComponentStyle",
@@ -192,12 +192,17 @@
         "text.MixinChatStyleRoot",
         "text.MixinClickEvent",
         "text.MixinHoverEvent",
-
+        "world.MixinAnvilSaveHandler",
         "world.MixinChunk",
+        "world.MixinSaveHandler",
         "world.MixinWorld",
         "world.MixinWorldBorder",
         "world.MixinWorldProvider",
+        "world.MixinWorldServerMulti",
+        "world.MixinWorldSettings",
+        "world.MixinWorldType",
         "world.biome.MixinBiomeGenBase",
-        "world.difficulty.MixinEnumDifficulty"
+        "world.difficulty.MixinEnumDifficulty",
+        "world.storage.MixinWorldInfo"
     ]
 }

--- a/src/main/resources/sponge_at.cfg
+++ b/src/main/resources/sponge_at.cfg
@@ -34,6 +34,7 @@ public-f org.spongepowered.api.text.translation.locale.Locales *
 
 public-f org.spongepowered.api.world.biome.BiomeTypes *
 public-f org.spongepowered.api.world.DimensionTypes *
+public-f org.spongepowered.api.world.GeneratorTypes *
 public-f org.spongepowered.api.util.rotation.Rotations *
 public-f org.spongepowered.api.world.weather.Weathers *
 public-f org.spongepowered.api.world.difficulty.Difficulties *
@@ -94,5 +95,11 @@ public net.minecraft.network.handshake.client.C00Handshake field_149598_b # ip
 public net.minecraft.network.handshake.client.C00Handshake field_149599_c # port
 
 protected net.minecraft.entity.player.EntityPlayer field_71077_c # spawnChunk
+
+public net.minecraft.entity.Entity field_70151_c # fire
+
+public net.minecraft.entity.EntityLivingBase field_70752_e # potionsNeedUpdate
+public net.minecraft.entity.EntityLivingBase field_70755_b # entityLivingToAttack
+public-f net.minecraft.entity.EntityLivingBase field_94063_bt # _combatTracker
 
 public net.minecraft.util.FoodStats field_75126_c # foodExhaustionLevel


### PR DESCRIPTION
In order to generate a proper level.dat per world, every world will now
use a seperate save handler unlike Forge/Vanilla which use only one.
This is required in order to have world settings saved per world.

In order to create a custom world, you will be required to use our new
WorldBuilder. This allows you to create and load a world immediately or
simply generate a world for later use.

Note: When creating a world, it will NOT be loaded. The world folder is
created along with initial data. If you want the world to be available,
you must load it by calling loadWorld.

After a world is created, Sponge will register these worlds,
if enabled, during server startup so they can be loaded automatically with
the default worlds. This should help plugins such as MultiVerse which had
to support this themselves.

UUID support has been added and is now stored with the world data.

All custom world data will be located in a new level dat file called
"level_sponge.dat". We chose to store all additional world data in a
seperate file to avoid loss of data if a user launched the server in a
non-forge or sponge environment.