### PR TITLE
Fixes Array(Mutable/Immutable)BlockBuffer bugs

### DIFF
--- a/src/main/java/org/spongepowered/common/data/persistence/LegacySchematicTranslator.java
+++ b/src/main/java/org/spongepowered/common/data/persistence/LegacySchematicTranslator.java
@@ -48,7 +48,6 @@ import org.spongepowered.common.block.SpongeTileEntityArchetypeBuilder;
 import org.spongepowered.common.data.util.DataQueries;
 import org.spongepowered.common.registry.type.block.TileEntityTypeRegistryModule;
 import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer;
-import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer.BackingDataType;
 import org.spongepowered.common.world.schematic.GlobalPalette;
 import org.spongepowered.common.world.schematic.SpongeSchematic;
 
@@ -110,8 +109,8 @@ public class LegacySchematicTranslator implements DataTranslator<Schematic> {
         int offsetY = view.getInt(DataQueries.Schematic.LEGACY_OFFSET_Y).orElse(0);
         int offsetZ = view.getInt(DataQueries.Schematic.LEGACY_OFFSET_Z).orElse(0);
         BlockPalette palette = GlobalPalette.instance;
-        ArrayMutableBlockBuffer buffer = new ArrayMutableBlockBuffer(palette, new Vector3i(-offsetX, -offsetY, -offsetZ),
-                new Vector3i(width, height, length), BackingDataType.CHAR);
+        ArrayMutableBlockBuffer buffer = new ArrayMutableBlockBuffer(new Vector3i(-offsetX, -offsetY, -offsetZ),
+                new Vector3i(width, height, length));
         byte[] block_ids = (byte[]) view.get(DataQueries.Schematic.LEGACY_BLOCKS).get();
         byte[] block_data = (byte[]) view.get(DataQueries.Schematic.LEGACY_BLOCK_DATA).get();
         byte[] add_block = (byte[]) view.get(DataQueries.Schematic.LEGACY_ADD_BLOCKS).orElse(null);

--- a/src/main/java/org/spongepowered/common/data/persistence/SchematicTranslator.java
+++ b/src/main/java/org/spongepowered/common/data/persistence/SchematicTranslator.java
@@ -49,7 +49,6 @@ import org.spongepowered.common.block.SpongeTileEntityArchetypeBuilder;
 import org.spongepowered.common.data.util.DataQueries;
 import org.spongepowered.common.registry.type.block.TileEntityTypeRegistryModule;
 import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer;
-import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer.BackingDataType;
 import org.spongepowered.common.world.schematic.BimapPalette;
 import org.spongepowered.common.world.schematic.GlobalPalette;
 import org.spongepowered.common.world.schematic.SpongeSchematic;
@@ -132,16 +131,8 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
             palette = GlobalPalette.instance;
         }
 
-        BackingDataType dataType;
-        if (palette_max <= 0xFF) {
-            dataType = BackingDataType.BYTE;
-        } else if (palette_max <= 0xFF) {
-            dataType = BackingDataType.CHAR;
-        } else {
-            dataType = BackingDataType.INT;
-        }
         MutableBlockVolume buffer =
-                new ArrayMutableBlockBuffer(palette, new Vector3i(-offset[0], -offset[1], -offset[2]), new Vector3i(width, height, length), dataType);
+                new ArrayMutableBlockBuffer(palette, new Vector3i(-offset[0], -offset[1], -offset[2]), new Vector3i(width, height, length));
 
         byte[] blockdata = (byte[]) view.get(DataQueries.Schematic.BLOCK_DATA).get();
         int index = 0;

--- a/src/main/java/org/spongepowered/common/util/gen/ArrayImmutableBlockBuffer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/ArrayImmutableBlockBuffer.java
@@ -36,15 +36,11 @@ import org.spongepowered.api.world.extent.UnmodifiableBlockVolume;
 import org.spongepowered.api.world.extent.worker.BlockVolumeWorker;
 import org.spongepowered.api.world.schematic.BlockPalette;
 import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer.BackingData;
-import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer.ByteBackingData;
 import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer.CharBackingData;
