### PR TITLE
Inventory properties

### DIFF
--- a/src/main/java/org/spongepowered/common/item/inventory/SpongeInventoryBuilder.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/SpongeInventoryBuilder.java
@@ -97,7 +97,7 @@ public class SpongeInventoryBuilder implements Inventory.Builder {
     @Override
     public Inventory.Builder from(Inventory value) {
         if (value instanceof CustomInventory) {
-            this.archetype = ((CustomInventory) value).getArchetype();
+            this.archetype = value.getArchetype();
             this.properties.putAll(((CustomInventory) value).getProperties());
             return this;
         }

--- a/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/MinecraftInventoryAdapter.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/MinecraftInventoryAdapter.java
@@ -39,7 +39,6 @@ import org.spongepowered.common.item.inventory.adapter.InventoryAdapter;
 import org.spongepowered.common.item.inventory.query.Query;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Optional;
 
@@ -143,7 +142,7 @@ public interface MinecraftInventoryAdapter extends InventoryAdapter<IInventory, 
     @Override
     default <T extends InventoryProperty<?, ?>> Collection<T> getProperties(Class<T> property) {
         if (this.parent() == this) {
-            return Collections.emptyList(); // TODO top level inventory properties
+            return Adapter.Logic.getRootProperties(this, property);
         }
         return this.parent().getProperties(this, property);
     }
@@ -153,7 +152,7 @@ public interface MinecraftInventoryAdapter extends InventoryAdapter<IInventory, 
     default <T extends InventoryProperty<?, ?>> Optional<T> getProperty(Inventory child, Class<T> property, Object key) {
         for (InventoryProperty<?, ?> prop : Adapter.Logic.getProperties(this, child, property)) {
             if (key.equals(prop.getKey())) {
-                return Optional.of(((T) prop));
+                return Optional.of((T)prop);
             }
         }
         return Optional.empty();
@@ -162,7 +161,7 @@ public interface MinecraftInventoryAdapter extends InventoryAdapter<IInventory, 
     @Override
     default <T extends InventoryProperty<?, ?>> Optional<T> getProperty(Class<T> property, Object key) {
         if (this.parent() == this) {
-            return Optional.empty(); // TODO top level inventory properties
+            return Adapter.Logic.getRootProperty(this, property, key);
         }
         return this.parent().getProperty(this, property, key);
     }

--- a/src/main/java/org/spongepowered/common/item/inventory/lens/impl/struct/LensHandle.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/lens/impl/struct/LensHandle.java
@@ -73,10 +73,8 @@ public final class LensHandle<TInventory, TStack> {
     public LensHandle(Lens<TInventory, TStack> lens, InventoryProperty<?, ?>... properties) {
         this.lens = lens;
         if (properties != null && properties.length > 0) {
-            this.properties = new ArrayList<InventoryProperty<?, ?>>();
-            for (InventoryProperty<?, ?> property : properties) {
-                this.properties.add(property);
-            }
+            this.properties = new ArrayList<>();
+            Collections.addAll(this.properties, properties);
         }
     }
 
@@ -90,13 +88,13 @@ public final class LensHandle<TInventory, TStack> {
     public LensHandle(Lens<TInventory, TStack> lens, Collection<InventoryProperty<?, ?>> properties) {
         this.lens = lens;
         if (properties != null && properties.size() > 0) {
-            this.properties = new ArrayList<InventoryProperty<?, ?>>(properties);
+            this.properties = new ArrayList<>(properties);
         }
     }
     
     public Collection<InventoryProperty<?, ?>> getProperties() {
         if (this.properties == null) {
-            return Collections.<InventoryProperty<?, ?>>emptyList();
+            return Collections.emptyList();
         }
         return Collections.unmodifiableCollection(this.properties);
     }


### PR DESCRIPTION
- [ ] Change InventoryTitle(Property) on Containers
-  [ ] Implement getProperty etc.
    -  [x] Implement getProperty for "intermediate" inventories
    -  [x] Implement getProperty for custom inventories
    -  [ ] Implement getProperty for top level inventories

Inventory Properties were not available.
This PR currently implements the getProperty/ies methods in the base interface `MinecraftInventoryAdapter` for Adapters and CustomInventories.

Questions:
- How am I supposed to get InventoryProperties from top level/vanilla inventories?
  (like InventoryTitle)
- What is the purpose of the property name when building custom inventories?
  It's only used with lowercased classname anyway (which is default in currently all  InventoryProperties)
  - `Inventory.Builder#property(name, property)` remove name in API?
