### PR TITLE
Don't restore slot if the slot has changed

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -60,6 +60,7 @@ public final class PacketPhaseUtil {
             final int slotNumber = slot.slotNumber;
             ItemStackSnapshot snapshot = eventCancelled || !slotTransaction.isValid() ? slotTransaction.getOriginal() : slotTransaction.getCustom().get();
             final ItemStack originalStack = ItemStackUtil.fromSnapshotToNative(snapshot);
+            final ItemStack defaultStack = ItemStackUtil.fromSnapshotToNative(slotTransaction.getDefault());
 
             // TODO: fix below
             /*if (originalStack == null) {
@@ -70,7 +71,12 @@ public final class PacketPhaseUtil {
 
             final Slot nmsSlot = player.openContainer.getSlot(slotNumber);
             if (nmsSlot != null) {
-                nmsSlot.putStack(originalStack);
+                ItemStack slotStack = nmsSlot.getStack();
+                // Don't replace the stack if it changed during the event
+                if ((slotStack.isEmpty() && defaultStack.isEmpty()) ||
+                        slotStack.isItemEqual(defaultStack)) {
+                    nmsSlot.putStack(originalStack);
+                }
             }
         }
         player.openContainer.detectAndSendChanges();


### PR DESCRIPTION
Some plugins change the slot directly instead of changing the slot transaction,
this makes it so that it works, instead of not changing the slot