### PR TITLE
[API 5.2] Fix incorrect command permission checks in some situations.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ ext.apiVersion = version
 
 dependencies {
     compile api
-    compile('org.spongepowered:mixin:0.6.6-SNAPSHOT') {
+    compile('org.spongepowered:mixin:0.6.8-SNAPSHOT') {
         exclude module: 'launchwrapper'
     }
 

--- a/src/main/java/org/spongepowered/common/command/MinecraftCommandWrapper.java
+++ b/src/main/java/org/spongepowered/common/command/MinecraftCommandWrapper.java
@@ -47,11 +47,11 @@ import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.common.interfaces.command.IMixinCommandBase;
 import org.spongepowered.common.interfaces.command.IMixinCommandHandler;
 import org.spongepowered.common.text.translation.SpongeTranslation;
 import org.spongepowered.common.util.VecHelper;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,10 +61,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 /**
  * Wrapper around ICommands so they fit into the Sponge command system.
  */
 public class MinecraftCommandWrapper implements CommandCallable {
+
     private static final String TRANSLATION_NO_PERMISSION = "commands.generic.permission";
     private final PluginContainer owner;
     protected final ICommand command;
@@ -81,6 +84,11 @@ public class MinecraftCommandWrapper implements CommandCallable {
     public MinecraftCommandWrapper(final PluginContainer owner, final ICommand command) {
         this.owner = owner;
         this.command = command;
+
+        // Add the namespaced alias to the wrapped command so permission checks are sent to the right command.
+        if (this.command instanceof IMixinCommandBase) {
+            ((IMixinCommandBase) this.command).updateNamespacedAlias(this.owner.getId());
+        }
     }
 
     private String[] splitArgs(String arguments) {

--- a/src/main/java/org/spongepowered/common/interfaces/command/IMixinCommandBase.java
+++ b/src/main/java/org/spongepowered/common/interfaces/command/IMixinCommandBase.java
@@ -30,4 +30,6 @@ public interface IMixinCommandBase {
 
     void setExpandedSelector(boolean expandedSelector);
 
+    void updateNamespacedAlias(String ownerId);
+
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandBase.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandBase.java
@@ -25,13 +25,20 @@
 package org.spongepowered.common.mixin.core.command;
 
 import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommand;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.common.interfaces.command.IMixinCommandBase;
 
+import javax.annotation.Nullable;
+
 @Mixin(CommandBase.class)
-public abstract class MixinCommandBase implements IMixinCommandBase {
+public abstract class MixinCommandBase implements IMixinCommandBase, ICommand {
 
     private boolean expandedSelector;
+    @Nullable private String namespacedAlias = null;
 
     @Override
     public boolean isExpandedSelector() {
@@ -41,6 +48,17 @@ public abstract class MixinCommandBase implements IMixinCommandBase {
     @Override
     public void setExpandedSelector(boolean expandedSelector) {
         this.expandedSelector = expandedSelector;
+    }
+
+    @Override
+    public void updateNamespacedAlias(String ownerId) {
+        this.namespacedAlias = ownerId + ":" + getCommandName();
+    }
+
+    @Redirect(method = "checkPermission",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/command/CommandBase;getCommandName()Ljava/lang/String;"))
+    private String onCheckPermissionGetNameCall(CommandBase thisObject) {
+        return this.namespacedAlias == null ? getCommandName() : this.namespacedAlias;
     }
 
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayer.java
@@ -391,7 +391,7 @@ public abstract class MixinEntityPlayer extends MixinEntityLivingBase implements
      */
     @Overwrite
     @Nullable
-    protected ItemStack dropItemAndGetStack(EntityItem p_184816_1_) {
+    public ItemStack dropItemAndGetStack(EntityItem p_184816_1_) {
         this.worldObj.spawnEntityInWorld(p_184816_1_);
         return p_184816_1_.getEntityItem();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinMinecraftServer.java
@@ -363,7 +363,7 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, IMi
      * generate spawn on server start. I enforce that here.
      */
     @Overwrite
-    protected void initialWorldChunkLoad() {
+    public void initialWorldChunkLoad() {
         for (WorldServer worldServer: this.worldServers) {
             this.prepareSpawnArea(worldServer);
         }
@@ -697,7 +697,7 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, IMi
      * @param dontLog Whether to log during saving
      */
     @Overwrite
-    protected void saveAllWorlds(boolean dontLog)
+    public void saveAllWorlds(boolean dontLog)
     {
         for (WorldServer worldserver : this.worldServers)
         {


### PR DESCRIPTION
[Original Issue](https://github.com/SpongePowered/SpongeCommon/issues/1243) | [Original PR on bleeding](https://github.com/SpongePowered/SpongeCommon/pull/1249)

For context, please see the linked issue and PR for bleeding above. The second commit is a cherry pick from bleeding, with method names updated to fit with 1.10.2. It has been tested to ensure it works.

This PR also contains a commit to bump Mixin to 0.6.8-SNAPSHOT, required for my `@Redirect`. The commit fixes the visibility of methods that Mixin now checks for, ensuring that Sponge will still compile.