### PR TITLE
Use TeleportCauses.PLUGIN for plugin-caused teleports.

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/phase/plugin/PluginPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/plugin/PluginPhase.java
@@ -29,6 +29,9 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldServer;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
+import org.spongepowered.api.event.cause.entity.teleport.TeleportCause;
+import org.spongepowered.api.event.cause.entity.teleport.TeleportTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.common.entity.PlayerTracker;
 import org.spongepowered.common.event.tracking.CauseTracker;
@@ -47,6 +50,7 @@ public final class PluginPhase extends TrackingPhase {
         public static final IPhaseState CUSTOM_SPAWN = new PluginPhaseState();
         public static final IPhaseState CUSTOM_EXPLOSION = new CustomExplosionState();
         public static final IPhaseState SCHEDULED_TASK = new ScheduledTaskPhaseState();
+        public static final IPhaseState TELEPORT = new PluginPhaseState();
 
         private State() {
         }
@@ -109,6 +113,11 @@ public final class PluginPhase extends TrackingPhase {
         if (state instanceof ListenerPhaseState) {
             ((ListenerPhaseState) state).capturePlayerUsingStackToBreakBlocks(context, playerMP, itemStack);
         }
+    }
+
+    @Override
+    public Cause generateTeleportCause(IPhaseState state, PhaseContext context) {
+        return Cause.of(NamedCause.source(TeleportCause.builder().type(TeleportTypes.PLUGIN).build()));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -118,6 +118,9 @@ import org.spongepowered.common.event.ShouldFire;
 import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.event.damage.DamageEventHandler;
 import org.spongepowered.common.event.damage.MinecraftBlockDamageSource;
+import org.spongepowered.common.event.tracking.CauseTracker;
+import org.spongepowered.common.event.tracking.PhaseContext;
+import org.spongepowered.common.event.tracking.phase.plugin.PluginPhase;
 import org.spongepowered.common.interfaces.block.IMixinBlock;
 import org.spongepowered.common.interfaces.data.IMixinCustomDataHolder;
 import org.spongepowered.common.interfaces.entity.IMixinEntity;
@@ -457,8 +460,11 @@ public abstract class MixinEntity implements IMixinEntity {
             return false;
         }
 
+        CauseTracker.getInstance().switchToPhase(PluginPhase.State.TELEPORT, PhaseContext.start().complete());
+
         MoveEntityEvent.Teleport event = EntityUtil.handleDisplaceEntityTeleportEvent((net.minecraft.entity.Entity) (Object) this, location);
         if (event.isCancelled()) {
+            CauseTracker.getInstance().completePhase(PluginPhase.State.TELEPORT);
             return false;
         }
         location = event.getToTransform().getLocation();
@@ -499,6 +505,7 @@ public abstract class MixinEntity implements IMixinEntity {
         }
 
         chunkProviderServer.setForceChunkRequests(false);
+        CauseTracker.getInstance().completePhase(PluginPhase.State.TELEPORT);
         return true;
     }
 


### PR DESCRIPTION
Fixes SpongePowered#1377.