### PR TITLE
Fix incorrect command permission checks in some situations.

### DIFF
--- a/src/main/java/org/spongepowered/common/command/MinecraftCommandWrapper.java
+++ b/src/main/java/org/spongepowered/common/command/MinecraftCommandWrapper.java
@@ -47,11 +47,11 @@ import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.common.interfaces.command.IMixinCommandBase;
 import org.spongepowered.common.interfaces.command.IMixinCommandHandler;
 import org.spongepowered.common.text.translation.SpongeTranslation;
 import org.spongepowered.common.util.VecHelper;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,10 +61,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 /**
  * Wrapper around ICommands so they fit into the Sponge command system.
  */
 public class MinecraftCommandWrapper implements CommandCallable {
+
     private static final String TRANSLATION_NO_PERMISSION = "commands.generic.permission";
     private final PluginContainer owner;
     protected final ICommand command;
@@ -81,6 +84,11 @@ public class MinecraftCommandWrapper implements CommandCallable {
     public MinecraftCommandWrapper(final PluginContainer owner, final ICommand command) {
         this.owner = owner;
         this.command = command;
+
+        // Add the namespaced alias to the wrapped command so permission checks are sent to the right command.
+        if (this.command instanceof IMixinCommandBase) {
+            ((IMixinCommandBase) this.command).updateNamespacedAlias(this.owner.getId());
+        }
     }
 
     private String[] splitArgs(String arguments) {

--- a/src/main/java/org/spongepowered/common/interfaces/command/IMixinCommandBase.java
+++ b/src/main/java/org/spongepowered/common/interfaces/command/IMixinCommandBase.java
@@ -30,4 +30,6 @@ public interface IMixinCommandBase {
 
     void setExpandedSelector(boolean expandedSelector);
 
+    void updateNamespacedAlias(String ownerId);
+
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandBase.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandBase.java
@@ -25,13 +25,20 @@
 package org.spongepowered.common.mixin.core.command;
 
 import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommand;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.common.interfaces.command.IMixinCommandBase;
 
+import javax.annotation.Nullable;
+
 @Mixin(CommandBase.class)
-public abstract class MixinCommandBase implements IMixinCommandBase {
+public abstract class MixinCommandBase implements IMixinCommandBase, ICommand {
 
     private boolean expandedSelector;
+    @Nullable private String namespacedAlias = null;
 
     @Override
     public boolean isExpandedSelector() {
@@ -41,6 +48,16 @@ public abstract class MixinCommandBase implements IMixinCommandBase {
     @Override
     public void setExpandedSelector(boolean expandedSelector) {
         this.expandedSelector = expandedSelector;
+    }
+
+    @Override
+    public void updateNamespacedAlias(String ownerId) {
+        this.namespacedAlias = ownerId + ":" + getName();
+    }
+
+    @Redirect(method = "checkPermission", at = @At(value = "INVOKE", target = "Lnet/minecraft/command/CommandBase;getName()Ljava/lang/String;"))
+    private String onCheckPermissionGetNameCall(CommandBase thisObject) {
+        return this.namespacedAlias == null ? getName() : this.namespacedAlias;
     }
 
 }


### PR DESCRIPTION
When a Sponge plugin command takes a command alias that either Vanilla Minecraft or a Forge mod tries to take later, any permission checks on for the vanilla/mod command are directed to the Sponge plugin's command instead. This commit fixes this by:

* Adding updateNamespacedAlias(String ownerId) method to the CommandBase (via `IMixinCommandBase`), which is called on instantiation of `MinecraftCommandWrapper` (and, by inheritance, `ForgeMinecraftCommandWrapper` in SF), prefixing the output of `getName()` with the owning plugin's ID followed by a colon.
* Injecting into the checkPermission call to use this namespaced alias, if it exists.

This then ensures that the permission check goes to the correct alias. I've opted to do it this way, rather than just change the `MinecraftCommandWrapper`, in case something calls `CommandBase#checkPermission` directly.

As an aside, I did want to use a `@Redirect` on `this.getName()`, but I couldn't get it to work. [I tried this](https://gist.github.com/dualspiral/bea485e2382e0c5e4d47c3e6e0786283), if someone would rather have a redirect and can point out what I've done wrong - I'll update it. Note that `Lnet/minecraft/command/CommandBase;getName()Ljava/lang/String;` matches what I get when I look at the bytecode...

**Test Plugin:** [something like this should suffice](https://gist.github.com/dualspiral/103cfe174610e0de4fe940f6368f1efd). Run `/tp` and `/minecraft:tp`. You should only get the permission check message for `/tp`, but unpatched, you get the permission check message for `/minecraft:tp` too. Patched, you do not.

This fixes #1243