### PR TITLE
Fix SF issues when disconnecting a player during ClientConnectionEvent#Login

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
@@ -501,6 +501,12 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection, IMi
     @Redirect(method = "onDisconnect", at = @At(value = "INVOKE",
             target = "Lnet/minecraft/server/management/PlayerList;sendMessage(Lnet/minecraft/util/text/ITextComponent;)V"))
     public void onDisconnectHandler(PlayerList this$0, ITextComponent component) {
+        // If this happens, the connection has not been fully established yet so we've kicked them during ClientConnectionEvent.Login,
+        // but FML has created this handler earlier to send their handshake. No message should be sent, no disconnection event should
+        // be fired either.
+        if (this.playerEntity.connection == null) {
+            return;
+        }
         final Player player = ((Player) this.playerEntity);
         final Text message = SpongeTexts.toText(component);
         final MessageChannel originalChannel = player.getMessageChannel();


### PR DESCRIPTION
**SpongeCommon** | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/1195) | [Original Issue](https://github.com/SpongePowered/SpongeForge/issues/885)

See SpongePowered/SpongeForge#885 for the original bug report. Whilst this PR is for SpongeCommon, it has no impact on SpongeVanilla - this is to fix an issue that is easier to fix here.

This PR does two things:

* Prevents ClientConnectionEvent#Disconnect from firing if #Login is cancelled in SpongeForge.
* Prevents disconnection messages from being broadcast to the server in SpongeForge.

I'm going to attempt to explain what I _think_ is happening, though there is every possibility that I might be wrong! However, I'm pretty sure of the solution.

Both are manifestations of how FML changes the login sequence itself - and where Sponge puts its code. As @Aaron1011 mentioned in the referenced issue, this is due to the fact that Sponge moves the ban/whitelist checks to a point where the `NetServerPlayHandler` _might_ have been created.

In SpongeVanilla, no `NetServerPlayHandler` seems to have been created (though I haven't fully looked, all I know is that one hasn't been passed to the `MixinPlayer#initializeConnectionToPlayer` method), so if a player is disconnected during login because the `ClientConnectEvent#Login` event is cancelled, then the `onDisconnect` method is not fired, no `ClientConnectionEvent#Disconnect` event is fired, and no message is returned.

In SpongeForge, FML sets up the `NetServerPlayHandler` before this and, importantly, registers this in the network pipeline. So, when a player disconnects, the `onDisconnect()` method _is_ fired, which is why the disconnect message appears. It's also why the `ClientConnectionEvent#Disconnect` event is fired, though the `Player` object is not entirely formed and calling `Player#getConnection()` returns `null`.

The fix, then, is to just check for whether `EntityPlayerMP.connection` is `null` before preceeding with Sponge's injected code - this is the only point where this is `null` and this brings SF to parity with SV, whilst allowing Minecraft/Forge to perform it's normal cleanup on the created handler, should it be required. The SpongeForge PR restores a Forge event that is prevented from being called ordinarily in this situation, more explanation is there and is not strictly required for this PR, though it is related (hence the link above).

Test code + logs from latest SF: https://gist.github.com/dualspiral/c568b2cd78162a3bbfd2673082a1bc8e

This is also a problem in 1.10.2.