### PR TITLE
ClassLoader and Event Fixes

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -60,6 +60,7 @@ public final class PacketPhaseUtil {
             final int slotNumber = slot.slotNumber;
             ItemStackSnapshot snapshot = eventCancelled || !slotTransaction.isValid() ? slotTransaction.getOriginal() : slotTransaction.getCustom().get();
             final ItemStack originalStack = ItemStackUtil.fromSnapshotToNative(snapshot);
+            final ItemStack defaultStack = ItemStackUtil.fromSnapshotToNative(slotTransaction.getDefault());
 
             // TODO: fix below
             /*if (originalStack == null) {
@@ -70,7 +71,12 @@ public final class PacketPhaseUtil {
 
             final Slot nmsSlot = player.openContainer.getSlot(slotNumber);
             if (nmsSlot != null) {
-                nmsSlot.putStack(originalStack);
+                ItemStack slotStack = nmsSlot.getStack();
+                // Don't replace the stack if it changed during the event
+                if ((slotStack.isEmpty() && defaultStack.isEmpty()) ||
+                        slotStack.isItemEqual(defaultStack)) {
+                    nmsSlot.putStack(originalStack);
+                }
             }
         }
         player.openContainer.detectAndSendChanges();


### PR DESCRIPTION
The first commit is for when a plugin changes the inventory targeted during a ClickInventoryEvent. It would previously revert the slot clicked unconditionally, even if a plugin has changed it. I added a check there so that wouldn't happen.

The second commit is a fix for when a Class in a separate ClassLoader registers an event. Previously this would cause a NoClassDefFoundError due to the handler class not being in the same ClassLoader as the registered class. 