### PR TITLE
Update Forge version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ apply plugin: 'forge'
 ext {
     minecraftPlugin = plugins.getPlugin('forge')
 
-    forgeBuild = '1371'
-    forgeVersion = "11.14.1.$forgeBuild"
+    forgeBuild = '1439'
+    forgeVersion = "11.14.2.$forgeBuild"
 }
 
 apply from: project(':SpongeCommon').file('gradle/implementation.gradle')


### PR DESCRIPTION
The version of Forge currently being used by the Sponge coremod is severely out of date - it lacks many of the enhancements and security patches found in the latest version of Forge. This PR updates Sponge to use a newer build of Forge (which doubtless will be outdated soon).

I've gone through all of the mixins specific to the Sponge coremod. The majority of them affect classes which have not been touched by the initial Forge update to 1.8; others, such as MixinEnchantment, haven't been affected by the changes made in Forge to their target class.

I have yet to inspect all of the mixins in SpongeCommon for compatibility with the Forge changes, however, I haven't found any glaring issues in my testing, or in a review of the changes made by Forge.