### PR TITLE
Added timings to SpongeScheduler

### DIFF
--- a/src/main/java/co/aikar/timings/SpongeTimings.java
+++ b/src/main/java/co/aikar/timings/SpongeTimings.java
@@ -126,6 +126,10 @@ public final class SpongeTimings {
         return SpongeTimingsFactory.ofSafe(plugin.getName(), context, TimingsManager.PLUGIN_EVENT_HANDLER);
     }
 
+    public static Timing getPluginSchedulerTimings(PluginContainer plugin) {
+        return SpongeTimingsFactory.ofSafe(plugin.getName(), TimingsManager.PLUGIN_SCHEDULER_HANDLER);
+    }
+
     public static Timing getCancelTasksTimer() {
         return SpongeTimingsFactory.ofSafe("Cancel Tasks");
     }

--- a/src/main/java/co/aikar/timings/TimingsManager.java
+++ b/src/main/java/co/aikar/timings/TimingsManager.java
@@ -46,6 +46,7 @@ public final class TimingsManager {
     public static final TimingHandler TIMINGS_TICK = SpongeTimingsFactory.ofSafe("Timings Tick", FULL_SERVER_TICK);
     public static final Timing DATA_GROUP_HANDLER = SpongeTimingsFactory.ofSafe("Data");
     public static final Timing MOD_EVENT_HANDLER = SpongeTimingsFactory.ofSafe("Mod Events");
+    public static final Timing PLUGIN_SCHEDULER_HANDLER = SpongeTimingsFactory.ofSafe("Plugin Scheduler");
     public static final Timing PLUGIN_EVENT_HANDLER = SpongeTimingsFactory.ofSafe("Plugin Events");
     public static final Timing PLUGIN_GROUP_HANDLER = SpongeTimingsFactory.ofSafe("Plugins");
     public static List<String> hiddenConfigs = new ArrayList<>();

--- a/src/main/java/org/spongepowered/common/scheduler/ScheduledTask.java
+++ b/src/main/java/org/spongepowered/common/scheduler/ScheduledTask.java
@@ -25,6 +25,10 @@
 package org.spongepowered.common.scheduler;
 
 import com.google.common.base.Objects;
+
+import co.aikar.timings.SpongeTimings;
+import co.aikar.timings.Timing;
+
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.scheduler.Task;
 
@@ -49,6 +53,7 @@ public class ScheduledTask implements Task {
     private final String name;
     private final TaskSynchronicity syncType;
     private final String stringRepresentation;
+    private Timing taskTimer;
 
     // Internal Task state. Not for user-service use.
     public enum ScheduledTaskState {
@@ -194,4 +199,10 @@ public class ScheduledTask implements Task {
         ASYNCHRONOUS
     }
 
+    public Timing getTimingsHandler() {
+        if (this.taskTimer == null) {
+            this.taskTimer = SpongeTimings.getPluginSchedulerTimings(this.owner);
+        }
+        return this.taskTimer;
+    }
 }

--- a/src/main/java/org/spongepowered/common/scheduler/SchedulerBase.java
+++ b/src/main/java/org/spongepowered/common/scheduler/SchedulerBase.java
@@ -26,6 +26,9 @@ package org.spongepowered.common.scheduler;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
+import co.aikar.timings.TimingsManager;
+
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.scheduler.Task;
 import org.spongepowered.common.SpongeImpl;
@@ -100,12 +103,14 @@ abstract class SchedulerBase {
      */
     protected final void runTick() {
         this.preTick();
+        TimingsManager.PLUGIN_SCHEDULER_HANDLER.startTimingIfSync();
         try {
             this.taskMap.values().forEach(this::processTask);
             this.postTick();
         } finally {
             this.finallyPostTick();
         }
+        TimingsManager.PLUGIN_SCHEDULER_HANDLER.stopTimingIfSync();
     }
 
     /**
@@ -173,12 +178,14 @@ abstract class SchedulerBase {
     protected void startTask(final ScheduledTask task) {
         this.executeTaskRunnable(() -> {
             task.setState(ScheduledTask.ScheduledTaskState.RUNNING);
+            task.getTimingsHandler().startTimingIfSync();
             try {
                 task.getConsumer().accept(task);
             } catch (Throwable t) {
                 SpongeImpl.getLogger().error("The Scheduler tried to run the task {} owned by {}, but an error occured.", task.getName(),
                                              task.getOwner(), t);
             }
+            task.getTimingsHandler().stopTimingIfSync();
         });
     }
 


### PR DESCRIPTION
Implemented some timings into the scheduler.

This should be needed if async tasks are synchronized to call the sponge api.
Currently timings for those tasks are recorded as "onTick", so there is no way to determine which task is freezing the server.

Tested with the following plugin:
https://github.com/Zartec/SchedulerTimingsTest
Before this change:
https://timings.aikar.co/v2/?id=e3d6bd2d6500496d82aa5eea74ed2719
After this change:
https://timings.aikar.co/v2/?id=f9de23b12b6a435482b276e4189f4a41