### PR TITLE
Negative one item stack quantities

### DIFF
--- a/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackBuilder.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackBuilder.java
@@ -95,6 +95,12 @@ public class SpongeItemStackBuilder implements ItemStack.Builder {
         return this;
     }
 
+    @Override public ItemStack.Builder unsafeQuantity(int quantity) {
+        checkArgument(quantity >= -1, "Quantity must be greater than or equal to -1");
+        this.quantity = quantity;
+        return this;
+    }
+
     @Override
     public <E> ItemStack.Builder keyValue(Key<? extends BaseValue<E>> key, E value) {
         if (this.keyValues == null) {

--- a/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackBuilder.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackBuilder.java
@@ -96,9 +96,8 @@ public class SpongeItemStackBuilder implements ItemStack.Builder {
     }
 
     @Override
-    public ItemStack.Builder unsafeQuantity(int quantity) {
-        checkArgument(quantity >= -1, "Quantity must be greater than or equal to -1");
-        this.quantity = quantity;
+    public ItemStack.Builder anySize() {
+        this.quantity = -1;
         return this;
     }
 

--- a/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackBuilder.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackBuilder.java
@@ -95,7 +95,8 @@ public class SpongeItemStackBuilder implements ItemStack.Builder {
         return this;
     }
 
-    @Override public ItemStack.Builder unsafeQuantity(int quantity) {
+    @Override
+    public ItemStack.Builder unsafeQuantity(int quantity) {
         checkArgument(quantity >= -1, "Quantity must be greater than or equal to -1");
         this.quantity = quantity;
         return this;


### PR DESCRIPTION
[API](https://github.com/SpongePowered/SpongeAPI/pull/1397) | Common

As discussed at https://github.com/SpongePowered/SpongeAPI/issues/1392, a -1 quantity would be useful for ignoring stack size differences with `Inventory#query(ItemStack)`.

In my implementation I have added `ItemStack.Builder#anySize` which can be used for querying inventories.
