### PR TITLE
Bump Mixin version to 0.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ ext.apiVersion = version
 
 dependencies {
     compile api
-    compile('org.spongepowered:mixin:0.6.15-SNAPSHOT') {
+    compile('org.spongepowered:mixin:0.7-SNAPSHOT') {
         exclude module: 'launchwrapper'
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/data/MixinDataHolder.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/data/MixinDataHolder.java
@@ -413,9 +413,4 @@ public abstract class MixinDataHolder implements DataHolder {
         return Collections.emptyList();
     }
 
-    @Override
-    public DataHolder copy() {
-        return this;
-    }
-
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinSpongeUser.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinSpongeUser.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.mixin.core.entity.player;
 
 import com.google.common.base.Objects;
+import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataView;
 import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.data.persistence.InvalidDataException;
@@ -99,5 +100,10 @@ public abstract class MixinSpongeUser implements User, IMixinSubject {
                 .add("isOnline", this.isOnline())
                 .add("profile", this.getProfile())
                 .toString();
+    }
+
+    @Override
+    public DataHolder copy() {
+        return this;
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntity.java
@@ -302,4 +302,9 @@ public abstract class MixinTileEntity implements TileEntity, IMixinTileEntity {
     public boolean hasSetOwner() {
         return this.hasSetOwner;
     }
+
+    @Override
+    public TileEntity copy() {
+        return this;
+    }
 }

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -1,6 +1,6 @@
 {
     "required": true,
-    "minVersion": "0.6.15",
+    "minVersion": "0.7",
     "package": "org.spongepowered.common.mixin.core",
     "refmap": "mixins.common.refmap.json",
     "plugin": "org.spongepowered.common.mixin.plugin.CorePlugin",


### PR DESCRIPTION
This PR bumps the `stable-5` Mixin version to 0.7 and resolves incompatibilities which arise as a result.