### PR TITLE
Fixed BlockState updates not updating physics. Fixed #1054

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/CauseTracker.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/CauseTracker.java
@@ -472,7 +472,7 @@ public final class CauseTracker {
         }
 
         if (flag.updateNeighbors()) { // Sponge - remove the isRemote check
-            minecraftWorld.updateObservingBlocksAt(pos, iblockstate.getBlock());
+            minecraftWorld.notifyNeighborsRespectDebug(pos, iblockstate.getBlock(), true);
 
             if (newState.hasComparatorInputOverride()) {
                 minecraftWorld.updateComparatorOutputLevel(pos, newBlock);


### PR DESCRIPTION
This fixes https://github.com/SpongePowered/SpongeCommon/issues/1054

It has been tested with CraftBook's ICs and HiddenSwitch system. 

Currently this method doesn't mirror the vanilla method; this PR fixes that.