### PR TITLE
Fix duplicate dimensionid

### DIFF
--- a/src/main/java/org/spongepowered/common/world/WorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/WorldManager.java
@@ -413,7 +413,10 @@ public final class WorldManager {
         setUuidOnProperties(getCurrentSavesDirectory().get(), (WorldProperties) worldInfo);
         if (dimensionId != null) {
             ((IMixinWorldInfo) worldInfo).setDimensionId(dimensionId);
-        } else if (((IMixinWorldInfo) worldInfo).getDimensionId() == null || ((IMixinWorldInfo) worldInfo).getDimensionId() == Integer.MIN_VALUE) {
+        } else if (((IMixinWorldInfo) worldInfo).getDimensionId() == null
+                || ((IMixinWorldInfo) worldInfo).getDimensionId() == Integer.MIN_VALUE
+                || getWorldByDimensionId(((IMixinWorldInfo) worldInfo).getDimensionId()).isPresent()) {
+            // DimensionID is null or 0 or the dimensionID is already assinged to a loaded world
             ((IMixinWorldInfo) worldInfo).setDimensionId(WorldManager.getNextFreeDimensionId());
         }
         ((WorldProperties) worldInfo).setGeneratorType(archetype.getGeneratorType());


### PR DESCRIPTION
When creating new WorldProperties for an existing worldfolder the dimesionId is taken from the world even if the dimensionId is already used in a loaded world.

This checks if there is already an existing world with the dimesionid and assigns a new one if needed.