### PR TITLE
Allow sending a specific page of a pagination list and add a test plugin

### DIFF
--- a/src/main/java/org/spongepowered/common/service/pagination/IterablePagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/IterablePagination.java
@@ -59,11 +59,15 @@ class IterablePagination extends ActivePagination {
     @Override
     protected Iterable<Text> getLines(int page) throws CommandException {
         if (!this.countIterator.hasNext()) {
-            throw new CommandException(t("Already at end of iterator"));
+            throw new CommandException(t("You're already at the end of the pagination list iterator."));
+        }
+
+        if (page < 1) {
+            throw new CommandException(t("Page %s does not exist!", page));
         }
 
         if (page <= this.lastPage) {
-            throw new CommandException(t("Cannot go backward in an IterablePagination"));
+            throw new CommandException(t("You cannot go to previous pages in an iterable pagination."));
         } else if (page > this.lastPage + 1) {
             getLines(page - 1);
         }
@@ -119,6 +123,6 @@ class IterablePagination extends ActivePagination {
 
     @Override
     public void previousPage() throws CommandException {
-        throw new CommandException(t("Cannot go backwards in a streaming pagination"));
+        throw new CommandException(t("You cannot go to previous pages in an iterable pagination."));
     }
 }

--- a/src/main/java/org/spongepowered/common/service/pagination/ListPagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/ListPagination.java
@@ -80,12 +80,13 @@ class ListPagination extends ActivePagination {
 
     @Override
     protected Iterable<Text> getLines(int page) throws CommandException {
-        if (this.pages.size() == 0) {
+        final int size = this.pages.size();
+        if (size == 0) {
             return ImmutableList.of();
         } else if (page < 1) {
             throw new CommandException(t("Page %s does not exist!", page));
-        } else if (page > this.pages.size()) {
-            throw new CommandException(t("Page %s is too high", page));
+        } else if (page > size) {
+            throw new CommandException(t("Page %s is greater than the max of %s!", page, size));
         }
         return this.pages.get(page - 1);
     }

--- a/src/main/java/org/spongepowered/common/service/pagination/SpongePaginationBuilder.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/SpongePaginationBuilder.java
@@ -25,16 +25,16 @@
 package org.spongepowered.common.service.pagination;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.service.pagination.PaginationList;
 import org.spongepowered.api.text.Text;
-import org.spongepowered.api.text.channel.MessageChannel;
-import org.spongepowered.api.text.channel.MessageReceiver;
 
 import javax.annotation.Nullable;
 
 public class SpongePaginationBuilder implements PaginationList.Builder {
+
     private final SpongePaginationService service;
     @Nullable
     private Iterable<Text> contents;
@@ -56,6 +56,7 @@ public class SpongePaginationBuilder implements PaginationList.Builder {
 
     @Override
     public PaginationList.Builder contents(Iterable<Text> contents) {
+        checkNotNull(contents, "The contents cannot be null!");
         this.contents = contents;
         this.paginationList = null;
         return this;
@@ -63,13 +64,14 @@ public class SpongePaginationBuilder implements PaginationList.Builder {
 
     @Override
     public PaginationList.Builder contents(Text... contents) {
+        checkNotNull(contents, "The contents cannot be null!");
         this.contents = ImmutableList.copyOf(contents);
         this.paginationList = null;
         return this;
     }
 
     @Override
-    public PaginationList.Builder title(Text title) {
+    public PaginationList.Builder title(@Nullable Text title) {
         this.title = title;
         this.paginationList = null;
         return this;
@@ -91,7 +93,7 @@ public class SpongePaginationBuilder implements PaginationList.Builder {
 
     @Override
     public PaginationList.Builder padding(Text padding) {
-        checkNotNull(padding, "padding");
+        checkNotNull(padding, "The padding cannot be null!");
         this.paginationSpacer = padding;
         this.paginationList = null;
         return this;
@@ -105,22 +107,12 @@ public class SpongePaginationBuilder implements PaginationList.Builder {
 
     @Override
     public PaginationList build() {
-        checkNotNull(this.contents, "contents");
+        checkState(this.contents != null, "The contents of the pagination list cannot be null!");
 
         if (this.paginationList == null) {
             this.paginationList = new SpongePaginationList(this.service, this.contents, this.title, this.header, this.footer, this.paginationSpacer, this.linesPerPage);
         }
         return this.paginationList;
-    }
-
-    @Override
-    public void sendTo(MessageReceiver source) {
-        this.build().sendTo(source);
-    }
-
-    @Override
-    public void sendTo(MessageChannel channel) {
-        this.build().sendTo(channel);
     }
 
     @Override

--- a/testplugins/src/main/java/org/spongepowered/test/PaginationServiceTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/PaginationServiceTest.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.service.pagination.PaginationList;
+import org.spongepowered.api.service.pagination.PaginationService;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+
+import java.util.Optional;
+
+@Plugin(id = "paginationtest", name = "PaginationTest", description = "A plugin to test the pagination service.")
+public class PaginationServiceTest {
+
+    @Inject
+    private Logger logger;
+
+    private PaginationList paginationList;
+
+    @Listener
+    public void onGamePreInitialization(final GamePreInitializationEvent event) {
+        final Optional<PaginationService> paginationService = Sponge.getServiceManager().provide(PaginationService.class);
+        if (paginationService.isPresent()) {
+            // Defaults to normal amount of lines per page to guarantee it is of appropriate size
+            paginationList = paginationService.get().builder()
+                    .title(Text.of(TextColors.RED, "This Is A Test"))
+                    .padding(Text.of(TextColors.GOLD, "="))
+                    .header(Text.of("This is the header"))
+                    .footer(Text.of("This is the footer"))
+                    .contents(ImmutableList.of(
+                            Text.of(TextColors.GRAY, "rhomboid"),
+                            Text.of(TextColors.GRAY, "analytic"),
+                            Text.of(TextColors.GRAY, "sandwich"),
+                            Text.of(TextColors.GRAY, "wallpaper"),
+                            Text.of(TextColors.GRAY, "fragmentation"),
+                            Text.of(TextColors.GRAY, "elephant"),
+                            Text.of(TextColors.GRAY, "idempotence"),
+                            Text.of(TextColors.GRAY, "finger"),
+                            Text.of(TextColors.GRAY, "licking"),
+                            Text.of(TextColors.GRAY, "netherborn"),
+                            Text.of(TextColors.GRAY, "facsimile"),
+                            Text.of(TextColors.GRAY, "drainpipe"),
+                            Text.of(TextColors.GRAY, "limerick"),
+                            Text.of(TextColors.GRAY, "toadstool"),
+                            Text.of(TextColors.GRAY, "talisman"),
+                            Text.of(TextColors.GRAY, "alligator"),
+                            Text.of(TextColors.GRAY, "whistle"),
+                            Text.of(TextColors.GRAY, "bollard"),
+                            Text.of(TextColors.GRAY, "slime"),
+                            Text.of(TextColors.GRAY, "gallant"),
+                            Text.of(TextColors.GRAY, "twisted"),
+                            Text.of(TextColors.GRAY, "moist"),
+                            Text.of(TextColors.GRAY, "himalayan"),
+                            Text.of(TextColors.GRAY, "mortals"),
+                            Text.of(TextColors.GRAY, "dollop"),
+                            Text.of(TextColors.GRAY, "pompous"),
+                            Text.of(TextColors.GRAY, "squeegee")
+                    ))
+                    .build();
+        } else {
+            this.logger.error("The pagination service was not properly registered for some reason :(");
+            return;
+        }
+
+        Sponge.getCommandManager().register(this,
+                CommandSpec.builder()
+                        .arguments(GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.integer(Text.of("page")))))
+                        .executor((src, args) -> {
+                            this.paginationList.sendTo(src, args.<Integer>getOne("page").orElse(1));
+
+                            return CommandResult.success();
+                        })
+                        .build(),
+                "paginationtest");
+    }
+
+}


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1622) | SpongeCommon

Accomplishes part of https://github.com/SpongePowered/SpongeCommon/pull/1305

Also cleans up some messages and code and makes it so a pagination list defaults to an empty list if no contents are specified.