### PR TITLE
Implement clearPassengers, and removePassenger(Entity)

### DIFF
--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongePassengerData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongePassengerData.java
@@ -25,19 +25,14 @@
 package org.spongepowered.common.data.manipulator.immutable.entity;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutablePassengerData;
 import org.spongepowered.api.data.manipulator.mutable.entity.PassengerData;
 import org.spongepowered.api.data.value.immutable.ImmutableListValue;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableListData;
-import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongePassengerData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongePassengerData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongePassengerData.java
@@ -40,16 +40,18 @@ import org.spongepowered.common.data.manipulator.mutable.entity.SpongePassengerD
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 import java.util.List;
+import java.util.UUID;
 
-public class ImmutableSpongePassengerData extends AbstractImmutableListData<EntitySnapshot, ImmutablePassengerData, PassengerData> implements ImmutablePassengerData {
+public class ImmutableSpongePassengerData extends AbstractImmutableListData<UUID, ImmutablePassengerData, PassengerData> implements
+        ImmutablePassengerData {
 
 
-    public ImmutableSpongePassengerData(List<EntitySnapshot> passenger) {
+    public ImmutableSpongePassengerData(List<UUID> passenger) {
         super(ImmutablePassengerData.class, checkNotNull(passenger), Keys.PASSENGERS, SpongePassengerData.class);
     }
 
     @Override
-    public ImmutableListValue<EntitySnapshot> passengers() {
+    public ImmutableListValue<UUID> passengers() {
         return this.getValueGetter();
     }
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongePassengerData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongePassengerData.java
@@ -29,33 +29,27 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutablePassengerData;
 import org.spongepowered.api.data.manipulator.mutable.entity.PassengerData;
 import org.spongepowered.api.data.value.mutable.ListValue;
-import org.spongepowered.api.data.value.mutable.Value;
-import org.spongepowered.api.entity.EntitySnapshot;
-import org.spongepowered.api.entity.EntityTypes;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongePassengerData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractListData;
-import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
 import org.spongepowered.common.data.util.ImplementationRequiredForTest;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
-import org.spongepowered.common.entity.SpongeEntitySnapshotBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @ImplementationRequiredForTest
-public class SpongePassengerData extends AbstractListData<EntitySnapshot, PassengerData, ImmutablePassengerData> implements PassengerData {
+public class SpongePassengerData extends AbstractListData<UUID, PassengerData, ImmutablePassengerData> implements PassengerData {
 
     public SpongePassengerData() {
         this(new ArrayList<>());
-        this.getValue().add(new SpongeEntitySnapshotBuilder().type(EntityTypes.UNKNOWN).build());
     }
 
-    public SpongePassengerData(List<EntitySnapshot> passengers) {
+    public SpongePassengerData(List<UUID> passengers) {
         super(PassengerData.class, passengers, Keys.PASSENGERS, ImmutableSpongePassengerData.class);
     }
 
     @Override
-    public ListValue<EntitySnapshot> passengers() {
+    public ListValue<UUID> passengers() {
         return getValueGetter();
     }
 

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/PassengerDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/PassengerDataProcessor.java
@@ -42,6 +42,7 @@ import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.util.GuavaCollectors;
+import org.spongepowered.api.world.World;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongePassengerData;
 import org.spongepowered.common.data.processor.common.AbstractEntitySingleDataProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeListValue;
@@ -54,18 +55,19 @@ import org.spongepowered.common.entity.SpongeEntitySnapshotBuilder;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
-public class PassengerDataProcessor extends AbstractEntitySingleDataProcessor<net.minecraft.entity.Entity, List<EntitySnapshot>, ListValue<EntitySnapshot>, PassengerData, ImmutablePassengerData> {
+public class PassengerDataProcessor extends AbstractEntitySingleDataProcessor<net.minecraft.entity.Entity, List<UUID>, ListValue<UUID>, PassengerData, ImmutablePassengerData> {
 
     public PassengerDataProcessor() {
         super(net.minecraft.entity.Entity.class, Keys.PASSENGERS);
     }
 
     @Override
-    protected boolean set(net.minecraft.entity.Entity entity, List<EntitySnapshot> snapshots) {
-        final List<net.minecraft.entity.Entity> passengers = snapshots.stream()
-                .map(EntitySnapshot::restore)
+    protected boolean set(net.minecraft.entity.Entity entity, List<UUID> uuids) {
+        final List<net.minecraft.entity.Entity> passengers = uuids.stream()
+                .map((uuid -> ((World) entity.getEntityWorld()).getEntity(uuid)))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .map(EntityUtil::toNative)
@@ -80,25 +82,25 @@ public class PassengerDataProcessor extends AbstractEntitySingleDataProcessor<ne
     }
 
     @Override
-    protected Optional<List<EntitySnapshot>> getVal(net.minecraft.entity.Entity dataHolder) {
+    protected Optional<List<UUID>> getVal(net.minecraft.entity.Entity dataHolder) {
         if (dataHolder.getPassengers().isEmpty()) {
             return Optional.empty();
         }
-        final List<EntitySnapshot> passengers = dataHolder.getPassengers()
+        final List<UUID> passengers = dataHolder.getPassengers()
                 .stream()
                 .map(EntityUtil::fromNative)
-                .map(Entity::createSnapshot)
+                .map(Entity::getUniqueId)
                 .collect(Collectors.toList());
         return Optional.of(passengers);
     }
 
     @Override
-    protected ImmutableListValue<EntitySnapshot> constructImmutableValue(List<EntitySnapshot> value) {
+    protected ImmutableListValue<UUID> constructImmutableValue(List<UUID> value) {
         return new ImmutableSpongeListValue<>(Keys.PASSENGERS, ImmutableList.copyOf(value));
     }
 
     @Override
-    protected ListValue<EntitySnapshot> constructValue(List<EntitySnapshot> actualValue) {
+    protected ListValue<UUID> constructValue(List<UUID> actualValue) {
         return new SpongeListValue<>(Keys.PASSENGERS, actualValue);
     }
 
@@ -107,10 +109,10 @@ public class PassengerDataProcessor extends AbstractEntitySingleDataProcessor<ne
         if (this.supports(container)) {
             net.minecraft.entity.Entity entity = ((net.minecraft.entity.Entity) container);
             if (entity.getPassengers().isEmpty()) {
-                final ImmutableList<EntitySnapshot> passengers = entity.getPassengers()
+                final ImmutableList<UUID> passengers = entity.getPassengers()
                         .stream()
                         .map(EntityUtil::fromNative)
-                        .map(Entity::createSnapshot)
+                        .map(Entity::getUniqueId)
                         .collect(GuavaCollectors.toImmutableList());
                 entity.removePassengers();
                 return DataTransactionResult.builder().result(DataTransactionResult.Type.SUCCESS).replace(constructImmutableValue(passengers)).build();
@@ -122,7 +124,7 @@ public class PassengerDataProcessor extends AbstractEntitySingleDataProcessor<ne
 
     @Override
     public Optional<PassengerData> fill(DataContainer container, PassengerData passengerData) {
-        passengerData.set(Keys.PASSENGERS, container.getSerializableList(Keys.PASSENGERS.getQuery(), EntitySnapshot.class).get());
+        passengerData.set(Keys.PASSENGERS, container.getObjectList(Keys.PASSENGERS.getQuery(), UUID.class).get());
         return Optional.of(passengerData);
     }
 

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/PassengerDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/PassengerDataProcessor.java
@@ -24,34 +24,23 @@
  */
 package org.spongepowered.common.data.processor.data.entity;
 
-import static org.spongepowered.common.data.util.DataUtil.getData;
-
 import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.data.DataContainer;
-import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutablePassengerData;
-import org.spongepowered.api.data.manipulator.mutable.entity.BreathingData;
 import org.spongepowered.api.data.manipulator.mutable.entity.PassengerData;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableListValue;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.ListValue;
-import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.util.GuavaCollectors;
 import org.spongepowered.api.world.World;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongePassengerData;
 import org.spongepowered.common.data.processor.common.AbstractEntitySingleDataProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeListValue;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeListValue;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.entity.EntityUtil;
-import org.spongepowered.common.entity.SpongeEntitySnapshot;
-import org.spongepowered.common.entity.SpongeEntitySnapshotBuilder;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -762,18 +762,18 @@ public abstract class MixinEntity implements IMixinEntity {
             throw new IllegalArgumentException(String.format("Cannot add entity %s as a passenger of %s, because the former already has the latter as a passenger!", entity, this));
         }
 
-        final ImmutableList.Builder<EntitySnapshot> passengerSnapshotsBuilder = ImmutableList.builder();
-        passengerSnapshotsBuilder.addAll(getPassengers().stream().map(Entity::createSnapshot).collect(Collectors.toList()));
+        final ImmutableList.Builder<UUID> passengerUUIDBuilder = ImmutableList.builder();
+        getPassengers().stream().map(Entity::getUniqueId).forEach(passengerUUIDBuilder::add);
 
         final DataTransactionResult.Builder builder = DataTransactionResult.builder();
         if (!((net.minecraft.entity.Entity) entity).startRiding((net.minecraft.entity.Entity) (Object) this, true)) {
-            return builder.result(DataTransactionResult.Type.FAILURE).reject(new ImmutableSpongeListValue<>(Keys.PASSENGERS, ImmutableList.of(entity
-                    .createSnapshot()))).build();
+            return builder.result(DataTransactionResult.Type.FAILURE).reject(new ImmutableSpongeListValue<>(Keys.PASSENGERS, ImmutableList.of(((net.minecraft.entity.Entity) entity)
+                    .getUniqueID()))).build();
         }
 
-        passengerSnapshotsBuilder.add(entity.createSnapshot());
+        passengerUUIDBuilder.add(((net.minecraft.entity.Entity) entity).getUniqueID());
 
-        return builder.result(DataTransactionResult.Type.SUCCESS).success(new ImmutableSpongeListValue<>(Keys.PASSENGERS, passengerSnapshotsBuilder
+        return builder.result(DataTransactionResult.Type.SUCCESS).success(new ImmutableSpongeListValue<>(Keys.PASSENGERS, passengerUUIDBuilder
                 .build())).build();
     }
 
@@ -787,11 +787,10 @@ public abstract class MixinEntity implements IMixinEntity {
         final DataTransactionResult.Builder builder = DataTransactionResult.builder();
         ((net.minecraft.entity.Entity) entity).dismountRidingEntity();
 
-        final ImmutableList.Builder<EntitySnapshot> passengerSnapshotsBuilder = ImmutableList.builder();
+        final ImmutableList.Builder<UUID> passengerUUIDBuilder = ImmutableList.builder();
+        getPassengers().stream().map(Entity::getUniqueId).forEach(passengerUUIDBuilder::add);
 
-        getPassengers().stream().map(Entity::createSnapshot).forEach(passengerSnapshotsBuilder::add);
-
-        return builder.result(DataTransactionResult.Type.SUCCESS).success(new ImmutableSpongeListValue<>(Keys.PASSENGERS, passengerSnapshotsBuilder
+        return builder.result(DataTransactionResult.Type.SUCCESS).success(new ImmutableSpongeListValue<>(Keys.PASSENGERS, passengerUUIDBuilder
                 .build())).build();
     }
 
@@ -799,10 +798,10 @@ public abstract class MixinEntity implements IMixinEntity {
     public DataTransactionResult clearPassengers() {
         this.removePassengers();
 
-        final ImmutableList.Builder<EntitySnapshot> passengerSnapshotsBuilder = ImmutableList.builder(); // This is an empty list. No passengers.
+        final ImmutableList.Builder<UUID> passengerUUIDBuilder = ImmutableList.builder(); // This is an empty list. No passengers.
 
         final DataTransactionResult.Builder builder = DataTransactionResult.builder();
-        return builder.result(DataTransactionResult.Type.SUCCESS).success(new ImmutableSpongeListValue<>(Keys.PASSENGERS, passengerSnapshotsBuilder
+        return builder.result(DataTransactionResult.Type.SUCCESS).success(new ImmutableSpongeListValue<>(Keys.PASSENGERS, passengerUUIDBuilder
                 .build())).build();
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -774,7 +774,7 @@ public abstract class MixinEntity implements IMixinEntity {
     @Override
     public void removePassenger(Entity entity) {
         checkNotNull(entity);
-        if (entity.getPassengers().contains(this)) {
+        if (!entity.getPassengers().contains(this)) {
             throw new IllegalArgumentException(String.format("Cannot remove entity %s, because it is not a passenger of %s ", entity, this));
         }
 


### PR DESCRIPTION
Currently these two API methods are not implemented. This implements them.

This also includes a lot of other changes that were requested for this PR, with the [accompanying API PR](https://github.com/SpongePowered/SpongeAPI/pull/1407).

Test case,
```
    @Listener
    public void onInteract(InteractBlockEvent.Secondary event, @First Player player) {
        player.getVehicle().ifPresent((Entity::clearPassengers));
    }

    @Listener
    public void onInteract(InteractBlockEvent.Primary event, @First Player player) {
        player.getVehicle().ifPresent((entity -> entity.removePassenger(player)));
    }
```
