### PR TITLE
Added login bypass permissions.

### DIFF
--- a/src/main/java/org/spongepowered/common/command/CommandPermissions.java
+++ b/src/main/java/org/spongepowered/common/command/CommandPermissions.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.service.permission.MemorySubjectData;
 import org.spongepowered.api.service.permission.SubjectData;
 import org.spongepowered.api.util.Tristate;
 import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.common.entity.player.LoginPermissions;
 
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -52,11 +53,11 @@ public final class CommandPermissions {
     }
 
     public static boolean testPermission(CommandSource source, String commandName) {
-        if (commandName.equals(CommandPermissions.SELECTOR_COMMAND)) {
-            return source.hasPermission(CommandPermissions.SELECTOR_PERMISSION);
+        if (commandName.equals(SELECTOR_COMMAND)) {
+            return source.hasPermission(SELECTOR_PERMISSION);
         }
-        if (commandName.equals(CommandPermissions.COMMAND_BLOCK_COMMAND)) {
-            return source.hasPermission(CommandPermissions.COMMAND_BLOCK_PERMISSION);
+        if (commandName.equals(COMMAND_BLOCK_COMMAND)) {
+            return source.hasPermission(COMMAND_BLOCK_PERMISSION);
         }
         Optional<? extends CommandMapping> mapping = SpongeImpl.getGame().getCommandManager().get(commandName);
         if (mapping.isPresent()) {
@@ -70,14 +71,17 @@ public final class CommandPermissions {
     }
 
     public static void populateNonCommandPermissions(SubjectData data, BiFunction<Integer, String, Boolean> testPermission) {
-        if (testPermission.apply(CommandPermissions.COMMAND_BLOCK_LEVEL, CommandPermissions.COMMAND_BLOCK_COMMAND)) {
-            data.setPermission(SubjectData.GLOBAL_CONTEXT, CommandPermissions.SELECTOR_PERMISSION, Tristate.TRUE);
+        if (testPermission.apply(COMMAND_BLOCK_LEVEL, COMMAND_BLOCK_COMMAND)) {
+            data.setPermission(SubjectData.GLOBAL_CONTEXT, COMMAND_BLOCK_PERMISSION, Tristate.TRUE);
         }
-        if (testPermission.apply(CommandPermissions.SELECTOR_LEVEL, CommandPermissions.SELECTOR_COMMAND)) {
-            data.setPermission(SubjectData.GLOBAL_CONTEXT, CommandPermissions.COMMAND_BLOCK_COMMAND, Tristate.TRUE);
+        if (testPermission.apply(SELECTOR_LEVEL, SELECTOR_COMMAND)) {
+            data.setPermission(SubjectData.GLOBAL_CONTEXT, SELECTOR_PERMISSION, Tristate.TRUE);
         }
-        if (testPermission.apply(CommandPermissions.SPONGE_HELP_LEVEL, CommandPermissions.SPONGE_HELP_COMMAND)) {
-            data.setPermission(SubjectData.GLOBAL_CONTEXT, CommandPermissions.SPONGE_HELP_PERMISSION, Tristate.TRUE);
+        if (testPermission.apply(SPONGE_HELP_LEVEL, SPONGE_HELP_COMMAND)) {
+            data.setPermission(SubjectData.GLOBAL_CONTEXT, SPONGE_HELP_PERMISSION, Tristate.TRUE);
+        }
+        if (testPermission.apply(LoginPermissions.BYPASS_WHITELIST_LEVEL, LoginPermissions.BYPASS_WHITELIST_PERMISSION)) {
+            data.setPermission(SubjectData.GLOBAL_CONTEXT, LoginPermissions.BYPASS_WHITELIST_PERMISSION, Tristate.TRUE);
         }
     }
 

--- a/src/main/java/org/spongepowered/common/entity/player/LoginPermissions.java
+++ b/src/main/java/org/spongepowered/common/entity/player/LoginPermissions.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.entity.player;
+
+public final class LoginPermissions {
+
+    public static final int BYPASS_WHITELIST_LEVEL = 1;
+
+    public static final String BYPASS_WHITELIST_PERMISSION = "minecraft.login.bypass-whitelist";
+
+    public static final String BYPASS_PLAYER_LIMIT_PERMISSION = "minecraft.login.bypass-player-limit";
+
+    private LoginPermissions() {
+    }
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinDedicatedPlayerList.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinDedicatedPlayerList.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.server;
+
+import com.mojang.authlib.GameProfile;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.service.permission.PermissionService;
+import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.service.permission.SubjectData;
+import org.spongepowered.api.util.Tristate;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.common.entity.player.LoginPermissions;
+import org.spongepowered.common.service.permission.SpongePermissionService;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.dedicated.DedicatedPlayerList;
+import net.minecraft.server.management.PlayerList;
+
+@Mixin(DedicatedPlayerList.class)
+public abstract class MixinDedicatedPlayerList extends PlayerList {
+
+    public MixinDedicatedPlayerList(MinecraftServer server) {
+        super(server);
+    }
+
+    @Inject(method = "canJoin", at = @At("HEAD"), cancellable = true)
+    private void onCanJoin(GameProfile profile, CallbackInfoReturnable<Boolean> ci) {
+        if (!isWhiteListEnabled() || getWhitelistedPlayers().isWhitelisted(profile)) {
+            ci.setReturnValue(true);
+            return;
+        }
+        final PermissionService permissionService = Sponge.getServiceManager().provideUnchecked(PermissionService.class);
+        final Subject subject = permissionService.getUserSubjects()
+                .getSubject(profile.getId().toString()).orElse(permissionService.getDefaults());
+        ci.setReturnValue(subject.hasPermission(LoginPermissions.BYPASS_WHITELIST_PERMISSION));
+    }
+
+    @Inject(method = "bypassesPlayerLimit", at = @At("HEAD"), cancellable = true)
+    private void onBypassPlayerLimit(GameProfile profile, CallbackInfoReturnable<Boolean> ci) {
+        final PermissionService permissionService = Sponge.getServiceManager().provideUnchecked(PermissionService.class);
+        final Subject subject = permissionService.getUserSubjects()
+                .getSubject(profile.getId().toString()).orElse(permissionService.getDefaults());
+        final Tristate tristate = subject.getPermissionValue(SubjectData.GLOBAL_CONTEXT, LoginPermissions.BYPASS_PLAYER_LIMIT_PERMISSION);
+        // Use the op list if the permission isn't overridden for the subject and
+        // if we are still using the default permission service
+        if (tristate == Tristate.UNDEFINED && permissionService instanceof SpongePermissionService) {
+            return;
+        }
+        ci.setReturnValue(tristate.asBoolean());
+    }
+}

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -543,6 +543,7 @@
     "server": [
         "network.rcon.MixinRConConsoleSource",
         "network.rcon.MixinRConThreadClient",
+        "server.MixinDedicatedPlayerList",
         "server.MixinDedicatedServer",
         "server.management.MixinUserList"
     ],


### PR DESCRIPTION
Common | [Forge](https://github.com/SpongePowered/SpongeForge/pull/1023) | [Vanilla](https://github.com/SpongePowered/SpongeVanilla/pull/277)

Fixes https://github.com/SpongePowered/SpongeCommon/issues/868

This PR adds 2 permissions, one that can be used to bypass the whitelist (defaults to true when op) and a permission to bypass the player limit.

`minecraft.login.bypass-whitelist`
`minecraft.login.bypass-player-limit`