### PR TITLE
Implement Inventory exactQuery and contains with quantity

### DIFF
--- a/src/main/java/org/spongepowered/common/item/inventory/EmptyInventoryImpl.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/EmptyInventoryImpl.java
@@ -138,6 +138,11 @@ public class EmptyInventoryImpl implements EmptyInventory, Observer<InventoryEve
     }
 
     @Override
+    public boolean containsAny(ItemStack stack) {
+        return false;
+    }
+
+    @Override
     public boolean contains(ItemType type) {
         return false;
     }
@@ -186,6 +191,12 @@ public class EmptyInventoryImpl implements EmptyInventory, Observer<InventoryEve
     @SuppressWarnings("unchecked")
     @Override
     public <T extends Inventory> T query(ItemStack... types) {
+        return (T)this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T extends Inventory> T queryAny(ItemStack... types) {
         return (T)this;
     }
 

--- a/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/MinecraftInventoryAdapter.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/MinecraftInventoryAdapter.java
@@ -108,6 +108,11 @@ public interface MinecraftInventoryAdapter extends InventoryAdapter<IInventory, 
     }
 
     @Override
+    default boolean containsAny(ItemStack stack) {
+        return Adapter.Logic.contains(this, stack, 1);
+    }
+
+    @Override
     default boolean contains(ItemType type) {
         return Adapter.Logic.contains(this, type);
     }
