### PR TITLE
Bugfix: getting registered DimensionType by type id.

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinDimensionType.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinDimensionType.java
@@ -132,7 +132,7 @@ public abstract class MixinDimensionType implements IMixinDimensionType {
      * their ids 1:1, this is a safe change that ensures a mixup can't happen.
      */
     @Overwrite
-    public static DimensionType getById(int dimensionId) {
-        return WorldManager.getDimensionType(dimensionId).orElseThrow(() -> new IllegalArgumentException("Invalid dimension id " + dimensionId));
+    public static DimensionType getById(int dimensionTypeId) {
+        return WorldManager.getDimensionTypeByTypeId(dimensionTypeId).orElseThrow(() -> new IllegalArgumentException("Invalid dimension id " + dimensionTypeId));
     }
 }

--- a/src/main/java/org/spongepowered/common/world/WorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/WorldManager.java
@@ -234,6 +234,10 @@ public final class WorldManager {
         return Optional.ofNullable(dimensionTypeByDimensionId.get(dimensionId));
     }
 
+    public static Optional<DimensionType> getDimensionTypeByTypeId(int dimensionTypeId) {
+        return Optional.ofNullable(dimensionTypeByTypeId.get(dimensionTypeId));
+    }
+
     public static Optional<DimensionType> getDimensionType(Class<? extends WorldProvider> providerClass) {
         checkNotNull(providerClass);
         for (Object rawDimensionType : dimensionTypeByTypeId.values()) {
@@ -258,7 +262,7 @@ public final class WorldManager {
     }
 
     public static int[] getRegisteredDimensionIds() {
-        return dimensionTypeByTypeId.keySet().toIntArray();
+        return dimensionTypeByDimensionId.keySet().toIntArray();
     }
 
     public static Path getWorldFolder(DimensionType dimensionType, int dimensionId) {


### PR DESCRIPTION
See https://github.com/SpongePowered/SpongeForge/issues/1429

This helps compatibility with Forge mods using vanilla DimensionType and Forge's DimensionManager.

I've done a [search](https://github.com/search?q=org%3ASpongePowered+getRegisteredDimensionIds&type=Code) and the only place ```WorldManager.getRegisteredDimensionIds()``` is referenced in Sponge code is from Forge's DimensionManager.