### PR TITLE
Move instance checks to direct fail fast methods for Phases and PhaseStates

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/IPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/IPhaseState.java
@@ -110,4 +110,11 @@ public interface IPhaseState {
     }
 
 
+    default boolean shouldStateAllowChunkRequest() {
+        return false;
+    }
+
+    default boolean doesStateDenyChunkRequests() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/TrackingPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/TrackingPhase.java
@@ -354,4 +354,8 @@ public abstract class TrackingPhase {
     public void appendExplosionCause(PhaseData phaseData) {
 
     }
+
+    public boolean canPhaseDenyChunkRequest(IPhaseState currentState) {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/block/BlockPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/block/BlockPhase.java
@@ -86,4 +86,8 @@ public final class BlockPhase extends TrackingPhase {
         return state == State.RESTORING_BLOCKS && (updateFlag & 1) == 0;
     }
 
+    @Override
+    public boolean canPhaseDenyChunkRequest(IPhaseState currentState) {
+        return true;
+    }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/entity/ChangingToDimensionState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/entity/ChangingToDimensionState.java
@@ -155,4 +155,10 @@ final class ChangingToDimensionState extends EntityPhaseState {
         teleportingEntity.worldObj.theProfiler.endSection();
         return teleportingEntity;
     }
+
+    @Override
+    public boolean shouldStateAllowChunkRequest() {
+        return true;
+    }
+
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/entity/EntityPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/entity/EntityPhase.java
@@ -72,6 +72,10 @@ public final class EntityPhase extends TrackingPhase {
         return true;
     }
 
+    @Override
+    public boolean canPhaseDenyChunkRequest(IPhaseState currentState) {
+        return true;
+    }
 
     public static EntityPhase getInstance() {
         return Holder.INSTANCE;

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GenerationPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GenerationPhase.java
@@ -58,7 +58,7 @@ public final class GenerationPhase extends TrackingPhase {
 
         public static final IPhaseState CHUNK_LOADING = new GeneralGenerationPhaseState("CHUNK_LOADING").bake();
 
-        public static final IPhaseState WORLD_SPAWNER_SPAWNING = new GeneralGenerationPhaseState("WORLD_SPAWNER_SPAWNING").bake();
+        public static final IPhaseState WORLD_SPAWNER_SPAWNING = new WorldSpawnerSpawningPhaseState().bake();
 
         public static final IPhaseState POPULATOR_RUNNING = new PopulatorGenerationPhaseState("POPULATOR_RUNNING");
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/WorldSpawnerSpawningPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/WorldSpawnerSpawningPhaseState.java
@@ -22,15 +22,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.event.tracking.phase.entity;
+package org.spongepowered.common.event.tracking.phase.generation;
 
-final class LeavingDimensionState extends EntityPhaseState {
+class WorldSpawnerSpawningPhaseState extends GeneralGenerationPhaseState {
 
-    LeavingDimensionState() {
+    WorldSpawnerSpawningPhaseState() {
+        super("WORLD_SPAWNER_SPAWNING");
     }
 
     @Override
-    public boolean shouldStateAllowChunkRequest() {
+    public boolean doesStateDenyChunkRequests() {
         return true;
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/plugin/PreWorldTickListenerState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/plugin/PreWorldTickListenerState.java
@@ -83,4 +83,8 @@ final class PreWorldTickListenerState extends ListenerPhaseState {
         context.getCapturedPlayerSupplier().addPlayer(playerMP);
     }
 
+    @Override
+    public boolean doesStateDenyChunkRequests() {
+        return true;
+    }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/DimensionTickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/DimensionTickPhaseState.java
@@ -98,6 +98,11 @@ class DimensionTickPhaseState extends TickPhaseState {
     }
 
     @Override
+    public boolean shouldStateAllowChunkRequest() {
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "DimensionTickPhase";
     }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/PlayerTickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/PlayerTickPhaseState.java
@@ -135,6 +135,11 @@ class PlayerTickPhaseState extends TickPhaseState {
     }
 
     @Override
+    public boolean shouldStateAllowChunkRequest() {
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "PlayerTickPhase";
     }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/TickPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/TickPhase.java
@@ -134,6 +134,11 @@ public final class TickPhase extends TrackingPhase {
     }
 
     @Override
+    public boolean canPhaseDenyChunkRequest(IPhaseState currentState) {
+        return true;
+    }
+
+    @Override
     public void appendContextPreExplosion(PhaseContext phaseContext, PhaseData currentPhaseData) {
         ((TickPhaseState) currentPhaseData.state).appendExplosionContext(phaseContext, currentPhaseData.context);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/MixinChunkProviderServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/MixinChunkProviderServer.java
@@ -196,23 +196,35 @@ public abstract class MixinChunkProviderServer implements WorldStorage, IMixinCh
             final CauseTracker causeTracker = ((IMixinWorldServer) this.worldObj).getCauseTracker();
             final IPhaseState currentState = causeTracker.getCurrentState();
             // States that cannot deny chunks
-            if (currentState == TickPhase.Tick.PLAYER
-                    || currentState == TickPhase.Tick.DIMENSION
-                    || currentState == EntityPhase.State.CHANGING_TO_DIMENSION
-                    || currentState == EntityPhase.State.LEAVING_DIMENSION) {
+            /*
+            The current set of states that cannot deny chunks are as follows:
+            TickPhase.Tick.PLAYER
+            TickPhase.Tick.DIMENSION
+            EntityPhase.State.CHANGING_TO_DIMENSION
+            EntityPhase.State.LEAVING_DIMENSION
+             */
+            if (currentState.shouldStateAllowChunkRequest()) {
                 return false;
             }
 
             // States that can deny chunks
-            if (currentState == GenerationPhase.State.WORLD_SPAWNER_SPAWNING
-                    || currentState == PluginPhase.Listener.PRE_WORLD_TICK_LISTENER) {
+            /*
+            The current set of states that can deny chunk requests are as follows:
+            GenerationPhase.State.WORLD_SPAWNER_SPAWNING
+            PluginPhase.Listener.PRE_WORLD_TICK_LISTENER
+             */
+            if (currentState.doesStateDenyChunkRequests()) {
                 return true;
             }
 
             // Phases that can deny chunks
-            if (currentState.getPhase() == TrackingPhases.BLOCK
-                    || currentState.getPhase() == TrackingPhases.ENTITY
-                    || currentState.getPhase() == TrackingPhases.TICK) {
+            /*
+            The current set of phases that can deny chunk requests are as follows:
+            TrackingPhases.BLOCK
+            TrackingPhases.ENTITY
+            TrackingPhases.TICK
+             */
+            if (currentState.getPhase().canPhaseDenyChunkRequest(currentState)) {
                 return true;
             }
         }


### PR DESCRIPTION
This improves on the existing chunk flags used to make the phase checks even faster than they currently are. Please look over @bloodmc and correct me ifI'm wrong @Deamon5550 and @Mumfrey that this indeed is faster than what currently exists.
