### PR TITLE
Fixed NullPointerException when removing REPRESENTED_ITEM_DATA from ItemFrames.

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/RepresentedItemDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/RepresentedItemDataProcessor.java
@@ -87,9 +87,9 @@ public class RepresentedItemDataProcessor extends
     public DataTransactionResult removeFrom(ValueContainer<?> container) {
         if (container instanceof EntityItemFrame) {
             EntityItemFrame frame = (EntityItemFrame) container;
-            if (frame.getDisplayedItem() != null) {
+            if (!frame.getDisplayedItem().isEmpty()) {
                 final ImmutableValue<ItemStackSnapshot> old = constructImmutableValue(getVal(frame).get());
-                frame.setDisplayedItem(null);
+                frame.setDisplayedItem(ItemStack.EMPTY);
                 return DataTransactionResult.successRemove(old);
             }
             return DataTransactionResult.successNoData();


### PR DESCRIPTION
This fixes the following issue, https://github.com/me4502/SlotMachines/issues/8