### PR TITLE
Fix erroneous behavior when inventory interaction is cancelled and inventory is closed

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketFunction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketFunction.java
@@ -691,9 +691,9 @@ public interface PacketFunction {
                 PacketPhaseUtil.handleCustomCursor(player, inventoryEvent.getCursorTransaction().getOriginal());
 
                 // Restore target slots
-                PacketPhaseUtil.handleSlotRestore(player, inventoryEvent.getTransactions(), true, inventoryEvent);
+                PacketPhaseUtil.handleSlotRestore(player, openContainer, inventoryEvent.getTransactions(), true, inventoryEvent);
             } else {
-                PacketPhaseUtil.handleSlotRestore(player, inventoryEvent.getTransactions(), false, inventoryEvent);
+                PacketPhaseUtil.handleSlotRestore(player, openContainer, inventoryEvent.getTransactions(), false, inventoryEvent);
 
                 // Custom cursor
                 if (inventoryEvent.getCursorTransaction().getCustom().isPresent()) {
@@ -821,11 +821,12 @@ public interface PacketFunction {
                 new ImmutableList.Builder<SlotTransaction>().add(sourceTransaction).add(targetTransaction).build();
         final ChangeInventoryEvent.Held changeInventoryEventHeld = SpongeEventFactory
                 .createChangeInventoryEventHeld(Cause.of(NamedCause.source(player)), (Inventory) inventoryContainer, transactions);
+        Container openContainer = player.openContainer;
         SpongeImpl.postEvent(changeInventoryEventHeld);
         if (changeInventoryEventHeld.isCancelled()) {
             player.connection.sendPacket(new SPacketHeldItemChange(previousSlot));
         } else {
-            PacketPhaseUtil.handleSlotRestore(player, changeInventoryEventHeld.getTransactions(), false, false);
+            PacketPhaseUtil.handleSlotRestore(player, openContainer, changeInventoryEventHeld.getTransactions(), false, false);
             inventory.currentItem = itemChange.getSlotId();
             player.markPlayerActive();
         }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -43,13 +43,13 @@ import java.util.List;
 
 public final class PacketPhaseUtil {
 
-    public static void handleSlotRestore(EntityPlayerMP player, List<SlotTransaction> slotTransactions, boolean eventCancelled, Event event) {
+    public static void handleSlotRestore(EntityPlayerMP player, Container openContainer, List<SlotTransaction> slotTransactions, boolean eventCancelled, Event event) {
         // We always need to force resync for shift click events, since a previous event cancellation could have caused a desync
         // (if the event is from a shift double click)c
-        handleSlotRestore(player, slotTransactions, eventCancelled, event instanceof ClickInventoryEvent.Shift);
+        handleSlotRestore(player, openContainer, slotTransactions, eventCancelled, event instanceof ClickInventoryEvent.Shift);
     }
 
-    public static void handleSlotRestore(EntityPlayerMP player, List<SlotTransaction> slotTransactions, boolean eventCancelled, boolean forceResync) {
+    public static void handleSlotRestore(EntityPlayerMP player, Container openContainer, List<SlotTransaction> slotTransactions, boolean eventCancelled, boolean forceResync) {
         for (SlotTransaction slotTransaction : slotTransactions) {
 
             if ((!slotTransaction.getCustom().isPresent() && slotTransaction.isValid()) && !eventCancelled) {
@@ -68,14 +68,15 @@ public final class PacketPhaseUtil {
                 slot.offer((org.spongepowered.api.item.inventory.ItemStack) originalStack);
             }*/
 
-            final Slot nmsSlot = player.openContainer.getSlot(slotNumber);
+            final Slot nmsSlot = openContainer.getSlot(slotNumber);
             if (nmsSlot != null) {
                 nmsSlot.putStack(originalStack);
             }
         }
-        player.openContainer.detectAndSendChanges();
-        if (forceResync) {
-            player.sendContainerToPlayer(player.openContainer);
+        openContainer.detectAndSendChanges();
+        // we must validate the player still has the same container open after the event has been processed
+        if (forceResync && player.openContainer == openContainer) {
+            player.sendContainerToPlayer(openContainer);
         }
     }
 


### PR DESCRIPTION
This commit replaces references to the player's open inventory when rolling back a cancelled `ClickInventoryEvent`, instead using a new `Container` parameter (added to relevant methods) which is guaranteed to contain the `Container` being interacted with.

The reason for this change is that `Player#openInventory` is not guaranteed to represent the `Container` being interacted with in the event, as said `Container` can be closed or another one opened while propagating the event to Sponge mods. This change guarantees that the correct `Container` is referenced when rolling back the event.

This PR should resolve #1045, #1166, #1175, and #1229.

Because the described bug exists in `stable-5` and an automatic merge should be possible, I would recommend that it be backported after being merged into `bleeding`.