### PR TITLE
Add cause tracker dump to crash reports

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/CauseTracker.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/CauseTracker.java
@@ -63,6 +63,8 @@ import org.spongepowered.common.interfaces.IMixinChunk;
 import org.spongepowered.common.interfaces.entity.IMixinEntity;
 import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -341,6 +343,20 @@ public final class CauseTracker {
         printer.add();
         generateVersionInfo(printer);
         printer.trace(System.err, SpongeImpl.getLogger(), Level.ERROR);
+    }
+
+    public String dumpStack() {
+        if (this.stack.isEmpty()) {
+            return "[Empty stack]";
+        }
+
+        final PrettyPrinter printer = new PrettyPrinter(40);
+        this.stack.forEach(data -> PHASE_PRINTER.accept(printer, data));
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        printer.print(new PrintStream(stream));
+
+        return stream.toString();
     }
 
     // ----------------- SIMPLE GETTERS --------------------------------------

--- a/src/main/java/org/spongepowered/common/event/tracking/CauseTrackerCrashHandler.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/CauseTrackerCrashHandler.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.event.tracking;
+
+import net.minecraft.crash.ICrashReportDetail;
+
+public class CauseTrackerCrashHandler implements ICrashReportDetail<String> {
+
+    public static final CauseTrackerCrashHandler INSTANCE = new CauseTrackerCrashHandler();
+
+    @Override
+    public String call() throws Exception {
+        return CauseTracker.getInstance().dumpStack();
+    }
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinMinecraftServer.java
@@ -31,6 +31,9 @@ import co.aikar.timings.TimingsManager;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.command.ICommandManager;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.crash.CrashReport;
+import net.minecraft.crash.CrashReportCategory;
+import net.minecraft.crash.ICrashReportDetail;
 import net.minecraft.entity.EntityTracker;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.profiler.Profiler;
@@ -94,6 +97,7 @@ import org.spongepowered.common.command.SpongeCommandManager;
 import org.spongepowered.common.event.InternalNamedCauses;
 import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.event.tracking.CauseTracker;
+import org.spongepowered.common.event.tracking.CauseTrackerCrashHandler;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.phase.generation.GenerationPhase;
 import org.spongepowered.common.event.tracking.phase.plugin.PluginPhase;
@@ -790,5 +794,11 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, IMi
     @Redirect(method = "updateTimeLightAndEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Util;runTask(Ljava/util/concurrent/FutureTask;Lorg/apache/logging/log4j/Logger;)Ljava/lang/Object;"))
     private Object onRun(FutureTask<?> task, Logger logger) {
         return SpongeImplHooks.onUtilRunTask(task, logger);
+    }
+
+    @Inject(method = "addServerInfoToCrashReport", at = @At("RETURN"), cancellable = true)
+    public void onCrashReport(CrashReport report, CallbackInfoReturnable<CrashReport> cir) {
+        report.makeCategory("Sponge CauseTracker").setDetail("Cause Stack", CauseTrackerCrashHandler.INSTANCE);
+        cir.setReturnValue(report);
     }
 }


### PR DESCRIPTION
This PR adds a cause tracker phase + context dump (as seen in 'Invalid Phase' and 'Runaway Phase' errors) to every crash report. This should aid in debugging problems like CauseTracker-induced stack overflows, where information about the specific block is often not available in the stack trace.