### PR TITLE
Fix pagination styling issue and clean up class a little

### DIFF
--- a/src/main/java/org/spongepowered/common/command/SpongeHelpCommand.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeHelpCommand.java
@@ -77,7 +77,8 @@ public class SpongeHelpCommand {
                 }
 
                 PaginationList.Builder builder = SpongeImpl.getGame().getServiceManager().provide(PaginationService.class).get().builder();
-                builder.title(Text.builder("Available commands:").color(TextColors.DARK_GREEN).build());
+                builder.title(Text.of(TextColors.DARK_GREEN, "Available commands:"));
+                builder.padding(Text.of(TextColors.DARK_GREEN, "="));
 
                 TreeSet<CommandMapping> commands = new TreeSet<>(COMMAND_COMPARATOR);
                 commands.addAll(Collections2.filter(SpongeImpl.getGame().getCommandManager().getAll().values(), input -> input.getCallable()

--- a/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
@@ -198,8 +198,8 @@ abstract class ActivePagination {
             ret.append(Text.of("»"));
         }
         if (this.title != null) {
-            ret.color(this.title.getColor());
-            ret.style(this.title.getStyle());
+            ret.color(this.padding.getColor());
+            ret.style(this.padding.getStyle());
         }
         return ret.build();
     }

--- a/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
@@ -199,7 +199,9 @@ abstract class ActivePagination {
         }
         if (this.padding != null) {
             ret.color(this.padding.getColor());
-            ret.style(this.padding.getStyle());
+        }
+        if (this.title != null) {
+            ret.style(this.title.getStyle());
         }
         return ret.build();
     }

--- a/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
@@ -197,7 +197,7 @@ abstract class ActivePagination {
             }
             ret.append(Text.of("»"));
         }
