### PR TITLE
Restore default state for blocks with invalid metadata instead of removing the block

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/chunk/MixinBlockStateContainer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/chunk/MixinBlockStateContainer.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.world.chunk;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.world.chunk.BlockStateContainer;
+import net.minecraft.world.chunk.NibbleArray;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import javax.annotation.Nullable;
+
+@Mixin(BlockStateContainer.class)
+public abstract class MixinBlockStateContainer {
+
+    @Shadow protected abstract void set(int index, IBlockState state);
+
+    /**
+     * @author barteks2x
+     *
+     * Attempts to fix invalid block metadata instead of completely throwing away the block.
+     * When block state lookup returns null - gets block by ID and attempts to use the default state.
+     */
+    @Redirect(
+            method = "setDataFromNBT",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/BlockStateContainer;set(ILnet/minecraft/block/state/IBlockState;)V")
+    )
+    private void setFixedBlockState(BlockStateContainer this_, int i, IBlockState state, byte[] id, NibbleArray meta, @Nullable NibbleArray add) {
+        IBlockState newState;
+
+        if (state != null) {
+            newState = state;
+        } else {
+            int x = i & 15;
+            int y = i >> 8 & 15;
+            int z = i >> 4 & 15;
+            int idAdd = add == null ? 0 : add.get(x, y, z);
+            int blockId = idAdd << 8 | (id[i] & 255);
+            Block block = Block.REGISTRY.getObjectById(blockId);
+            if (block != null) {
+                newState = block.getDefaultState();
+            } else {
+                newState = null;
+            }
+        }
+        this.set(i, newState);
+    }
+}

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -465,6 +465,7 @@
         "world.biome.MixinBiomeTaiga",
         "world.biome.MixinBiomeSwamp",
         "world.biome.MixinBiomeProvider",
+        "world.chunk.MixinBlockStateContainer",
         "world.chunk.storage.MixinAnvilChunkLoader",
         "world.end.MixinDragonFightManager",
         "world.extent.MixinExtent",


### PR DESCRIPTION
Some worlds (at least old bukkit worlds with some plugins) have blocks with invalid metadata and loading these worlds in any MC version above 1.7.10 makes these blocks disappear. This resets them to default state instead. 

This shouldn't affect vanilla behavior for worlds with valid blocks.

Should I make it configurable and move it out of core package? And should I use overwrite here instead of redirect? It would make the code a bit simpler.