### PR TITLE
Implement ItemStack isEmpty

### DIFF
--- a/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackBuilder.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackBuilder.java
@@ -90,7 +90,7 @@ public class SpongeItemStackBuilder implements ItemStack.Builder {
 
     @Override
     public ItemStack.Builder quantity(int quantity) throws IllegalArgumentException {
-        checkArgument(quantity > 0, "Quantity must be greater than 0");
+        checkArgument(quantity >= 0, "Quantity must not be smaller than 0");
         this.quantity = quantity;
         return this;
     }
@@ -296,9 +296,12 @@ public class SpongeItemStackBuilder implements ItemStack.Builder {
     @Override
     public ItemStack build() throws IllegalStateException {
         checkState(this.type != null, "Item type has not been set");
-        int max = this.type.getMaxStackQuantity();
-        // This should be enabled, but for some reason, people are getting this in some forge environments.
-//        checkState(this.quantity <= max, "Quantity cannot be greater than the max quantity (%s)", max);
+
+        if (type == ItemTypes.NONE || quantity <= 0) {
+            // If either type is none(air) or quantity is 0 return the vanilla EMPTY item
+            return ((ItemStack) net.minecraft.item.ItemStack.EMPTY);
+        }
+
         final ItemStack stack = (ItemStack) new net.minecraft.item.ItemStack((Item) this.type, this.quantity, this.damageValue);
         if (this.compound != null) {
             ((net.minecraft.item.ItemStack) stack).setTagCompound(this.compound.copy());

--- a/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackSnapshot.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackSnapshot.java
@@ -44,6 +44,7 @@ import org.spongepowered.api.data.merge.MergeFunction;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.common.data.DataProcessor;
@@ -140,6 +141,11 @@ public class SpongeItemStackSnapshot implements ItemStackSnapshot {
     @Override
     public int getCount() {
         return this.count;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.privateStack.isEmpty();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemStack.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemStack.java
@@ -52,6 +52,9 @@ import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.text.translation.Translation;
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -84,6 +87,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 @Mixin(net.minecraft.item.ItemStack.class)
+@Implements(@Interface(iface = ItemStack.class, prefix = "itemstack$"))
 public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMixinCustomDataHolder {
 
     @Shadow public abstract int getCount();
@@ -94,6 +98,7 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
     @Shadow public abstract int getItemDamage();
     @Shadow public abstract int getMaxStackSize();
     @Shadow public abstract boolean hasTagCompound();
+    @Shadow public abstract boolean shadow$isEmpty();
     @Shadow public abstract NBTTagCompound getTagCompound();
     @Shadow public abstract NBTTagCompound getOrCreateSubCompound(String key);
     @Shadow public abstract net.minecraft.item.ItemStack shadow$copy();
@@ -154,7 +159,7 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
     @Override
     public ItemType getItem() {
         final Item item = shadow$getItem();
-        return item == null ? (ItemType) ItemTypeRegistryModule.NONE_ITEM : (ItemType) item;
+        return item == null || shadow$isEmpty() ? (ItemType) ItemTypeRegistryModule.NONE_ITEM : (ItemType) item;
     }
 
     @Override
@@ -236,6 +241,11 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
                 (net.minecraft.item.ItemStack) (Object) this,
                 (net.minecraft.item.ItemStack) that
         );
+    }
+
+    @Intrinsic
+    public boolean itemstack$isEmpty() {
+        return this.shadow$isEmpty();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/registry/type/ItemTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/ItemTypeRegistryModule.java
@@ -96,7 +96,7 @@ public final class ItemTypeRegistryModule implements SpongeAdditionalCatalogRegi
 
     @Override
     public void registerDefaults() {
-        ItemTypeRegistryModule.NONE_ITEM = net.minecraft.item.ItemStack.EMPTY.getItem();
+        ItemTypeRegistryModule.NONE_ITEM = net.minecraft.item.ItemStack.EMPTY.getItem();;
         ItemTypeRegistryModule.NONE = (ItemStack) net.minecraft.item.ItemStack.EMPTY;
         ItemTypeRegistryModule.NONE_SNAPSHOT = NONE.createSnapshot();
 


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1487) | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1205)

Adds an isEmpty Method to ItemStacks.

Also ItemTypes.NONE is now the same as ItemTypes.AIR.