### PR TITLE
If the dimension ID isn't valid, don't try setting the world's name to 'null'.

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinWorldInfo.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinWorldInfo.java
@@ -217,7 +217,7 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
             return;
         }
 
-        final String name = WorldManager.getWorldFolderByDimensionId(this.dimensionId).orElse(null);
+        final String name = WorldManager.getWorldFolderByDimensionId(this.dimensionId).orElse(this.levelName);
         if (!this.levelName.equalsIgnoreCase(name)) {
             this.levelName = name;
         }


### PR DESCRIPTION
This fixes https://github.com/SpongePowered/SpongeCommon/issues/1078