### PR TITLE
Allow PluginPhase to run during unwinding.

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/phase/general/PostState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/general/PostState.java
@@ -37,7 +37,9 @@ final class PostState extends GeneralState {
 
     @Override
     public boolean canSwitchTo(IPhaseState state) {
-        return state.getPhase() == TrackingPhases.GENERATION || state == BlockPhase.State.RESTORING_BLOCKS;
+        return state.getPhase() == TrackingPhases.GENERATION
+                || state.getPhase() == TrackingPhases.PLUGIN
+                || state == BlockPhase.State.RESTORING_BLOCKS;
     }
 
     @Override


### PR DESCRIPTION
Many phase states fire events during unwinding, and plugins can perform actions that would push new phases (such as setting blocks or creating explosions). `PostState` whitelists which states can be switched to; this adds support for that.

I'm making a PR first because I want to make sure this is OK; I assume the whitelist is there for a reason. @gabizou 

Fixes SpongePowered/SpongeVanilla#314.