### PR TITLE
SlotTransformation and Root Inventory

### DIFF
--- a/src/main/java/org/spongepowered/common/item/inventory/EmptyInventoryImpl.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/EmptyInventoryImpl.java
@@ -259,6 +259,11 @@ public class EmptyInventoryImpl implements EmptyInventory, Observer<InventoryEve
         return this.parent;
     }
 
+    @Override
+    public Inventory root() {
+        return this.parent == this ? this : this.parent.root();
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public <T extends Inventory> T next() {

--- a/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/MinecraftInventoryAdapter.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/MinecraftInventoryAdapter.java
@@ -51,6 +51,11 @@ public interface MinecraftInventoryAdapter extends InventoryAdapter<IInventory, 
     }
 
     @Override
+    default Inventory root() {
+        return this.parent() == this ? this : this.parent().root();
+    }
+
+    @Override
     default Optional<ItemStack> poll() {
         return Adapter.Logic.pollSequential(this);
     }

--- a/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/slots/SlotAdapter.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/slots/SlotAdapter.java
@@ -32,12 +32,13 @@ import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.item.inventory.transaction.InventoryTransactionResult;
-import org.spongepowered.api.item.inventory.transaction.InventoryTransactionResult.Type;
 import org.spongepowered.common.interfaces.inventory.IMixinSlot;
 import org.spongepowered.common.item.inventory.adapter.InventoryAdapter;
 import org.spongepowered.common.item.inventory.adapter.impl.Adapter;
 import org.spongepowered.common.item.inventory.lens.Fabric;
 import org.spongepowered.common.item.inventory.lens.impl.MinecraftFabric;
+import org.spongepowered.common.item.inventory.lens.impl.fabric.ContainerFabric;
+import org.spongepowered.common.item.inventory.lens.impl.fabric.DelegatingFabric;
 import org.spongepowered.common.item.inventory.lens.impl.slots.FakeSlotLensImpl;
 import org.spongepowered.common.item.inventory.lens.impl.slots.SlotLensImpl;
 import org.spongepowered.common.item.inventory.lens.slots.SlotLens;
@@ -156,7 +157,7 @@ public class SlotAdapter extends Adapter implements Slot {
 //        this.inventory.markDirty();
 //        return InventoryTransactionResult.successNoTransactions();
 
-        InventoryTransactionResult.Builder result = InventoryTransactionResult.builder().type(Type.SUCCESS);
+        InventoryTransactionResult.Builder result = InventoryTransactionResult.builder().type(InventoryTransactionResult.Type.SUCCESS);
         net.minecraft.item.ItemStack nativeStack = ItemStackUtil.toNative(stack);
 
         int maxStackSize = this.slot.getMaxStackSize(this.inventory);
@@ -185,7 +186,7 @@ public class SlotAdapter extends Adapter implements Slot {
 
     @Override
     public InventoryTransactionResult set(ItemStack stack) {
-        InventoryTransactionResult.Builder result = InventoryTransactionResult.builder().type(Type.SUCCESS);
+        InventoryTransactionResult.Builder result = InventoryTransactionResult.builder().type(InventoryTransactionResult.Type.SUCCESS);
         net.minecraft.item.ItemStack nativeStack = ItemStackUtil.toNative(stack);
 
         net.minecraft.item.ItemStack old = this.slot.getStack(this.inventory);
@@ -256,7 +257,27 @@ public class SlotAdapter extends Adapter implements Slot {
         return super.getMaxStackSize();
     }
 
-//    @Override
+    @Override
+    public Slot transform(Type type) {
+        switch (type) {
+            case INVENTORY:
+                if (this.inventory instanceof DelegatingFabric) {
+                    return ((Slot) ((DelegatingFabric) this.inventory).getDelegate());
+                }
+                if (this.inventory instanceof ContainerFabric) {
+                    return ((Slot) ((ContainerFabric) this.inventory).getContainer().getSlot(this.slotNumber));
+                }
+            default:
+                return this;
+        }
+    }
+
+    @Override
+    public Slot transform() {
+        return this.transform(Type.INVENTORY);
+    }
+
+    //    @Override
 //    public Iterator<Inventory> iterator() {
 //        // TODO
 //        return super.iterator();

--- a/src/main/java/org/spongepowered/common/item/inventory/lens/impl/fabric/ContainerFabric.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/lens/impl/fabric/ContainerFabric.java
@@ -133,4 +133,7 @@ public class ContainerFabric extends MinecraftFabric {
         }
     }
 
+    public Container getContainer() {
+        return this.container;
+    }
 }

--- a/src/main/java/org/spongepowered/common/item/inventory/lens/impl/fabric/DelegatingFabric.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/lens/impl/fabric/DelegatingFabric.java
@@ -91,4 +91,7 @@ public class DelegatingFabric extends MinecraftFabric {
         this.slot.onSlotChanged();
     }
 
+    public Slot getDelegate() {
+        return this.slot;
+    }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/inventory/MixinInventoryCrafting.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/inventory/MixinInventoryCrafting.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.inventory;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.InventoryBasic;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.item.inventory.adapter.InventoryAdapter;
+import org.spongepowered.common.item.inventory.adapter.impl.MinecraftInventoryAdapter;
+import org.spongepowered.common.item.inventory.lens.Fabric;
+import org.spongepowered.common.item.inventory.lens.Lens;
+import org.spongepowered.common.item.inventory.lens.LensProvider;
+import org.spongepowered.common.item.inventory.lens.SlotProvider;
+import org.spongepowered.common.item.inventory.lens.impl.collections.SlotCollection;
+import org.spongepowered.common.item.inventory.lens.impl.comp.OrderedInventoryLensImpl;
+import org.spongepowered.common.item.inventory.lens.impl.fabric.DefaultInventoryFabric;
+
+@Mixin(InventoryCrafting.class)
+@Implements(value = @Interface(iface = MinecraftInventoryAdapter.class, prefix = "inventory$"))
+public abstract class MixinInventoryCrafting implements IInventory, LensProvider<IInventory, ItemStack> {
+
+    protected Fabric<IInventory> fabric;
+    protected SlotCollection slots;
+    protected Lens<IInventory, ItemStack> lens;
+
+    @Shadow public abstract int getSizeInventory();
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    public void onConstructed(CallbackInfo ci) {
+        this.fabric = new DefaultInventoryFabric(this);
+        this.slots = new SlotCollection.Builder().add(this.getSizeInventory()).build();
+        this.lens = getRootLens(fabric, ((InventoryAdapter) this));
+    }
+
+    @Override
+    public Lens<IInventory, ItemStack> getRootLens(Fabric<IInventory> fabric, InventoryAdapter<IInventory, ItemStack> adapter) {
+        if (this.getSizeInventory() == 0) {
+            return null; // No Lens when inventory has no slots
+        }
+        return new OrderedInventoryLensImpl(0, this.getSizeInventory(), 1, this.slots);
+    }
+
+    public SlotProvider<IInventory, ItemStack> inventory$getSlotProvider() {
+        return this.slots;
+    }
+
+    public Lens<IInventory, ItemStack> inventory$getRootLens() {
+        return this.lens;
+    }
+
+    public Fabric<IInventory> inventory$getInventory() {
+        return this.fabric;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/item/inventory/MixinSlot.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/inventory/MixinSlot.java
@@ -48,4 +48,14 @@ public abstract class MixinSlot implements org.spongepowered.api.item.inventory.
     public Inventory parent() {
         return ((Inventory) this.inventory);
     }
+
+    @Override
+    public org.spongepowered.api.item.inventory.Slot transform(Type type) {
+        return this;
+    }
+
+    @Override
+    public org.spongepowered.api.item.inventory.Slot transform() {
+        return this.transform(Type.INVENTORY);
+    }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/item/inventory/MixinSlot.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/inventory/MixinSlot.java
@@ -24,7 +24,9 @@
  */
 package org.spongepowered.common.mixin.core.item.inventory;
 
+import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
+import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -35,9 +37,15 @@ public abstract class MixinSlot implements org.spongepowered.api.item.inventory.
 
     @Shadow @Final private int slotIndex;
 
+    @Shadow @Final public IInventory inventory;
+
     @Override
     public int getSlotIndex() {
         return this.slotIndex;
     }
 
+    @Override
+    public Inventory parent() {
+        return ((Inventory) this.inventory);
+    }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/item/inventory/TraitInventoryAdapter.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/inventory/TraitInventoryAdapter.java
@@ -87,6 +87,11 @@ public abstract class TraitInventoryAdapter implements MinecraftInventoryAdapter
         return this.parent == null ? this : this.parent();
     }
 
+    @Override
+    public Inventory root() {
+        return this.parent() == this ? this : this.parent.root();
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public <T extends Inventory> T first() {

--- a/src/main/java/org/spongepowered/common/mixin/core/item/inventory/TraitInventoryAdapter.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/inventory/TraitInventoryAdapter.java
@@ -29,6 +29,7 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryBasic;
+import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.inventory.InventoryLargeChest;
 import net.minecraft.tileentity.TileEntityLockable;
 import org.spongepowered.api.Sponge;
@@ -68,7 +69,8 @@ import java.util.Optional;
         TileEntityLockable.class,
         CustomInventory.class,
         InventoryBasic.class,
-        SpongeUserInventory.class
+        SpongeUserInventory.class,
+        InventoryCrafting.class
 }, priority = 999)
 @Implements(@Interface(iface = Inventory.class, prefix = "inventory$"))
 public abstract class TraitInventoryAdapter implements MinecraftInventoryAdapter {

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -324,6 +324,7 @@
         "event.cause.entity.damage.MixinMinecraftBlockDamageSource",
         "event.cause.entity.damage.MixinMinecraftFallingBlockDamageSource",
         "inventory.MixinInventoryBasic",
+        "inventory.MixinInventoryCrafting",
         "inventory.MixinInventoryEnderChest",
         "inventory.MixinInventoryHelper",
         "inventory.MixinInventoryLargeChest",

--- a/testplugins/src/main/java/org/spongepowered/test/CustomInventoryTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/CustomInventoryTest.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.event.block.InteractBlockEvent;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.entity.InteractEntityEvent;
 import org.spongepowered.api.event.filter.Getter;
+import org.spongepowered.api.event.filter.cause.First;
 import org.spongepowered.api.event.filter.cause.Root;
 import org.spongepowered.api.event.item.inventory.ClickInventoryEvent;
 import org.spongepowered.api.item.ItemTypes;
@@ -181,20 +182,16 @@ public class CustomInventoryTest {
                         Sponge.getCauseStackManager().popCause();
                         event.setCancelled(true);
                     }
-                })
-        ;
+                });
     }
 
     @Listener
