### PR TITLE
Register block type mappings.

### DIFF
--- a/src/main/java/org/spongepowered/mod/registry/SpongeModGameRegistry.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeModGameRegistry.java
@@ -64,7 +64,9 @@ public class SpongeModGameRegistry extends SpongeGameRegistry {
 
             @Override
             public BlockType apply(String fieldName) {
-                return getBlock(fieldName.toLowerCase()).get();
+                final BlockType blockType = getBlock(fieldName.toLowerCase()).get();
+                SpongeModGameRegistry.this.blockTypeMappings.put(fieldName.toLowerCase(), blockType);
+                return blockType;
             }
         });
     }


### PR DESCRIPTION
As the PR title says, adds the `BlockType` mappings for `getType` and `getAllOf` registration. This is pairing with SpongePowered/SpongeCommon#78.