### PR TITLE
Fix a thread safety problem which may occur in SpongeEventManager

### DIFF
--- a/src/main/java/org/spongepowered/common/event/SpongeEventManager.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeEventManager.java
@@ -168,19 +168,19 @@ public class SpongeEventManager implements EventManager {
     }
 
     private void register(List<RegisteredListener<? extends Event>> handlers) {
-        synchronized (this.lock) {
-            boolean changed = false;
+        boolean changed = false;
 
+        synchronized (this.lock) {
             for (RegisteredListener<?> handler : handlers) {
                 if (this.handlersByEvent.put(handler.getEventClass(), handler)) {
                     changed = true;
                     this.checker.registerListenerFor(handler.getEventClass());
                 }
             }
+        }
 
-            if (changed) {
-                this.handlersCache.invalidateAll();
-            }
+        if (changed) {
+            this.handlersCache.invalidateAll();
         }
     }
 
@@ -301,9 +301,9 @@ public class SpongeEventManager implements EventManager {
     }
 
     private void unregister(Predicate<RegisteredListener<?>> unregister) {
-        synchronized (this.lock) {
-            boolean changed = false;
+        boolean changed = false;
 
+        synchronized (this.lock) {
             Iterator<RegisteredListener<?>> itr = this.handlersByEvent.values().iterator();
             while (itr.hasNext()) {
                 RegisteredListener<?> handler = itr.next();
@@ -313,10 +313,10 @@ public class SpongeEventManager implements EventManager {
                     this.checker.unregisterListenerFor(handler.getEventClass());
                 }
             }
+        }
 
-            if (changed) {
-                this.handlersCache.invalidateAll();
-            }
+        if (changed) {
+            this.handlersCache.invalidateAll();
         }
     }
 


### PR DESCRIPTION
There is a thread safety problem in `SpongeEventManager`, and it could cause dead locks.
Here is a typical crash log: <http://paste.ubuntu.com/24604406/>

The reason is that, on one hand, when a thread tries to post a event, it locks the `LoadingCache` provided by Caffeine first to get something, and then the `CacheLoader` callback tries to lock the `lock` field in `SpongeEventManager`, on the other hand, another thread which wants to register/unregister events locks the `lock` field first, and then tries to lock the `LoadingCache` in order to make all the caches invalid.

After browsing through the relevant code, I found that the lock before calling the `invalidateAll` method of `LoadingCache` is unnecessary. The operation of the `LoadingCache` is thread safe and the call to the method can be done after the lock is released.

That's all of what this Pull Request does.