### PR TITLE
Implementing DestructEntityEvent for non-living entities.

### DIFF
--- a/src/main/java/org/spongepowered/common/event/ShouldFire.java
+++ b/src/main/java/org/spongepowered/common/event/ShouldFire.java
@@ -62,6 +62,8 @@ public class ShouldFire {
     public static boolean CHANGE_BLOCK_EVENT_PLACE = false;
     public static boolean CHANGE_BLOCK_EVENT_POST = false;
 
+    public static boolean DESTRUCT_ENTITY_EVENT = false;
+
     public static boolean DROP_ITEM_EVENT = false;
     public static boolean DROP_ITEM_EVENT_DESTRUCT = false;
     public static boolean DROP_ITEM_EVENT_DISPENSE = false;

--- a/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
@@ -192,4 +192,6 @@ public interface IMixinEntity extends org.spongepowered.api.entity.Entity, IMixi
     default void onCancelledBlockChange(EntityTickContext phaseContext) {
 
     }
+
+    void onEntityRemoved();
 }

--- a/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
@@ -193,5 +193,10 @@ public interface IMixinEntity extends org.spongepowered.api.entity.Entity, IMixi
 
     }
 
+    /**
+     * Called when the entity is being removed.
+     * Usually because it was marked as dead the previous tick.
+     *
+     */
     void onEntityRemoved();
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -1473,9 +1473,8 @@ public abstract class MixinEntity implements org.spongepowered.api.entity.Entity
             MessageChannel originalChannel = MessageChannel.TO_NONE;
             try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
                 Object source = PhaseTracker.getInstance().getCurrentContext().getSource();
-                if (source != null) {
-                    frame.pushCause(source);
-                }
+                frame.pushCause(source);
+
                 DestructEntityEvent event = SpongeEventFactory.createDestructEntityEvent(
                         frame.getCurrentCause(), originalChannel, Optional.of(originalChannel),
                         new MessageEvent.MessageFormatter(), this, true

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -1469,7 +1469,7 @@ public abstract class MixinEntity implements org.spongepowered.api.entity.Entity
 
     @Inject(method = "setDead", at = @At(value = "RETURN"))
     private void onSetDead(CallbackInfo ci) {
-        if (ShouldFire.DESTRUCT_ENTITY_EVENT && !this.world.isRemote && !(EntityUtil.toNative(this) instanceof EntityLiving)) {
+        if (ShouldFire.DESTRUCT_ENTITY_EVENT && !((IMixinWorld) this.world).isFake() && !(EntityUtil.toNative(this) instanceof EntityLiving)) {
             MessageChannel originalChannel = MessageChannel.TO_NONE;
             try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
 

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -1472,7 +1472,6 @@ public abstract class MixinEntity implements org.spongepowered.api.entity.Entity
         if (ShouldFire.DESTRUCT_ENTITY_EVENT && !this.world.isRemote && !(EntityUtil.toNative(this) instanceof EntityLiving)) {
             MessageChannel originalChannel = MessageChannel.TO_NONE;
             try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
-                frame.pushCause(this);
                 Object source = PhaseTracker.getInstance().getCurrentContext().getSource();
                 if (source != null) {
                     frame.pushCause(source);

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -1472,8 +1472,6 @@ public abstract class MixinEntity implements org.spongepowered.api.entity.Entity
         if (ShouldFire.DESTRUCT_ENTITY_EVENT && !this.world.isRemote && !(EntityUtil.toNative(this) instanceof EntityLiving)) {
             MessageChannel originalChannel = MessageChannel.TO_NONE;
             try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
-                Object source = PhaseTracker.getInstance().getCurrentContext().getSource();
-                frame.pushCause(source);
 
                 DestructEntityEvent event = SpongeEventFactory.createDestructEntityEvent(
                         frame.getCurrentCause(), originalChannel, Optional.of(originalChannel),

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -1450,6 +1450,13 @@ public abstract class MixinWorld implements World, IMixinWorld {
         }
     }
 
+    @Inject(method = "onEntityRemoved", at = @At(value = "HEAD"))
+    private void onEntityRemoved(net.minecraft.entity.Entity entity, CallbackInfo ci) {
+        if (!this.isRemote) {
+            ((IMixinEntity) entity).onEntityRemoved();
+        }
+    }
+
 
     /*********************** TIMINGS ***********************/
 

--- a/testplugins/src/main/java/org/spongepowered/test/DestructEventTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/DestructEventTest.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.entity.DestructEntityEvent;
+import org.spongepowered.api.event.filter.Getter;
+import org.spongepowered.api.event.filter.type.Exclude;
+import org.spongepowered.api.event.game.state.GameInitializationEvent;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+
+@Plugin(name = "Destruct Test", id = "destructtest", version = "0.0.0")
+public class DestructEventTest {
+
+    private final DestructListener listener = new DestructListener();
+    private boolean registered = false;
+
+    @Listener
+    public void onInit(GameInitializationEvent event) {
+        Sponge.getCommandManager().register(this,
+                CommandSpec.builder().executor((source, context) -> {
+                    if (this.registered) {
+                        this.registered = false;
+                        Sponge.getEventManager().unregisterListeners(this.listener);
+                    } else {
+                        this.registered = true;
+                        Sponge.getEventManager().registerListeners(this, this.listener);
+                    }
+                    source.sendMessage(Text.of("destructlog set to " + this.registered));
+                    return CommandResult.success();
+                }).build(), "toggledestructlog");
+    }
+
+    public static class DestructListener {
+
+        @Listener
+        @Exclude(DestructEntityEvent.Death.class)
+        public void onIgnite(DestructEntityEvent event, @Getter("getTargetEntity") Entity entity) {
+            Text message = Text.of(event.getTargetEntity().getType().getName() + " has been removed by " + event.getCause().root());
+            Sponge.getServer().getBroadcastChannel().send(message);
+        }
+    }
+
+}


### PR DESCRIPTION
This PR implements DestructEntityEvent for non-living entities.

The following code has been used to test it,

```
@Listener
public void onBlockForm(DestructEntityEvent event) {
    System.out.println(event.getCause());
}
```