### PR TITLE
Actually track entity spawns during inventory clicks.

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/BasicInventoryPacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/BasicInventoryPacketState.java
@@ -100,5 +100,10 @@ public class BasicInventoryPacketState extends BasicPacketState {
                .addEntityDropCaptures();
     }
 
+    @Override
+    public boolean shouldCaptureEntity() {
+        // Example: Furnaces dropping XP when an item is picked up
+        return true;
+    }
 
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketFunction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketFunction.java
@@ -708,6 +708,12 @@ public interface PacketFunction {
                 }
                 if (inventoryEvent instanceof SpawnEntityEvent) {
                     processSpawnedEntities(player, ((IMixinWorldServer) player.getServerWorld()).getCauseTracker(), (SpawnEntityEvent) inventoryEvent);
+                } else if (!context.getCapturedEntitySupplier().isEmpty()) {
+                    SpawnEntityEvent spawnEntityEvent = SpongeEventFactory.createSpawnEntityEvent(cause, context.getCapturedEntities(), (World) player.getServerWorld());
+                    SpongeImpl.postEvent(spawnEntityEvent);
+                    if (!spawnEntityEvent.isCancelled()) {
+                        processSpawnedEntities(player, ((IMixinWorldServer) player.getServerWorld()).getCauseTracker(), spawnEntityEvent);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes SpongePowered#1193.

Test code:
```java
package jbyoshi.sponge.test;

import org.spongepowered.api.event.Listener;
import org.spongepowered.api.event.item.inventory.ClickInventoryEvent;
import org.spongepowered.api.item.ItemTypes;
import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
import org.spongepowered.api.plugin.Plugin;

@Plugin(id = "testspongecommon1193")
public class TestSpongeCommon1193 {

    @Listener
    public void onClickInventory(ClickInventoryEvent event) {
        if (event.getTargetInventory().getClass().getName().endsWith(".ContainerFurnace")) {
            for (SlotTransaction transaction : event.getTransactions()) {
                if (transaction.getOriginal().getType() == ItemTypes.GLASS) {
                    event.setCancelled(true);
                    break;
                }
            }
        }
    }
}
```

To test, smelt some sand and try to remove the glass. Be aware that smelting glass naturally does not always give XP; try removing it repeatedly.