### PR TITLE
Fix saturation property value to match actual saturation gained - Fixes #1418

### DIFF
--- a/src/main/java/org/spongepowered/common/data/property/store/item/SaturationPropertyStore.java
+++ b/src/main/java/org/spongepowered/common/data/property/store/item/SaturationPropertyStore.java
@@ -36,7 +36,9 @@ public class SaturationPropertyStore extends AbstractItemStackPropertyStore<Satu
     @Override
     protected Optional<SaturationProperty> getFor(ItemStack itemStack) {
         if (itemStack.getItem() instanceof ItemFood) {
-            final double saturationModifier = ((ItemFood) itemStack.getItem()).getSaturationModifier(itemStack);
+            final ItemFood food = (ItemFood) itemStack.getItem();
+            // Translate's Minecraft's weird internal value to the actual saturation value
+            final double saturationModifier = food.getSaturationModifier(itemStack) * food.getHealAmount(itemStack) * 2.0;
             return Optional.of(new SaturationProperty(saturationModifier));
         }
         return Optional.empty();


### PR DESCRIPTION
Remade the PR since I accidentally messed up the last one by having it on my bleeding branch and not realizing. 

I went over this in more detail in https://github.com/SpongePowered/SpongeCommon/issues/1418

But essentially the `SaturationProperty` value is the internal one that Mojang uses for what seems like no apparent reason as they just multiply it by the food value and by 2 when applying it to the player. To allow this property to accurately display the saturation the player will gain from the food, I added this calculation to the saturation property store.

To show this with some actual numbers and food, with the following code: 

```java
@Listener
public void onRightClick(InteractItemEvent event, @First Player player) {
    final Optional<SaturationProperty> saturationProperty = event.getItemStack().getProperty(SaturationProperty.class);
    if (saturationProperty.isPresent()) {
        player.sendMessage(Text.of("Saturation value for " + event.getItemStack().getType().getId() + ": " + saturationProperty.get().getValue()));
    } else {
        player.sendMessage(Text.of("No saturation property."));
    }
}
```

Clicking with the following items before this change returned this values: 

![beforesaturation](https://user-images.githubusercontent.com/18372958/28241580-f2c32e58-695c-11e7-9d6a-eafb35736eb3.PNG)

Now after this change returns these values:

![aftersaturation](https://user-images.githubusercontent.com/18372958/28241583-f764b1b6-695c-11e7-924d-145374c5550b.png)

Which match the saturation gained and what the Minecraft wiki states:

Raw rabbit:

![raw_rabbit](https://user-images.githubusercontent.com/18372958/28241587-20668814-695d-11e7-8cb4-d044ca4dd6fc.png)

Cooked chicken:

![cooked_chicken](https://user-images.githubusercontent.com/18372958/28241591-3270efd6-695d-11e7-8f13-1186e632a926.png)

Raw porkchop:

![image](https://user-images.githubusercontent.com/18372958/28241596-51f3867a-695d-11e7-9136-34abd0552831.png)

_As a whole, this is still a proposal, but I do believe this change should be made unless I am missing something. This way the actual amount of saturation of a food can be accurately retrieved and other SpongeAPI implementations don't have to use Mojang's strange/unnecessary math in the first place._