### PR TITLE
Method Tracking System

### DIFF
--- a/src/main/java/org/spongepowered/common/launch/transformer/tracker/MethodEntry.java
+++ b/src/main/java/org/spongepowered/common/launch/transformer/tracker/MethodEntry.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.launch.transformer.tracker;
+
+import org.spongepowered.asm.lib.Type;
+
+import java.util.HashMap;
+import java.util.Map;
+
+final class MethodEntry {
+
+    final String desc;
+    final Type[] paramTypes;
+    final Type returnType;
+    final Map<TrackedType, String> entries = new HashMap<>();
+
+    MethodEntry(String desc, Type[] paramTypes, Type returnType) {
+        this.paramTypes = paramTypes;
+        this.returnType = returnType;
+        this.desc = desc;
+    }
+}

--- a/src/main/java/org/spongepowered/common/launch/transformer/tracker/TrackedType.java
+++ b/src/main/java/org/spongepowered/common/launch/transformer/tracker/TrackedType.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.launch.transformer.tracker;
+
+import java.util.HashSet;
+import java.util.Set;
+
+final class TrackedType {
+
+    final String name;
+    final Set<String> knownSubtypes = new HashSet<>();
+
+    TrackedType(String name) {
+        this.knownSubtypes.add(name);
+        this.name = name;
+    }
+}

