### PR TITLE
Fixed 'null' item check in FireworkUtils.

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/common/FireworkUtils.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/FireworkUtils.java
@@ -58,7 +58,7 @@ public class FireworkUtils {
 
     public static ItemStack getItem(EntityFireworkRocket firework) {
         ItemStack item = firework.getDataManager().get(EntityFireworkRocket.FIREWORK_ITEM);
-        if (item == null) {
+        if (item.isEmpty()) {
             item = (ItemStack) new SpongeItemStackBuilder().itemType(ItemTypes.FIREWORKS).build();
             firework.getDataManager().set(EntityFireworkRocket.FIREWORK_ITEM, item);
         }


### PR DESCRIPTION
Currently it's impossible to assign a List<FireworkEffect> to a firework entity, as it needs to create an item to base the NBTTagCompound off. This change fixes the missed item null check, that prevents the item ever being set.