### PR TITLE
Fix the getOpenInventory method.

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketFunction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketFunction.java
@@ -81,6 +81,7 @@ import org.spongepowered.common.event.tracking.ItemDropData;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.TrackingUtil;
 import org.spongepowered.common.interfaces.IMixinContainer;
+import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayerMP;
 import org.spongepowered.common.interfaces.network.IMixinNetHandlerPlayServer;
 import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 import org.spongepowered.common.item.inventory.adapter.impl.slots.SlotAdapter;
@@ -914,6 +915,7 @@ public interface PacketFunction {
             if (event.isCancelled()) {
                 player.closeScreen();
             } else {
+                ((IMixinEntityPlayerMP) player).setPlayerInventoryOpen();
                 // Custom cursor
                 if (event.getCursorTransaction().getCustom().isPresent()) {
                     PacketPhaseUtil.handleCustomCursor(player, event.getCursorTransaction().getFinal());

--- a/src/main/java/org/spongepowered/common/interfaces/entity/player/IMixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/player/IMixinEntityPlayerMP.java
@@ -55,4 +55,6 @@ public interface IMixinEntityPlayerMP extends IMixinEntityPlayer {
 
     // todo
     void restorePacketItem();
+
+    void setPlayerInventoryOpen();
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -195,6 +195,8 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
 
     private EntityPlayerMP this$ = (EntityPlayerMP) (Object) this;
 
+    private boolean playerInventoryOpen;
+
     public int newExperience = 0;
     public int newLevel = 0;
     public int newTotalExperience = 0;
@@ -486,6 +488,7 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
         this.foodStats = new FoodStats();
         this.potionsNeedUpdate = true;
         this.openContainer = this.inventoryContainer;
+        this.playerInventoryOpen = false;
         this.attackingPlayer = null;
         this.entityLivingToAttack = null;
         this.lastExperience = -1;
@@ -505,6 +508,9 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
 
     @Override
     public Optional<Container> getOpenInventory() {
+        if (this.openContainer == this.inventoryContainer && !this.playerInventoryOpen) {
+            return Optional.empty();
+        }
         return Optional.ofNullable((Container) this.openContainer);
     }
 
@@ -827,5 +833,11 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
             mixinContainer.setCaptureInventory(false);
             mixinContainer.getCapturedTransactions().clear();
         }
+        this.playerInventoryOpen = false;
+    }
+
+    @Override
+    public void setPlayerInventoryOpen() {
+        this.playerInventoryOpen = true;
     }
 }


### PR DESCRIPTION
The `Player#getOpenInventory` method returns currently always a container, even if the player inventory is closed. The reason of this is that the `openContainer` is never, but rather reset to the `inventoryContainer` when a inventory is closed.