@@ -174,6 +179,12 @@ public interface MinecraftInventoryAdapter extends InventoryAdapter<IInventory, 
     @SuppressWarnings("unchecked")
     @Override
     default <T extends Inventory> T query(ItemStack... types) {
+        return (T) Query.compileExact(this, types).execute();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    default <T extends Inventory> T queryAny(ItemStack... types) {
         return (T) Query.compile(this, types).execute();
     }
 

--- a/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/slots/SlotAdapter.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/slots/SlotAdapter.java
@@ -223,13 +223,20 @@ public class SlotAdapter extends Adapter implements Slot {
     @Override
     public boolean contains(ItemStack stack) {
         net.minecraft.item.ItemStack slotStack = this.slot.getStack(this.inventory);
-        return slotStack.isEmpty() ? (stack == null) : ItemStackUtil.compareIgnoreQuantity(slotStack, stack);
+        return slotStack.isEmpty() ? ItemStackUtil.toNative(stack).isEmpty() :
+                ItemStackUtil.compareIgnoreQuantity(slotStack, stack) && slotStack.getCount() >= stack.getQuantity();
+    }
+
+    @Override
+    public boolean containsAny(ItemStack stack) {
+        net.minecraft.item.ItemStack slotStack = this.slot.getStack(this.inventory);
+        return slotStack.isEmpty() ? ItemStackUtil.toNative(stack).isEmpty() : ItemStackUtil.compareIgnoreQuantity(slotStack, stack);
     }
 
     @Override
     public boolean contains(ItemType type) {
         net.minecraft.item.ItemStack slotStack = this.slot.getStack(this.inventory);
-        return slotStack.isEmpty() ? (type == null) : slotStack.getItem().equals(type);
+        return slotStack.isEmpty() ? (type == null || type == ItemTypes.AIR) : slotStack.getItem().equals(type);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/item/inventory/query/Query.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/query/Query.java
@@ -43,6 +43,7 @@ import org.spongepowered.common.item.inventory.lens.impl.collections.MutableLens
 import org.spongepowered.common.item.inventory.query.result.MinecraftResultAdapterProvider;
 import org.spongepowered.common.item.inventory.query.result.QueryResult;
 import org.spongepowered.common.item.inventory.query.strategy.ClassStrategy;
+import org.spongepowered.common.item.inventory.query.strategy.ExactItemStackStrategy;
 import org.spongepowered.common.item.inventory.query.strategy.GenericStrategy;
 import org.spongepowered.common.item.inventory.query.strategy.ItemStackStrategy;
 import org.spongepowered.common.item.inventory.query.strategy.ItemTypeStrategy;
@@ -56,11 +57,12 @@ import java.util.Map;
 
 public class Query<TInventory, TStack> {
 
-    public static enum Type {
+    public enum Type {
 
         CLASS("class", ClassStrategy.class),
         TYPE("type", ItemTypeStrategy.class),
         STACK("stack", ItemStackStrategy.class),
+        EXACT_STACK("exact_stack", ExactItemStackStrategy.class),
         PROPERTIES("property", PropertyStrategy.class),
         NAME("name", NameStrategy.class),
         EXPRESSION("expr", ExpressionStrategy.class),
@@ -71,7 +73,7 @@ public class Query<TInventory, TStack> {
         private final Class<? extends QueryStrategy<?, ?, ?>> defaultStrategyClass;
 
         @SuppressWarnings({ "rawtypes", "unchecked" })
-        private Type(String key, Class<? extends QueryStrategy> defaultStrategyClass) {
+        Type(String key, Class<? extends QueryStrategy> defaultStrategyClass) {
             this.key = key;
             this.defaultStrategyClass = (Class<? extends QueryStrategy<?, ?, ?>>) defaultStrategyClass;
         }
@@ -86,9 +88,9 @@ public class Query<TInventory, TStack> {
 
     }
 
-    public abstract interface ResultAdapterProvider<TInventory, TStack> {
+    public interface ResultAdapterProvider<TInventory, TStack> {
 
-        public abstract QueryResult<TInventory, TStack> getResultAdapter(Fabric<TInventory> inventory, MutableLensSet<TInventory, TStack> matches);
+        QueryResult<TInventory, TStack> getResultAdapter(Fabric<TInventory> inventory, MutableLensSet<TInventory, TStack> matches);
 
     }
 
@@ -217,6 +219,11 @@ public class Query<TInventory, TStack> {
 
     public static <TInventory, TStack> Query<TInventory, TStack> compile(InventoryAdapter<TInventory, TStack> adapter, ItemStack... types) {
         QueryStrategy<TInventory, TStack, ItemStack> strategy = Query.<TInventory, TStack, ItemStack>getStrategy(Type.STACK).with(types);
+        return new Query<TInventory, TStack>(adapter, strategy);
+    }
+
+    public static <TInventory, TStack> Query<TInventory, TStack> compileExact(InventoryAdapter<TInventory, TStack>  adapter, ItemStack... types) {
+        QueryStrategy<TInventory, TStack, ItemStack> strategy = Query.<TInventory, TStack, ItemStack>getStrategy(Type.EXACT_STACK).with(types);
         return new Query<TInventory, TStack>(adapter, strategy);
     }
 

--- a/src/main/java/org/spongepowered/common/item/inventory/query/strategy/ExactItemStackStrategy.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/query/strategy/ExactItemStackStrategy.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.item.inventory.query.strategy;
+
+import com.google.common.collect.ImmutableSet;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.common.item.inventory.lens.Fabric;
+import org.spongepowered.common.item.inventory.lens.Lens;
+import org.spongepowered.common.item.inventory.lens.slots.SlotLens;
+import org.spongepowered.common.item.inventory.query.QueryStrategy;
+
+import java.util.Set;
+
+public class ExactItemStackStrategy<TInventory> extends QueryStrategy<TInventory, ItemStack, ItemStack> {
+    
+    private Set<ItemStack> stacks;
+
+    @Override
+    public QueryStrategy<TInventory, ItemStack, ItemStack> with(ItemStack[] types) {
+        this.stacks = ImmutableSet.<ItemStack>copyOf(types);
+        return this;
+    }
+    
+    @Override
+    public boolean matches(Lens<TInventory, ItemStack> lens, Lens<TInventory, ItemStack> parent, Fabric<TInventory> inventory) {
+        if (this.stacks.isEmpty()) {
+            return true;
+        }
+        
+        if (lens instanceof SlotLens) {
+            ItemStack stack = ((SlotLens<TInventory, ItemStack>)lens).getStack(inventory);
+            if (stack == null) {
+                return false;
+            }
+            for (ItemStack candidate : this.stacks) {
+                if (stack.equalTo(candidate)) {
+                    return true;
+                }
+            }
+        }
+        
+        return false;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemStack.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemStack.java
@@ -164,11 +164,7 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
 
     @Override
     public void setQuantity(int quantity) throws IllegalArgumentException {
-        if (quantity > this.getMaxStackQuantity()) {
-            throw new IllegalArgumentException("Quantity (" + quantity + ") exceeded the maximum stack size (" + this.getMaxStackQuantity() + ")");
-        } else {
-            this.setCount(quantity);
-        }
+        this.setCount(quantity);
     }
 
     @Override


### PR DESCRIPTION
[API](https://github.com/SpongePowered/SpongeAPI/pull/1437) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/1095)

This also allows setting the ItemStack size greater then its maximum. (e.g. to be used with contains)
Implementation of Inventory#offer/set splits the stack if too large.

Listenercode for testing:
```
if (event.getTargetInventory().contains(ItemStack.of(ItemTypes.EMERALD, 128))) {
player.sendMessage(Text.of("You left at least 128 emeralds in there!"));
}
else if (event.getTargetInventory().containsAny(ItemStack.of(ItemTypes.EMERALD, 128))) {
player.sendMessage(Text.of("You left emeralds in there!"));
}
player.sendMessage(Text.of(event.getTargetInventory().queryAny(ItemStack.of(ItemTypes.EMERALD, 64)).capacity(), " emerald stacks found"));
player.sendMessage(Text.of(event.getTargetInventory().query(ItemStack.of(ItemTypes.EMERALD, 64)).capacity(), " are full"));
```