### PR TITLE
Updated link to the Contributing Guidelines with current location.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 We will always have a need for developers to help us improve Sponge. There is no such thing as a perfect project and things can always be improved. If you are a developer and are interested in helping then please do not hesitate. Just make sure you follow our guidelines.
 
-Please check our [Contribution Guidelines in the Sponge Documentation](https://docs.spongepowered.org/en/latest/devs/guidelines/) for more information.
+Please check our [Contribution Guidelines in the Sponge Documentation](https://docs.spongepowered.org/en/contributing/guidelines.html) for more information.


### PR DESCRIPTION
The current link to the Contributing Guidelines is dead (e751ae0ea56a882cfffdc07b9f25dbdb9b6d5606).
This pull request replaces the dead link with a working one (1a2bb935879810eb45ff05a0d30a7fb10f59db7f).