### PR TITLE
Fix HarvestingProperty for pickaxes

### DIFF
--- a/src/main/java/org/spongepowered/common/data/property/store/item/HarvestingPropertyStore.java
+++ b/src/main/java/org/spongepowered/common/data/property/store/item/HarvestingPropertyStore.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.data.property.store.item;
 import com.google.common.collect.ImmutableSet;  
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemPickaxe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemTool;
 import org.spongepowered.api.block.BlockType;
@@ -44,7 +45,7 @@ public class HarvestingPropertyStore extends AbstractItemStackPropertyStore<Harv
     @Override
     protected Optional<HarvestingProperty> getFor(ItemStack itemStack) {
         final Item item = itemStack.getItem();
-        if (item instanceof ItemTool) {
+        if (item instanceof ItemTool && !(item instanceof ItemPickaxe)) {
             final ImmutableSet<BlockType> blocks = ImmutableSet.copyOf((Set) ((ItemTool) item).effectiveBlocks);
             return Optional.of(new HarvestingProperty(blocks));
         }


### PR DESCRIPTION
This fixes obtaining the correct set of blocks in HarvestingProperty for pickaxes. I made a plugin that can easily demonstrate this change. When a player begins breaking a block, the plugin will automatically switch the item in their hand with the correct item for breaking that block. Currently, if a player has a diamond pickaxe in their inventory and tries to break obsidian it won't switch but with this change it does. [Plugin source](https://github.com/RysingDragon/ToolSwitch/blob/master/src/main/java/com/rysingdragon/toolswitch/ToolSwitch.java)