### PR TITLE
Fix Potion Effects When Switching World

### DIFF
--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntity.java
@@ -111,6 +111,11 @@ public abstract class MixinEntity {
             entityplayermp1.theItemInWorldManager.setWorld(toWorld);
             entityplayermp1.addSelfToInternalCraftingInventory();
             entityplayermp1.setHealth(entityplayermp1.getHealth());
+            
+            for(Object effect : entityplayermp1.getActivePotionEffects()) {
+                entityplayermp1.playerNetServerHandler.sendPacket(new S1DPacketEntityEffect(entityplayermp1.getEntityId(), (PotionEffect) effect));
+            }
+            
             net.minecraftforge.fml.common.FMLCommonHandler.instance().firePlayerChangedDimensionEvent(entityplayermp1, currentDim, targetDim);
         } else {
             toWorld.spawnEntityInWorld(entity);

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntity.java
@@ -28,6 +28,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.play.server.S07PacketRespawn;
+import net.minecraft.network.play.server.S1DPacketEntityEffect;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.util.Constants;


### PR DESCRIPTION
Self explanatory- fixes the bug where potion effects would not be updated on the client when they were teleported to another dimension. Requested to be changed by a pull request by @Zidane.