### PR TITLE
Fixed Skull's not looking up Skin Data if both the UUID and Name is present. Fixes #1013

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/common/SkullUtils.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/SkullUtils.java
@@ -128,7 +128,9 @@ public class SkullUtils {
         }
         // Skulls need a name in order to properly display -> resolve if no name is contained in the given profile
         final GameProfileManager resolver = Sponge.getGame().getServer().getGameProfileManager();
-        if (!profile.getName().isPresent() || profile.getName().get().isEmpty()) {
+        if (profile.getPropertyMap().containsKey("textures")) {
+            return profile;
+        } else if (profile.getUniqueId() != null) {
             final CompletableFuture<GameProfile> future = resolver.get(profile.getUniqueId());
             try {
                 return future.get();
@@ -136,7 +138,7 @@ public class SkullUtils {
                 SpongeImpl.getLogger().debug("Exception while trying to resolve GameProfile: ", e);
                 return null;
             }
-        } else if (profile.getUniqueId() == null) {
+        } else if (profile.getName().isPresent()) {
             final CompletableFuture<GameProfile> future = resolver.get(profile.getName().get());
             try {
                 return future.get();

--- a/src/main/java/org/spongepowered/common/data/processor/common/SkullUtils.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/SkullUtils.java
@@ -135,7 +135,7 @@ public class SkullUtils {
             try {
                 return future.get();
             } catch (InterruptedException | ExecutionException e) {
-                SpongeImpl.getLogger().debug("Exception while trying to fill GameProfile: ", e);
+                SpongeImpl.getLogger().debug("Exception while trying to fill skull GameProfile for '"+ profile + "'", e);
                 return profile;
             }
         }

--- a/src/main/java/org/spongepowered/common/data/processor/common/SkullUtils.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/SkullUtils.java
@@ -130,24 +130,14 @@ public class SkullUtils {
         final GameProfileManager resolver = Sponge.getGame().getServer().getGameProfileManager();
         if (profile.getPropertyMap().containsKey("textures")) {
             return profile;
-        } else if (profile.getUniqueId() != null) {
-            final CompletableFuture<GameProfile> future = resolver.get(profile.getUniqueId());
-            try {
-                return future.get();
-            } catch (InterruptedException | ExecutionException e) {
-                SpongeImpl.getLogger().debug("Exception while trying to resolve GameProfile: ", e);
-                return null;
-            }
-        } else if (profile.getName().isPresent()) {
-            final CompletableFuture<GameProfile> future = resolver.get(profile.getName().get());
-            try {
-                return future.get();
-            } catch (InterruptedException | ExecutionException e) {
-                SpongeImpl.getLogger().debug("Exception while trying to resolve GameProfile: ", e);
-                return null;
-            }
         } else {
-            return profile;
+            final CompletableFuture<GameProfile> future = resolver.fill(profile);
+            try {
+                return future.get();
+            } catch (InterruptedException | ExecutionException e) {
+                SpongeImpl.getLogger().debug("Exception while trying to fill GameProfile: ", e);
+                return profile;
+            }
         }
     }
 

--- a/src/main/java/org/spongepowered/common/data/processor/common/SkullUtils.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/SkullUtils.java
@@ -126,16 +126,15 @@ public class SkullUtils {
         if (profile == null) {
             return null;
         }
-        // Skulls need a name in order to properly display -> resolve if no name is contained in the given profile
-        final GameProfileManager resolver = Sponge.getGame().getServer().getGameProfileManager();
         if (profile.getPropertyMap().containsKey("textures")) {
             return profile;
         } else {
-            final CompletableFuture<GameProfile> future = resolver.fill(profile);
+            // Skulls need a name in order to properly display -> resolve if no name is contained in the given profile
+            final CompletableFuture<GameProfile> future = Sponge.getGame().getServer().getGameProfileManager().fill(profile);
             try {
                 return future.get();
             } catch (InterruptedException | ExecutionException e) {
-                SpongeImpl.getLogger().debug("Exception while trying to fill skull GameProfile for '"+ profile + "'", e);
+                SpongeImpl.getLogger().debug("Exception while trying to fill skull GameProfile for '" + profile + "'", e);
                 return profile;
             }
         }


### PR DESCRIPTION
This fixes the issue #1013 by looking up the texture data even if both the UUID and Name are present.

Whilst I could have put an or in place in the previous lookup, the most 'proper' way is to lookup via UUID.