### PR TITLE
Replace a hacky (and now broken) client-side test to allow connecting to external servers.

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/tracking/world/MixinChunk_Tracker.java
+++ b/src/main/java/org/spongepowered/common/mixin/tracking/world/MixinChunk_Tracker.java
@@ -55,7 +55,6 @@ import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.phase.generation.GenerationPhase;
 import org.spongepowered.common.interfaces.IMixinChunk;
 import org.spongepowered.common.interfaces.world.IMixinWorldInfo;
-import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 import org.spongepowered.common.profile.SpongeProfileManager;
 import org.spongepowered.common.util.SpongeHooks;
 import org.spongepowered.common.util.SpongeUsernameCache;
@@ -95,7 +94,7 @@ public abstract class MixinChunk_Tracker implements Chunk, IMixinChunk {
     @Final // need this constructor to never be overwritten by anything.
     @Inject(method = "<init>(Lnet/minecraft/world/World;II)V", at = @At("RETURN"), remap = false)
     public void onConstructedTracker(World world, int x, int z, CallbackInfo ci) {
-        if (((org.spongepowered.api.world.World)world).getUniqueId() != null) { // Client worlds have no UUID
+        if (!world.isRemote) {
             this.spongeProfileManager = ((SpongeProfileManager) Sponge.getServer().getGameProfileManager());
             this.userStorageService = SpongeImpl.getGame().getServiceManager().provide(UserStorageService.class).get();
         }


### PR DESCRIPTION
This assumption was broken with 5470f0e613bad359c32d50d3da3f04eec47c9a82. It resulted in an `IllegalStateException` from trying to grab the `Server` below whenever someone tries to connect to an external server. This PR fixes that.