### PR TITLE
Add an optimized version of Entity.getNearbyEntities(double).

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -833,6 +833,13 @@ public abstract class MixinEntity implements IMixinEntity {
         return entity != null && entity.addPassenger(this);
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public Collection<Entity> getNearbyEntities(double distance) {
+        return (Collection) this.world.getEntitiesWithinAABB(net.minecraft.entity.Entity.class,
+                new AxisAlignedBB(this.posX - distance, this.posY - distance, this.posZ - distance, this.posX + distance, this.posY + distance,
+                        this.posZ + distance), e1 -> e1.getDistanceSqToEntity((net.minecraft.entity.Entity) (Object) this) <= distance * distance);
+    }
 
     /**
      * @author blood - May 28th, 2016


### PR DESCRIPTION
The `default`-implemented version in the API checks every entity in the world. This version only checks entities in chunks that could be within the specified distance.