### PR TITLE
Use ext.refMap to fix compatibility with later Gradle versions

### DIFF
--- a/gradle/minecraft.gradle
+++ b/gradle/minecraft.gradle
@@ -28,7 +28,7 @@ minecraft {
 // Mixins
 sourceSets {
     main {
-        refMap = "mixins.${implementation.toLowerCase()}.refmap.json"
+        ext.refMap = "mixins.${implementation.toLowerCase()}.refmap.json"
     }
 }
 


### PR DESCRIPTION
This does not break compatibility with the wrapper version.

Signed-off-by: Steven Downer <grinch@outlook.com>