### PR TITLE
JDK-8176055: Fix heap dumps on Java 8u141+

### DIFF
--- a/src/main/java/org/spongepowered/common/command/SpongeCommand.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommand.java
@@ -349,7 +349,7 @@ public class SpongeCommand {
                 .permission("sponge.command.heap")
                 .executor((src, args) -> {
                     File file = new File(new File(new File("."), "dumps"),
-                            "heap-dump-" + DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss").format(LocalDateTime.now()) + "-server.bin");
+                            "heap-dump-" + DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss").format(LocalDateTime.now()) + "-server.hprof");
                     src.sendMessage(Text.of("Writing JVM heap data to: ", file));
                     SpongeHooks.dumpHeap(file, true);
                     src.sendMessage(Text.of("Heap dump complete"));


### PR DESCRIPTION
In Java 8u141 (1.8.0_141-b15) and newer, the
com.sun.management.HotSpotDiagnostic::dumpHeap API has changed and now
requires all heap dumps to end with the .hprof file extension.

Before this change, servers running 8u141 would be unable to perform a
heap dump.

For more information, please see the official release notes of Java 8
Update 141, linked below.
http://www.oracle.com/technetwork/java/javase/8u141-relnotes-3720385.html