### PR TITLE
Add method to get the precipitation level of a column

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinChunk.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinChunk.java
@@ -173,6 +173,7 @@ public abstract class MixinChunk implements Chunk, IMixinChunk, IMixinCachable {
     List<T> listToFill, Predicate <? super T > p_177430_4_);
     @Shadow private void propagateSkylightOcclusion(int x, int z) { };
     @Shadow private void relightBlock(int x, int y, int z) { };
+    @Shadow public abstract BlockPos getPrecipitationHeight(BlockPos pos);
     // @formatter:on
 
     @Inject(method = "<init>(Lnet/minecraft/world/World;II)V", at = @At("RETURN"), remap = false)
@@ -379,6 +380,11 @@ public abstract class MixinChunk implements Chunk, IMixinChunk, IMixinCachable {
 
     public double getHighestYAt(double x, double z) {
         return this.sponge_world.getHighestYAt(this.xPosition << 4 + ((int)x & 15), this.zPosition << 4 + ((int)z & 15));
+    }
+
+    @Override
+    public int getPrecipitationLevel(int x, int z) {
+        return this.getPrecipitationHeight(new BlockPos(x, 0, z)).getY();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinChunk.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinChunk.java
@@ -383,7 +383,7 @@ public abstract class MixinChunk implements Chunk, IMixinChunk, IMixinCachable {
     }
 
     @Override
-    public int getPrecipitationLevel(int x, int z) {
+    public int getPrecipitationLevelAt(int x, int z) {
         return this.getPrecipitationHeight(new BlockPos(x, 0, z)).getY();
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -374,7 +374,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
     }
 
     @Override
-    public int getPrecipitationLevel(int x, int z) {
+    public int getPrecipitationLevelAt(int x, int z) {
         return this.getPrecipitationHeight(new BlockPos(x, 0, z)).getY();
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -274,7 +274,6 @@ public abstract class MixinWorld implements World, IMixinWorld {
         return null; // Shadowed
     }
     @Shadow public abstract int getHeight(int x, int z);
-
     // @formatter:on
 
     @Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/WorldProvider;"
@@ -371,6 +370,11 @@ public abstract class MixinWorld implements World, IMixinWorld {
     @Override
     public int getHighestYAt(int x, int z) {
         return this.getHeight(x, z);
+    }
+
+    @Override
+    public int getPrecipitationLevel(int x, int z) {
+        return this.getPrecipitationHeight(new BlockPos(x, 0, z)).getY();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -274,6 +274,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
         return null; // Shadowed
     }
     @Shadow public abstract int getHeight(int x, int z);
+
     // @formatter:on
 
     @Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/WorldProvider;"

--- a/src/main/java/org/spongepowered/common/world/extent/ExtentViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/ExtentViewDownsize.java
@@ -610,4 +610,10 @@ public class ExtentViewDownsize implements DefaultedExtent {
         return this.extent.getHighestYAt(x, z);
     }
 
+    @Override
+    public int getPrecipitationLevel(int x, int z) {
+        checkBlockRange(x, 0, z);
+        return this.extent.getPrecipitationLevel(x, z);
+    }
+
 }

--- a/src/main/java/org/spongepowered/common/world/extent/ExtentViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/ExtentViewDownsize.java
@@ -611,9 +611,9 @@ public class ExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override
-    public int getPrecipitationLevel(int x, int z) {
+    public int getPrecipitationLevelAt(int x, int z) {
         checkBlockRange(x, 0, z);
-        return this.extent.getPrecipitationLevel(x, z);
+        return this.extent.getPrecipitationLevelAt(x, z);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/extent/SoftBufferExtentViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/SoftBufferExtentViewDownsize.java
@@ -627,9 +627,9 @@ public class SoftBufferExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override
-    public int getPrecipitationLevel(int x, int z) {
+    public int getPrecipitationLevelAt(int x, int z) {
         checkBlockRange(x, 0, z);
-        return this.extent.getPrecipitationLevel(x, z);
+        return this.extent.getPrecipitationLevelAt(x, z);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/extent/SoftBufferExtentViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/SoftBufferExtentViewDownsize.java
@@ -626,4 +626,10 @@ public class SoftBufferExtentViewDownsize implements DefaultedExtent {
         return this.extent.getHighestYAt(x, z);
     }
 
+    @Override
+    public int getPrecipitationLevel(int x, int z) {
+        checkBlockRange(x, 0, z);
+        return this.extent.getPrecipitationLevel(x, z);
+    }
+
 }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1572) | **SpongeCommon**

This is a response to the SpongeAPI feature request #1560, adding a method to Extent to get the y level that precipitation ends.