-    public void onInventoryClick(ClickInventoryEvent event, @Root Player player, @Getter("getTargetInventory") CarriedInventory<?> container) {
-        Optional<? extends Carrier> carrier = container.getCarrier();
-        if (carrier.isPresent() && carrier.get() instanceof BasicCarrier) {
-            for (SlotTransaction trans : event.getTransactions()) {
-                Slot slot = trans.getSlot();
-                Slot realSlot = slot.transform();
-                Integer slotClicked = slot.getProperty(SlotIndex.class, "slotindex").map(SlotIndex::getValue).orElse(-1);
-                player.sendMessage(Text.of("You clicked Slot ", slotClicked, " in ", container.getName(), "/", realSlot.parent().getName()));
-            }
+    public void onInventoryClick(ClickInventoryEvent event, @First Player player, @Getter("getTargetInventory") CarriedInventory<?> container) {
+        for (SlotTransaction trans : event.getTransactions()) {
+            Slot slot = trans.getSlot();
+            Slot realSlot = slot.transform();
+            Integer slotClicked = slot.getProperty(SlotIndex.class, "slotindex").map(SlotIndex::getValue).orElse(-1);
+            player.sendMessage(Text.of("You clicked Slot ", slotClicked, " in ", container.getName(), "/", realSlot.parent().getName()));
         }
     }
 

--- a/testplugins/src/main/java/org/spongepowered/test/CustomInventoryTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/CustomInventoryTest.java
@@ -44,6 +44,7 @@ import org.spongepowered.api.item.inventory.Carrier;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.InventoryArchetypes;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.item.inventory.property.GuiIdProperty;
 import org.spongepowered.api.item.inventory.property.GuiIds;
 import org.spongepowered.api.item.inventory.property.InventoryDimension;
@@ -189,8 +190,10 @@ public class CustomInventoryTest {
         Optional<? extends Carrier> carrier = container.getCarrier();
         if (carrier.isPresent() && carrier.get() instanceof BasicCarrier) {
             for (SlotTransaction trans : event.getTransactions()) {
-                Integer slotClicked = trans.getSlot().getProperty(SlotIndex.class, "slotindex").map(SlotIndex::getValue).orElse(-1);
-                player.sendMessage(Text.of("You clicked Slot ", slotClicked, " in ", container.getName()));
+                Slot slot = trans.getSlot();
+                Slot realSlot = slot.transform();
+                Integer slotClicked = slot.getProperty(SlotIndex.class, "slotindex").map(SlotIndex::getValue).orElse(-1);
+                player.sendMessage(Text.of("You clicked Slot ", slotClicked, " in ", container.getName(), "/", realSlot.parent().getName()));
             }
         }
     }

--- a/testplugins/src/main/java/org/spongepowered/test/CustomInventoryTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/CustomInventoryTest.java
@@ -34,7 +34,6 @@ import org.spongepowered.api.entity.living.monster.Slime;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.block.InteractBlockEvent;
-import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.entity.InteractEntityEvent;
 import org.spongepowered.api.event.filter.Getter;
 import org.spongepowered.api.event.filter.cause.First;
@@ -58,8 +57,6 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
-import java.util.Optional;
-
 /**
  * When trying to break an Inventory TE while sneaking you open a custom Version of it instead.
  * Clicks in the opened Inventory are recorded with their SlotIndex in your Chat.
@@ -73,8 +70,8 @@ public class CustomInventoryTest {
         if (!player.get(Keys.IS_SNEAKING).orElse(false)) {
             return;
         }
-        event.getTargetBlock().getLocation().ifPresent(loc ->{
-                interactCarrier(event, player, loc);
+        event.getTargetBlock().getLocation().ifPresent(loc -> {
+                    interactCarrier(event, player, loc);
                     interactOtherBlock(event, player, loc);
                 }
         );
@@ -92,7 +89,7 @@ public class CustomInventoryTest {
             } else {
                 builder = Inventory.builder().of(InventoryArchetypes.HORSE_WITH_CHEST);
             }
-            Inventory inventory =  builder.property(InventoryTitle.PROPERTY_NAME, InventoryTitle.of(Text.of("Custom Mule")))
+            Inventory inventory = builder.property(InventoryTitle.PROPERTY_NAME, InventoryTitle.of(Text.of("Custom Mule")))
                     .withCarrier(((Horse) event.getTargetEntity()))
                     .build(this);
             int i = 1;
@@ -110,7 +107,7 @@ public class CustomInventoryTest {
             } else {
                 builder = Inventory.builder().of(InventoryArchetypes.HORSE_WITH_CHEST);
             }
-            Inventory inventory =  builder.property(InventoryTitle.PROPERTY_NAME, InventoryTitle.of(Text.of("Custom Llama")))
+            Inventory inventory = builder.property(InventoryTitle.PROPERTY_NAME, InventoryTitle.of(Text.of("Custom Llama")))
                     .withCarrier(((Horse) event.getTargetEntity()))
                     .build(this);
             int i = 1;
@@ -170,19 +167,19 @@ public class CustomInventoryTest {
 
     private void interactCarrier(InteractBlockEvent.Primary event, Player player, Location<World> loc) {
         loc.getTileEntity().ifPresent(te -> {
-                    if (te instanceof Carrier) {
-                        BasicCarrier myCarrier = new BasicCarrier();
-                        Inventory custom = Inventory.builder().from(((Carrier) te).getInventory())
-                                .property(InventoryTitle.PROPERTY_NAME, InventoryTitle.of(Text.of("Custom ", ((Carrier) te).getInventory().getName())))
-                                .withCarrier(myCarrier)
-                                .build(this);
-                        myCarrier.init(custom);
-                        Sponge.getCauseStackManager().pushCause(player);
-                        player.openInventory(custom);
-                        Sponge.getCauseStackManager().popCause();
-                        event.setCancelled(true);
-                    }
-                });
+            if (te instanceof Carrier) {
+                BasicCarrier myCarrier = new BasicCarrier();
+                Inventory custom = Inventory.builder().from(((Carrier) te).getInventory())
+                        .property(InventoryTitle.PROPERTY_NAME, InventoryTitle.of(Text.of("Custom ", ((Carrier) te).getInventory().getName())))
+                        .withCarrier(myCarrier)
+                        .build(this);
+                myCarrier.init(custom);
+                Sponge.getCauseStackManager().pushCause(player);
+                player.openInventory(custom);
+                Sponge.getCauseStackManager().popCause();
+                event.setCancelled(true);
+            }
+        });
     }
 
     @Listener


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1642) | *SpongeCommon*


For now the only tranformation is for transforming
ContainerSlots into InventorySlots

so that `eventSlot.transform().root()` is always the actual inventory clicked 