### PR TITLE
Allow reregistration in unregisterPluginListeners().

### DIFF
--- a/src/main/java/org/spongepowered/common/event/SpongeEventManager.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeEventManager.java
@@ -311,6 +311,7 @@ public class SpongeEventManager implements EventManager {
                     itr.remove();
                     changed = true;
                     this.checker.unregisterListenerFor(handler.getEventClass());
+                    this.registeredListeners.remove(handler.getHandle());
                 }
             }
         }
@@ -324,7 +325,6 @@ public class SpongeEventManager implements EventManager {
     public void unregisterListeners(final Object listener) {
         checkNotNull(listener, "listener");
         unregister(handler -> listener.equals(handler.getHandle()));
-        this.registeredListeners.remove(listener);
     }
 
     @Override


### PR DESCRIPTION
I'm working on a unit testing framework for Sponge, and it would be pretty useful for me to be able to prevent one test from receiving events from another test. However, I unregister the listeners using `unregisterPluginListeners()`, and I get an error when trying to reregister them since the event manager still thinks the objects are registered. This PR fixes that.