-import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer.IntBackingData;
 import org.spongepowered.common.world.extent.ImmutableBlockViewDownsize;
 import org.spongepowered.common.world.extent.ImmutableBlockViewTransform;
 import org.spongepowered.common.world.extent.worker.SpongeBlockVolumeWorker;
 import org.spongepowered.common.world.schematic.GlobalPalette;
-
-import java.util.Arrays;
 
 public class ArrayImmutableBlockBuffer extends AbstractBlockBuffer implements ImmutableBlockVolume {
 
@@ -74,21 +70,9 @@ public class ArrayImmutableBlockBuffer extends AbstractBlockBuffer implements Im
         this.palette = palette;
     }
 
-    public ArrayImmutableBlockBuffer(BlockPalette palette, Vector3i start, Vector3i size, byte[] blocks) {
-        super(start, size);
-        this.data = new ByteBackingData(Arrays.copyOf(blocks, blocks.length));
-        this.palette = palette;
-    }
-
     public ArrayImmutableBlockBuffer(BlockPalette palette, Vector3i start, Vector3i size, char[] blocks) {
         super(start, size);
-        this.data = new CharBackingData(Arrays.copyOf(blocks, blocks.length));
-        this.palette = palette;
-    }
-
-    public ArrayImmutableBlockBuffer(BlockPalette palette, Vector3i start, Vector3i size, int[] blocks) {
-        super(start, size);
-        this.data = new IntBackingData(Arrays.copyOf(blocks, blocks.length));
+        this.data = new CharBackingData(blocks.clone());
         this.palette = palette;
     }
 