--- a/src/main/java/org/spongepowered/common/launch/transformer/tracker/TrackerClassTransformer.java
+++ b/src/main/java/org/spongepowered/common/launch/transformer/tracker/TrackerClassTransformer.java
@@ -1,0 +1,191 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.launch.transformer.tracker;
+
+import static org.spongepowered.asm.lib.Opcodes.ACC_PRIVATE;
+import static org.spongepowered.asm.lib.Opcodes.ACC_STATIC;
+import static org.spongepowered.asm.lib.Opcodes.ALOAD;
+import static org.spongepowered.asm.lib.Opcodes.ASM5;
+import static org.spongepowered.asm.lib.Opcodes.CHECKCAST;
+import static org.spongepowered.asm.lib.Opcodes.F_SAME;
+import static org.spongepowered.asm.lib.Opcodes.IFEQ;
+import static org.spongepowered.asm.lib.Opcodes.ILOAD;
+import static org.spongepowered.asm.lib.Opcodes.INSTANCEOF;
+import static org.spongepowered.asm.lib.Opcodes.INVOKEINTERFACE;
+import static org.spongepowered.asm.lib.Opcodes.INVOKESTATIC;
+import static org.spongepowered.asm.lib.Opcodes.INVOKEVIRTUAL;
+import static org.spongepowered.asm.lib.Opcodes.IRETURN;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+import org.spongepowered.asm.lib.ClassReader;
+import org.spongepowered.asm.lib.ClassVisitor;
+import org.spongepowered.asm.lib.ClassWriter;
+import org.spongepowered.asm.lib.Label;
+import org.spongepowered.asm.lib.MethodVisitor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class TrackerClassTransformer implements IClassTransformer {
+
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass) {
+        if (basicClass == null || TrackerRegistry.trackerClasses.contains(name)) {
+            return basicClass;
+        }
+
+        final ClassReader classReader = new ClassReader(basicClass);
+        final ClassWriter classWriter = new ClassWriter(classReader, 0);
+
+        final TrackerClassVisitor classVisitor = new TrackerClassVisitor(classWriter);
+        classReader.accept(classVisitor, 0);
+
+        return classWriter.toByteArray();
+    }
+
+    private static class TrackerClassVisitor extends ClassVisitor {
+
+        private final Map<String, TrackerMethodEntry> addedMethods = new HashMap<>();
+        private String name;
+
+        TrackerClassVisitor(ClassVisitor cv) {
+            super(ASM5, cv);
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            super.visit(version, access, name, signature, superName, interfaces);
+            this.name = name;
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+            return new TrackerMethodVisitor(super.visitMethod(access, name, desc, signature, exceptions), this);
+        }
+
+        @Override
+        public void visitEnd() {
+            for (TrackerMethodEntry e : this.addedMethods.values()) {
+                final MethodVisitor m = super.visitMethod(ACC_PRIVATE | ACC_STATIC, e.nName, e.nDesc, null, null);
+                m.visitCode();
+                final Set<Map.Entry<TrackedType, String>> set = e.entry.entries.entrySet();
+                for (Map.Entry<TrackedType, String> entry1 : set) {
+                    final String targetName = entry1.getKey().name;
+                    // Do instance check
+                    m.visitVarInsn(ALOAD, 0);
+                    m.visitTypeInsn(INSTANCEOF, targetName);
+                    final Label ifLabel = new Label();
+                    m.visitJumpInsn(IFEQ, ifLabel);
+                    // Call the static tracker method
+                    m.visitVarInsn(ALOAD, 0);
+                    // Cast the target object
+                    m.visitTypeInsn(CHECKCAST, targetName);
+                    for (int i = 1; i < e.entry.paramTypes.length; i++) {
+                        m.visitVarInsn(e.entry.paramTypes[i].getOpcode(ILOAD), i);
+                    }
+                    m.visitMethodInsn(INVOKESTATIC, entry1.getValue(), e.oName, e.entry.desc, false);
+                    m.visitInsn(e.entry.returnType.getOpcode(IRETURN));
+                    m.visitLabel(ifLabel);
+                    m.visitFrame(F_SAME, 0, null, 0, null);
+                }
+                // None of the instance checks succeeded, call the original method
+                m.visitVarInsn(ALOAD, 0);
+                for (int i = 1; i < e.entry.paramTypes.length; i++) {
+                    m.visitVarInsn(e.entry.paramTypes[i].getOpcode(ILOAD), i);
+                }
+                m.visitMethodInsn(e.oOpcode, e.oOwner, e.oName, e.oDesc, e.oItf);
+                m.visitInsn(e.entry.returnType.getOpcode(IRETURN));
+                final int locals = e.entry.paramTypes.length;
+                m.visitMaxs(locals, locals);
+                m.visitEnd();
+            }
+            super.visitEnd();
+        }
+    }
+
+    private static class TrackerMethodEntry {
+
+        private MethodEntry entry;
+
+        private String oOwner;
+        private String oName;
+        private String oDesc;
+        private int oOpcode;
+        private boolean oItf;
+
+        private String nName;
+        private String nDesc;
+    }
+
+    private static class TrackerMethodVisitor extends MethodVisitor {
+
+        private final TrackerClassVisitor classVisitor;
+
+        TrackerMethodVisitor(MethodVisitor mv, TrackerClassVisitor classVisitor) {
+            super(ASM5, mv);
+            this.classVisitor = classVisitor;
+        }
+
+        @Override
+        public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+            MethodEntry entry;
+            if ((opcode != INVOKEVIRTUAL && opcode != INVOKEINTERFACE) ||
+                    (entry = TrackerRegistry.methodLists.get(name + ';' + desc)) == null) {
+                super.visitMethodInsn(opcode, owner, name, desc, itf);
+                return;
+            }
+            // First, try to directly redirect the method
+            for (Map.Entry<TrackedType, String> entry1 : entry.entries.entrySet()) {
+                if (entry1.getKey().knownSubtypes.contains(owner)) {
+                    super.visitMethodInsn(INVOKESTATIC, entry1.getValue(), name, entry.desc, false);
+                    return;
+                }
+            }
+            // Now try to generate a static helper method
+            String simpleOwner = owner;
+            final int index = simpleOwner.lastIndexOf('/');
+            if (index != -1) {
+                simpleOwner = simpleOwner.substring(index + 1);
+            }
+            final String methodName = "redirect" + simpleOwner + '$' + name;
+            final String methodId = methodName + ';' + desc;
+            final String methodDesc = "(L" + owner + ';' + desc.substring(1);
+            if (!this.classVisitor.addedMethods.containsKey(methodId)) {
+                final TrackerMethodEntry methodEntry = new TrackerMethodEntry();
+                methodEntry.entry = entry;
+                methodEntry.oOpcode = opcode;
+                methodEntry.oName = name;
+                methodEntry.oDesc = desc;
+                methodEntry.oOwner = owner;
+                methodEntry.oItf = itf;
+                methodEntry.nName = methodName;
+                methodEntry.nDesc = methodDesc;
+                this.classVisitor.addedMethods.put(methodId, methodEntry);
+            }
+            super.visitMethodInsn(INVOKESTATIC, this.classVisitor.name, methodName, methodDesc, false);
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/common/launch/transformer/tracker/TrackerMethod.java
+++ b/src/main/java/org/spongepowered/common/launch/transformer/tracker/TrackerMethod.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.launch.transformer.tracker;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Can be used to track a method.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface TrackerMethod {
+
+}

--- a/src/main/java/org/spongepowered/common/launch/transformer/tracker/TrackerRegistry.java
+++ b/src/main/java/org/spongepowered/common/launch/transformer/tracker/TrackerRegistry.java
@@ -1,0 +1,172 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.launch.transformer.tracker;
+
+import static java.util.Objects.requireNonNull;
+import static org.spongepowered.asm.lib.Opcodes.ASM5;
+
+import net.minecraft.launchwrapper.Launch;
+import org.spongepowered.asm.lib.AnnotationVisitor;
+import org.spongepowered.asm.lib.ClassReader;
+import org.spongepowered.asm.lib.ClassVisitor;
+import org.spongepowered.asm.lib.MethodVisitor;
+import org.spongepowered.asm.lib.Type;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class TrackerRegistry {
+
+    static final Map<String, MethodEntry> methodLists = new HashMap<>();
+    static final Set<String> trackerClasses = new HashSet<>();
+    private static final Map<String, TrackedType> trackedTypes = new HashMap<>();
+    private static boolean initialized = false;
+
+    /**
+     * Initializes the method tracking.
+     */
+    public static void initialize() {
+        if (initialized) {
+            return;
+        }
+        initialized = true;
+        Launch.classLoader.addTransformerExclusion("org.spongepowered.common.launch.transformer.tracker.");
+        Launch.classLoader.registerTransformer("org.spongepowered.common.launch.transformer.tracker.TrackerClassTransformer");
+    }
+
+    /**
+     * Registers subtypes for the given base type. Registering sub types removes
+     * in those cases the need to do instance checks.
+     *
+     * @param baseType The base type
+     * @param subTypes The sub types
+     */
+    public static void registerKnownSubtypes(String baseType, String... subTypes) {
+        registerKnownSubtypes(baseType, Arrays.asList(subTypes));
+    }
+
+    /**
+     * Registers subtypes for the given base type. Registering sub types removes
+     * in those cases the need to do instance checks.
+     *
+     * @param baseType The base type
+     * @param subTypes The sub types
+     */
+    public static void registerKnownSubtypes(String baseType, Collection<String> subTypes) {
+        trackedTypes.computeIfAbsent(baseType.replace('.', '/'), TrackedType::new).knownSubtypes
+                .addAll(subTypes.stream().map(e -> e.replace('.', '/')).collect(Collectors.toList()));
+    }
+
+    /**
+     * Registers a tracker class, in this class may methods be
+     * annotated with {@link TrackerMethod}.
+     *
+     * @param trackerClass The tracker class
+     */
+    public static void registerTracker(String trackerClass) {
+        requireNonNull(trackerClass, "trackerClass");
+        // Don't transform the tracker class with the TrackerClassTransformer
+        trackerClasses.add(trackerClass);
+
+        final List<Entry> entries = new ArrayList<>();
+        try {
+            final String trackedMethodDesc = Type.getDescriptor(TrackerMethod.class);
+            final ClassReader classReader = new ClassReader(trackerClass);
+            classReader.accept(new ClassVisitor(ASM5) {
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+                    return new MethodVisitor(ASM5) {
+                        @Override
+                        public AnnotationVisitor visitAnnotation(String annoDesc, boolean visible) {
+                            if (annoDesc.equals(trackedMethodDesc)) {
+                                entries.add(new Entry(name, desc, access));
+                            }
+                            return super.visitAnnotation(desc, visible);
+                        }
+                    };
+                }
+            }, ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+        final String trackerType = trackerClass.replace('.', '/');
+        for (Entry entry : entries) {
+            if (!Modifier.isStatic(entry.access)) {
+                throw new IllegalArgumentException("A tracker method must be static, at " +
+                        entry.name + ':' + entry.desc + " located in " + trackerClass);
+            }
+            if (!Modifier.isPublic(entry.access)) {
+                throw new IllegalArgumentException("A tracker method must be public, at " +
+                        entry.name + ':' + entry.desc + " located in " + trackerClass);
+            }
+            if (entry.desc.indexOf(')') == 1) {
+                throw new IllegalArgumentException("At least one parameter must be present (this is the tracked type), at " +
+                        entry.name + ':' + entry.desc + " located in " + trackerClass);
+            }
+            final int start = entry.desc.indexOf('L');
+            if (start != 1) {
+                throw new IllegalArgumentException("The tracked type may not be a primitive or array, at " +
+                        entry.name + ':' + entry.desc + " located in " + trackerClass);
+            }
+            final int end = entry.desc.indexOf(';');
+            // Extract the target type
+            final String targetType = entry.desc.substring(start + 1, end);
+            final TrackedType trackedType = trackedTypes.computeIfAbsent(targetType, TrackedType::new);
+            // Extract the method desc we need to target/replace
+            final String oldDesc = '(' + entry.desc.substring(end + 1);
+            // Store the method
+            final String id = entry.name + ';' + oldDesc;
+            final MethodEntry methodEntry = methodLists.computeIfAbsent(id, id1 -> new MethodEntry(
+                    entry.desc, Type.getArgumentTypes(entry.desc), Type.getReturnType(entry.desc)));
+            if (methodEntry.entries.containsKey(trackedType)) {
+                throw new IllegalArgumentException("Attempted to track a method twice, at " +
+                        entry.name + ':' + entry.desc + " located in " + trackerClass);
+            }
+            methodEntry.entries.put(trackedType, trackerType);
+        }
+    }
+
+    private static final class Entry {
+
+        private final String name;
+        private final String desc;
+        private final int access;
+
+        private Entry(String name, String desc, int access) {
+            this.access = access;
+            this.name = name;
+            this.desc = desc;
+        }
+    }
+}


### PR DESCRIPTION
**Common** | [Forge](https://github.com/SpongePowered/SpongeForge/pull/1723)

This PR adds a `ClassTransformer` that allows the methods of target classes (mainly interfaces) to be redirected so actions can be executed before and after the method, and even cancel the method or modify it's parameters.

The main reason for this system was to track calls to `IItemHandler`, `IFluidTank`, `IFluidHandler` and `IFluidBlock`. These are all forge interfaces and will be tracked in `SpongeForge`.

The way the tracker class system is designed is that no classes will be loaded that could trigger class loading, ASM will be used to read all the `TrackerMethod`s from registered tracker classes. This is already a preparation for the separated core/main mod refactor.

A example of the usage can be found in the `SpongeForge` PR.