### PR TITLE
Apply world generator modifiers in level_sponge.dat

### DIFF
--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinWorld.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinWorld.java
@@ -39,4 +39,7 @@ public interface IMixinWorld {
     ImmutableList<GeneratorPopulator> getGeneratorPopulators();
 
     void setWorldInfo(WorldInfo worldInfo);
+
+    void updateWorldGenerator();
+
 }

--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinWorldSettings.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinWorldSettings.java
@@ -26,14 +26,19 @@ package org.spongepowered.mod.interfaces;
 
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.world.DimensionType;
+import org.spongepowered.api.world.gen.WorldGeneratorModifier;
+
+import java.util.Collection;
 
 public interface IMixinWorldSettings {
 
     void setDimensionType(DimensionType type);
 
-    void setEnabled(boolean isWorldEnabled);
-
     void setGeneratorSettings(DataContainer generatorSettings);
+
+    void setGeneratorModifiers(Collection<WorldGeneratorModifier> modifiers);
+
+    void setEnabled(boolean isWorldEnabled);
 
     void setLoadOnStartup(boolean loadOnStartup);
 

--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinWorldType.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinWorldType.java
@@ -25,13 +25,13 @@
 package org.spongepowered.mod.interfaces;
 
 import org.spongepowered.api.data.DataContainer;
-import org.spongepowered.api.world.gen.WorldGenerator;
-
-import java.util.concurrent.Callable;
+import org.spongepowered.api.data.DataQuery;
+import org.spongepowered.api.world.World;
+import org.spongepowered.mod.world.gen.SpongeWorldGenerator;
 
 public interface IMixinWorldType {
 
-    void setWorldGenerator(Callable<WorldGenerator> generator);
+    public static final DataQuery STRING_VALUE = DataQuery.of("customSettings");
 
-    void setGeneratorSettings(DataContainer settings);
+    SpongeWorldGenerator createGenerator(World world, DataContainer settings);
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/server/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/server/MixinMinecraftServer.java
@@ -290,8 +290,9 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, Sub
 
         WorldSettings settings = new WorldSettings(worldInfo);
 
-        // TODO - handle custom generators
-        //ChunkGenerator gen = settings.getGeneratorType().createGenerator();
+        if (!DimensionManager.isDimensionRegistered(dim)) { // handle reloads properly
+            DimensionManager.registerDimension(dim, ((SpongeDimensionType) ((WorldProperties) worldInfo).getDimensionType()).getDimensionTypeId());
+        }
 
         WorldServer world = (WorldServer) new WorldServer((MinecraftServer) (Object) this, savehandler, worldInfo, dim, this.theProfiler).init();
 

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldServer.java
@@ -25,6 +25,7 @@
 package org.spongepowered.mod.mixin.core.world;
 
 import net.minecraft.util.BlockPos;
+import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.WorldSettings;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -34,6 +35,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.mod.interfaces.IMixinWorld;
 
 @NonnullByDefault
 @Mixin(WorldServer.class)
@@ -46,5 +49,13 @@ public abstract class MixinWorldServer extends MixinWorld {
             this.worldInfo.setSpawn(new BlockPos(55, 60, 0));
             ci.cancel();
         }
+    }
+
+    @Inject(method = "init", at = @At("RETURN"))
+    public void onPostInit(CallbackInfoReturnable<World> ci) {
+        // Run the world generator modifiers in the init method
+        // (the "init" method, not the "<init>" constructor)
+        IMixinWorld world = (IMixinWorld) ci.getReturnValue();
+        world.updateWorldGenerator();
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldSettings.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldSettings.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.mod.mixin.core.world;
 
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
 import net.minecraft.world.WorldSettings;
 import net.minecraft.world.WorldType;
 import org.spongepowered.api.entity.player.gamemode.GameMode;
@@ -37,6 +39,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.mod.entity.player.gamemode.SpongeGameMode;
 import org.spongepowered.mod.interfaces.IMixinWorldSettings;
+import org.spongepowered.mod.world.gen.WorldGeneratorRegistry;
 
 import java.util.Collection;
 
@@ -49,6 +52,7 @@ public class MixinWorldSettings implements WorldCreationSettings, IMixinWorldSet
     private boolean worldEnabled;
     private boolean loadOnStartup;
     private boolean keepSpawnLoaded;
+    private ImmutableCollection<WorldGeneratorModifier> generatorModifiers;
 
     @Shadow
     private long seed;
@@ -165,8 +169,17 @@ public class MixinWorldSettings implements WorldCreationSettings, IMixinWorldSet
     }
 
     @Override
+    public void setGeneratorModifiers(Collection<WorldGeneratorModifier> modifiers) {
+        ImmutableList<WorldGeneratorModifier> defensiveCopy = ImmutableList.copyOf(modifiers);
+        WorldGeneratorRegistry.getInstance().checkAllRegistered(defensiveCopy);
+        this.generatorModifiers = defensiveCopy;
+    }
+
+    @Override
     public Collection<WorldGeneratorModifier> getGeneratorModifiers() {
-        // TODO Auto-generated method stub
-        return null;
+        if (this.generatorModifiers == null) {
+            return ImmutableList.of();
+        }
+        return this.generatorModifiers;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldType.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldType.java
@@ -24,24 +24,36 @@
  */
 package org.spongepowered.mod.mixin.core.world;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTException;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.WorldServer;
 import net.minecraft.world.WorldType;
+import net.minecraft.world.biome.WorldChunkManager;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.ChunkProviderSettings;
+import net.minecraft.world.gen.FlatGeneratorInfo;
 import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.GeneratorType;
 import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.gen.GeneratorPopulator;
+import org.spongepowered.api.world.gen.Populator;
 import org.spongepowered.api.world.gen.WorldGenerator;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.mod.interfaces.IMixinWorldType;
-
-import java.util.concurrent.Callable;
+import org.spongepowered.mod.service.persistence.NbtTranslator;
+import org.spongepowered.mod.world.gen.SpongeBiomeGenerator;
+import org.spongepowered.mod.world.gen.SpongeGeneratorPopulator;
+import org.spongepowered.mod.world.gen.SpongeWorldGenerator;
 
 @NonnullByDefault
 @Mixin(WorldType.class)
-public class MixinWorldType implements GeneratorType, IMixinWorldType {
-
-    private Callable<WorldGenerator> generator;
-    private DataContainer generatorSettings;
+public abstract class MixinWorldType implements GeneratorType, IMixinWorldType {
 
     @Shadow private String worldType;
     @Shadow private int worldTypeId;
@@ -51,30 +63,85 @@ public class MixinWorldType implements GeneratorType, IMixinWorldType {
         return this.worldType;
     }
 
+    @Shadow
+    public abstract WorldChunkManager getChunkManager(net.minecraft.world.World world);
+
+    @Shadow
+    public abstract IChunkProvider getChunkGenerator(net.minecraft.world.World world, String options);
+
     @Override
     public String getName() {
         return this.worldType;
     }
 
     @Override
-    public WorldGenerator createGenerator(World world) {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public void setWorldGenerator(Callable<WorldGenerator> generator) {
-        this.generator = generator;
-    }
-
-    @Override
-    public void setGeneratorSettings(DataContainer settings) {
-        this.generatorSettings = settings;
-    }
-
-    @Override
     public DataContainer getGeneratorSettings() {
-        return this.generatorSettings;
+        // Minecraft stores the generator settings as a string. For the flat
+        // world, they use a custom format, for WorldType.CUSTOMIZED they use
+        // a serialized JSON string
+        if ((Object) this == WorldType.FLAT) {
+            String defaultSettings = FlatGeneratorInfo.getDefaultFlatGenerator().toString();
+            MemoryDataContainer container = new MemoryDataContainer();
+            container.set(STRING_VALUE, defaultSettings);
+            return container;
+        }
+        if ((Object) this == WorldType.CUSTOMIZED) {
+            // They easiest way to go from ChunkProviderSettings to
+            // DataContainer
+            // is via json and NBT
+            try {
+                String jsonString = ChunkProviderSettings.Factory.func_177865_a("").toString();
+                NBTTagCompound nbt = JsonToNBT.getTagFromJson(jsonString);
+                return NbtTranslator.getInstance().translateFrom(nbt);
+            } catch (NBTException e) {
+                AssertionError error = new AssertionError("Failed to parse default settings of CUSTOMIZED world type");
+                error.initCause(e);
+                throw error;
+            }
+        }
+        return new MemoryDataContainer();
+    }
+
+    @Override
+    public WorldGenerator createGenerator(World world) {
+        return this.createGeneratorFromString(world, "");
+    }
+
+    @Override
+    public SpongeWorldGenerator createGenerator(World world, DataContainer settings) {
+        // Minecraft uses a string for world generator settings
+        // This string can be a JSON string, or be a string of a custom format
+
+        // Try to convert to custom format
+        Optional<String> asString = settings.getString(STRING_VALUE);
+        if (asString.isPresent()) {
+            return this.createGeneratorFromString(world, asString.get());
+        }
+
+        // Convert to JSON
+        String json = ""; // TODO how to convert datacontainer to JSON?
+        return this.createGeneratorFromString(world, json);
+    }
+
+    private SpongeWorldGenerator createGeneratorFromString(World world, String settings) {
+        net.minecraft.world.World mcWorld = (net.minecraft.world.World) world;
+        IChunkProvider chunkProvider = this.getChunkGenerator(mcWorld, settings);
+        WorldChunkManager chunkManager = this.getChunkManager(mcWorld);
+
+        return new SpongeWorldGenerator(
+                SpongeBiomeGenerator.of(chunkManager),
+                SpongeGeneratorPopulator.of((WorldServer) world, chunkProvider),
+                ImmutableList.<GeneratorPopulator> of(),
+                ImmutableList.<Populator> of());
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + this.getName().hashCode();
+        result = prime * result + worldTypeId;
+        return result;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
@@ -283,7 +283,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 
 @SuppressWarnings("unchecked")
 @NonnullByDefault
@@ -528,7 +527,6 @@ public class SpongeGameRegistry implements GameRegistry {
     private final Map<String, CookedFish> cookedFishMappings = Maps.newHashMap();
     private final Map<String, GoldenApple> goldenAppleMappings = Maps.newHashMap();
     private final WorldGeneratorRegistry worldGeneratorRegistry = new WorldGeneratorRegistry();
-    public final Map<String, Callable<WorldGenerator>> generatorMappings = Maps.newHashMap();
     private final Hashtable<Class<? extends WorldProvider>, Integer> classToProviders = new Hashtable<Class<? extends WorldProvider>, Integer>();
     private final ArrayList<Integer> spongeDims = new ArrayList<Integer>(); // used to keep track of Sponge dimensions
     private final Map<UUID, WorldProperties> worldPropertiesMappings = Maps.newHashMap();
@@ -600,6 +598,7 @@ public class SpongeGameRegistry implements GameRegistry {
             .put(Visibility.class, ImmutableMap.<String, CatalogType>of()) // TODO
             .put(WallType.class, ImmutableMap.<String, CatalogType>of()) // TODO
             .put(Weather.class, ImmutableMap.<String, CatalogType>of()) // TODO
+            .put(WorldGeneratorModifier.class, this.worldGeneratorRegistry.viewModifiersMap())
             .build();
     private final Map<Class<?>, Class<?>> builderMap = ImmutableMap.of(); // TODO FIGURE OUT HOW TO DO THIS!!?!
 
@@ -841,8 +840,12 @@ public class SpongeGameRegistry implements GameRegistry {
     }
 
     @Override
-    public void registerWorldGeneratorModifier(PluginContainer plugin, String id, WorldGeneratorModifier modifier) {
-        this.worldGeneratorRegistry.registerModifier(plugin, id, modifier);
+    public void registerWorldGeneratorModifier(WorldGeneratorModifier modifier) {
+        this.worldGeneratorRegistry.registerModifier(modifier);
+    }
+
+    public WorldGeneratorRegistry getWorldGeneratorRegistry() {
+        return this.worldGeneratorRegistry;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/service/persistence/NbtTranslator.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/NbtTranslator.java
@@ -136,7 +136,7 @@ public final class NbtTranslator implements DataTranslator<NBTTagCompound> {
     }
 
     @SuppressWarnings("unchecked")
-    private static DataView getViewFromCompound(NBTTagCompound compound) {
+    private static DataContainer getViewFromCompound(NBTTagCompound compound) {
         DataContainer container = new MemoryDataContainer();
         for (String key : (Set<String>) compound.getKeySet()) {
             NBTBase base = compound.getTag(key);
@@ -239,7 +239,7 @@ public final class NbtTranslator implements DataTranslator<NBTTagCompound> {
     }
 
     @Override
-    public DataView translateFrom(NBTTagCompound node) {
+    public DataContainer translateFrom(NBTTagCompound node) {
         return NbtTranslator.getViewFromCompound(node);
     }
 }

--- a/src/main/java/org/spongepowered/mod/world/gen/SpongeGeneratorPopulator.java
+++ b/src/main/java/org/spongepowered/mod/world/gen/SpongeGeneratorPopulator.java
@@ -40,7 +40,7 @@ import org.spongepowered.api.world.gen.GeneratorPopulator;
  * Generator populator that wraps a Minecraft {@link IChunkProvider}.
  *
  */
-public class SpongeGeneratorPopulator implements GeneratorPopulator {
+public final class SpongeGeneratorPopulator implements GeneratorPopulator {
 
     private final IChunkProvider chunkGenerator;
     private final World world;
@@ -54,7 +54,7 @@ public class SpongeGeneratorPopulator implements GeneratorPopulator {
      * @param chunkGenerator The chunk generator.
      * @return The generator populator.
      */
-    static GeneratorPopulator of(World world, IChunkProvider chunkGenerator) {
+    public static GeneratorPopulator of(World world, IChunkProvider chunkGenerator) {
         if (chunkGenerator instanceof CustomChunkProviderGenerate) {
             return ((CustomChunkProviderGenerate) chunkGenerator).generatorPopulator;
         }


### PR DESCRIPTION
A new list appeared in the level_sponge.dat file, the list that stores the names of the world generator modifiers.

My test plugin has been updated, and can be found [here](https://github.com/rutgerkok/SpongeGeneratorTest).

![2015-04-14_21 52 42](https://cloud.githubusercontent.com/assets/1462188/7146001/abcda176-e2f0-11e4-90c4-3a9a0f6e19fb.png)

All methods to get/set the active world generator modifiers are now implemented.

Some things are still missing:
* I haven't found a way to convert a DataContainer to JSON. This is needed to store custom settings in a level.dat-compatible format.
* There's no configuration option and/or command in Sponge to decide which world generation modifiers are used in a world. You have to manually edit the level_sponge.dat file.

This pull request depends on [a pull request made to SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/569).