### PR TITLE
Don't track block drops in NoCaptureBlockTickPhaseState.

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/NoCaptureBlockTickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/NoCaptureBlockTickPhaseState.java
@@ -37,4 +37,9 @@ class NoCaptureBlockTickPhaseState extends BlockTickPhaseState {
     public boolean shouldCaptureBlockChangeOrSkip(PhaseContext phaseContext, BlockPos pos) {
         return false;
     }
+
+    @Override
+    public boolean tracksBlockSpecificDrops() {
+        return false;
+    }
 }


### PR DESCRIPTION
Fixes SpongePowered/SpongeVanilla#300.
Fixes #1167.