### PR TITLE
Fix synchronous task delay

### DIFF
--- a/src/main/java/org/spongepowered/mod/service/scheduler/SyncScheduler.java
+++ b/src/main/java/org/spongepowered/mod/service/scheduler/SyncScheduler.java
@@ -265,6 +265,7 @@ public class SyncScheduler implements SynchronousScheduler {
         if (nonRepeatingTask == null) {
             SpongeMod.instance.getLogger().warn(SchedulerLogMessages.CANNOT_MAKE_TASK_WARNING);
         } else {
+            nonRepeatingTask.setTimestamp(this.counter);
             resultTask = this.schedulerHelper.utilityForAddingTask(this.taskMap, nonRepeatingTask);
         }
 
@@ -319,6 +320,7 @@ public class SyncScheduler implements SynchronousScheduler {
         if (nonRepeatingTask == null) {
             SpongeMod.instance.getLogger().warn(SchedulerLogMessages.CANNOT_MAKE_TASK_WARNING);
         } else {
+            nonRepeatingTask.setTimestamp(this.counter);
             resultTask = this.schedulerHelper.utilityForAddingTask(this.taskMap, nonRepeatingTask);
         }
 
@@ -389,6 +391,7 @@ public class SyncScheduler implements SynchronousScheduler {
         if (repeatingTask == null) {
             SpongeMod.instance.getLogger().warn(SchedulerLogMessages.CANNOT_MAKE_TASK_WARNING);
         } else {
+            repeatingTask.setTimestamp(this.counter);
             resultTask = this.schedulerHelper.utilityForAddingTask(this.taskMap, repeatingTask);
         }
 
@@ -459,6 +462,7 @@ public class SyncScheduler implements SynchronousScheduler {
         if (repeatingTask == null) {
             SpongeMod.instance.getLogger().warn(SchedulerLogMessages.CANNOT_MAKE_TASK_WARNING);
         } else {
+            repeatingTask.setTimestamp(this.counter);
             resultTask = this.schedulerHelper.utilityForAddingTask(this.taskMap, repeatingTask);
         }
 


### PR DESCRIPTION
Before this fix, a ScheduledTask's timestamp would by default be set to 0 rather than the current server tick counter. This would cause the task to be fired immediately, rather than after the appropriate delay. This PR fixes this issue, correctly firing ScheduledTasks after the correct delay. If pulled, this would resolve #220.