### PR TITLE
Supported some data for shulker boxes

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -689,6 +689,8 @@ public class DataRegistrar {
 
         dataManager.registerDataProcessorAndImpl(MobSpawnerData.class, SpongeMobSpawnerData.class, ImmutableMobSpawnerData.class,
                 ImmutableSpongeMobSpawnerData.class, new MobSpawnerDataProcessor());
+        dataManager.registerDataProcessorAndImpl(DyeableData.class, SpongeDyeableData.class, ImmutableDyeableData.class,
+                ImmutableSpongeDyeableData.class, new ShulkerBoxDyeableDataProcessor());
 
 
         // Values
@@ -755,6 +757,7 @@ public class DataRegistrar {
         dataManager.registerValueProcessor(Keys.DYE_COLOR, new WolfDyeColorValueProcessor());
         dataManager.registerValueProcessor(Keys.DYE_COLOR, new SheepDyeColorValueProcessor());
         dataManager.registerValueProcessor(Keys.DYE_COLOR, new ItemDyeColorValueProcessor());
+        dataManager.registerValueProcessor(Keys.DYE_COLOR, new ShulkerBoxDyeColorValueProcessor());
         dataManager.registerValueProcessor(Keys.FIRST_DATE_PLAYED, new FirstJoinValueProcessor());
         dataManager.registerValueProcessor(Keys.LAST_DATE_PLAYED, new LastPlayedValueProcessor());
         dataManager.registerValueProcessor(Keys.HIDE_ENCHANTMENTS, new HideEnchantmentsValueProcessor());

--- a/src/main/java/org/spongepowered/common/data/processor/data/tileentity/ShulkerBoxDyeableDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/tileentity/ShulkerBoxDyeableDataProcessor.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.data.tileentity;
+
+import net.minecraft.item.EnumDyeColor;
+import net.minecraft.tileentity.TileEntityShulkerBox;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableDyeableData;
+import org.spongepowered.api.data.manipulator.mutable.DyeableData;
+import org.spongepowered.api.data.merge.MergeFunction;
+import org.spongepowered.api.data.type.DyeColor;
+import org.spongepowered.api.data.type.DyeColors;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.registry.RegistryException;
+import org.spongepowered.common.data.ImmutableDataCachingUtil;
+import org.spongepowered.common.data.manipulator.mutable.SpongeDyeableData;
+import org.spongepowered.common.data.processor.common.AbstractSingleDataProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.interfaces.block.tile.IMixinTileEntityShulkerBox;
+
+import java.util.Optional;
+
+public class ShulkerBoxDyeableDataProcessor extends AbstractSingleDataProcessor<DyeColor, Value<DyeColor>, DyeableData, ImmutableDyeableData> {
+
+    public ShulkerBoxDyeableDataProcessor() {
+        super(Keys.DYE_COLOR);
+    }
+
+    @Override
+    protected DyeableData createManipulator() {
+        return new SpongeDyeableData(DyeColors.PURPLE);
+    }
+
+    @Override
+    public boolean supports(DataHolder dataHolder) {
+        return dataHolder instanceof TileEntityShulkerBox;
+    }
+
+    @Override
+    public Optional<DyeableData> from(DataHolder dataHolder) {
+        EnumDyeColor enumType = ((IMixinTileEntityShulkerBox) dataHolder).getColor();
+        if (enumType != null) {
+            return Optional.of(new SpongeDyeableData((DyeColor) (Object) enumType));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<DyeableData> fill(DataContainer container, DyeableData dyeableData) {
+        Optional<String> id = container.getString(Keys.DYE_COLOR.getQuery());
+        if (id.isPresent()) {
+            Optional<DyeColor> color = Sponge.getGame().getRegistry().getType(DyeColor.class, id.get());
+            dyeableData.set(Keys.DYE_COLOR,
+                color.orElseThrow(() -> new RegistryException("Corresponding color " + id.get() + " missing in registry")));
+            return Optional.of(dyeableData);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public DataTransactionResult set(DataHolder dataHolder, DyeableData manipulator, MergeFunction function) {
+        DyeableData original = dataHolder.require(DyeableData.class);
+        DyeableData merged = function.merge(original, manipulator);
+        Value<DyeColor> mergedValue = merged.type();
+        ((IMixinTileEntityShulkerBox) dataHolder).setColor((EnumDyeColor) (Object) mergedValue.get());
+        return DataTransactionResult.successReplaceResult(original.type().asImmutable(), mergedValue.asImmutable());
+    }
+
+    @Override
+    public Optional<ImmutableDyeableData> with(Key<? extends BaseValue<?>> key, Object value, ImmutableDyeableData immutable) {
+        if (key.equals(Keys.DYE_COLOR)) {
+            return Optional.of(ImmutableDataCachingUtil.getManipulator(ImmutableDyeableData.class, value));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public DataTransactionResult remove(DataHolder dataHolder) {
+        IMixinTileEntityShulkerBox box = (IMixinTileEntityShulkerBox) dataHolder;
+        DyeColor color = (DyeColor) (Object) box.getColor();
+        box.setColor(null);
+        if (color == null) {
+            return DataTransactionResult.failNoData();
+        }
+        return DataTransactionResult.successRemove(ImmutableSpongeValue.cachedOf(Keys.DYE_COLOR, DyeColors.PURPLE, color));
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/tileentity/ShulkerBoxDyeColorValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/tileentity/ShulkerBoxDyeColorValueProcessor.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.tileentity;
+
+import net.minecraft.item.EnumDyeColor;
+import net.minecraft.tileentity.TileEntityShulkerBox;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.type.DyeColor;
+import org.spongepowered.api.data.type.DyeColors;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.interfaces.block.tile.IMixinTileEntityShulkerBox;
+
+import java.util.Optional;
+
+public class ShulkerBoxDyeColorValueProcessor extends AbstractSpongeValueProcessor<TileEntityShulkerBox, DyeColor, Value<DyeColor>> {
+
+    public ShulkerBoxDyeColorValueProcessor() {
+        super(TileEntityShulkerBox.class, Keys.DYE_COLOR);
+    }
+
+    @Override
+    protected Value<DyeColor> constructValue(DyeColor actualValue) {
+        return new SpongeValue<>(Keys.DYE_COLOR, DyeColors.PURPLE, actualValue);
+    }
+
+    @Override
+    protected boolean set(TileEntityShulkerBox container, DyeColor value) {
+        ((IMixinTileEntityShulkerBox) container).setColor((EnumDyeColor) (Object) value);
+        return true;
+    }
+
+    @Override
+    protected Optional<DyeColor> getVal(TileEntityShulkerBox container) {
+        EnumDyeColor enumType = ((IMixinTileEntityShulkerBox) container).getColor();
+        if (enumType != null) {
+            return Optional.of((DyeColor) (Object) enumType);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected ImmutableValue<DyeColor> constructImmutableValue(DyeColor value) {
+        return ImmutableSpongeValue.cachedOf(Keys.DYE_COLOR, DyeColors.PURPLE, value);
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        DyeColor color = (DyeColor) (Object) ((IMixinTileEntityShulkerBox) container).getColor();
+        if (color == null) {
+            return DataTransactionResult.failNoData();
+        }
+        ((IMixinTileEntityShulkerBox) container).setColor(null);
+        return DataTransactionResult.successRemove(constructImmutableValue(color));
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/interfaces/block/tile/IMixinTileEntityShulkerBox.java
+++ b/src/main/java/org/spongepowered/common/interfaces/block/tile/IMixinTileEntityShulkerBox.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.interfaces.block.tile;
+
+import net.minecraft.item.EnumDyeColor;
+import net.minecraft.tileentity.TileEntityShulkerBox;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import javax.annotation.Nullable;
+
+public interface IMixinTileEntityShulkerBox {
+
+    @Nullable
+    EnumDyeColor getColor();
+
+    void setColor(@Nullable EnumDyeColor color);
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityChest.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityChest.java
@@ -39,7 +39,6 @@ import org.spongepowered.api.block.tileentity.carrier.Chest;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.block.ConnectedDirectionData;
 import org.spongepowered.api.item.inventory.Inventory;
-import org.spongepowered.api.item.inventory.type.TileEntityInventory;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -73,10 +72,6 @@ public abstract class MixinTileEntityChest extends MixinTileEntityLockableLoot i
     @Shadow public TileEntityChest adjacentChestZPos;
 
     @Shadow public abstract void checkForAdjacentChests();
-
-    private Fabric<IInventory> fabric;
-    private SlotCollection slots;
-    private Lens<IInventory, ItemStack> lens;
 
     @Inject(method = "<init>", at = @At("RETURN"))
     public void onConstructed(CallbackInfo ci) {
@@ -124,7 +119,8 @@ public abstract class MixinTileEntityChest extends MixinTileEntityLockableLoot i
                 posZ += 0.5D;
             }
 
-            this.world.playSound(null, posX, posY, posZ, SoundEvents.BLOCK_CHEST_OPEN, SoundCategory.BLOCKS, 0.5F, this.world.rand.nextFloat() * 0.1F + 0.9F);
+            this.world.playSound(null, posX, posY, posZ, SoundEvents.BLOCK_CHEST_OPEN, SoundCategory.BLOCKS, 0.5F,
+                    this.world.rand.nextFloat() * 0.1F + 0.9F);
         }
     }
 
@@ -148,9 +144,9 @@ public abstract class MixinTileEntityChest extends MixinTileEntityLockableLoot i
                 this.lidAngle = 0.0f;
             }
 
-            double posX = (double)this.pos.getX() + 0.5D;
-            double posY = (double)this.pos.getY() + 0.5D;
-            double posZ = (double)this.pos.getZ() + 0.5D;
+            double posX = (double) this.pos.getX() + 0.5D;
+            double posY = (double) this.pos.getY() + 0.5D;
+            double posZ = (double) this.pos.getZ() + 0.5D;
 
             if (this.adjacentChestXPos != null) {
                 posX += 0.5D;
@@ -160,7 +156,8 @@ public abstract class MixinTileEntityChest extends MixinTileEntityLockableLoot i
                 posZ += 0.5D;
             }
 
-            this.world.playSound(null, posX, posY, posZ, SoundEvents.BLOCK_CHEST_CLOSE, SoundCategory.BLOCKS, 0.5F, this.world.rand.nextFloat() * 0.1F + 0.9F);
+            this.world.playSound(null, posX, posY, posZ, SoundEvents.BLOCK_CHEST_CLOSE, SoundCategory.BLOCKS, 0.5F,
+                    this.world.rand.nextFloat() * 0.1F + 0.9F);
         }
     }
 
@@ -171,11 +168,6 @@ public abstract class MixinTileEntityChest extends MixinTileEntityLockableLoot i
         if (connectedChestData.isPresent()) {
             manipulators.add(connectedChestData.get());
         }
-    }
-
-    @Override
-    public void setCustomDisplayName(String customName) {
-        ((TileEntityChest) (Object) this).setCustomName(customName);
     }
 
     public SlotProvider<IInventory, ItemStack> inventory$getSlotProvider() {
@@ -200,11 +192,10 @@ public abstract class MixinTileEntityChest extends MixinTileEntityLockableLoot i
             if (tileentity1 instanceof TileEntityChest) {
                 InventoryLargeChest inventory;
 
-                if (enumfacing != EnumFacing.WEST && enumfacing != EnumFacing.NORTH)
-                {
-                    inventory = new InventoryLargeChest("container.chestDouble", this, (TileEntityChest)tileentity1);
+                if (enumfacing != EnumFacing.WEST && enumfacing != EnumFacing.NORTH) {
+                    inventory = new InventoryLargeChest("container.chestDouble", this, (TileEntityChest) tileentity1);
                 } else {
-                    inventory = new InventoryLargeChest("container.chestDouble", (TileEntityChest)tileentity1, this);
+                    inventory = new InventoryLargeChest("container.chestDouble", (TileEntityChest) tileentity1, this);
                 }
 
                 return Optional.of((Inventory) inventory);

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityHopper.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityHopper.java
@@ -47,7 +47,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.common.entity.PlayerTracker;
 import org.spongepowered.common.interfaces.IMixinChunk;
-import org.spongepowered.common.interfaces.data.IMixinCustomNameable;
 import org.spongepowered.common.interfaces.entity.IMixinEntity;
 import org.spongepowered.common.item.inventory.adapter.impl.MinecraftInventoryAdapter;
 import org.spongepowered.common.item.inventory.lens.Fabric;
@@ -63,13 +62,9 @@ import java.util.Optional;
 @NonnullByDefault
 @Mixin(TileEntityHopper.class)
 @Implements(@Interface(iface = MinecraftInventoryAdapter.class, prefix = "inventory$"))
-public abstract class MixinTileEntityHopper extends MixinTileEntityLockableLoot implements Hopper, IMixinCustomNameable {
+public abstract class MixinTileEntityHopper extends MixinTileEntityLockableLoot implements Hopper {
 
     @Shadow private int transferCooldown;
-
-    private Fabric<IInventory> fabric;
-    private SlotCollection slots;
-    private Lens<IInventory, ItemStack> lens;
 
     @Inject(method = "<init>", at = @At("RETURN"))
     public void onConstructed(CallbackInfo ci) {
@@ -104,11 +99,6 @@ public abstract class MixinTileEntityHopper extends MixinTileEntityLockableLoot 
         if (cooldownData.isPresent()) {
             manipulators.add(cooldownData.get());
         }
-    }
-
-    @Override
-    public void setCustomDisplayName(String customName) {
-        ((TileEntityHopper) (Object) this).setCustomName(customName);
     }
 
     public SlotProvider<IInventory, ItemStack> inventory$getSlotProvider() {

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityLockableLoot.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityLockableLoot.java
@@ -26,15 +26,28 @@ package org.spongepowered.common.mixin.core.tileentity;
 
 import static org.spongepowered.api.data.DataQuery.of;
 
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntityLockableLoot;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.interfaces.data.IMixinCustomNameable;
+import org.spongepowered.common.item.inventory.lens.Fabric;
+import org.spongepowered.common.item.inventory.lens.Lens;
+import org.spongepowered.common.item.inventory.lens.impl.collections.SlotCollection;
 
 @Mixin(TileEntityLockableLoot.class)
-public abstract class MixinTileEntityLockableLoot extends MixinTileEntityLockable {
+public abstract class MixinTileEntityLockableLoot extends MixinTileEntityLockable implements IMixinCustomNameable {
 
     @Shadow protected String customName;
+
+    @Shadow
+    public abstract void setCustomName(String p_190575_1_);
+
+    protected Fabric<IInventory> fabric;
+    protected SlotCollection slots;
+    protected Lens<IInventory, ItemStack> lens;
 
     @Override
     public DataContainer toContainer() {
@@ -43,6 +56,11 @@ public abstract class MixinTileEntityLockableLoot extends MixinTileEntityLockabl
             container.set(of("CustomName"), this.customName);
         }
         return container;
+    }
+
+    @Override
+    public void setCustomDisplayName(String name) {
+        setCustomName(name);
     }
 
 }


### PR DESCRIPTION
List of things I did: 
1. Supported inventory lens for shulker boxes. (I need these function)
2. Moved `setCustomDisplayName` to `MixinTileEntityLockableLoot`, the superclass of mixins for chests, hoppers, and shulker boxes.
3. Supported colored data for shulker box block entites (although it is not possible for items, but it is possible for block entities by the way vanilla stores data)

This is my first pull on SpongeCommon, so may be erroneous since this is my first time working with data processors and mixin.