### PR TITLE
Implement parrot data and variants

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -426,6 +426,9 @@ public class DataRegistrar {
         DataUtil.registerDualProcessor(PickupRuleData.class, SpongePickupRuleData.class, ImmutablePickupRuleData.class,
                 ImmutableSpongePickupRuleData.class, new PickupRuleDataProcessor());
 
+        DataUtil.registerDualProcessor(ParrotData.class, SpongeParrotData.class, ImmutableParrotData.class,
+                ImmutableSpongeParrotData.class, new ParrotDataProcessor());
+
         DataUtil.registerDataProcessorAndImpl(PickupDelayData.class, SpongePickupDelayData.class, ImmutablePickupDelayData.class,
                 ImmutableSpongePickupDelayData.class, new PickupDelayDataProcessor());
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeParrotData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeParrotData.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableParrotData;
+import org.spongepowered.api.data.manipulator.mutable.entity.ParrotData;
+import org.spongepowered.api.data.type.ParrotVariant;
+import org.spongepowered.api.data.type.ParrotVariants;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleCatalogData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeParrotData;
+
+public class ImmutableSpongeParrotData extends AbstractImmutableSingleCatalogData<ParrotVariant, ImmutableParrotData, ParrotData>
+        implements ImmutableParrotData {
+
+    public ImmutableSpongeParrotData(ParrotVariant variant) {
+        super(ImmutableParrotData.class, variant, ParrotVariants.RED, Keys.PARROT_VARIANT, SpongeParrotData.class);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeParrotData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeParrotData.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.entity;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableParrotData;
+import org.spongepowered.api.data.manipulator.mutable.entity.ParrotData;
+import org.spongepowered.api.data.type.ParrotVariant;
+import org.spongepowered.api.data.type.ParrotVariants;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeParrotData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleCatalogData;
+
+public class SpongeParrotData extends AbstractSingleCatalogData<ParrotVariant, ParrotData, ImmutableParrotData> implements ParrotData {
+
+    public SpongeParrotData() {
+        this(ParrotVariants.RED);
+    }
+
+    public SpongeParrotData(ParrotVariant variant) {
+        super(ParrotData.class, checkNotNull(variant, "The parrot variant cannot be null!"),
+                Keys.PARROT_VARIANT, ImmutableSpongeParrotData.class);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/ParrotDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/ParrotDataProcessor.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.data.entity;
+
+import net.minecraft.entity.passive.EntityParrot;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableParrotData;
+import org.spongepowered.api.data.manipulator.mutable.entity.ParrotData;
+import org.spongepowered.api.data.type.ParrotVariant;
+import org.spongepowered.api.data.type.ParrotVariants;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeParrotData;
+import org.spongepowered.common.data.processor.common.AbstractEntitySingleDataProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.entity.SpongeEntityConstants;
+import org.spongepowered.common.entity.SpongeParrotVariant;
+
+import java.util.Optional;
+
+public class ParrotDataProcessor extends
+        AbstractEntitySingleDataProcessor<EntityParrot, ParrotVariant, Value<ParrotVariant>, ParrotData, ImmutableParrotData> {
+
+    public ParrotDataProcessor() {
+        super(EntityParrot.class, Keys.PARROT_VARIANT);
+    }
+
+    @Override
+    protected boolean set(EntityParrot dataHolder, ParrotVariant value) {
+        dataHolder.setVariant(((SpongeParrotVariant)value).type);
+        return true;
+    }
+
+    @Override
+    protected Optional<ParrotVariant> getVal(EntityParrot dataHolder) {
+        return Optional.of(SpongeEntityConstants.PARROT_VARIANT_IDMAP.get(dataHolder.getVariant()));
+    }
+
+    @Override
+    protected ImmutableValue<ParrotVariant> constructImmutableValue(ParrotVariant value) {
+        return ImmutableSpongeValue.cachedOf(this.key, ParrotVariants.RED, value);
+    }
+
+    @Override
+    protected Value<ParrotVariant> constructValue(ParrotVariant actualValue) {
+        return new SpongeValue<>(this.key, ParrotVariants.RED, actualValue);
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionResult.failNoData();
+    }
+
+    @Override
+    protected ParrotData createManipulator() {
+        return new SpongeParrotData();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/util/DataConstants.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataConstants.java
@@ -209,4 +209,10 @@ public final class DataConstants {
         public static final int MAXIMUM_STRENGTH = 5;
 
     }
+
+    public static final class Parrot {
+
+        public static final ParrotVariant DEFAULT_VARIANT = ParrotVariants.RED;
+
+    }
 }

--- a/src/main/java/org/spongepowered/common/entity/SpongeEntityConstants.java
+++ b/src/main/java/org/spongepowered/common/entity/SpongeEntityConstants.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Maps;
 import org.spongepowered.api.data.type.HorseColor;
 import org.spongepowered.api.data.type.HorseStyle;
 import org.spongepowered.api.data.type.OcelotType;
+import org.spongepowered.api.data.type.ParrotVariant;
 import org.spongepowered.api.data.type.RabbitType;
 
 import java.util.Map;
@@ -42,6 +43,8 @@ public class SpongeEntityConstants {
     public static final Map<Integer, HorseColor> HORSE_COLOR_IDMAP = Maps.newHashMap();
     public static final Map<String, HorseStyle> HORSE_STYLES = Maps.newHashMap();
     public static final Map<Integer, HorseStyle> HORSE_STYLE_IDMAP = Maps.newHashMap();
+    public static final Map<String, ParrotVariant> PARROT_VARIANTS = Maps.newHashMap();
+    public static final Map<Integer, ParrotVariant> PARROT_VARIANT_IDMAP = Maps.newHashMap();
 
     // ocelot types
     public static final SpongeOcelotType WILD_OCELOT = new SpongeOcelotType(0, "WILD_OCELOT");
@@ -74,6 +77,12 @@ public class SpongeEntityConstants {
     public static final SpongeHorseStyle WHITE_DOTS = new SpongeHorseStyle(3, "WHITE_DOTS");
     public static final SpongeHorseStyle BLACK_DOTS = new SpongeHorseStyle(4, "BLACK_DOTS");
 
+    // parrot variants
+    public static final SpongeParrotVariant RED_PARROT = new SpongeParrotVariant(0, "RED");
+    public static final SpongeParrotVariant BLUE_PARROT = new SpongeParrotVariant(1, "BLUE");
+    public static final SpongeParrotVariant GREEN_PARROT = new SpongeParrotVariant(2, "GREEN");
+    public static final SpongeParrotVariant CYAN_PARROT = new SpongeParrotVariant(3, "CYAN");
+    public static final SpongeParrotVariant GRAY_PARROT = new SpongeParrotVariant(4, "GRAY");
 
     static {
         OCELOT_TYPES.put("wild_ocelot", WILD_OCELOT);
@@ -130,5 +139,16 @@ public class SpongeEntityConstants {
         HORSE_STYLE_IDMAP.put(3, WHITE_DOTS);
         HORSE_STYLE_IDMAP.put(4, BLACK_DOTS);
 
+        PARROT_VARIANTS.put("red", RED_PARROT);
+        PARROT_VARIANTS.put("blue", BLUE_PARROT);
+        PARROT_VARIANTS.put("green", GREEN_PARROT);
+        PARROT_VARIANTS.put("cyan", CYAN_PARROT);
+        PARROT_VARIANTS.put("gray", GRAY_PARROT);
+
+        PARROT_VARIANT_IDMAP.put(0, RED_PARROT);
+        PARROT_VARIANT_IDMAP.put(1, BLUE_PARROT);
+        PARROT_VARIANT_IDMAP.put(2, GREEN_PARROT);
+        PARROT_VARIANT_IDMAP.put(3, CYAN_PARROT);
+        PARROT_VARIANT_IDMAP.put(4, GRAY_PARROT);
     }
 }

--- a/src/main/java/org/spongepowered/common/entity/SpongeParrotVariant.java
+++ b/src/main/java/org/spongepowered/common/entity/SpongeParrotVariant.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.entity;
+
+import org.spongepowered.api.data.type.ParrotVariant;
+
+public class SpongeParrotVariant extends SpongeEntityMeta implements ParrotVariant {
+
+    public SpongeParrotVariant(int type, String name) {
+        super(type, name);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityParrot.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityParrot.java
@@ -1,0 +1,69 @@
+package org.spongepowered.common.mixin.core.entity.passive;
+
+import net.minecraft.entity.passive.EntityParrot;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.entity.ParrotData;
+import org.spongepowered.api.data.type.ParrotVariant;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.entity.living.animal.Parrot;
+import org.spongepowered.api.event.CauseStackManager.StackFrame;
+import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeParrotData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSittingData;
+import org.spongepowered.common.data.util.DataConstants;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.entity.SpongeEntityConstants;
+
+import java.util.List;
+import java.util.Random;
+
+@Mixin(EntityParrot.class)
+public abstract class MixinEntityParrot extends MixinEntityTameable implements Parrot {
+
+    @Shadow public abstract int getVariant();
+
+    @Redirect(method = "processInteract", at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 0, remap = false))
+    public int onTame(Random rand, int bound, EntityPlayer player, EnumHand hand) {
+        ItemStack stack = player.getHeldItem(hand);
+        int random = rand.nextInt(bound);
+        if (random == 0) {
+            stack.setCount(stack.getCount() + 1);
+            try (StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+                Sponge.getCauseStackManager().pushCause(player);
+                if (!SpongeImpl.postEvent(SpongeEventFactory.createTameEntityEvent(Sponge.getCauseStackManager().getCurrentCause(), this))) {
+                    stack.setCount(stack.getCount() - 1);
+                    return random;
+                }
+            }
+        }
+        return 1;
+    }
+
+    @Override
+    public ParrotData getParrotData() {
+        return new SpongeParrotData(SpongeEntityConstants.PARROT_VARIANT_IDMAP.get(this.getVariant()));
+    }
+
+    @Override
+    public Value<ParrotVariant> variant() {
+        return new SpongeValue<>(Keys.PARROT_VARIANT, DataConstants.Parrot.DEFAULT_VARIANT, SpongeEntityConstants.PARROT_VARIANT_IDMAP.get(this.getVariant()));
+    }
+
+    @Override
+    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+        super.supplyVanillaManipulators(manipulators);
+        manipulators.add(new SpongeSittingData(this.shadow$isSitting()));
+        manipulators.add(getParrotData());
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityParrot.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityParrot.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.common.mixin.core.entity.passive;
 
 import net.minecraft.entity.passive.EntityParrot;

--- a/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
@@ -392,6 +392,7 @@ public final class CommonModuleRegistry {
             .registerModule(NotePitch.class, new NotePitchRegistryModule())
             .registerModule(ObjectiveDisplayMode.class, new ObjectiveDisplayModeRegistryModule())
             .registerModule(OcelotType.class, new OcelotTypeRegistryModule())
+            .registerModule(ParrotVariant.class, new ParrotVariantRegistryModule())
             .registerModule(ParticleType.class, ParticleRegistryModule.getInstance())
             .registerModule((Class<ParticleOption<?>>) (Class<?>) ParticleOption.class, new ParticleOptionRegistryModule())
             .registerModule(PistonType.class, new PistonTypeRegistryModule())

--- a/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
@@ -378,6 +378,8 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
 
         this.fieldMap.put("rabbit_type", makeSingleKey(TypeTokens.RABBIT_TOKEN, TypeTokens.RABBIT_VALUE_TOKEN, of("RabbitType"), "sponge:rabbit_type", "Rabbit Type"));
 
+        this.fieldMap.put("parrot_variant", makeSingleKey(TypeTokens.PARROT_VARIANT_TOKEN, TypeTokens.PARROT_VARIANT_VALUE_TOKEN, of("ParrotVariant"), "sponge:parrot_variant", "Parrot Variant"));
+
         this.fieldMap.put("lock_token", makeSingleKey(TypeTokens.STRING_TOKEN, TypeTokens.STRING_VALUE_TOKEN, of("Lock"), "sponge:lock", "Lock"));
 
         this.fieldMap.put("banner_base_color", makeSingleKey(TypeTokens.DYE_COLOR_TOKEN, TypeTokens.DYE_COLOR_VALUE_TOKEN, of("BannerBaseColor"), "sponge:banner_base_color", "Banner Base Color"));

--- a/src/main/java/org/spongepowered/common/registry/type/entity/EntityTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/entity/EntityTypeRegistryModule.java
@@ -40,6 +40,7 @@ import net.minecraft.util.ResourceLocation;
 import org.spongepowered.api.data.type.HorseColors;
 import org.spongepowered.api.data.type.HorseStyles;
 import org.spongepowered.api.data.type.OcelotTypes;
+import org.spongepowered.api.data.type.ParrotVariants;
 import org.spongepowered.api.data.type.RabbitTypes;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.EntityTypes;
@@ -233,6 +234,7 @@ public final class EntityTypeRegistryModule implements ExtraClassCatalogRegistry
         RegistryHelper.mapFields(HorseStyles.class, SpongeEntityConstants.HORSE_STYLES);
         RegistryHelper.mapFields(OcelotTypes.class, SpongeEntityConstants.OCELOT_TYPES);
         RegistryHelper.mapFields(RabbitTypes.class, SpongeEntityConstants.RABBIT_TYPES);
+        RegistryHelper.mapFields(ParrotVariants.class, SpongeEntityConstants.PARROT_VARIANTS);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/registry/type/entity/ParrotVariantRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/entity/ParrotVariantRegistryModule.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.registry.type.entity;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.data.type.ParrotVariant;
+import org.spongepowered.api.data.type.ParrotVariants;
+import org.spongepowered.api.registry.CatalogRegistryModule;
+import org.spongepowered.api.registry.util.RegisterCatalog;
+import org.spongepowered.common.entity.SpongeEntityConstants;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+public class ParrotVariantRegistryModule implements CatalogRegistryModule<ParrotVariant> {
+
+    @RegisterCatalog(ParrotVariants.class)
+    private final Map<String, ParrotVariant> parrotVariantMap = new HashMap<>();
+
+    @Override
+    public Optional<ParrotVariant> getById(String id) {
+        return Optional.ofNullable(this.parrotVariantMap.get(checkNotNull(id).toLowerCase(Locale.ENGLISH)));
+    }
+
+    @Override
+    public Collection<ParrotVariant> getAll() {
+        return ImmutableList.copyOf(this.parrotVariantMap.values());
+    }
+
+    @Override
+    public void registerDefaults() {
+        this.parrotVariantMap.putAll(SpongeEntityConstants.PARROT_VARIANTS);
+
+    }
+
+}

--- a/src/main/resources/META-INF/common_at.cfg
+++ b/src/main/resources/META-INF/common_at.cfg
@@ -400,6 +400,7 @@ public-f org.spongepowered.api.data.type.HorseStyles *
 public-f org.spongepowered.api.data.type.LogAxes *
 public-f org.spongepowered.api.data.type.NotePitches *
 public-f org.spongepowered.api.data.type.OcelotTypes *
+public-f org.spongepowered.api.data.type.ParrotVariants *
 public-f org.spongepowered.api.data.type.PickupRules *
 public-f org.spongepowered.api.data.type.PistonTypes *
 public-f org.spongepowered.api.data.type.PlantTypes *

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -287,6 +287,7 @@
         "entity.passive.MixinEntityMooshroom",
         "entity.passive.MixinEntityMule",
         "entity.passive.MixinEntityOcelot",
+        "entity.passive.MixinEntityParrot",
         "entity.passive.MixinEntityPig",
         "entity.passive.MixinEntityPolarBear",
         "entity.passive.MixinEntityRabbit",

--- a/testplugins/src/main/java/org/spongepowered/test/ParrotDataTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/ParrotDataTest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.type.ParrotVariant;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntityTypes;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.entity.InteractEntityEvent;
+import org.spongepowered.api.event.filter.cause.Root;
+import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+
+@Plugin(id = "parrotdatatest", name = "Parrot Data Test", description = "A plugin to test parrot data.")
+public class ParrotDataTest {
+
+    private ParrotVariant parrotVariant;
+
+    @Listener
+    public void onGamePreInitialization(GamePreInitializationEvent event) {
+        Sponge.getCommandManager().register(this,
+                CommandSpec.builder()
+                        .arguments(GenericArguments.onlyOne(GenericArguments.catalogedElement(Text.of("parrot variant"), ParrotVariant.class)))
+                        .executor((src, args) -> {
+                            this.parrotVariant = args.<ParrotVariant>getOne("parrot variant").get();
+
+                            src.sendMessage(Text.of(TextColors.DARK_GREEN, "Click a parrot to change their variant to: ",
+                                    TextColors.GRAY, this.parrotVariant.getName()));
+
+                            return CommandResult.success();
+                        })
+                        .build(),
+                "parrottest");
+    }
+
+    @Listener
+    public void onEntityInteract(InteractEntityEvent event, @Root Player player) {
+        final Entity entity = event.getTargetEntity();
+        if (entity.getType().equals(EntityTypes.PARROT) && this.parrotVariant != null) {
+            entity.offer(Keys.PARROT_VARIANT, this.parrotVariant);
+            player.sendMessage(Text.of(TextColors.GOLD, "The selected parrot has been turned to the variant: ",
+                    TextColors.GRAY, this.parrotVariant.getName()));
+            this.parrotVariant = null;
+        }
+    }
+
+}


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1638) | **SpongeCommon**

This pull request implements parrot data and parrot variants, as well as adding a cute little test plugin.

For now I default to red in places as that is the parrot in vanilla with the 0 meta, so it made sense, but I'm open to changing this.

Cheers 🐦 

(Here's me using the test plugin to make a ton of red parrots)
![2017-08-18_02 23 47](https://user-images.githubusercontent.com/18372958/29448581-e8561956-83bc-11e7-8609-0398478fd58c.png)