-        if (this.title != null) {
+        if (this.padding != null) {
             ret.color(this.padding.getColor());
             ret.style(this.padding.getStyle());
         }

--- a/src/main/java/org/spongepowered/common/service/pagination/PaginationCalculator.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/PaginationCalculator.java
@@ -46,9 +46,11 @@ import java.util.List;
 import java.util.PrimitiveIterator;
 
 /**
- * Pagination calculator for players.
+ * Pagination calculator for players. Handles calculation of text widths,
+ * centering text, adding padding, adding spacing, and more.
  */
-public class PaginationCalculator {
+class PaginationCalculator {
+
     private static final String NON_UNICODE_CHARS;
     private static final int[] NON_UNICODE_CHAR_WIDTHS;
     private static final byte[] UNICODE_CHAR_WIDTHS;
@@ -56,7 +58,12 @@ public class PaginationCalculator {
 
     private final int linesPerPage;
 
-    public PaginationCalculator(int linesPerPage) {
+    /**
+     * Constructs a new pagination calculator.
+     *
+     * @param linesPerPage The amount of lines per page there should be
+     */
+    PaginationCalculator(int linesPerPage) {
         this.linesPerPage = linesPerPage;
     }
 
@@ -75,7 +82,6 @@ public class PaginationCalculator {
             }
             NON_UNICODE_CHAR_WIDTHS = nonUnicodeCharWidths;
 
-
             List<? extends ConfigurationNode> glyphWidths = node.getNode("glyph-widths").getChildrenList();
             byte[] unicodeCharWidths = new byte[glyphWidths.size()];
             for (int i = 0; i < unicodeCharWidths.length; ++i) {
@@ -87,28 +93,36 @@ public class PaginationCalculator {
         }
     }
 
-    public int getLinesPerPage(MessageReceiver source) {
+    int getLinesPerPage(MessageReceiver source) {
         return this.linesPerPage;
     }
 
     /**
+     * Gets the number of lines the specified text flows into.
      *
-     * @param text
-     * @return the number of lines that this text flows into.
+     * @param text The text to calculate the number of lines for
+     * @return The number of lines that this text flows into
      */
-    public int getLines(Text text) {
+    int getLines(Text text) {
         //TODO: this needs fixing as well.
         return (int) Math.ceil((double) this.getWidth(text) / LINE_WIDTH);
     }
 
+    /**
+     * Gets the width of a character with the specified code
+     * point, accounting for if its text is bold our not.
+     *
+     * @param codePoint The code point of the character
+     * @param isBold Whether or not the character is bold or not
+     * @return The width of the character at the code point
+     */
     @VisibleForTesting
     int getWidth(int codePoint, boolean isBold) {
         int nonUnicodeIdx = NON_UNICODE_CHARS.indexOf(codePoint);
         int width;
         if (codePoint == 32) {
             width = 4;
-        }
-        else if (codePoint > 0 && nonUnicodeIdx != -1) {
+        } else if (codePoint > 0 && nonUnicodeIdx != -1) {
             width = NON_UNICODE_CHAR_WIDTHS[nonUnicodeIdx];
         } else if (UNICODE_CHAR_WIDTHS[codePoint] != 0) {
             //from 1.9 & 255 to avoid strange signed int math ruining things.
@@ -127,20 +141,24 @@ public class PaginationCalculator {
             // font however there is a int math vs float math bug in the Minecraft FontRenderer.
             //The float math is adjusted for rendering, they attempt to do the same thing for calculating string widths
             //using integer math, this has potential rounding errors, but we should copy it and use ints as well.
-            width = (width / 2)+1;
+            width = (width / 2) + 1;
         } else {
             width = 0;
         }
         //if bolded width gets 1 added.
-        if(isBold && width > 0) width = width + 1;
+        if(isBold && width > 0) {
+            width = width + 1;
+        }
 
         return width;
     }
 
     /**
-     * compute the width of a given text
-     * @param text
-     * @return the number of character pixels/columns the line takes up
+     * Calculates the width of a given text as the number of character
+     * pixels/columns the line takes up.
+     *
+     * @param text The text to get the width of
+     * @return The amount of character pixels/columns the text takes up
      */
     @VisibleForTesting
     int getWidth(Text text) {
@@ -156,9 +174,7 @@ public class PaginationCalculator {
                 continue;
             }
 
-            boolean bold = child
-                    .getStyle()
-                    .getBold();
+            boolean bold = child.getStyle().getBold();
 
             Integer cp;
             boolean newLine = false;
@@ -184,45 +200,49 @@ public class PaginationCalculator {
     }
 
     /**
-     * Center a text in the middle of the chat box
-     * @param text or 0 width text for no heading
-     * @param padding a >1 width padding character
-     * @return the centered text, or if too big, the original text.
+     * Centers a text within the middle of the chat box.
+     *
+     * <p>Generally used for titles and footers.</p>
+     *
+     * <p>To use no heading, just pass in a 0 width text for
+     * the first argument.</p>
+     *
+     * @param text The text to center
+     * @param padding A padding character with a width >1
+     * @return The centered text, or if too big, the original text
      */
     //TODO: Probably should completely rewrite this to not compute padding, but loop until the padding is done, unless
     //we can get accurate computation of padding ahead of time.
-    public Text center(Text text, Text padding) {
-        int inputLength = this.getWidth(text);
+    Text center(Text text, Text padding) {
+        int inputLength = getWidth(text);
         //Minecraft breaks lines when the next character would be > then LINE_WIDTH, this seems most graceful way to fail
         if (inputLength >= LINE_WIDTH) {
             return text;
         }
-        Text styledSpace = this.withStyle(LiteralText.of(" "), text);
-        Text textWithSpaces = this.addSpaces(styledSpace, text);
+        final Text textWithSpaces = addSpaces(LiteralText.of(" "), text);
 
         //Minecraft breaks lines when the next character would be > then LINE_WIDTH
         boolean addSpaces = getWidth(textWithSpaces) <= LINE_WIDTH;
 
         //TODO: suspect, why are we changing the style of the padding, they may want different styles on the padding.
-        int paddingLength = this.getWidth(this.withStyle(padding, text));
-        final Text.Builder output =  Text.builder();
+        Text styledPadding = withStyle(padding, text);
+        int paddingLength = getWidth(styledPadding);
+        final Text.Builder output = Text.builder();
 
         //Using 0 width unicode symbols as padding throws us into an unending loop, replace them with the default padding
         if(paddingLength < 1) {
-            Text defaultPadding = Text.of("=");
-            padding = defaultPadding;
-            paddingLength = this.getWidth(this.withStyle(defaultPadding, text));
+            padding = Text.of("=");
+            styledPadding = withColor(withStyle(padding, text), text);
+            paddingLength = getWidth(styledPadding);
         }
-
-        Text styledPadding = this.withStyle(padding, text);
 
         //if we only need padding
         if (inputLength == 0) {
-            this.addPadding(padding, output, GenericMath.floor((double) LINE_WIDTH / paddingLength));
+            addPadding(padding, output, GenericMath.floor((double) LINE_WIDTH / paddingLength));
         } else {
             if(addSpaces) {
                 text = textWithSpaces;
-                inputLength = this.getWidth(textWithSpaces);
+                inputLength = getWidth(textWithSpaces);
             }
 
             int paddingNecessary = LINE_WIDTH - inputLength;
@@ -231,34 +251,81 @@ public class PaginationCalculator {
             //pick a halfway point
             int beforePadding = GenericMath.floor(paddingCount / 2.0);
             //Do not use ceil, this prevents floating point errors.
-            int afterPadding = paddingCount-beforePadding;
+            int afterPadding = paddingCount - beforePadding;
 
-            this.addPadding(styledPadding, output, beforePadding);
+            addPadding(styledPadding, output, beforePadding);
             output.append(text);
-            this.addPadding(styledPadding, output, afterPadding);
+            addPadding(styledPadding, output, afterPadding);
         }
 
         return this.finalizeBuilder(text, output);
     }
 
+    /**
+     * Gives the first text argument the style of the second.
+     *
+     * @param text The text to stylize
+     * @param styled The styled text
+     * @return The original text now stylized
+     */
     private Text withStyle(Text text, Text styled) {
-        return text.toBuilder().color(styled.getColor()).style(styled.getStyle()).build();
+        return text.toBuilder()
+                .style(styled.getStyle())
+                .build();
     }
 
+    /**
+     * Gives the first text argument the color of the second.
+     *
+     * @param text The text to color
+     * @param colored The colored text
+     * @return The original text now colored
+     */
+    private Text withColor(Text text, Text colored) {
+        return text.toBuilder()
+                .color(colored.getColor())
+                .build();
+    }
+
+    /**
+     * Finalizes the builder used in centering text.
+     *
+     * @param text The text to get the style from
+     * @param build The work in progress text builder
+     * @return The finalized, properly styled text.
+     */
     private Text finalizeBuilder(Text text, Text.Builder build) {
-        build.color(text.getColor())
-            .style(text.getStyle());
-        return build.build();
+        return build.style(text.getStyle()).build();
     }
 
+    /**
+     * Adds spaces to both sides of the specified text.
+     *
+     * <p>Overrides all color and style with the
+     * text's color and style.</p>
+     *
+     * @param spaces The spaces to use
+     * @param text The text to add to
+     * @return The text with the added spaces
+     */
     private Text addSpaces(Text spaces, Text text) {
-        Text.Builder build = Text.builder().color(text.getColor()).style(text.getStyle());
-        build.append(spaces);
-        build.append(text);
-        build.append(spaces);
-        return build.build();
+        return Text.builder()
+                .append(spaces)
+                .append(text)
+                .append(spaces)
+                .color(text.getColor())
+                .style(text.getStyle())
+                .build();
     }
 
+    /**
+     * Adds the specified padding text to a piece of text being built
+     * up to a certain amount specified by a count.
+     *
+     * @param padding The padding text to use
+     * @param build The work in progress text to add to
+     * @param count The amount of padding to add
+     */
     private void addPadding(Text padding, Text.Builder build, int count) {
         if (count > 0) {
             build.append(Collections.nCopies(count, padding));


### PR DESCRIPTION
This pull request accomplishes a few things. First of all it fixes the issue where the color of the title/header/footer overrides the color the padding. So a paginated list will go from this: 

![image](https://cloud.githubusercontent.com/assets/18372958/25684424/fd2242cc-3026-11e7-9693-85991dc9f7fe.png)
to this as it should:
![image](https://cloud.githubusercontent.com/assets/18372958/25684430/04c2f350-3027-11e7-9557-6ad74a14e6af.png)

To accomplish this and keep the arrows(« 1/2 »)  colored, I used the padding color instead of the title color which seems to work better actually anyway as they reside right next to the padding. Doing this made me think in the API we should allow this color to be specified on its own.

I had to modify Sponge's help command as well so it would keep its padding color. 

I also cleaned up some the pagination calculator in general, and while I was at it cleaned up some of the Javadocs and added some other ones.

Fixes https://github.com/SpongePowered/SpongeCommon/issues/1153