### PR TITLE
Fire Sponge events on the Forge bus

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeCoremod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeCoremod.java
@@ -40,26 +40,26 @@ import java.util.Map;
 
 @IFMLLoadingPlugin.MCVersion("1.8")
 public class SpongeCoremod implements IFMLLoadingPlugin {
-    
+
     public static final class TokenProvider implements IEnvironmentTokenProvider {
-        
+
         @Override
         public int getPriority() {
             return IEnvironmentTokenProvider.DEFAULT_PRIORITY;
         }
-        
+
         @Override
         public Integer getToken(String token, MixinEnvironment env) {
             if ("FORGE".equals(token)) {
                 return Integer.valueOf(ForgeVersion.getBuildVersion());
             } else if ("FML".equals(token)) {
-                String fmlVersion = Loader.instance().getFMLVersionString(); 
+                String fmlVersion = Loader.instance().getFMLVersionString();
                 int build = Integer.parseInt(fmlVersion.substring(fmlVersion.lastIndexOf('.') + 1));
                 return Integer.valueOf(build);
             }
             return null;
         }
-        
+
     }
 
     public SpongeCoremod() {
@@ -93,6 +93,10 @@ public class SpongeCoremod implements IFMLLoadingPlugin {
         Launch.classLoader.addClassLoaderExclusion("org.spongepowered.api.event.cause.CauseTracked");
         Launch.classLoader.addClassLoaderExclusion("org.spongepowered.api.event.Cancellable");
         Launch.classLoader.addClassLoaderExclusion("org.spongepowered.api.util.event.callback.CallbackList");
+        Launch.classLoader.addTransformerExclusion("org.spongepowered.mod.interfaces.IMixinEvent");
+        Launch.classLoader.addClassLoaderExclusion("org.spongepowered.api.event.Event");
+        Launch.classLoader.addClassLoaderExclusion("org.spongepowered.api.util.annotation.ImplementedBy");
+        Launch.classLoader.addClassLoaderExclusion("org.spongepowered.api.event.AbstractEvent");
 
         // Transformer exclusions
         Launch.classLoader.addTransformerExclusion("ninja.leaping.configurate.");

--- a/src/main/java/org/spongepowered/mod/event/SpongeModEventManager.java
+++ b/src/main/java/org/spongepowered/mod/event/SpongeModEventManager.java
@@ -26,21 +26,63 @@ package org.spongepowered.mod.event;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ServerChatEvent;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.event.entity.item.ItemTossEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.event.terraingen.BiomeEvent;
+import net.minecraftforge.event.terraingen.DecorateBiomeEvent;
+import net.minecraftforge.event.terraingen.InitMapGenEvent;
+import net.minecraftforge.event.terraingen.InitNoiseGensEvent;
+import net.minecraftforge.event.terraingen.OreGenEvent;
+import net.minecraftforge.event.terraingen.PopulateChunkEvent;
+import net.minecraftforge.event.terraingen.SaplingGrowTreeEvent;
+import net.minecraftforge.event.terraingen.WorldTypeEvent;
+import net.minecraftforge.fml.common.eventhandler.EventBus;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.IEventListener;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.block.BlockEvent;
+import org.spongepowered.api.event.block.BlockUpdateEvent;
+import org.spongepowered.api.event.entity.EntityConstructingEvent;
+import org.spongepowered.api.event.entity.EntityEvent;
+import org.spongepowered.api.event.entity.EntitySpawnEvent;
+import org.spongepowered.api.event.entity.living.LivingEvent;
+import org.spongepowered.api.event.entity.player.PlayerBreakBlockEvent;
+import org.spongepowered.api.event.entity.player.PlayerChatEvent;
+import org.spongepowered.api.event.entity.player.PlayerDropItemEvent;
+import org.spongepowered.api.event.entity.player.PlayerEvent;
+import org.spongepowered.api.event.entity.player.PlayerInteractBlockEvent;
+import org.spongepowered.api.event.entity.player.PlayerPlaceBlockEvent;
+import org.spongepowered.api.event.world.ChunkEvent;
+import org.spongepowered.api.event.world.ChunkLoadEvent;
+import org.spongepowered.api.event.world.ChunkUnloadEvent;
+import org.spongepowered.api.event.world.WorldEvent;
+import org.spongepowered.api.event.world.WorldLoadEvent;
+import org.spongepowered.api.event.world.WorldUnloadEvent;
 import org.spongepowered.api.plugin.PluginManager;
 import org.spongepowered.common.event.RegisteredHandler;
 import org.spongepowered.common.event.SpongeEventManager;
 import org.spongepowered.mod.SpongeMod;
+import org.spongepowered.mod.interfaces.IMixinEventBus;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Map;
 
 import javax.inject.Inject;
 
 public class SpongeModEventManager extends SpongeEventManager {
 
-    private final ImmutableMap<EventPriority, Order> priorityMappings = new ImmutableMap.Builder<EventPriority, Order>()
+    private static final String PACKAGE_PREFIX = "org.spongepowered.api.event.impl";
+
+    private final ImmutableBiMap<EventPriority, Order> priorityMappings = new ImmutableBiMap.Builder<EventPriority, Order>()
             .put(EventPriority.HIGHEST, Order.FIRST)
             .put(EventPriority.HIGH, Order.EARLY)
             .put(EventPriority.NORMAL, Order.DEFAULT)
@@ -48,9 +90,65 @@ public class SpongeModEventManager extends SpongeEventManager {
             .put(EventPriority.LOWEST, Order.LAST)
             .build();
 
+    private final ImmutableMap<Class<? extends Event>, Class<? extends net.minecraftforge.fml.common.eventhandler.Event>> eventMappings = new ImmutableMap.Builder<Class<? extends Event>, Class<? extends net.minecraftforge.fml.common.eventhandler.Event>>()
+            .put(BlockEvent.class, net.minecraftforge.event.world.BlockEvent.class)
+            .put(BlockUpdateEvent.class, net.minecraftforge.event.world.BlockEvent.NeighborNotifyEvent.class)
+            .put(LivingEvent.class, net.minecraftforge.event.entity.living.LivingEvent.class)
+            .put(EntityEvent.class, net.minecraftforge.event.entity.EntityEvent.class)
+            .put(EntityConstructingEvent.class, net.minecraftforge.event.entity.EntityEvent.EntityConstructing.class)
+            .put(EntitySpawnEvent.class, EntityJoinWorldEvent.class)
+            .put(PlayerEvent.class, net.minecraftforge.event.entity.player.PlayerEvent.class)
+            .put(PlayerBreakBlockEvent.class, net.minecraftforge.event.world.BlockEvent.BreakEvent.class)
+            .put(PlayerChatEvent.class, ServerChatEvent.class)
+            .put(PlayerInteractBlockEvent.class, PlayerInteractEvent.class)
+            .put(PlayerPlaceBlockEvent.class, net.minecraftforge.event.world.BlockEvent.PlaceEvent.class)
+            .put(ChunkEvent.class, net.minecraftforge.event.world.ChunkEvent.class)
+            .put(ChunkLoadEvent.class, net.minecraftforge.event.world.ChunkEvent.Load.class)
+            .put(ChunkUnloadEvent.class, net.minecraftforge.event.world.ChunkEvent.Unload.class)
+            .put(WorldEvent.class, net.minecraftforge.event.world.WorldEvent.class)
+            .put(WorldLoadEvent.class, net.minecraftforge.event.world.WorldEvent.Load.class)
+            .put(WorldUnloadEvent.class, net.minecraftforge.event.world.WorldEvent.Unload.class)
+            .build();
+
+    private final ImmutableMap<Class<? extends net.minecraftforge.fml.common.eventhandler.Event>, EventBus> busMappings = new ImmutableMap.Builder<Class<? extends net.minecraftforge.fml.common.eventhandler.Event>, EventBus>()
+            .put(OreGenEvent.class, MinecraftForge.ORE_GEN_BUS)
+
+            .put(WorldTypeEvent.class, MinecraftForge.TERRAIN_GEN_BUS)
+            .put(BiomeEvent.class, MinecraftForge.TERRAIN_GEN_BUS)
+            .put(DecorateBiomeEvent.class, MinecraftForge.TERRAIN_GEN_BUS)
+            .put(InitMapGenEvent.class, MinecraftForge.TERRAIN_GEN_BUS)
+            .put(InitNoiseGensEvent.class, MinecraftForge.TERRAIN_GEN_BUS)
+            .put(PopulateChunkEvent.class, MinecraftForge.TERRAIN_GEN_BUS)
+            .put(SaplingGrowTreeEvent.class, MinecraftForge.TERRAIN_GEN_BUS)
+
+            .build();
+
+    private final Map<Class<? extends Event>, Method> factoryMethodMappings = Maps.newHashMap();
+
+
     @Inject
     public SpongeModEventManager(PluginManager pluginManager) {
         super(pluginManager);
+        this.buildFactoryMethodMappings();
+    }
+
+    private void buildFactoryMethodMappings() {
+        for (Map.Entry<Class<? extends Event>, Class<? extends net.minecraftforge.fml.common.eventhandler.Event>> entry: this.eventMappings.entrySet()) {
+            try {
+                Method method = entry.getValue().getDeclaredMethod("fromSpongeEvent", entry.getKey());
+                if (!Modifier.isStatic(method.getModifiers())) {
+                    throw new IllegalStateException(String.format("Method %s must be static!", method));
+                } else if (!method.getReturnType().equals(entry.getValue())) {
+                    throw new IllegalStateException(String.format("Method %s has an invalid signature!"));
+                }
+
+                method.setAccessible(true);
+
+                this.factoryMethodMappings.put(entry.getKey(), method);
+            } catch (NoSuchMethodException e) {
+                throw new IllegalStateException(String.format("Unable to locate method fromSpongeEvent in class %s!", entry.getValue()), e);
+            }
+        }
     }
 
     public boolean post(net.minecraftforge.fml.common.eventhandler.Event forgeEvent, IEventListener[] listeners) {
@@ -83,6 +181,38 @@ public class SpongeModEventManager extends SpongeEventManager {
         }
 
         return forgeEvent.isCancelable() && forgeEvent.isCanceled();
+    }
+
+    @Override
+    public boolean post(Event event) {
+        if (event.getClass().getCanonicalName().startsWith(PACKAGE_PREFIX)) {
+            if (!(event.getClass().getInterfaces().length == 1)) {
+                throw new IllegalArgumentException("This isn't a real generated event class at all! Any class"
+                                                   + "created by the event generator should implement exactly one interface!"
+                                                   + "(If you're a plugin, nice try.)");
+            }
+            Class<?> interfaceClazz = event.getClass().getInterfaces()[0];
+            if (this.factoryMethodMappings.containsKey(interfaceClazz)) {
+                try {
+                    net.minecraftforge.fml.common.eventhandler.Event
+                            forgeEvent =
+                            (net.minecraftforge.fml.common.eventhandler.Event) this.factoryMethodMappings.get(interfaceClazz).invoke(null, event);
+                    Class<?>
+                            enclosingClass =
+                            forgeEvent.getClass().getEnclosingClass(); // Avoid separate mappings for events defined as inner classes
+
+                    EventBus bus = this.busMappings.get(enclosingClass == null ? forgeEvent.getClass() : enclosingClass);
+                    if (bus == null) {
+                        bus = MinecraftForge.EVENT_BUS;
+                    }
+
+                    return post(forgeEvent, forgeEvent.getListenerList().getListeners(((IMixinEventBus) bus).getBusID()));
+                } catch (Exception e) {
+                    throw new RuntimeException("Error while firing event!", e);
+                }
+            }
+        }
+        return super.post(event);
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinEvent.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinEvent.java
@@ -22,26 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.event.entity;
+package org.spongepowered.mod.interfaces;
 
-import net.minecraft.entity.Entity;
-import net.minecraftforge.event.entity.EntityEvent;
-import org.spongepowered.api.event.entity.EntityConstructingEvent;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.mod.interfaces.IMixinEvent;
+import org.spongepowered.api.event.Event;
 
-@NonnullByDefault
-@Mixin(value = EntityEvent.EntityConstructing.class, remap = false)
-public abstract class MixinEventEntityConstructing extends EntityEvent implements EntityConstructingEvent {
+public interface IMixinEvent {
 
-    public MixinEventEntityConstructing(Entity entity) {
-        super(entity);
-    }
+    void setSpongeEvent(Event spongeEvent);
 
-    private static EntityConstructing fromSpongeEvent(EntityConstructingEvent spongeEvent) {
-        EntityConstructing event = new EntityConstructing((net.minecraft.entity.Entity) spongeEvent.getEntity());
-        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
-        return event;
-    }
 }

--- a/src/main/java/org/spongepowered/mod/interfaces/IMixinEventBus.java
+++ b/src/main/java/org/spongepowered/mod/interfaces/IMixinEventBus.java
@@ -22,26 +22,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.event.entity;
+package org.spongepowered.mod.interfaces;
 
-import net.minecraft.entity.Entity;
-import net.minecraftforge.event.entity.EntityEvent;
-import org.spongepowered.api.event.entity.EntityConstructingEvent;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.mod.interfaces.IMixinEvent;
+public interface IMixinEventBus {
 
-@NonnullByDefault
-@Mixin(value = EntityEvent.EntityConstructing.class, remap = false)
-public abstract class MixinEventEntityConstructing extends EntityEvent implements EntityConstructingEvent {
+    int getBusID();
 
-    public MixinEventEntityConstructing(Entity entity) {
-        super(entity);
-    }
-
-    private static EntityConstructing fromSpongeEvent(EntityConstructingEvent spongeEvent) {
-        EntityConstructing event = new EntityConstructing((net.minecraft.entity.Entity) spongeEvent.getEntity());
-        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
-        return event;
-    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/entity/MixinEventEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/entity/MixinEventEntity.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.mod.SpongeMod;
+import org.spongepowered.mod.interfaces.IMixinEvent;
 
 @NonnullByDefault
 @Mixin(value = net.minecraftforge.event.entity.EntityEvent.class, remap = false)
@@ -48,5 +49,11 @@ public abstract class MixinEventEntity extends Event implements EntityEvent {
     @Override
     public Game getGame() {
         return SpongeMod.instance.getGame();
+    }
+
+    private static net.minecraftforge.event.entity.EntityEvent fromSpongeEvent(EntityEvent spongeEvent) {
+        net.minecraftforge.event.entity.EntityEvent event = new net.minecraftforge.event.entity.EntityEvent((net.minecraft.entity.Entity) spongeEvent.getEntity());
+        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
+        return event;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/entity/MixinEventEntityJoinWorld.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/entity/MixinEventEntityJoinWorld.java
@@ -25,11 +25,15 @@
 package org.spongepowered.mod.mixin.core.event.entity;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
 import net.minecraftforge.event.entity.EntityEvent;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import org.spongepowered.api.event.entity.EntityConstructingEvent;
 import org.spongepowered.api.event.entity.EntitySpawnEvent;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.mod.interfaces.IMixinEvent;
 
 @NonnullByDefault
 @Mixin(value = net.minecraftforge.event.entity.EntityJoinWorldEvent.class, remap = false)
@@ -42,5 +46,11 @@ public abstract class MixinEventEntityJoinWorld extends EntityEvent implements E
     @Override
     public Location getLocation() {
         return getEntity().getLocation();
+    }
+
+    private static EntityJoinWorldEvent fromSpongeEvent(EntitySpawnEvent spongeEvent) {
+        EntityJoinWorldEvent event = new EntityJoinWorldEvent((net.minecraft.entity.Entity) spongeEvent.getEntity(), (World) spongeEvent.getLocation().getExtent());
+        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
+        return event;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/entity/item/MixinEventItem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/entity/item/MixinEventItem.java
@@ -22,33 +22,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.mod.mixin.core.event.world;
+package org.spongepowered.mod.mixin.core.event.entity.item;
 
-import net.minecraftforge.event.world.ChunkEvent;
-import org.spongepowered.api.event.world.ChunkUnloadEvent;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.api.world.Chunk;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Interface;
+import net.minecraft.entity.item.EntityItem;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.mod.interfaces.IMixinEvent;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.mixin.core.event.entity.MixinEventEntity;
 
-@NonnullByDefault
-@Mixin(value = net.minecraftforge.event.world.ChunkEvent.Unload.class, remap = false)
-@Implements(@Interface(iface = ChunkUnloadEvent.class, prefix = "chunkunload$"))
-public abstract class MixinEventChunkUnload extends ChunkEvent {
+@Mixin(value = net.minecraftforge.event.entity.item.ItemEvent.class, remap = false)
+public abstract class MixinEventItem extends MixinEventEntity {
 
-    public MixinEventChunkUnload(net.minecraft.world.chunk.Chunk chunk) {
-        super(chunk);
-    }
+    @Shadow public EntityItem entityItem;
 
-    public Chunk chunkunload$getChunk() {
-        return (Chunk) getChunk();
-    }
-
-    private static net.minecraftforge.event.world.ChunkEvent.Unload fromSpongeEvent(org.spongepowered.api.event.world.ChunkUnloadEvent spongeEvent) {
-        net.minecraftforge.event.world.ChunkEvent.Unload event = new net.minecraftforge.event.world.ChunkEvent.Unload(((net.minecraft.world.chunk.Chunk) spongeEvent.getChunk()));
-        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
-        return event;
-    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/entity/living/MixinEventLiving.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/entity/living/MixinEventLiving.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.event.entity.living.LivingEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.interfaces.IMixinEvent;
 
 @Mixin(value = net.minecraftforge.event.entity.living.LivingEvent.class, remap = false)
 public abstract class MixinEventLiving extends EntityEvent implements LivingEvent {
@@ -45,5 +46,11 @@ public abstract class MixinEventLiving extends EntityEvent implements LivingEven
     @Override
     public Living getEntity() {
         return (Living) this.entityLiving;
+    }
+
+    private static net.minecraftforge.event.entity.living.LivingEvent fromSpongeEvent(LivingEvent spongeEvent) {
+        net.minecraftforge.event.entity.living.LivingEvent event = new net.minecraftforge.event.entity.living.LivingEvent((EntityLivingBase) spongeEvent.getEntity());
+        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
+        return event;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/inventory/MixinEventItem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/inventory/MixinEventItem.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.event.inventory.ItemEvent;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.interfaces.IMixinEvent;
 
 @NonnullByDefault
 @Mixin(net.minecraftforge.event.entity.item.ItemEvent.class)
@@ -51,5 +52,11 @@ public abstract class MixinEventItem extends EntityEvent implements ItemEvent {
     @Override
     public Item getEntity() {
         return (Item) this.entityItem;
+    }
+
+    private static net.minecraftforge.event.entity.item.ItemEvent fromSpongeEvent(ItemEvent spongeEvent) {
+        net.minecraftforge.event.entity.item.ItemEvent event = new net.minecraftforge.event.entity.item.ItemEvent((EntityItem) spongeEvent.getEntity());
+        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
+        return event;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayer.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.event.entity.player.PlayerEvent;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.interfaces.IMixinEvent;
 
 @NonnullByDefault
 @Mixin(value = net.minecraftforge.event.entity.player.PlayerEvent.class, remap = false)
@@ -51,5 +52,11 @@ public abstract class MixinEventPlayer extends LivingEvent implements PlayerEven
     @Override
     public Player getUser() {
         return (Player) this.entityPlayer;
+    }
+
+    private static net.minecraftforge.event.entity.player.PlayerEvent fromSpongeEvent(PlayerEvent spongeEvent) {
+        net.minecraftforge.event.entity.player.PlayerEvent event = new net.minecraftforge.event.entity.player.PlayerEvent((EntityPlayer) spongeEvent.getEntity());
+        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
+        return event;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerDropItem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerDropItem.java
@@ -24,31 +24,24 @@
  */
 package org.spongepowered.mod.mixin.core.event.player;
 
-import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraftforge.event.entity.item.ItemEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
-import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.player.Player;
 import org.spongepowered.api.event.entity.player.PlayerDropItemEvent;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.mixin.core.event.entity.item.MixinEventItem;
 
 import java.util.Collection;
 import java.util.Collections;
 
 @NonnullByDefault
 @Mixin(value = ItemTossEvent.class, remap = false)
-public abstract class MixinEventPlayerDropItem extends ItemEvent implements PlayerDropItemEvent {
+public abstract class MixinEventPlayerDropItem extends MixinEventItem implements PlayerDropItemEvent {
 
-    public MixinEventPlayerDropItem(EntityItem itemEntity) {
-        super(itemEntity);
-    }
-
-    @Shadow
-    public EntityPlayer player;
+    @Shadow public EntityPlayer player;
 
     @Override
     public Collection<ItemStack> getDroppedItems() {

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventChunk.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventChunk.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.Chunk;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.mod.interfaces.IMixinEvent;
 
 @NonnullByDefault
 @Mixin(value = net.minecraftforge.event.world.ChunkEvent.class, remap = false)
@@ -46,6 +47,12 @@ public abstract class MixinEventChunk extends WorldEvent implements ChunkEvent {
     @Override
     public Chunk getChunk() {
         return (Chunk) this.chunk;
+    }
+
+    private static net.minecraftforge.event.world.ChunkEvent fromSpongeEvent(org.spongepowered.api.event.world.ChunkEvent spongeEvent) {
+        net.minecraftforge.event.world.ChunkEvent event = new net.minecraftforge.event.world.ChunkEvent(((net.minecraft.world.chunk.Chunk) spongeEvent.getChunk()));
+        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
+        return event;
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventChunkLoad.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventChunkLoad.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.world.Chunk;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.mod.interfaces.IMixinEvent;
 
 @NonnullByDefault
 @Mixin(value = net.minecraftforge.event.world.ChunkEvent.Load.class, remap = false)
@@ -43,5 +44,11 @@ public abstract class MixinEventChunkLoad extends ChunkEvent {
 
     public Chunk chunkload$getChunk() {
         return (Chunk) getChunk();
+    }
+
+    private static net.minecraftforge.event.world.ChunkEvent.Load fromSpongeEvent(org.spongepowered.api.event.world.ChunkLoadEvent spongeEvent) {
+        net.minecraftforge.event.world.ChunkEvent.Load event = new net.minecraftforge.event.world.ChunkEvent.Load(((net.minecraft.world.chunk.Chunk) spongeEvent.getChunk()));
+        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
+        return event;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventWorld.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventWorld.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.mod.SpongeMod;
+import org.spongepowered.mod.interfaces.IMixinEvent;
 
 @NonnullByDefault
 @Mixin(value = net.minecraftforge.event.world.WorldEvent.class, remap = false)
@@ -48,5 +49,11 @@ public abstract class MixinEventWorld extends Event implements WorldEvent {
     @Override
     public Game getGame() {
         return SpongeMod.instance.getGame();
+    }
+
+    private static net.minecraftforge.event.world.WorldEvent fromSpongeEvent(WorldEvent spongeEvent) {
+        net.minecraftforge.event.world.WorldEvent event = new net.minecraftforge.event.world.WorldEvent((net.minecraft.world.World) spongeEvent.getWorld());
+        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
+        return event;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventWorldLoad.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventWorldLoad.java
@@ -29,6 +29,7 @@ import net.minecraftforge.event.world.WorldEvent;
 import org.spongepowered.api.event.world.WorldLoadEvent;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.mod.interfaces.IMixinEvent;
 
 @NonnullByDefault
 @Mixin(value = net.minecraftforge.event.world.WorldEvent.Load.class, remap = false)
@@ -36,6 +37,12 @@ public abstract class MixinEventWorldLoad extends WorldEvent implements WorldLoa
 
     public MixinEventWorldLoad(World world) {
         super(world);
+    }
+
+    private static net.minecraftforge.event.world.WorldEvent.Load fromSpongeEvent(org.spongepowered.api.event.world.WorldLoadEvent spongeEvent) {
+        net.minecraftforge.event.world.WorldEvent.Load event = new net.minecraftforge.event.world.WorldEvent.Load((net.minecraft.world.World) spongeEvent.getWorld());
+        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
+        return event;
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventWorldUnload.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventWorldUnload.java
@@ -29,6 +29,7 @@ import net.minecraftforge.event.world.WorldEvent;
 import org.spongepowered.api.event.world.WorldUnloadEvent;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.mod.interfaces.IMixinEvent;
 
 @NonnullByDefault
 @Mixin(value = net.minecraftforge.event.world.WorldEvent.Unload.class, remap = false)
@@ -36,6 +37,12 @@ public abstract class MixinEventWorldUnload extends WorldEvent implements WorldU
 
     public MixinEventWorldUnload(World world) {
         super(world);
+    }
+
+    private static net.minecraftforge.event.world.WorldEvent.Unload fromSpongeEvent(org.spongepowered.api.event.world.WorldUnloadEvent spongeEvent) {
+        net.minecraftforge.event.world.WorldEvent.Unload event = new net.minecraftforge.event.world.WorldEvent.Unload((net.minecraft.world.World) spongeEvent.getWorld());
+        ((IMixinEvent) event).setSpongeEvent(spongeEvent);
+        return event;
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/fml/common/eventhandler/MixinEvent.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/fml/common/eventhandler/MixinEvent.java
@@ -27,6 +27,7 @@ package org.spongepowered.mod.mixin.core.fml.common.eventhandler;
 import com.google.common.base.Optional;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.CauseTracked;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -34,13 +35,18 @@ import org.spongepowered.api.util.event.callback.CallbackList;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.mod.SpongeMod;
+import org.spongepowered.mod.interfaces.IMixinEvent;
+
+import java.lang.reflect.InvocationTargetException;
 
 @NonnullByDefault
 @Mixin(value = net.minecraftforge.fml.common.eventhandler.Event.class, remap = false)
-public abstract class MixinEvent implements CauseTracked, Cancellable {
+public abstract class MixinEvent implements CauseTracked, Cancellable, IMixinEvent {
 
     @Shadow public abstract void setCanceled(boolean cancel);
     @Shadow public abstract boolean isCanceled();
+
+    protected Event spongeEvent;
 
     public Game getGame() {
         return SpongeMod.instance.getGame();
@@ -53,12 +59,23 @@ public abstract class MixinEvent implements CauseTracked, Cancellable {
 
     @Override
     public boolean isCancelled() {
+        if (spongeEvent instanceof Cancellable) {
+            return ((Cancellable) spongeEvent).isCancelled();
+        }
         return isCanceled();
     }
 
     @Override
     public void setCancelled(boolean cancel) {
+        if (spongeEvent instanceof Cancellable) {
+            ((Cancellable) spongeEvent).setCancelled(cancel);
+        }
         setCanceled(cancel);
+    }
+
+    @Override
+    public void setSpongeEvent(Event spongeEvent) {
+        this.spongeEvent = spongeEvent;
     }
 
     public CallbackList getCallbacks() {

--- a/src/main/java/org/spongepowered/mod/mixin/core/fml/common/eventhandler/MixinEventBus.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/fml/common/eventhandler/MixinEventBus.java
@@ -35,10 +35,11 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.mod.SpongeMod;
 import org.spongepowered.mod.event.SpongeModEventManager;
+import org.spongepowered.mod.interfaces.IMixinEventBus;
 
 @NonnullByDefault
 @Mixin(value = net.minecraftforge.fml.common.eventhandler.EventBus.class, remap = false)
-public abstract class MixinEventBus {
+public abstract class MixinEventBus implements IMixinEventBus {
 
     private EventBus eventBus = (EventBus) (Object) this;
 
@@ -69,4 +70,8 @@ public abstract class MixinEventBus {
         }
     }
 
+    @Override
+    public int getBusID() {
+        return this.busID;
+    }
 }


### PR DESCRIPTION
Currently, Forge events which implement Sponge interfaces are automatically fired on the Sponge event bus. This isn't done in reverse when a Sponge even is fired.

This PR fires Sponge events on the Forge bus by creating a new instance of a Forge event, which delegates any setter methods back to the Sponge event.

Only events created through the event generator are fired on the Forge bus. This is for two reasons:
* Complex situations can arise if an event implements multiple Sponge interfaces, when choosing which Forge events to instantiate. An event created from the event generator is a built-in event, which has a clearly defined function known to the event bus.
* Not firing other events, even if they only implement one Sponge interface, allows plugins to manually fire their event on the Forge bus, choosing exactly what Forge event(s) to create. Firing the event in all cases would prevent plugins from implementing their own logic without causing the event to be fired twice.