### PR TITLE
The (de)serialization of GameProfile is not implemented correctly

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -54,6 +54,7 @@ import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidItemData;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.text.BookView;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.serializer.BookViewDataBuilder;
@@ -64,6 +65,7 @@ import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.common.block.SpongeBlockSnapshotBuilder;
 import org.spongepowered.common.block.SpongeBlockStateBuilder;
+import org.spongepowered.common.data.builder.authlib.SpongeGameProfileBuilder;
 import org.spongepowered.common.data.builder.block.state.SpongeBlockStateMetaContentUpdater;
 import org.spongepowered.common.data.builder.block.tileentity.*;
 import org.spongepowered.common.data.builder.item.SpongeFireworkEffectDataBuilder;
@@ -175,6 +177,8 @@ public class DataRegistrar {
 
         dataManager.registerBuilder((Class<Location<World>>) (Class<?>) Location.class, new LocationBuilder());
         dataManager.registerBuilder(SpongePlayerData.class, new SpongePlayerData.Builder());
+
+        dataManager.registerBuilder(GameProfile.class, new SpongeGameProfileBuilder());
 
         // Content Updaters
         dataManager.registerContentUpdater(BlockState.class, new SpongeBlockStateMetaContentUpdater());

--- a/src/main/java/org/spongepowered/common/data/builder/authlib/SpongeGameProfileBuilder.java
+++ b/src/main/java/org/spongepowered/common/data/builder/authlib/SpongeGameProfileBuilder.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.builder.authlib;
+
+import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.persistence.AbstractDataBuilder;
+import org.spongepowered.api.data.persistence.InvalidDataException;
+import org.spongepowered.api.profile.GameProfile;
+import org.spongepowered.common.data.manipulator.mutable.SpongeRepresentedPlayerData;
+import org.spongepowered.common.data.util.DataQueries;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class SpongeGameProfileBuilder extends AbstractDataBuilder<GameProfile> {
+
+    public SpongeGameProfileBuilder() {
+        super(GameProfile.class, 0);
+    }
+
+    @Override
+    protected Optional<GameProfile> buildContent(DataView container) throws InvalidDataException {
+        if (!container.contains(DataQueries.USER_UUID)) {
+            return Optional.of(SpongeRepresentedPlayerData.NULL_PROFILE);
+        }
+        UUID uuid = this.getUUIDByString(container.getString(DataQueries.USER_UUID).get());
+        if (!container.contains(DataQueries.USER_NAME)) {
+            return Optional.of(GameProfile.of(uuid));
+        }
+        return Optional.of(GameProfile.of(uuid, container.getString(DataQueries.USER_NAME).get()));
+    }
+
+    private UUID getUUIDByString(String uuidString) throws InvalidDataException {
+        try {
+            return UUID.fromString(uuidString);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidDataException("Invalid UUID string: " + uuidString);
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/builder/authlib/package-info.java
+++ b/src/main/java/org/spongepowered/common/data/builder/authlib/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.common.data.builder.authlib;

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeRepresentedPlayerData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeRepresentedPlayerData.java
@@ -61,7 +61,7 @@ public class SpongeRepresentedPlayerData extends AbstractSingleData<GameProfile,
 
         @Override
         public DataContainer toContainer() {
-            return DataContainer.createNew();
+            return DataContainer.createNew().set(DataQueries.CONTENT_VERSION, this.getContentVersion());
         }
 
         @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/authlib/MixinGameProfile.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/authlib/MixinGameProfile.java
@@ -28,6 +28,8 @@ import com.google.common.collect.Multimap;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.PropertyMap;
 import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataQuery;
+import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.profile.property.ProfileProperty;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -66,11 +68,18 @@ public abstract class MixinGameProfile {
         return this.isComplete();
     }
 
+    public int profile$getContentVersion() {
+        return 0;
+    }
+
     public DataContainer profile$toContainer() {
-        final DataContainer container = DataContainer.createNew()
-                .set(DataQueries.USER_UUID, this.profile$getUniqueId().toString());
-        if (this.profile$getName() != null) {
-            container.set(DataQueries.USER_NAME, this.profile$getName());
+        final DataContainer container = DataContainer.createNew();
+
+        container.set(DataQueries.CONTENT_VERSION, this.profile$getContentVersion());
+        container.set(DataQueries.USER_UUID, this.profile$getUniqueId().toString());
+
+        if (this.profile$getName().isPresent()) {
+            container.set(DataQueries.USER_NAME, this.profile$getName().get());
         }
 
         return container;


### PR DESCRIPTION
Almost everything used in the Sponge Data system can be serialized and deserialized, except GameProfile.

I also wrote a test but I really don't know where should I place the test code, so I decided to put the related code snippet here:
```java
    @Test
    public void testGameProfile()
    {
        String nameForTest = "Dinnerbone", uuidForTest = "61699b2e-d327-4a01-9f1e-0ea8c3f06bc6";

        GameProfile p1 = SpongeRepresentedPlayerData.NULL_PROFILE;
        GameProfile p2 = GameProfile.of(UUID.fromString(uuidForTest));
        GameProfile p3 = GameProfile.of(UUID.fromString(uuidForTest), nameForTest);

        DataContainer c1 = p1.toContainer();
        DataContainer c2 = p2.toContainer();
        DataContainer c3 = p3.toContainer();

        assertEquals(1, c1.getKeys(true).size());
        assertEquals(2, c2.getKeys(true).size());
        assertEquals(3, c3.getKeys(true).size());

        assertEquals(uuidForTest, c2.getString(DataQueries.USER_UUID).get());
        assertEquals(uuidForTest, c3.getString(DataQueries.USER_UUID).get());
        assertEquals(nameForTest, c3.getString(DataQueries.USER_NAME).get());

        SpongeDataManager dataManager = SpongeDataManager.getInstance();

        GameProfile p4 = dataManager.deserialize(GameProfile.class, c1).get();
        GameProfile p5 = dataManager.deserialize(GameProfile.class, c2).get();
        GameProfile p6 = dataManager.deserialize(GameProfile.class, c3).get();

        assertEquals(p1, p4);
        assertEquals(p2, p5);
        assertEquals(p3, p6);
    }
```