### PR TITLE
Uses pagination to display plugin list for players in game.

### DIFF
--- a/src/main/java/org/spongepowered/common/command/SpongeCommand.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommand.java
@@ -96,6 +96,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -490,7 +491,8 @@ public class SpongeCommand {
                             src.sendMessage(builder.build());
                         }
                     } else {
-                        Collection<PluginContainer> plugins = SpongeImpl.getGame().getPluginManager().getPlugins();
+                        List<PluginContainer> plugins = new ArrayList<PluginContainer>(SpongeImpl.getGame().getPluginManager().getPlugins());
+                        plugins.sort(Comparator.comparing(PluginContainer::getName));
                         if (src instanceof Player) {
                             List<Text> pluginList = new ArrayList<Text>();
                             PaginationList.Builder builder = PaginationList.builder();

--- a/src/main/java/org/spongepowered/common/command/SpongeCommand.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommand.java
@@ -494,7 +494,7 @@ public class SpongeCommand {
                         if (src instanceof Player) {
                             List<Text> pluginList = new ArrayList<Text>();
                             PaginationList.Builder builder = PaginationList.builder();
-                            builder.title(Text.builder(String.format("Plugins: (%d): ", plugins.size())).build()).padding(Text.of("-"));
+                            builder.title(Text.builder(String.format("Plugins: (%d)", plugins.size())).build()).padding(Text.of("-"));
                             int counter = 1;
                             for (PluginContainer next : plugins) {
 

--- a/src/main/java/org/spongepowered/common/command/SpongeCommand.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommand.java
@@ -491,21 +491,37 @@ public class SpongeCommand {
                         }
                     } else {
                         Collection<PluginContainer> plugins = SpongeImpl.getGame().getPluginManager().getPlugins();
-                        List<Text> pluginList = new ArrayList<Text>();
-                        PaginationList.Builder builder = PaginationList.builder();
-                        builder.title(Text.builder(String.format("Plugins: (%d): ", plugins.size())).build()).padding(Text.of("-"));
-                        int counter = 1;
-                        for (PluginContainer next : plugins) {
+                        if (src instanceof Player) {
+                            List<Text> pluginList = new ArrayList<Text>();
+                            PaginationList.Builder builder = PaginationList.builder();
+                            builder.title(Text.builder(String.format("Plugins: (%d): ", plugins.size())).build()).padding(Text.of("-"));
+                            int counter = 1;
+                            for (PluginContainer next : plugins) {
 
-                            Text.Builder pluginBuilder = Text.builder((counter++) + next.getName())
-                                    .color(TextColors.GREEN)
-                                    .onClick(TextActions.runCommand("/sponge:sponge plugins " + next.getId()));
+                                Text.Builder pluginBuilder = Text.builder((counter++) + ". " + next.getName())
+                                        .color(TextColors.GREEN)
+                                        .onClick(TextActions.runCommand("/sponge:sponge plugins " + next.getId()));
 
-                            next.getVersion()
-                                    .ifPresent(version -> pluginBuilder.onHover(TextActions.showText(Text.of("Version " + version))));
-                            pluginList.add(pluginBuilder.build());
+                                next.getVersion()
+                                        .ifPresent(version -> pluginBuilder.onHover(TextActions.showText(Text.of("Version " + version))));
+                                pluginList.add(pluginBuilder.build());
+                            }
+                            builder.contents(pluginList).sendTo(src);
+                        } else {
+                            Text.Builder builder = Text.builder(String.format("Plugins (%d): ", plugins.size()));
+                            boolean first = true;
+                            for (PluginContainer next : plugins) {
+                                if (!first) {
+                                    builder.append(SEPARATOR_TEXT);
+                                }
+                                first = false;
+
+                                Text.Builder pluginBuilder = Text.builder(next.getName())
+                                        .color(TextColors.GREEN);
+                                builder.append(pluginBuilder.build());
+                            }
+                            src.sendMessage(builder.build());
                         }
-                        builder.contents(pluginList).sendTo(src);
                     }
                     return CommandResult.success();
                 }).build();

--- a/src/main/java/org/spongepowered/common/command/SpongeCommand.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommand.java
@@ -63,6 +63,7 @@ import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.service.pagination.PaginationList;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.action.TextActions;
 import org.spongepowered.api.text.format.TextColors;
@@ -93,7 +94,9 @@ import java.text.DecimalFormat;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -488,23 +491,21 @@ public class SpongeCommand {
                         }
                     } else {
                         Collection<PluginContainer> plugins = SpongeImpl.getGame().getPluginManager().getPlugins();
-                        Text.Builder build = Text.builder(String.format("Plugins (%d): ", plugins.size()));
-                        boolean first = true;
+                        List<Text> pluginList = new ArrayList<Text>();
+                        PaginationList.Builder builder = PaginationList.builder();
+                        builder.title(Text.builder(String.format("Plugins: (%d): ", plugins.size())).build()).padding(Text.of("-"));
+                        int counter = 1;
                         for (PluginContainer next : plugins) {
-                            if (!first) {
-                                build.append(SEPARATOR_TEXT);
-                            }
-                            first = false;
 
-                            Text.Builder pluginBuilder = Text.builder(next.getName())
+                            Text.Builder pluginBuilder = Text.builder((counter++) + next.getName())
                                     .color(TextColors.GREEN)
                                     .onClick(TextActions.runCommand("/sponge:sponge plugins " + next.getId()));
 
                             next.getVersion()
                                     .ifPresent(version -> pluginBuilder.onHover(TextActions.showText(Text.of("Version " + version))));
-                            build.append(pluginBuilder.build());
+                            pluginList.add(pluginBuilder.build());
                         }
-                        src.sendMessage(build.build());
+                        builder.contents(pluginList).sendTo(src);
                     }
                     return CommandResult.success();
                 }).build();


### PR DESCRIPTION
Fixes #1239. Plugin lists can get extremely long. It is basically useless to have a massively long list of plugins displayed to you. Pagination gives you much more useful snippets of information. In addition, sometimes plugin lists would get so long that they would cause a crash when the server attempted to send a packet with a string length that was too long. This resolves that issue. I have attached a screenshot that shows how the PR works from a players view and from the console view.
![screenshot from 2017-03-12 01-45-44](https://cloud.githubusercontent.com/assets/1052396/23830721/38f0ade6-06c6-11e7-8c97-fa2392044667.png)
