### PR TITLE
Fail to apply Keys.ART when the painting can't fit the EnumArt value. Fixed #1053

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/ArtDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/ArtDataProcessor.java
@@ -52,7 +52,7 @@ public class ArtDataProcessor extends AbstractEntitySingleDataProcessor<EntityPa
     @Override
     protected boolean set(EntityPainting entity, Art value) {
         if (!entity.world.isRemote) {
-            EntityUtil.refreshPainting(entity, (EntityPainting.EnumArt) (Object) value);
+            return EntityUtil.refreshPainting(entity, (EntityPainting.EnumArt) (Object) value);
         }
         return true;
     }

--- a/src/main/java/org/spongepowered/common/entity/EntityUtil.java
+++ b/src/main/java/org/spongepowered/common/entity/EntityUtil.java
@@ -552,6 +552,15 @@ public final class EntityUtil {
     }
     @SuppressWarnings("unchecked")
     public static boolean refreshPainting(EntityPainting painting, EntityPainting.EnumArt art) {
+        EntityPainting.EnumArt oldArt = painting.art;
+        painting.art = art;
+        painting.updateFacingWithBoundingBox(painting.facingDirection);
+        if (!painting.onValidSurface()) {
+            painting.art = oldArt;
+            painting.updateFacingWithBoundingBox(painting.facingDirection);
+            return false;
+        }
+
         final EntityTracker paintingTracker = ((WorldServer) painting.world).getEntityTracker();
         EntityTrackerEntry paintingEntry = paintingTracker.trackedEntityHashTable.lookup(painting.getEntityId());
         List<EntityPlayerMP> playerMPs = new ArrayList<>();
@@ -560,8 +569,6 @@ public final class EntityUtil {
             player.connection.sendPacket(packet);
             playerMPs.add(player);
         }
-        painting.art = art;
-        painting.updateFacingWithBoundingBox(painting.facingDirection);
         for (EntityPlayerMP playerMP : playerMPs) {
             SpongeImpl.getGame().getScheduler().createTaskBuilder()
                     .delayTicks(SpongeImpl.getGlobalConfig().getConfig().getEntity().getPaintingRespawnDelaly())


### PR DESCRIPTION
Fixes https://github.com/SpongePowered/SpongeCommon/issues/1053.

I moved the changing of the art to before the packets are sent, as it still seems to work fine and it also means when it fails useless packets aren't being sent.

Test code,

```java
            List<Art> artsCollection = new ArrayList<>(Sponge.getRegistry().getAllOf(Art.class));

            int current = artsCollection.indexOf(painting.art().get());

            current += 1;
            current %= artsCollection.size();

            System.out.println(current);

            while (!painting.offer(Keys.ART, artsCollection.get(current)).isSuccessful()) {
                current += 1;
                current %= artsCollection.size();

                System.out.println(current);
            }
```