### PR TITLE
Fixed EntityActivationRange ArmorStand cast crash

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/plugin/entityactivation/EntityActivationRange.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/entityactivation/EntityActivationRange.java
@@ -351,7 +351,7 @@ public class EntityActivationRange {
             if (living.hurtTime > 0 || living.getActivePotionEffects().size() > 0) {
                 return true;
             }
-            if (entity instanceof EntityLiving && ((EntityLiving) entity).getAITarget() != null || ((EntityLiving) entity).getAttackTarget() != null) {
+            if (entity instanceof EntityLiving && (((EntityLiving) entity).getAITarget() != null || ((EntityLiving) entity).getAttackTarget() != null)) {
                 return true;
             }
             if (entity instanceof EntityVillager && ((EntityVillager) entity).isMating()) {

--- a/src/main/java/org/spongepowered/common/mixin/plugin/entityactivation/EntityActivationRange.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/entityactivation/EntityActivationRange.java
@@ -351,7 +351,7 @@ public class EntityActivationRange {
             if (living.hurtTime > 0 || living.getActivePotionEffects().size() > 0) {
                 return true;
             }
-            if (((EntityLiving) entity).getAITarget() != null || ((EntityLiving) entity).getAttackTarget() != null) {
+            if (entity instanceof EntityLiving && ((EntityLiving) entity).getAITarget() != null || ((EntityLiving) entity).getAttackTarget() != null) {
                 return true;
             }
             if (entity instanceof EntityVillager && ((EntityVillager) entity).isMating()) {


### PR DESCRIPTION
EntityLivingBase does not always cast to EntityLiving, as is the case with ArmorStands to name one.
Crash that this fixes: http://pastebin.com/L2AYnA3G