@@ -129,7 +113,7 @@ public class ArrayImmutableBlockBuffer extends AbstractBlockBuffer implements Im
     public MutableBlockVolume getBlockCopy(StorageType type) {
         switch (type) {
             case STANDARD:
-                return new ArrayMutableBlockBuffer(this.palette, this.start, this.size, this.data);
+                return new ArrayMutableBlockBuffer(this.palette, this.start, this.size, this.data.copyOf());
             case THREAD_SAFE:
             default:
                 throw new UnsupportedOperationException(type.name());
@@ -145,33 +129,7 @@ public class ArrayImmutableBlockBuffer extends AbstractBlockBuffer implements Im
      * @param size The size of the volume
      * @return A new buffer using the same array reference
      */
-    public static ImmutableBlockVolume newWithoutArrayClone(BlockPalette palette, Vector3i start, Vector3i size, byte[] blocks) {
-        return new ArrayImmutableBlockBuffer(palette, new ByteBackingData(blocks), start, size);
-    }
-
-    /**
-     * This method doesn't clone the array passed into it. INTERNAL USE ONLY.
-     * Make sure your code doesn't leak the reference if you're using it.
-     *
-     * @param blocks The blocks to store
-     * @param start The start of the volume
-     * @param size The size of the volume
-     * @return A new buffer using the same array reference
-     */
     public static ImmutableBlockVolume newWithoutArrayClone(BlockPalette palette, Vector3i start, Vector3i size, char[] blocks) {
         return new ArrayImmutableBlockBuffer(palette, new CharBackingData(blocks), start, size);
-    }
-
-    /**
-     * This method doesn't clone the array passed into it. INTERNAL USE ONLY.
-     * Make sure your code doesn't leak the reference if you're using it.
-     *
-     * @param blocks The blocks to store
-     * @param start The start of the volume
-     * @param size The size of the volume
-     * @return A new buffer using the same array reference
-     */
-    public static ImmutableBlockVolume newWithoutArrayClone(BlockPalette palette, Vector3i start, Vector3i size, int[] blocks) {
-        return new ArrayImmutableBlockBuffer(palette, new IntBackingData(blocks), start, size);
     }
 }

--- a/src/main/java/org/spongepowered/common/util/gen/ArrayMutableBlockBuffer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/ArrayMutableBlockBuffer.java
@@ -45,7 +45,12 @@ import org.spongepowered.common.world.schematic.GlobalPalette;
 
 public class ArrayMutableBlockBuffer extends AbstractBlockBuffer implements MutableBlockVolume {
 
-    private static final int LOCAL_PALETTE_THRESHOLD = 256;
+    /**
+     * If the area is lower than this amount, a global palette will be used.<br/>
+     * Example: If its only a 4 block area why allocate a local palette that
+     * by its self will take up more space in memory than it saves.
+     */
+    private static final int SMALL_AREA_THRESHOLD = 256;
 
     @SuppressWarnings("ConstantConditions")
     private static final BlockState AIR = BlockTypes.AIR.getDefaultState();
@@ -54,7 +59,7 @@ public class ArrayMutableBlockBuffer extends AbstractBlockBuffer implements Muta
     private BackingData data;
 
     public ArrayMutableBlockBuffer(Vector3i start, Vector3i size) {
-        this(size.getX() * size.getY() * size.getZ() > LOCAL_PALETTE_THRESHOLD ?
+        this(size.getX() * size.getY() * size.getZ() > SMALL_AREA_THRESHOLD ?
                 new BimapPalette() : GlobalPalette.instance, start, size);
     }
 

--- a/src/main/java/org/spongepowered/common/util/gen/ArrayMutableBlockBuffer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/ArrayMutableBlockBuffer.java
@@ -61,7 +61,16 @@ public class ArrayMutableBlockBuffer extends AbstractBlockBuffer implements Muta
     public ArrayMutableBlockBuffer(BlockPalette palette, Vector3i start, Vector3i size) {
         super(start, size);
         this.palette = palette;
-        this.data = new PackedBackingData(size.getX() * size.getY() * size.getZ(), palette.getHighestId());
+        int dataSize = size.getX() * size.getY() * size.getZ();
+        this.data = new PackedBackingData(dataSize, palette.getHighestId());
+
+        // all blocks default to air
+        int airId = this.palette.getOrAssign(AIR);
+        if (airId != 0) {
+            for (int i = 0; i < dataSize; i++) {
+                data.set(i, airId);
+            }
+        }
     }
 
     public ArrayMutableBlockBuffer(BlockPalette palette, Vector3i start, Vector3i size, char[] blocks) {

--- a/src/main/java/org/spongepowered/common/util/gen/ArrayMutableBlockBuffer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/ArrayMutableBlockBuffer.java
@@ -93,8 +93,7 @@ public class ArrayMutableBlockBuffer extends AbstractBlockBuffer implements Muta
     @Override
     public BlockState getBlock(int x, int y, int z) {
         checkRange(x, y, z);
-        BlockState block = this.palette.get(this.data.get(getIndex(x, y, z))).get();
-        return block == null ? AIR : block;
+        return this.palette.get(this.data.get(getIndex(x, y, z))).orElse(AIR);
     }
 
     @Override
@@ -192,12 +191,12 @@ public class ArrayMutableBlockBuffer extends AbstractBlockBuffer implements Muta
 
         @Override
         public int get(int index) {
-            return this.data[index];
+            return this.data[index] & 0xFF;
         }
 
         @Override
         public void set(int index, int val) {
-            this.data[index] = (byte) (val & 0xFF);
+            this.data[index] = (byte) val;
         }
 
         @Override
@@ -225,12 +224,12 @@ public class ArrayMutableBlockBuffer extends AbstractBlockBuffer implements Muta
 
         @Override
         public int get(int index) {
-            return this.data[index];
+            return this.data[index] & 0xFFFF;
         }
 
         @Override
         public void set(int index, int val) {
-            this.data[index] = (char) (val & 0xFFFF);
+            this.data[index] = (char) val;
         }
 
         @Override

--- a/src/main/java/org/spongepowered/common/world/extent/AbstractBlockViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/AbstractBlockViewDownsize.java
@@ -90,6 +90,7 @@ public abstract class AbstractBlockViewDownsize<V extends BlockVolume> implement
     public MutableBlockVolume getBlockCopy(StorageType type) {
         switch (type) {
             case STANDARD:
+                // TODO: Optimize and use a local palette
                 char[] data = ExtentBufferUtil.copyToArray(this, this.min, this.max, this.size);
                 return new ArrayMutableBlockBuffer(GlobalPalette.instance, this.min, this.size, data);
             case THREAD_SAFE:

--- a/src/main/java/org/spongepowered/common/world/extent/AbstractBlockViewTransform.java
+++ b/src/main/java/org/spongepowered/common/world/extent/AbstractBlockViewTransform.java
@@ -92,6 +92,7 @@ public abstract class AbstractBlockViewTransform<V extends BlockVolume> implemen
     public MutableBlockVolume getBlockCopy(StorageType type) {
         switch (type) {
             case STANDARD:
+                // TODO: Optimize and use a local palette
                 char[] data = ExtentBufferUtil.copyToArray(this, this.min, this.max, this.size);
                 return new ArrayMutableBlockBuffer(GlobalPalette.instance, this.min, this.size, data);
             case THREAD_SAFE:

--- a/src/main/java/org/spongepowered/common/world/extent/SpongeExtentBufferFactory.java
+++ b/src/main/java/org/spongepowered/common/world/extent/SpongeExtentBufferFactory.java
@@ -30,10 +30,9 @@ import org.spongepowered.api.world.extent.ArchetypeVolume;
 import org.spongepowered.api.world.extent.ExtentBufferFactory;
 import org.spongepowered.api.world.extent.MutableBiomeVolume;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
+import org.spongepowered.api.world.schematic.BlockPaletteTypes;
 import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer;
-import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer.BackingDataType;
 import org.spongepowered.common.util.gen.ByteArrayMutableBiomeBuffer;
-import org.spongepowered.common.world.schematic.GlobalPalette;
 import org.spongepowered.common.world.schematic.SpongeArchetypeVolume;
 
 public final class SpongeExtentBufferFactory implements ExtentBufferFactory {
@@ -55,7 +54,7 @@ public final class SpongeExtentBufferFactory implements ExtentBufferFactory {
 
     @Override
     public MutableBlockVolume createBlockBuffer(Vector3i size) {
-        return new ArrayMutableBlockBuffer(GlobalPalette.instance, Vector3i.ZERO, size, BackingDataType.CHAR);
+        return new ArrayMutableBlockBuffer(Vector3i.ZERO, size);
     }
 
     @Override
@@ -65,7 +64,7 @@ public final class SpongeExtentBufferFactory implements ExtentBufferFactory {
 
     @Override
     public ArchetypeVolume createArchetypeVolume(Vector3i size, Vector3i origin) {
-        MutableBlockVolume backing = new ArrayMutableBlockBuffer(GlobalPalette.instance, origin.mul(-1), size, BackingDataType.CHAR);
+        MutableBlockVolume backing = new ArrayMutableBlockBuffer(origin.mul(-1), size);
         return new SpongeArchetypeVolume(backing, ImmutableMap.of());
     }
 

--- a/src/main/java/org/spongepowered/common/world/schematic/SpongeSchematicBuilder.java
+++ b/src/main/java/org/spongepowered/common/world/schematic/SpongeSchematicBuilder.java
@@ -43,7 +43,6 @@ import org.spongepowered.api.world.schematic.Schematic;
 import org.spongepowered.api.world.schematic.Schematic.Builder;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer;
-import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer.BackingDataType;
 
 import java.util.Map;
 import java.util.Optional;
@@ -139,15 +138,7 @@ public class SpongeSchematicBuilder implements Schematic.Builder {
             this.metadata.set(DataQuery.of(".", entry.getKey()), entry.getValue());
         }
         if (this.volume == null) {
-            BackingDataType dataType;
-            if (this.palette.getHighestId() <= 0xFF) {
-                dataType = BackingDataType.BYTE;
-            } else if (this.palette.getHighestId() <= 0xFFFF) {
-                dataType = BackingDataType.CHAR;
-            } else {
-                dataType = BackingDataType.INT;
-            }
-            final MutableBlockVolume volume = new ArrayMutableBlockBuffer(this.palette, min, size, dataType);
+            final MutableBlockVolume volume = new ArrayMutableBlockBuffer(this.palette, min, size);
             Map<Vector3i, TileEntityArchetype> tiles = Maps.newHashMap();
             this.view.getBlockWorker(SpongeImpl.getImplementationCause()).iterate((v, x, y, z) -> {
                 volume.setBlock(x, y, z, v.getBlock(x, y, z), SpongeImpl.getImplementationCause());

--- a/src/test/java/org/spongepowered/common/util/gen/ArrayBlockBufferTest.java
+++ b/src/test/java/org/spongepowered/common/util/gen/ArrayBlockBufferTest.java
@@ -1,0 +1,202 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.util.gen;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.flowpowered.math.vector.Vector3i;
+import com.google.common.collect.Lists;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.GameRegistry;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
+import org.spongepowered.api.world.extent.BlockVolume;
+import org.spongepowered.api.world.extent.MutableBlockVolume;
+import org.spongepowered.api.world.schematic.BlockPalette;
+import org.spongepowered.common.world.schematic.BimapPalette;
+import org.spongepowered.common.world.schematic.GlobalPalette;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.Iterator;
+
+import javax.annotation.Nullable;
+
+public class ArrayBlockBufferTest {
+
+    private static BlockState AIR;
+    private static BlockState TNT;
+    private static Cause CAUSE;
+
+    @BeforeClass
+    public static void init() {
+        try {
+            // Create fake block states
+            AIR = createBlockState("AIR");
+            TNT = createBlockState("TNT");
+            for (int i = 0; i < 4000; i++) {
+                createBlockState();
+            }
+
+            // Make BlockTypes.AIR.getDefaultState() work
+            BlockType airType = mock(BlockType.class);
+            when(airType.getDefaultState()).thenReturn(AIR);
+            setField(BlockTypes.class, null, "AIR", airType);
+
+            //Hack Sponge so GlobalPalette does not explode when we touch it
+            GameRegistry registry = mock(GameRegistry.class);
+            when(registry.getAllOf(BlockState.class)).thenReturn(
+                    (Collection<BlockState>) (Object) Lists.newArrayList(Block.BLOCK_STATE_IDS.iterator()));
+            Game game = mock(Game.class);
+            when(game.getRegistry()).thenReturn(registry);
+            setField(Sponge.class, null, "game", game);
+
+        } catch (Exception e) {
+            fail(e.toString());
+        }
+
+        CAUSE = Cause.of(NamedCause.of("array_block_buffer_test", ArrayBlockBufferTest.class));
+    }
+
+    private static void setField(Class clazz, @Nullable Object obj, String fieldName, Object value) {
+        try {
+            Field field = clazz.getDeclaredField(fieldName);
+            field.setAccessible(true);
+
+            Field modifiers = field.getClass().getDeclaredField("modifiers");
+            modifiers.setAccessible(true);
+            modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+            field.set(obj, value);
+
+        } catch (Exception e) {
+            fail(e.toString());
+        }
+    }
+
+    private static BlockState createBlockState() {
+        return createBlockState("block_state_G" + Block.BLOCK_STATE_IDS.size());
+    }
+
+    private static BlockState createBlockState(String name) {
+        FakeBlockState bs = mock(FakeBlockState.class, name);
+        Block.BLOCK_STATE_IDS.put(bs, Block.BLOCK_STATE_IDS.size());
+        return bs;
+    }
+
+    private abstract class FakeBlockState implements BlockState, IBlockState {}
+
+    @Test
+    public void testLargeAirDefault() {
+        Vector3i size = new Vector3i(10, 20, 30);
+        ArrayMutableBlockBuffer buffer = new ArrayMutableBlockBuffer(Vector3i.ZERO, size);
+        TestBuffer testBuffer = new TestBuffer(size);
+
+        testBuffer.assertEqualz(buffer);
+
+        BlockPalette nonZeroAirId = new BimapPalette();
+        nonZeroAirId.getOrAssign(TNT);
+
+        buffer = new ArrayMutableBlockBuffer(nonZeroAirId, Vector3i.ZERO, size);
+
+        testBuffer.assertEqualz(buffer);
+    }
+
+    @Test
+    public void testSmallAirDefault() {
+        Vector3i size = new Vector3i(1, 2, 3);
+        ArrayMutableBlockBuffer buffer = new ArrayMutableBlockBuffer(Vector3i.ZERO, size);
+        TestBuffer testBuffer = new TestBuffer(size);
+
+        testBuffer.assertEqualz(buffer);
+
+        BlockPalette nonZeroAirId = new BimapPalette();
+        nonZeroAirId.getOrAssign(TNT);
+
+        buffer = new ArrayMutableBlockBuffer(nonZeroAirId, Vector3i.ZERO, size);
+
+        testBuffer.assertEqualz(buffer);
+    }
+
+    @Test
+    public void testBlockStates() {
+        Vector3i size = new Vector3i(10, 10, 10);
+        ArrayMutableBlockBuffer buffer = new ArrayMutableBlockBuffer(Vector3i.ZERO, size);
+        TestBuffer testBuffer = new TestBuffer(size);
+
+        Iterator<BlockState> statesIter = GlobalPalette.instance.getEntries().iterator();
+        buffer.getBlockWorker(CAUSE).iterate((volume, x, y, z) -> {
+            if (statesIter.hasNext()) {
+                testBuffer.setInBoth(volume, x, y, z, statesIter.next());
+                testBuffer.assertEqualz(volume);
+            }
+        });
+    }
+
+    private class TestBuffer {
+
+        private BlockState[][][] blocks;
+        private Vector3i size;
+
+        private TestBuffer(Vector3i size) {
+            this.size = size;
+            this.blocks = new BlockState[size.getX()][size.getY()][size.getZ()];
+        }
+
+        private void set(int x, int y, int z, BlockState block) {
+            blocks[x][y][z] = block;
+        }
+
+        private void setInBoth(MutableBlockVolume volume, int x, int y, int z, BlockState block) {
+            set(x, y, z, block);
+            volume.setBlock(volume.getBlockMin().add(x, y, z), block, CAUSE);
+        }
+
+        private BlockState get(int x, int y, int z) {
+            return blocks[x][y][z] != null ? blocks[x][y][z] : AIR;
+        }
+
+        private void assertEqualz(BlockVolume volume) {
+            assertEquals(size, volume.getBlockSize());
+            for (int x = 0; x < size.getX(); x++) {
+                for (int y = 0; y < size.getY(); y++) {
+                    for (int z = 0; z < size.getZ(); z++) {
+                        assertEquals(get(x, y, z), volume.getBlock(volume.getBlockMin().add(x, y, z)));
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes three bugs that effect ArrayMutableBlockBuffer and or ArrayImmutableBlockBuffer.

Bug 1:
ArrayMutableBlockBuffer#getBlock() had a broken null check. (Optional#get() would crash before it got there)

Bug 2:
ArrayMutableBlockBuffer.BackingData#get() would return negative ids. Example: ByteBackingData would only support 128 local state ids.
http://i.imgur.com/v3WkeKy.png
(To the left is the original structure containing exactly 256 different block states. To the right is what was pasted form the schematic. Ignore the "modifying it in the world" chat message)

Bug 3:
ByteBackingData can not handle more than 256 state ids. This means that when ArrayMutableBlockBuffer#setBlock() adds a new local block state id past 255 it will wrap around!
http://i.imgur.com/CDsMIwW.png
(To the left is the original structure containing exactly 256 different block states. In the middle is the pasted schematic with sponge added **after** it was pasted. To the right is the pasted schematic with sponge added **before** it was pasted, causing it to wrap around and turn to bedrock.)

To fix this bug I added PackedBackingData to replace some of the old BackingData implementations. This is sort of like how net.minecraft.world.chunk.BlockStateContainer works with some with some improvements. Example: If there are only 10 local state ids, than PackedBackingData will only use 4 bits per block.

The only other BackingData implementation I left was CharBackingData as there are a lot of places that create an ArrayMutableBlockBuffer with a char[] array.
It might be a good idea to transition away from that.

http://i.imgur.com/KtM3Kak.png
(after all fixes)