### PR TITLE
Implement SizeData

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -435,6 +435,9 @@ public class DataRegistrar {
         DataUtil.registerDataProcessorAndImpl(AreaEffectCloudData.class, SpongeAreaEffectData.class, ImmutableAreaEffectCloudData.class,
                 ImmutableSpongeAreaEffectCloudData.class, new AreaEffectCloudDataProcessor());
 
+        DataUtil.registerDataProcessorAndImpl(SizeData.class, SpongeSizeData.class, ImmutableSizeData.class,
+                ImmutableSpongeSizeData.class, new SizeDataProcessor());
+
         // Item Processors
 
         DataUtil.registerDualProcessor(FireworkEffectData.class, SpongeFireworkEffectData.class,
@@ -811,6 +814,9 @@ public class DataRegistrar {
         DataUtil.registerValueProcessor(Keys.IS_ADULT, new IsAdultValueProcessor());
         DataUtil.registerValueProcessor(Keys.IS_ADULT, new IsAdultZombieValueProcessor());
         DataUtil.registerValueProcessor(Keys.AGE, new AgeableAgeValueProcessor());
+        DataUtil.registerValueProcessor(Keys.BASE_SIZE, new BaseSizeValueProcessor());
+        DataUtil.registerValueProcessor(Keys.HEIGHT, new HeightValueProcessor());
+        DataUtil.registerValueProcessor(Keys.SCALE, new ScaleValueProcessor());
 
         // Properties
         final PropertyRegistry propertyRegistry = Sponge.getPropertyRegistry();

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSizeData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSizeData.java
@@ -1,0 +1,124 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.entity;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSizeData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SizeData;
+import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSizeData;
+import org.spongepowered.common.data.value.SpongeValueFactory;
+
+public class ImmutableSpongeSizeData extends AbstractImmutableData<ImmutableSizeData, SizeData> implements ImmutableSizeData {
+
+    private final float base;
+    private final float height;
+    private final float scale;
+
+    private final ImmutableBoundedValue<Float> baseValue;
+    private final ImmutableBoundedValue<Float> heightValue;
+    private final ImmutableBoundedValue<Float> scaleValue;
+
+    public ImmutableSpongeSizeData(float base, float height, float scale) {
+        super(ImmutableSizeData.class);
+
+        checkArgument(base > 0, "The base size must be greater than 0.");
+        checkArgument(height > 0, "The height must be greater than 0.");
+        checkArgument(scale > 0, "The scale must be greater than 0.");
+
+        this.base = base;
+        this.height = height;
+        this.scale = scale;
+
+        this.baseValue = SpongeValueFactory.boundedBuilder(Keys.BASE_SIZE)
+                .defaultValue(1f)
+                .minimum(0f)
+                .maximum(Float.MAX_VALUE)
+                .actualValue(this.base)
+                .build()
+                .asImmutable();
+        this.heightValue = SpongeValueFactory.boundedBuilder(Keys.HEIGHT)
+                .defaultValue(1f)
+                .minimum(0f)
+                .maximum(Float.MAX_VALUE)
+                .actualValue(this.height)
+                .build()
+                .asImmutable();
+        this.scaleValue = SpongeValueFactory.boundedBuilder(Keys.SCALE)
+                .defaultValue(1f)
+                .minimum(0f)
+                .maximum(Float.MAX_VALUE)
+                .actualValue(this.scale)
+                .build()
+                .asImmutable();
+
+        registerGetters();
+    }
+
+    @Override
+    public ImmutableBoundedValue<Float> base() {
+        return this.baseValue;
+    }
+
+    @Override
+    public ImmutableBoundedValue<Float> height() {
+        return this.heightValue;
+    }
+
+    @Override
+    public ImmutableBoundedValue<Float> scale() {
+        return this.scaleValue;
+    }
+
+    @Override
+    protected void registerGetters() {
+        registerFieldGetter(Keys.BASE_SIZE, () -> this.base);
+        registerKeyValue(Keys.BASE_SIZE, this::base);
+
+        registerFieldGetter(Keys.HEIGHT, () -> this.height);
+        registerKeyValue(Keys.HEIGHT, this::height);
+
+        registerFieldGetter(Keys.SCALE, () -> this.scale);
+        registerKeyValue(Keys.SCALE, this::scale);
+    }
+
+    @Override
+    public SizeData asMutable() {
+        return new SpongeSizeData(this.base, this.height, this.scale);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer()
+                .set(Keys.BASE_SIZE.getQuery(), this.base)
+                .set(Keys.HEIGHT.getQuery(), this.height)
+                .set(Keys.SCALE.getQuery(), this.scale);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSizeData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSizeData.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSizeData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SizeData;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeSizeData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractData;
+import org.spongepowered.common.data.value.SpongeValueFactory;
+
+public class SpongeSizeData extends AbstractData<SizeData, ImmutableSizeData> implements SizeData {
+
+    private float base;
+    private float height;
+    private float scale;
+
+    public SpongeSizeData() {
+        this(1f, 1f, 1f);
+    }
+
+    public SpongeSizeData(float base, float height, float scale) {
+        super(SizeData.class);
+
+        this.base = base;
+        this.height = height;
+        this.scale = scale;
+
+        registerGettersAndSetters();
+    }
+
+    @Override
+    public MutableBoundedValue<Float> base() {
+        return SpongeValueFactory.boundedBuilder(Keys.BASE_SIZE)
+                .defaultValue(1f)
+                .minimum(0f)
+                .maximum(Float.MAX_VALUE)
+                .actualValue(this.base)
+                .build();
+    }
+
+    @Override
+    public MutableBoundedValue<Float> height() {
+        return SpongeValueFactory.boundedBuilder(Keys.HEIGHT)
+                .defaultValue(1f)
+                .minimum(0f)
+                .maximum(Float.MAX_VALUE)
+                .actualValue(this.height)
+                .build();
+    }
+
+    @Override
+    public MutableBoundedValue<Float> scale() {
+        return SpongeValueFactory.boundedBuilder(Keys.SCALE)
+                .defaultValue(1f)
+                .minimum(0f)
+                .maximum(Float.MAX_VALUE)
+                .actualValue(this.scale)
+                .build();
+    }
+
+    @Override
+    protected void registerGettersAndSetters() {
+        registerFieldGetter(Keys.BASE_SIZE, () -> this.base);
+        registerFieldSetter(Keys.BASE_SIZE, b -> this.base = b);
+        registerKeyValue(Keys.BASE_SIZE, this::base);
+
+        registerFieldGetter(Keys.HEIGHT, () -> this.height);
+        registerFieldSetter(Keys.HEIGHT, h -> this.height = h);
+        registerKeyValue(Keys.HEIGHT, this::height);
+
+        registerFieldGetter(Keys.SCALE, () -> this.scale);
+        registerFieldSetter(Keys.SCALE, s -> this.scale = s);
+        registerKeyValue(Keys.SCALE, this::scale);
+    }
+
+    @Override
+    public SizeData copy() {
+        return new SpongeSizeData(this.base, this.height, this.scale);
+    }
+
+    @Override
+    public ImmutableSizeData asImmutable() {
+        return new ImmutableSpongeSizeData(this.base, this.height, this.scale);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer()
+                .set(Keys.BASE_SIZE.getQuery(), this.base)
+                .set(Keys.HEIGHT.getQuery(), this.height)
+                .set(Keys.SCALE.getQuery(), this.scale);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/multi/entity/SizeDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/entity/SizeDataProcessor.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.multi.entity;
+
+import static org.spongepowered.common.data.util.DataUtil.getData;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.entity.Entity;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSizeData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SizeData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSizeData;
+import org.spongepowered.common.data.processor.common.AbstractEntityDataProcessor;
+import org.spongepowered.common.interfaces.entity.IMixinEntity;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class SizeDataProcessor extends AbstractEntityDataProcessor<Entity, SizeData, ImmutableSizeData> {
+
+    public SizeDataProcessor() {
+        super(Entity.class);
+    }
+
+    @Override
+    protected boolean doesDataExist(Entity dataHolder) {
+        return true;
+    }
+
+    @Override
+    protected boolean set(Entity dataHolder, Map<Key<?>, Object> keyValues) {
+        float base = (Float) keyValues.get(Keys.BASE_SIZE);
+        float height = (Float) keyValues.get(Keys.HEIGHT);
+        ((IMixinEntity) dataHolder).setSpongeSize(base, height);
+        return true;
+    }
+
+    @Override
+    protected Map<Key<?>, ?> getValues(Entity entity) {
+        final float base = entity.width;
+        final float height = entity.height;
+        final float scale = ((IMixinEntity) entity).getSizeScale();
+
+        return ImmutableMap.<Key<?>, Object>of(
+                Keys.BASE_SIZE, base,
+                Keys.HEIGHT, height,
+                Keys.SCALE, scale);
+    }
+
+    @Override
+    protected SizeData createManipulator() {
+        return new SpongeSizeData();
+    }
+
+    @Override
+    public Optional<SizeData> fill(DataContainer container, SizeData sizeData) {
+        sizeData.set(Keys.BASE_SIZE, getData(container, Keys.BASE_SIZE));
+        sizeData.set(Keys.HEIGHT, getData(container, Keys.HEIGHT));
+        sizeData.set(Keys.SCALE, getData(container, Keys.SCALE));
+        return Optional.of(sizeData);
+    }
+
+    @Override
+    public DataTransactionResult remove(DataHolder dataHolder) {
+        return DataTransactionResult.failNoData();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/BaseSizeValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/BaseSizeValueProcessor.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.entity;
+
+import net.minecraft.entity.Entity;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.SpongeValueFactory;
+import org.spongepowered.common.interfaces.entity.IMixinEntity;
+
+import java.util.Optional;
+
+public class BaseSizeValueProcessor extends AbstractSpongeValueProcessor<Entity, Float, MutableBoundedValue<Float>> {
+
+    public BaseSizeValueProcessor() {
+        super(Entity.class, Keys.BASE_SIZE);
+    }
+
+    @Override
+    protected MutableBoundedValue<Float> constructValue(Float actualValue) {
+        return SpongeValueFactory.boundedBuilder(Keys.BASE_SIZE)
+                .defaultValue(1f)
+                .minimum(0f)
+                .maximum(Float.MAX_VALUE)
+                .actualValue(actualValue)
+                .build();
+    }
+
+    @Override
+    protected boolean set(Entity container, Float value) {
+        ((IMixinEntity) container).setSpongeSize(value, container.height);
+        return true;
+    }
+
+    @Override
+    protected Optional<Float> getVal(Entity container) {
+        return Optional.of(container.width);
+    }
+
+    @Override
+    protected ImmutableValue<Float> constructImmutableValue(Float value) {
+        return constructValue(value).asImmutable();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionResult.failNoData();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/HeightValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/HeightValueProcessor.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.entity;
+
+import net.minecraft.entity.Entity;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.SpongeValueFactory;
+import org.spongepowered.common.interfaces.entity.IMixinEntity;
+
+import java.util.Optional;
+
+public class HeightValueProcessor extends AbstractSpongeValueProcessor<Entity, Float, MutableBoundedValue<Float>> {
+
+    public HeightValueProcessor() {
+        super(Entity.class, Keys.HEIGHT);
+    }
+
+    @Override
+    protected MutableBoundedValue<Float> constructValue(Float actualValue) {
+        return SpongeValueFactory.boundedBuilder(Keys.HEIGHT)
+                .defaultValue(1f)
+                .minimum(0f)
+                .maximum(Float.MAX_VALUE)
+                .actualValue(actualValue)
+                .build();
+    }
+
+    @Override
+    protected boolean set(Entity container, Float value) {
+        ((IMixinEntity) container).setSpongeSize(container.width, value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Float> getVal(Entity container) {
+        return Optional.of(container.height);
+    }
+
+    @Override
+    protected ImmutableValue<Float> constructImmutableValue(Float value) {
+        return constructValue(value).asImmutable();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionResult.failNoData();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/ScaleValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/ScaleValueProcessor.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.entity;
+
+import net.minecraft.entity.Entity;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.SpongeValueFactory;
+import org.spongepowered.common.interfaces.entity.IMixinEntity;
+
+import java.util.Optional;
+
+public class ScaleValueProcessor extends AbstractSpongeValueProcessor<Entity, Float, MutableBoundedValue<Float>> {
+
+    public ScaleValueProcessor() {
+        super(Entity.class, Keys.SCALE);
+    }
+
+    @Override
+    protected MutableBoundedValue<Float> constructValue(Float actualValue) {
+        return SpongeValueFactory.boundedBuilder(Keys.SCALE)
+                .defaultValue(1f)
+                .minimum(0f)
+                .maximum(Float.MAX_VALUE)
+                .actualValue(actualValue)
+                .build();
+    }
+
+    @Override
+    protected boolean set(Entity container, Float value) {
+        return false;
+    }
+
+    @Override
+    protected Optional<Float> getVal(Entity container) {
+        return Optional.of(((IMixinEntity) container).getSizeScale());
+    }
+
+    @Override
+    protected ImmutableValue<Float> constructImmutableValue(Float value) {
+        return constructValue(value).asImmutable();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionResult.failNoData();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
@@ -144,4 +144,9 @@ public interface IMixinEntity extends org.spongepowered.api.entity.Entity {
     @Nullable IMixinChunk getActiveChunk();
 
     void setActiveChunk(IMixinChunk chunk);
+
+    void setSpongeSize(float base, float height);
+
+    float getSizeScale();
+
 }

--- a/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
@@ -544,8 +544,6 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
 
         this.fieldMap.put("attack_damage", makeSingleKey(TypeTokens.DOUBLE_TOKEN, TypeTokens.BOUNDED_DOUBLE_VALUE_TOKEN, of("EntityAttackDamage"), "sponge:entity_attack_damage", "Entity Attack Damage"));
 
-        this.fieldMap.put("base_size", makeSingleKey(TypeTokens.DOUBLE_TOKEN, TypeTokens.BOUNDED_DOUBLE_VALUE_TOKEN, of("EntityBaseSize"), "sponge:base_size", "Entity Base Size"));
-
         this.fieldMap.put("damage_entity_map", makeMapKey(TypeTokens.ENTITY_TYPE_DOUBLE_MAP_TOKEN, TypeTokens.ENTITY_TYPE_DOUBLE_MAP_VALUE_TOKEN, of("DamageEntityTypeMap"), "sponge:entity_type_damage_map", "Entity Type Damage Map"));
 
         this.fieldMap.put("dominant_hand", makeSingleKey(TypeTokens.HAND_PREFERENCE_TYPE_TOKEN, TypeTokens.HAND_PREFERENCE_VALUE_TOKEN, of("HandPreference"), "sponge:hand_preference", "Hand Preference"));
@@ -555,8 +553,6 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
         this.fieldMap.put("fluid_level", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("LiquidLevel"), "sponge:fluid_level", "Fluid Level"));
 
         this.fieldMap.put("health_scale", makeSingleKey(TypeTokens.DOUBLE_TOKEN, TypeTokens.BOUNDED_DOUBLE_VALUE_TOKEN, of("HealthScale"), "sponge:health_scale", "Health Scale"));
-
-        this.fieldMap.put("height", makeSingleKey(TypeTokens.DOUBLE_TOKEN, TypeTokens.BOUNDED_DOUBLE_VALUE_TOKEN, of("EntityHeight"), "sponge:entity_height", "Entity Height"));
 
         this.fieldMap.put("held_experience", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("HeldExperience"), "sponge:held_experience", "Held Experience"));
 
@@ -569,8 +565,6 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
         this.fieldMap.put("llama_strength", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("LlamaStrength"), "sponge:llama_strength", "Llama Strength"));
 
         this.fieldMap.put("llama_variant", makeSingleKey(TypeTokens.LLAMA_VARIANT_TOKEN, TypeTokens.LLAMA_VARIANT_VALUE_TOKEN, of("LlamaVariant"), "sponge:llama_variant", "Llama Variant"));
-
-        this.fieldMap.put("scale", makeSingleKey(TypeTokens.DOUBLE_TOKEN, TypeTokens.DOUBLE_VALUE_TOKEN, of("EntityScale"), "sponge:entity_scale", "Entity Scale"));
 
         this.fieldMap.put("will_shatter", makeSingleKey(TypeTokens.BOOLEAN_TOKEN, TypeTokens.BOOLEAN_VALUE_TOKEN, of("WillShatter"), "sponge:will_shatter", "Will Shatter"));
 
@@ -586,6 +580,11 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
         this.fieldMap.put("is_baby", makeSingleKey(TypeTokens.BOOLEAN_TOKEN, TypeTokens.BOOLEAN_VALUE_TOKEN, of("IsBaby"), "sponge:is_baby", "Is Baby"));
 
         this.fieldMap.put("health_scale", makeSingleKey(TypeTokens.DOUBLE_TOKEN, TypeTokens.BOUNDED_DOUBLE_VALUE_TOKEN, of("HealthScale"), "sponge:health_scale", "Health Scale"));
+
+        this.fieldMap.put("base_size", makeSingleKey(TypeTokens.FLOAT_TOKEN, TypeTokens.BOUNDED_FLOAT_VALUE_TOKEN, of("EntityBaseSize"), "sponge:base_size", "Entity Base Size"));
+        this.fieldMap.put("height", makeSingleKey(TypeTokens.FLOAT_TOKEN, TypeTokens.BOUNDED_FLOAT_VALUE_TOKEN, of("EntityHeight"), "sponge:entity_height", "Entity Height"));
+        this.fieldMap.put("scale", makeSingleKey(TypeTokens.FLOAT_TOKEN, TypeTokens.BOUNDED_FLOAT_VALUE_TOKEN, of("EntityScale"), "sponge:entity_scale", "Entity Scale"));
+
 
         for (Key<?> key : this.fieldMap.values()) {
             this.keyMap.put(key.getId().toLowerCase(Locale.ENGLISH), key);

--- a/testplugins/src/main/java/org/spongepowered/test/SizeDataTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/SizeDataTest.java
@@ -37,8 +37,6 @@ import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.EntityTypes;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
-import org.spongepowered.api.event.cause.Cause;
-import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.text.Text;
@@ -74,7 +72,7 @@ public class SizeDataTest {
                             entity.offer(Keys.BASE_SIZE, base.floatValue());
                             entity.offer(Keys.HEIGHT, height.floatValue());
 
-                            player.getWorld().spawnEntity(entity, Cause.of(NamedCause.source(player)));
+                            player.getWorld().spawnEntity(entity);
 
                             player.sendMessage(Text.of(TextColors.DARK_GREEN, "You have successfully spawned a " + entityType.getName() + " with the following stats:"));
                             player.sendMessage(Text.of(TextColors.GOLD, "Base size(width): ", TextColors.GRAY, entity.get(Keys.BASE_SIZE).orElse(1f)));

--- a/testplugins/src/main/java/org/spongepowered/test/SizeDataTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/SizeDataTest.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.entity.EntityTypes;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
+import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.util.blockray.BlockRay;
+import org.spongepowered.api.util.blockray.BlockRayHit;
+import org.spongepowered.api.world.World;
+
+@Plugin(id = "sizedatatest", name = "Size Data Test", description = "A plugin to test the size data implementation.")
+public class SizeDataTest {
+
+    @Listener
+    public void onGameInit(GamePreInitializationEvent event) {
+        Sponge.getCommandManager().register(this,
+                CommandSpec.builder()
+                        .description(Text.of("Size Command"))
+                        .arguments(
+                                GenericArguments.onlyOne(GenericArguments.catalogedElement(Text.of("entity"), EntityType.class)),
+                                GenericArguments.onlyOne(GenericArguments.doubleNum(Text.of("base"))),
+                                GenericArguments.onlyOne(GenericArguments.doubleNum(Text.of("height"))))
+                        .executor((src, args) -> {
+                            if (!(src instanceof Player)) {
+                                throw new CommandException(Text.of(TextColors.RED, "You must be an in-game player to use this command!"));
+                            }
+                            final EntityType entityType = args.<EntityType>getOne("entity").orElse(EntityTypes.ZOMBIE);
+
+                            final Double base = args.<Double>getOne("base").get();
+                            final Double height = args.<Double>getOne("height").get();
+
+                            final Player player = (Player) src;
+
+                            final Entity entity = player.getWorld().createEntity(entityType, getSpawnPosition(player));
+                            entity.offer(Keys.BASE_SIZE, base.floatValue());
+                            entity.offer(Keys.HEIGHT, height.floatValue());
+
+                            player.getWorld().spawnEntity(entity, Cause.of(NamedCause.source(player)));
+
+                            player.sendMessage(Text.of(TextColors.DARK_GREEN, "You have successfully spawned a " + entityType.getName() + " with the following stats:"));
+                            player.sendMessage(Text.of(TextColors.GOLD, "Base size(width): ", TextColors.GRAY, entity.get(Keys.BASE_SIZE).orElse(1f)));
+                            player.sendMessage(Text.of(TextColors.GOLD, "Height: ", TextColors.GRAY, entity.get(Keys.HEIGHT).orElse(1f)));
+                            player.sendMessage(Text.of(TextColors.GOLD, "Scale: ", TextColors.GRAY, entity.get(Keys.SCALE).orElse(1f)));
+
+                            return CommandResult.success();
+                        })
+                        .build(),
+                "sizetest");
+    }
+
+    private Vector3i getSpawnPosition(Player player) {
+        final BlockRay<World> playerBlockRay = BlockRay.from(player).distanceLimit(350).build();
+
+        BlockRayHit<World> finalHitRay = null;
+        Vector3i previousPosition = Vector3i.ONE;
+
+        while (playerBlockRay.hasNext()) {
+            final BlockRayHit<World> currentHitRay = playerBlockRay.next();
+
+            if (!player.getWorld().getBlockType(currentHitRay.getBlockPosition()).equals(BlockTypes.AIR)) {
+                finalHitRay = currentHitRay;
+                break;
+            }
+            previousPosition = currentHitRay.getBlockPosition();
+        }
+
+        if (finalHitRay == null) {
+            return player.getLocation().getBlockPosition();
+        } else {
+            return previousPosition;
+        }
+    }
+
+}


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1636) | **SpongeCommon**

Supersedes https://github.com/SpongePowered/SpongeCommon/pull/402

Implements size data based on Hassan's changes, but with some changes to the API and implementation, including the inclusion of a modified version of his test plugin. 

With this PR you can modify the base_size(width) and height, but developers have to keep in mind that this only changes the bounding box, it isn't super reliable, and Sponge(maybe Minecraft idk) limits the max size of a bounding box to 1000.

I am open to changes everywhere, from documentation to functionality, so please give this a good review.