### PR TITLE
Add a global cause manager to apply global phases to all worlds.

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeImplHooks.java
+++ b/src/main/java/org/spongepowered/common/SpongeImplHooks.java
@@ -38,11 +38,9 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.ReportedException;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Util;
-import net.minecraft.util.ReportedException;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.GameType;
@@ -55,13 +53,10 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.storage.MapStorage;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.api.event.cause.NamedCause;
-import org.spongepowered.common.event.tracking.CauseTracker;
+import org.spongepowered.common.event.tracking.GlobalCauseTracker;
 import org.spongepowered.common.event.tracking.ItemDropData;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.phase.plugin.PluginPhase;
-import org.spongepowered.common.interfaces.world.IMixinWorldServer;
-import org.spongepowered.common.mixin.core.world.MixinWorldType;
-import org.spongepowered.common.world.WorldManager;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -246,18 +241,13 @@ public final class SpongeImplHooks {
     }
 
     public static Object onUtilRunTask(FutureTask<?> task, Logger logger) {
-        for (WorldServer worldServer : WorldManager.getWorlds()) {
-            final CauseTracker otherCauseTracker = ((IMixinWorldServer) worldServer).getCauseTracker();
-            otherCauseTracker.switchToPhase(PluginPhase.State.SCHEDULED_TASK, PhaseContext.start()
-                    .add(NamedCause.source(task))
-                    .addCaptures()
-                    .complete()
-            );
-        }
+        GlobalCauseTracker.getInstance().switchToPhase(PluginPhase.State.SCHEDULED_TASK, PhaseContext.start()
+                .add(NamedCause.source(task))
+                .addCaptures()
+                .complete()
+        );
         Object value = Util.runTask(task, logger);
-        for (WorldServer worldServer : WorldManager.getWorlds()) {
-            ((IMixinWorldServer) worldServer).getCauseTracker().completePhase(PluginPhase.State.SCHEDULED_TASK);
-        }
+        GlobalCauseTracker.getInstance().completePhase(PluginPhase.State.SCHEDULED_TASK);
         return value;
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/BaseCauseTracker.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/BaseCauseTracker.java
@@ -1,0 +1,285 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.event.tracking;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.apache.logging.log4j.Level;
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.asm.util.PrettyPrinter;
+import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.common.event.tracking.phase.general.GeneralPhase;
+
+import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
+
+public abstract class BaseCauseTracker {
+    protected static final BiConsumer<PrettyPrinter, PhaseContext> CONTEXT_PRINTER = (printer, context) ->
+            context.forEach(namedCause -> {
+                        printer.add("        - Name: %s", namedCause.getName());
+                        printer.addWrapped(100, "          Object: %s", namedCause.getCauseObject());
+                    }
+            );
+
+    protected static final BiConsumer<PrettyPrinter, PhaseData> PHASE_PRINTER = (printer, data) -> {
+        printer.add("  - Phase: %s", data.state);
+        printer.add("    Context:");
+        data.context.forEach(namedCause -> {
+            printer.add("    - Name: %s", namedCause.getName());
+            final Object causeObject = namedCause.getCauseObject();
+            if (causeObject instanceof PhaseContext) {
+                CONTEXT_PRINTER.accept(printer, (PhaseContext) causeObject);
+            } else {
+                printer.addWrapped(100, "      Object: %s", causeObject);
+            }
+        });
+    };
+
+    protected final CauseStack stack = new CauseStack();
+
+    public final boolean isVerbose = SpongeImpl.getGlobalConfig().getConfig().getCauseTracker().isVerbose();
+    public final boolean verboseErrors = SpongeImpl.getGlobalConfig().getConfig().getCauseTracker().verboseErrors();
+
+    public void switchToPhase(IPhaseState state, PhaseContext phaseContext) {
+        checkNotNull(state, "State cannot be null!");
+        checkNotNull(state.getPhase(), "Phase cannot be null!");
+        checkNotNull(phaseContext, "PhaseContext cannot be null!");
+        checkArgument(phaseContext.isComplete(), "PhaseContext must be complete!");
+        final IPhaseState currentState = this.stack.peek().state;
+        if (this.isVerbose) {
+            if (this.stack.size() > 6 && !currentState.isExpectedForReEntrance()) {
+                // This printing is to detect possibilities of a phase not being cleared properly
+                // and resulting in a "runaway" phase state accumulation.
+                printRunawayPhase(state, phaseContext);
+            }
+            if (!currentState.canSwitchTo(state) && state != GeneralPhase.Post.UNWINDING && currentState == GeneralPhase.Post.UNWINDING) {
+                // This is to detect incompatible phase switches.
+                printPhaseIncompatibility(currentState, state);
+            }
+        }
+
+        this.stack.push(state, phaseContext);
+    }
+
+    /**
+     * This method pushes a new phase onto the stack, runs phaseBody,
+     * and calls completePhase afterwards.
+     *
+     * <p>This method ensures that the necessary cleanup is performed if
+     * an exception is thrown by phaseBody - i.e. logging a message,
+     * and calling completePhase</p>
+     * @param state
+     * @param context
+     * @param phaseBody
+     */
+    public void switchToPhase(IPhaseState state, PhaseContext context, Callable<Void> phaseBody) {
+        this.switchToPhase(state, context);
+        try {
+            phaseBody.call();
+        } catch (Exception e) {
+            this.abortCurrentPhase(e);
+            return;
+        }
+        this.completePhase(state);
+    }
+
+    /**
+     * Used when exception occurs during the main body of a phase.
+     * Avoids running the normal unwinding code
+     */
+    public void abortCurrentPhase(Exception e) {
+        PhaseData data = this.stack.peek();
+        this.printMessageWithCaughtException("Exception during phase body", "Something happened trying to run the main body of a phase", data.state, data.context, e);
+
+        // Since an exception occured during the main phase code, we don't know what state we're in.
+        // Therefore, we skip running the normal unwind functions that completePhase calls,
+        // and simply op the phase from the stack.
+        popFromError();
+    }
+
+    public void completePhase(IPhaseState prevState) {
+        final PhaseData currentPhaseData = this.stack.peek();
+        final IPhaseState state = currentPhaseData.state;
+        final boolean isEmpty = this.stack.isEmpty();
+        if (isEmpty) {
+            // The random occurrence that we're told to complete a phase
+            // while a world is being changed unknowingly.
+            printEmptyStackOnCompletion();
+            return;
+        }
+
+        if (prevState != state) {
+            printIncorrectPhaseCompletion(prevState, state);
+
+            // The phase on the top of the stack was most likely never completed.
+            // Since we don't know when and where completePhase was intended to be called for it,
+            // we simply pop it to allow processing to continue (somewhat) as normal
+            popFromError();
+
+        }
+
+        if (this.isVerbose && this.stack.size() > 6 && state != GeneralPhase.Post.UNWINDING && !state.isExpectedForReEntrance()) {
+            // This printing is to detect possibilities of a phase not being cleared properly
+            // and resulting in a "runaway" phase state accumulation.
+            printRunnawayPhaseCompletion(state);
+        }
+        this.stack.pop();
+        doCompletePhase(currentPhaseData);
+    }
+
+    protected void popFromError() {
+        this.stack.pop();
+    }
+
+    protected abstract void doCompletePhase(PhaseData currentPhaseData);
+
+    private void printRunnawayPhaseCompletion(IPhaseState state) {
+        final PrettyPrinter printer = new PrettyPrinter(60);
+        printer.add("Completing Phase").centre().hr();
+        printer.addWrapped(50, "Detecting a runaway phase! Potentially a problem where something isn't completing a phase!!!");
+        printer.add("  %s : %s", "Affected Tracker", this.getTrackerDescription());
+        printer.add();
+        printer.addWrapped(60, "%s : %s", "Completing phase", state);
+        printer.add(" Phases Remaining:");
+        this.stack.forEach(data -> PHASE_PRINTER.accept(printer, data));
+        printer.add("Stacktrace:");
+        printer.add(new Exception("Stack trace"));
+        printer.add();
+        generateVersionInfo(printer);
+        printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
+    }
+
+    protected abstract String getTrackerDescription();
+
+    private void generateVersionInfo(PrettyPrinter printer) {
+        for (PluginContainer pluginContainer : SpongeImpl.getInternalPlugins()) {
+            pluginContainer.getVersion().ifPresent(version ->
+                    printer.add("%s : %s", pluginContainer.getName(), version)
+            );
+        }
+    }
+
+    private void printIncorrectPhaseCompletion(IPhaseState prevState, IPhaseState state) {
+        PrettyPrinter printer = new PrettyPrinter(60).add("Completing incorrect phase").centre().hr()
+                .addWrapped(50, "Sponge's tracking system is very dependent on knowing when"
+                        + "a change to any world takes place, however, we are attempting"
+                        + "to complete a \"phase\" other than the one we most recently entered."
+                        + "This is an error usually on Sponge's part, so a report"
+                        + "is required on the issue tracker on GitHub.").hr()
+                .add("  %s : %s", "Affected Tracker", this.getTrackerDescription())
+                .add("Expected to exit phase: %s", prevState)
+                .add("But instead found phase: %s", state)
+                .add("StackTrace:")
+                .add(new Exception());
+        printer.add(" Phases Remaining:");
+        this.stack.forEach(data -> PHASE_PRINTER.accept(printer, data));
+        printer.add();
+        generateVersionInfo(printer);
+        printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
+    }
+
+    private void printEmptyStackOnCompletion() {
+        final PrettyPrinter printer = new PrettyPrinter(60).add("Unexpected ").centre().hr()
+                .addWrapped(50, "Sponge's tracking system is very dependent on knowing when"
+                        + "a change to any world takes place, however, we have been told"
+                        + "to complete a \"phase\" without having entered any phases."
+                        + "This is an error usually on Sponge's part, so a report"
+                        + "is required on the issue tracker on GitHub.").hr()
+                .add("  %s : %s", "Affected Tracker", this.getTrackerDescription())
+                .add("StackTrace:")
+                .add(new Exception())
+                .add();
+        generateVersionInfo(printer);
+        printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
+    }
+
+    private void printRunawayPhase(IPhaseState state, PhaseContext context) {
+        final PrettyPrinter printer = new PrettyPrinter(40);
+        printer.add("Switching Phase").centre().hr();
+        printer.addWrapped(50, "Detecting a runaway phase! Potentially a problem where something isn't completing a phase!!!");
+        printer.add("  %s : %s", "Affected Tracker", this.getTrackerDescription());
+        printer.add("  %s : %s", "Entering Phase", state.getPhase());
+        printer.add("  %s : %s", "Entering State", state);
+        CONTEXT_PRINTER.accept(printer, context);
+        printer.addWrapped(60, "%s :", "Phases remaining");
+        this.stack.forEach(data -> PHASE_PRINTER.accept(printer, data));
+        printer.add("  %s :", "Printing stack trace")
+                .add(new Exception("Stack trace"));
+        printer.add();
+        generateVersionInfo(printer);
+        printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
+    }
+
+    private void printPhaseIncompatibility(IPhaseState currentState, IPhaseState incompatibleState) {
+        PrettyPrinter printer = new PrettyPrinter(80);
+        printer.add("Switching Phase").centre().hr();
+        printer.add("Phase incompatibility detected! Attempting to switch to an invalid phase!");
+        printer.add("  %s : %s", "Affected Tracker", this.getTrackerDescription());
+        printer.add("  %s : %s", "Current Phase", currentState.getPhase());
+        printer.add("  %s : %s", "Current State", currentState);
+        printer.add("  %s : %s", "Entering incompatible Phase", incompatibleState.getPhase());
+        printer.add("  %s : %s", "Entering incompatible State", incompatibleState);
+        printer.add("%s :", "Current phases");
+        this.stack.forEach(data -> PHASE_PRINTER.accept(printer, data));
+        printer.add("  %s :", "Printing stack trace");
+        printer.add(new Exception("Stack trace"));
+        printer.add();
+        generateVersionInfo(printer);
+        printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
+    }
+
+    public void printMessageWithCaughtException(String header, String subHeader, Exception e) {
+        this.printMessageWithCaughtException(header, subHeader, this.getCurrentState(), this.getCurrentContext(), e);
+    }
+
+    public void printMessageWithCaughtException(String header, String subHeader, IPhaseState state, PhaseContext context, Exception e) {
+        final PrettyPrinter printer = new PrettyPrinter(40);
+        printer.add(header).centre().hr()
+                .add("%s %s", subHeader, state)
+                .addWrapped(40, "%s :", "PhaseContext");
+        printer.add("  %s : %s", "Affected Tracker", this.getTrackerDescription());
+        CONTEXT_PRINTER.accept(printer, context);
+        printer.addWrapped(60, "%s :", "Phases remaining");
+        this.stack.forEach(data -> PHASE_PRINTER.accept(printer, data));
+        printer.add("Stacktrace:")
+                .add(e);
+        printer.add();
+        generateVersionInfo(printer);
+        printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
+    }
+
+    public PhaseData getCurrentPhaseData() {
+        return this.stack.peek();
+    }
+
+    public IPhaseState getCurrentState() {
+        return this.stack.peekState();
+    }
+
+    public PhaseContext getCurrentContext() {
+        return this.stack.peekContext();
+    }
+}

--- a/src/main/java/org/spongepowered/common/event/tracking/CauseStack.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/CauseStack.java
@@ -92,6 +92,10 @@ final class CauseStack {
         this.states.forEach(consumer::accept);
     }
 
+    public void forEachFromBase(Consumer<PhaseData> consumer) {
+        this.states.descendingIterator().forEachRemaining(consumer);
+    }
+
     public boolean isEmpty() {
         return this.states.isEmpty();
     }

--- a/src/main/java/org/spongepowered/common/event/tracking/CauseTracker.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/CauseTracker.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.event.tracking;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import net.minecraft.block.Block;
@@ -48,7 +47,6 @@ import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.entity.SpawnEntityEvent;
-import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.World;
 import org.spongepowered.asm.util.PrettyPrinter;
@@ -65,8 +63,6 @@ import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.function.BiConsumer;
 
 import javax.annotation.Nullable;
 
@@ -75,39 +71,13 @@ import javax.annotation.Nullable;
  * proxy object entering and processing between different states of the
  * world and its objects.
  */
-public final class CauseTracker {
+public final class CauseTracker extends BaseCauseTracker {
 
     public static final boolean ENABLED = Booleans.parseBoolean(System.getProperty("sponge.causeTracking"), true);
 
-    static final BiConsumer<PrettyPrinter, PhaseContext> CONTEXT_PRINTER = (printer, context) ->
-            context.forEach(namedCause -> {
-                        printer.add("        - Name: %s", namedCause.getName());
-                        printer.addWrapped(100, "          Object: %s", namedCause.getCauseObject());
-                    }
-            );
-
-    private static final BiConsumer<PrettyPrinter, PhaseData> PHASE_PRINTER = (printer, data) -> {
-        printer.add("  - Phase: %s", data.state);
-        printer.add("    Context:");
-        data.context.forEach(namedCause -> {
-            printer.add("    - Name: %s", namedCause.getName());
-            final Object causeObject = namedCause.getCauseObject();
-            if (causeObject instanceof PhaseContext) {
-                CONTEXT_PRINTER.accept(printer, (PhaseContext) causeObject);
-            } else {
-                printer.addWrapped(100, "      Object: %s", causeObject);
-            }
-        });
-    };
-
     private final WorldServer targetWorld;
 
-    private final CauseStack stack = new CauseStack();
-
-    @Nullable private PhaseData currentProcessingState = null;
-
-    public final boolean isVerbose = SpongeImpl.getGlobalConfig().getConfig().getCauseTracker().isVerbose();
-    public final boolean verboseErrors = SpongeImpl.getGlobalConfig().getConfig().getCauseTracker().verboseErrors();
+    @Nullable private PhaseData currentProcessingState;
 
     @SuppressWarnings("ConstantConditions")
     public CauseTracker(WorldServer targetWorld) {
@@ -116,238 +86,6 @@ public final class CauseTracker {
         }
         this.targetWorld = targetWorld;
     }
-
-    // ----------------- STATE ACCESS ----------------------------------
-
-    public void switchToPhase(IPhaseState state, PhaseContext phaseContext) {
-        checkNotNull(state, "State cannot be null!");
-        checkNotNull(state.getPhase(), "Phase cannot be null!");
-        checkNotNull(phaseContext, "PhaseContext cannot be null!");
-        checkArgument(phaseContext.isComplete(), "PhaseContext must be complete!");
-        final IPhaseState currentState = this.stack.peek().state;
-        if (this.isVerbose) {
-            if (this.stack.size() > 6 && !currentState.isExpectedForReEntrance()) {
-                // This printing is to detect possibilities of a phase not being cleared properly
-                // and resulting in a "runaway" phase state accumulation.
-                printRunawayPhase(state, phaseContext);
-            }
-            if (!currentState.canSwitchTo(state) && state != GeneralPhase.Post.UNWINDING && currentState == GeneralPhase.Post.UNWINDING) {
-                // This is to detect incompatible phase switches.
-                printPhaseIncompatibility(currentState, state);
-            }
-        }
-
-        this.stack.push(state, phaseContext);
-    }
-
-    /**
-     * This method pushes a new phase onto the stack, runs phaseBody,
-     * and calls completePhase afterwards.
-     *
-     * <p>This method ensures that the necessary cleanup is performed if
-     * an exception is thrown by phaseBody - i.e. logging a message,
-     * and calling completePhase</p>
-     * @param state
-     * @param context
-     * @param phaseBody
-     */
-    public void switchToPhase(IPhaseState state, PhaseContext context, Callable<Void> phaseBody) {
-        this.switchToPhase(state, context);
-        try {
-            phaseBody.call();
-        } catch (Exception e) {
-            this.abortCurrentPhase(e);
-            return;
-        }
-        this.completePhase(state);
-    }
-
-    /**
-     * Used when exception occurs during the main body of a phase.
-     * Avoids running the normal unwinding code
-     */
-    public void abortCurrentPhase(Exception e) {
-        PhaseData data = this.stack.peek();
-        this.printMessageWithCaughtException("Exception during phase body", "Something happened trying to run the main body of a phase", data.state, data.context, e);
-
-        // Since an exception occured during the main phase code, we don't know what state we're in.
-        // Therefore, we skip running the normal unwind functions that completePhase calls,
-        // and simply op the phase from the stack.
-        stack.pop();
-    }
-
-    public void completePhase(IPhaseState prevState) {
-        final PhaseData currentPhaseData = this.stack.peek();
-        final IPhaseState state = currentPhaseData.state;
-        final boolean isEmpty = this.stack.isEmpty();
-        if (isEmpty) {
-            // The random occurrence that we're told to complete a phase
-            // while a world is being changed unknowingly.
-            printEmptyStackOnCompletion();
-            return;
-        }
-
-        if (prevState != state) {
-            printIncorrectPhaseCompletion(prevState, state);
-
-            // The phase on the top of the stack was most likely never completed.
-            // Since we don't know when and where completePhase was intended to be called for it,
-            // we simply pop it to allow processing to continue (somewhat) as normal
-            stack.pop();
-
-        }
-
-        if (this.isVerbose && this.stack.size() > 6 && state != GeneralPhase.Post.UNWINDING && !state.isExpectedForReEntrance()) {
-            // This printing is to detect possibilities of a phase not being cleared properly
-            // and resulting in a "runaway" phase state accumulation.
-            printRunnawayPhaseCompletion(state);
-        }
-        this.stack.pop();
-        // If pop is called, the Deque will already throw an exception if there is no element
-        // so it's an error properly handled.
-        final TrackingPhase phase = state.getPhase();
-        final PhaseContext context = currentPhaseData.context;
-        try {
-            if (state != GeneralPhase.Post.UNWINDING && phase.requiresPost(state)) {
-                // Note that UnwindingPhaseContext is required for something? I don't think it requires anything tbh.
-                switchToPhase(GeneralPhase.Post.UNWINDING, UnwindingPhaseContext.unwind(state, context)
-                        .addCaptures()
-                        .addEntityDropCaptures()
-                        .complete());
-            }
-            try { // Yes this is a nested try, but in the event the current phase cannot be unwound, at least unwind UNWINDING
-                this.currentProcessingState = currentPhaseData;
-                phase.unwind(this, state, context);
-                this.currentProcessingState = null;
-            } catch (Exception e) {
-                printMessageWithCaughtException("Exception Exiting Phase", "Something happened when trying to unwind", state, context, e);
-            }
-            if (state != GeneralPhase.Post.UNWINDING && phase.requiresPost(state)) {
-                try {
-                    completePhase(GeneralPhase.Post.UNWINDING);
-                } catch (Exception e) {
-                    printMessageWithCaughtException("Exception attempting to capture or spawn an Entity!", "Something happened trying to unwind", state, context, e);
-                }
-            }
-        } catch (Exception e) {
-            printMessageWithCaughtException("Exception Post Dispatching Phase", "Something happened when trying to post dispatch state", state, context, e);
-        }
-    }
-
-    private void printRunnawayPhaseCompletion(IPhaseState state) {
-        final PrettyPrinter printer = new PrettyPrinter(60);
-        printer.add("Completing Phase").centre().hr();
-        printer.addWrapped(50, "Detecting a runaway phase! Potentially a problem where something isn't completing a phase!!!");
-        printer.add("  %s : %s", "Affected World", this.targetWorld);
-        printer.add();
-        printer.addWrapped(60, "%s : %s", "Completing phase", state);
-        printer.add(" Phases Remaining:");
-        this.stack.forEach(data -> PHASE_PRINTER.accept(printer, data));
-        printer.add("Stacktrace:");
-        printer.add(new Exception("Stack trace"));
-        printer.add();
-        generateVersionInfo(printer);
-        printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
-    }
-
-    private void generateVersionInfo(PrettyPrinter printer) {
-        for (PluginContainer pluginContainer : SpongeImpl.getInternalPlugins()) {
-            pluginContainer.getVersion().ifPresent(version ->
-                    printer.add("%s : %s", pluginContainer.getName(), version)
-            );
-        }
-    }
-
-    private void printIncorrectPhaseCompletion(IPhaseState prevState, IPhaseState state) {
-        PrettyPrinter printer = new PrettyPrinter(60).add("Completing incorrect phase").centre().hr()
-                .addWrapped(50, "Sponge's tracking system is very dependent on knowing when"
-                        + "a change to any world takes place, however, we are attempting"
-                        + "to complete a \"phase\" other than the one we most recently entered."
-                        + "This is an error usually on Sponge's part, so a report"
-                        + "is required on the issue tracker on GitHub.").hr()
-                .add("  %s : %s", "Affected World", this.targetWorld)
-                .add("Expected to exit phase: %s", prevState)
-                .add("But instead found phase: %s", state)
-                .add("StackTrace:")
-                .add(new Exception());
-        printer.add(" Phases Remaining:");
-        this.stack.forEach(data -> PHASE_PRINTER.accept(printer, data));
-        printer.add();
-        generateVersionInfo(printer);
-        printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
-    }
-
-    private void printEmptyStackOnCompletion() {
-        final PrettyPrinter printer = new PrettyPrinter(60).add("Unexpected ").centre().hr()
-                .addWrapped(50, "Sponge's tracking system is very dependent on knowing when"
-                                + "a change to any world takes place, however, we have been told"
-                                + "to complete a \"phase\" without having entered any phases."
-                                + "This is an error usually on Sponge's part, so a report"
-                                + "is required on the issue tracker on GitHub.").hr()
-                .add("  %s : %s", "Affected World", this.targetWorld)
-                .add("StackTrace:")
-                .add(new Exception())
-                .add();
-        generateVersionInfo(printer);
-        printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
-    }
-
-    private void printRunawayPhase(IPhaseState state, PhaseContext context) {
-        final PrettyPrinter printer = new PrettyPrinter(40);
-        printer.add("Switching Phase").centre().hr();
-        printer.addWrapped(50, "Detecting a runaway phase! Potentially a problem where something isn't completing a phase!!!");
-        printer.add("  %s : %s", "Affected World", this.targetWorld);
-        printer.add("  %s : %s", "Entering Phase", state.getPhase());
-        printer.add("  %s : %s", "Entering State", state);
-        CONTEXT_PRINTER.accept(printer, context);
-        printer.addWrapped(60, "%s :", "Phases remaining");
-        this.stack.forEach(data -> PHASE_PRINTER.accept(printer, data));
-        printer.add("  %s :", "Printing stack trace")
-                .add(new Exception("Stack trace"));
-        printer.add();
-        generateVersionInfo(printer);
-        printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
-    }
-
-    private void printPhaseIncompatibility(IPhaseState currentState, IPhaseState incompatibleState) {
-        PrettyPrinter printer = new PrettyPrinter(80);
-        printer.add("Switching Phase").centre().hr();
-        printer.add("Phase incompatibility detected! Attempting to switch to an invalid phase!");
-        printer.add("  %s : %s", "Affected World", this.targetWorld);
-        printer.add("  %s : %s", "Current Phase", currentState.getPhase());
-        printer.add("  %s : %s", "Current State", currentState);
-        printer.add("  %s : %s", "Entering incompatible Phase", incompatibleState.getPhase());
-        printer.add("  %s : %s", "Entering incompatible State", incompatibleState);
-        printer.add("%s :", "Current phases");
-        this.stack.forEach(data -> PHASE_PRINTER.accept(printer, data));
-        printer.add("  %s :", "Printing stack trace");
-        printer.add(new Exception("Stack trace"));
-        printer.add();
-        generateVersionInfo(printer);
-        printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
-    }
-
-    public void printMessageWithCaughtException(String header, String subHeader, Exception e) {
-        this.printMessageWithCaughtException(header, subHeader, this.getCurrentState(), this.getCurrentContext(), e);
-    }
-
-    public void printMessageWithCaughtException(String header, String subHeader, IPhaseState state, PhaseContext context, Exception e) {
-        final PrettyPrinter printer = new PrettyPrinter(40);
-        printer.add(header).centre().hr()
-                .add("%s %s", subHeader, state)
-                .addWrapped(40, "%s :", "PhaseContext");
-        printer.add("  %s : %s", "Affected World", this.targetWorld);
-        CONTEXT_PRINTER.accept(printer, context);
-        printer.addWrapped(60, "%s :", "Phases remaining");
-        this.stack.forEach(data -> PHASE_PRINTER.accept(printer, data));
-        printer.add("Stacktrace:")
-                .add(e);
-        printer.add();
-        generateVersionInfo(printer);
-        printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
-    }
-
-    // ----------------- SIMPLE GETTERS --------------------------------------
 
     /**
      * Gets the {@link World} as a SpongeAPI world.
@@ -376,20 +114,44 @@ public final class CauseTracker {
         return (IMixinWorldServer) this.targetWorld;
     }
 
-    public PhaseData getCurrentPhaseData() {
-        return this.stack.peek();
-    }
-
-    public IPhaseState getCurrentState() {
-        return this.stack.peekState();
-    }
-
-    public PhaseContext getCurrentContext() {
-        return this.stack.peekContext();
-    }
-
     public PhaseData getCurrentProcessingPhase() {
         return this.currentProcessingState == null ? CauseStack.EMPTY_DATA : this.currentProcessingState;
+    }
+
+    @Override
+    protected String getTrackerDescription() {
+        return this.targetWorld.toString();
+    }
+
+    protected void doCompletePhase(PhaseData currentPhaseData) {
+        IPhaseState state = currentPhaseData.state;
+        final TrackingPhase phase = state.getPhase();
+        final PhaseContext context = currentPhaseData.context;
+        try {
+            if (state != GeneralPhase.Post.UNWINDING && phase.requiresPost(state)) {
+                // Note that UnwindingPhaseContext is required for something? I don't think it requires anything tbh.
+                switchToPhase(GeneralPhase.Post.UNWINDING, UnwindingPhaseContext.unwind(state, context)
+                        .addCaptures()
+                        .addEntityDropCaptures()
+                        .complete());
+            }
+            try { // Yes this is a nested try, but in the event the current phase cannot be unwound, at least unwind UNWINDING
+                this.currentProcessingState = currentPhaseData;
+                phase.unwind(this, state, context);
+                this.currentProcessingState = null;
+            } catch (Exception e) {
+                printMessageWithCaughtException("Exception Exiting Phase", "Something happened when trying to unwind", state, context, e);
+            }
+            if (state != GeneralPhase.Post.UNWINDING && phase.requiresPost(state)) {
+                try {
+                    completePhase(GeneralPhase.Post.UNWINDING);
+                } catch (Exception e) {
+                    printMessageWithCaughtException("Exception attempting to capture or spawn an Entity!", "Something happened trying to unwind", state, context, e);
+                }
+            }
+        } catch (Exception e) {
+            printMessageWithCaughtException("Exception Post Dispatching Phase", "Something happened when trying to post dispatch state", state, context, e);
+        }
     }
 
     // --------------------- DELEGATED WORLD METHODS -------------------------

--- a/src/main/java/org/spongepowered/common/event/tracking/GlobalCauseTracker.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/GlobalCauseTracker.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.event.tracking;
+
+import net.minecraft.world.WorldServer;
+import org.spongepowered.common.interfaces.world.IMixinWorldServer;
+import org.spongepowered.common.world.WorldManager;
+
+public final class GlobalCauseTracker extends BaseCauseTracker {
+
+    private static final GlobalCauseTracker INSTANCE = new GlobalCauseTracker();
+
+    private GlobalCauseTracker() {
+    }
+
+    public static GlobalCauseTracker getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void switchToPhase(IPhaseState state, PhaseContext phaseContext) {
+        super.switchToPhase(state, phaseContext);
+        for (WorldServer world : WorldManager.getWorlds()) {
+            ((IMixinWorldServer) world).getCauseTracker().switchToPhase(state, phaseContext.copy());
+        }
+    }
+
+    @Override
+    protected void doCompletePhase(PhaseData currentPhaseData) {
+        for (WorldServer world : WorldManager.getWorlds()) {
+            ((IMixinWorldServer) world).getCauseTracker().completePhase(currentPhaseData.state);
+        }
+    }
+
+    @Override
+    protected String getTrackerDescription() {
+        return GlobalCauseTracker.class.getSimpleName();
+    }
+
+    @Override
+    protected void popFromError() {
+        IPhaseState currentState = this.getCurrentState();
+        super.popFromError();
+        for (WorldServer server : WorldManager.getWorlds()) {
+            CauseTracker worldTracker = ((IMixinWorldServer) server).getCauseTracker();
+            if (!worldTracker.getCurrentState().equals(currentState)) {
+                // The last phase must not have been completed.
+                worldTracker.popFromError();
+            }
+            worldTracker.popFromError();
+        }
+    }
+
+    public void addWorld(WorldServer world) {
+        this.stack.forEachFromBase(data -> ((IMixinWorldServer) world).getCauseTracker()
+                .switchToPhase(data.state, data.context.copy()));
+    }
+}

--- a/src/main/java/org/spongepowered/common/event/tracking/PhaseContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/PhaseContext.java
@@ -50,6 +50,7 @@ import java.util.UUID;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 
 /**
  * Similar to {@link Cause} except it can be built continuously
@@ -701,5 +702,52 @@ public class PhaseContext {
         public int hashCode() {
             return com.google.common.base.Objects.hashCode(this.pos);
         }
+    }
+
+    public PhaseContext copy() {
+        PhaseContext to = new PhaseContext();
+        copy(to);
+        return to;
+    }
+
+    @OverridingMethodsMustInvokeSuper
+    protected void copy(PhaseContext to) {
+        to.cause = this.cause;
+        to.isCompleted = this.isCompleted;
+        to.contextObjects.clear();
+        to.contextObjects.addAll(this.contextObjects);
+        if (this.blocksSupplier != null) {
+            to.blocksSupplier = new CapturedBlocksSupplier();
+        }
+        if (this.blockItemDropsSupplier != null) {
+            to.blockItemDropsSupplier = new BlockItemDropsSupplier();
+        }
+        if (this.blockItemEntityDropsSupplier != null) {
+            to.blockItemEntityDropsSupplier = new BlockItemEntityDropsSupplier();
+        }
+        if (this.capturedItemsSupplier != null) {
+            to.capturedItemsSupplier = new CapturedItemsSupplier();
+        }
+        if (this.capturedEntitiesSupplier != null) {
+            to.capturedEntitiesSupplier = new CapturedEntitiesSupplier();
+        }
+        if (this.capturedItemStackSupplier != null) {
+            to.capturedItemStackSupplier = new CapturedItemStackSupplier();
+        }
+        if (this.entityItemDropsSupplier != null) {
+            to.entityItemDropsSupplier = new EntityItemDropsSupplier();
+        }
+        if (this.entityItemEntityDropsSupplier != null) {
+            to.entityItemEntityDropsSupplier = new EntityItemEntityDropsSupplier();
+        }
+        if (this.blockEntitySpawnSupplier != null) {
+            to.blockEntitySpawnSupplier = new CapturedBlockEntitySpawnSupplier();
+        }
+        if (this.captureBlockPos != null) {
+            to.captureBlockPos = new CaptureBlockPos(this.captureBlockPos.pos);
+        }
+        to.owner = this.owner;
+        to.notifier = this.notifier;
+        to.source = this.source;
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/PhaseContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/PhaseContext.java
@@ -750,4 +750,5 @@ public class PhaseContext {
         to.notifier = this.notifier;
         to.source = this.source;
     }
+
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/TrackingUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/TrackingUtil.java
@@ -37,7 +37,6 @@ import net.minecraft.block.BlockRedstoneLight;
 import net.minecraft.block.BlockRedstoneRepeater;
 import net.minecraft.block.BlockRedstoneTorch;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.boss.dragon.phase.IPhase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ITickable;
@@ -217,14 +216,9 @@ public final class TrackingUtil {
         causeTracker.switchToPhase(TickPhase.Tick.TILE_ENTITY, phaseContext
                 .complete());
 
-        for (WorldServer world: SpongeImpl.getServer().worlds) {
-            if (world == worldServer) {
-                continue;
-            }
-            ((IMixinWorldServer) world).getCauseTracker().switchToPhase(GeneralPhase.State.MARKER_CROSS_WORLD, PhaseContext.start()
-                    .add(NamedCause.source(Sponge.getGame()))
-            .complete());
-        }
+        GlobalCauseTracker.getInstance().switchToPhase(GeneralPhase.State.MARKER_CROSS_WORLD, PhaseContext.start()
+                .add(NamedCause.source(Sponge.getGame()))
+                .complete(), world -> !world.equals(worldServer));
 
         mixinTileEntity.getTimingsHandler().startTiming();
         try {
@@ -232,13 +226,7 @@ public final class TrackingUtil {
         } finally {
             mixinTileEntity.getTimingsHandler().stopTiming();
             causeTracker.completePhase(TickPhase.Tick.TILE_ENTITY);
-
-            for (WorldServer world: SpongeImpl.getServer().worlds) {
-                if (world == worldServer) {
-                    continue;
-                }
-                ((IMixinWorldServer) world).getCauseTracker().completePhase(GeneralPhase.State.MARKER_CROSS_WORLD);
-            }
+            GlobalCauseTracker.getInstance().completePhase(GeneralPhase.State.MARKER_CROSS_WORLD);
         }
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/UnwindingPhaseContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/UnwindingPhaseContext.java
@@ -99,4 +99,5 @@ final class UnwindingPhaseContext extends PhaseContext {
         copy(to);
         return to;
     }
+
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/UnwindingPhaseContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/UnwindingPhaseContext.java
@@ -92,4 +92,11 @@ final class UnwindingPhaseContext extends PhaseContext {
         }
         return Optional.ofNullable(super.getSource(sourceClass).orElseGet(() -> this.unwindingContext.getSource(sourceClass).orElse(null)));
     }
+
+    @Override
+    public UnwindingPhaseContext copy() {
+        UnwindingPhaseContext to = new UnwindingPhaseContext(this.unwindingState, this.unwindingContext);
+        copy(to);
+        return to;
+    }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
@@ -99,6 +99,7 @@ import org.spongepowered.common.entity.player.tab.SpongeTabList;
 import org.spongepowered.common.event.InternalNamedCauses;
 import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.event.tracking.CauseTracker;
+import org.spongepowered.common.event.tracking.GlobalCauseTracker;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseData;
 import org.spongepowered.common.event.tracking.phase.tick.TickPhase;
@@ -196,35 +197,14 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection, IMi
             player.onUpdateEntity();
             return;
         }
-        final IMixinWorldServer mixinWorldServer = (IMixinWorldServer) player.world;
-        final CauseTracker causeTracker = mixinWorldServer.getCauseTracker();
-        causeTracker.switchToPhase(TickPhase.Tick.PLAYER, PhaseContext.start()
+        GlobalCauseTracker.getInstance().switchToPhase(TickPhase.Tick.PLAYER, PhaseContext.start()
                 .add(NamedCause.source(player))
                 .addCaptures()
                 .addEntityDropCaptures()
                 //.addBlockCaptures()
                 .complete());
-        for (WorldServer worldServer : WorldManager.getWorlds()) {
-            if (worldServer == mixinWorldServer) { // we don't care about entering the phase for this world server of which we already entered
-                continue;
-            }
-            final IMixinWorldServer otherMixinWorldServer = (IMixinWorldServer) worldServer;
-            otherMixinWorldServer.getCauseTracker().switchToPhase(TickPhase.Tick.PLAYER, PhaseContext.start()
-                    .add(NamedCause.source(player))
-                    .addCaptures()
-                    .addEntityDropCaptures()
-                    //.addBlockCaptures()
-                    .complete());
-        }
         player.onUpdateEntity();
-        causeTracker.completePhase(TickPhase.Tick.PLAYER);
-        for (WorldServer worldServer : WorldManager.getWorlds()) {
-            if (worldServer == mixinWorldServer) { // we don't care about entering the phase for this world server of which we already entered
-                continue;
-            }
-            final IMixinWorldServer otherMixinWorldServer = (IMixinWorldServer) worldServer;
-            otherMixinWorldServer.getCauseTracker().completePhase(TickPhase.Tick.PLAYER);
-        }
+        GlobalCauseTracker.getInstance().completePhase(TickPhase.Tick.PLAYER);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/scheduler/SyncScheduler.java
+++ b/src/main/java/org/spongepowered/common/scheduler/SyncScheduler.java
@@ -24,15 +24,10 @@
  */
 package org.spongepowered.common.scheduler;
 
-import net.minecraft.world.WorldServer;
 import org.spongepowered.api.event.cause.NamedCause;
-import org.spongepowered.common.event.InternalNamedCauses;
-import org.spongepowered.common.event.tracking.CauseTracker;
+import org.spongepowered.common.event.tracking.GlobalCauseTracker;
 import org.spongepowered.common.event.tracking.PhaseContext;
-import org.spongepowered.common.event.tracking.phase.general.GeneralPhase;
 import org.spongepowered.common.event.tracking.phase.plugin.PluginPhase;
-import org.spongepowered.common.interfaces.world.IMixinWorldServer;
-import org.spongepowered.common.world.WorldManager;
 
 public class SyncScheduler extends SchedulerBase {
 
@@ -73,18 +68,13 @@ public class SyncScheduler extends SchedulerBase {
 
     @Override
     protected void executeTaskRunnable(ScheduledTask task, Runnable runnable) {
-        for (WorldServer worldServer : WorldManager.getWorlds()) {
-            final CauseTracker otherCauseTracker = ((IMixinWorldServer) worldServer).getCauseTracker();
-            otherCauseTracker.switchToPhase(PluginPhase.State.SCHEDULED_TASK, PhaseContext.start()
-                    .add(NamedCause.source(task))
-                    .addCaptures()
-                    .complete()
-            );
-        }
+        GlobalCauseTracker.getInstance().switchToPhase(PluginPhase.State.SCHEDULED_TASK, PhaseContext.start()
+                .add(NamedCause.source(task))
+                .addCaptures()
+                .complete()
+        );
         runnable.run();
-        for (WorldServer worldServer : WorldManager.getWorlds()) {
-            ((IMixinWorldServer) worldServer).getCauseTracker().completePhase(PluginPhase.State.SCHEDULED_TASK);
-        }
+        GlobalCauseTracker.getInstance().completePhase(PluginPhase.State.SCHEDULED_TASK);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/WorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/WorldManager.java
@@ -68,6 +68,7 @@ import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.config.SpongeConfig;
 import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.data.util.NbtDataUtil;
+import org.spongepowered.common.event.tracking.GlobalCauseTracker;
 import org.spongepowered.common.interfaces.IMixinIntegratedServer;
 import org.spongepowered.common.interfaces.IMixinMinecraftServer;
 import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayerMP;
@@ -816,6 +817,7 @@ public final class WorldManager {
         // Set the worlds on the Minecraft server
         reorderWorldsVanillaFirst();
 
+        GlobalCauseTracker.getInstance().addWorld(worldServer);
         SpongeImpl.postEvent(SpongeEventFactory.createLoadWorldEvent(Cause.of(NamedCause.source(Sponge.getServer())),
                 (org.spongepowered.api.world.World) worldServer));
         ((IMixinMinecraftServer) server).prepareSpawnArea(worldServer);


### PR DESCRIPTION
`CauseTracker`s are specific to each world. This doesn't change that.

However, sometimes some code needs to track not just one world, but all worlds. Previously, it would look like this:
```java
for (WorldServer world : WorldManager.getWorlds()) {
    ((IMixinWorldServer) world).getCauseTracker().switchToPhase(/* ... */);
}

// code to track goes here

for (WorldServer world : WorldManager.getWorlds()) {
    ((IMixinWorldServer) world).getCauseTracker().completePhase(/* ... */);
}
```

But what happens when, during one of these states, a plugin loads a new world?
```java
Sponge.getServer().loadWorld("testcaseworld");
```

The server crashes.

The initial code tracks all worlds by looping through them before and after. But if a world is loaded in the meantime, then it's never tracked. Even worse, when the "global phase" ends, the tracking code tries to complete it in all worlds... even the new world in which it was never started.

`GlobalCauseTracker` fixes that. It manages its own phase stack (by using common code moved from `CauseTracker` into a new base class, `BaseCauseTracker`) and applies phase changes to all worlds. In addition, whenever a new world is loaded, the global phases are *automatically applied to that world.* It currently doesn't stop tracking a world when that world is unloaded, but that won't cause a crash, and I can add behavior for that fairly quickly if necessary.

Fixes #1256.