### PR TITLE
Fix a bug where a CustomInventory cannot handle inventory events

### DIFF
--- a/src/main/java/org/spongepowered/common/item/inventory/custom/CustomInventoryListener.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/custom/CustomInventoryListener.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.event.EventListener;
 import org.spongepowered.api.event.item.inventory.InteractInventoryEvent;
 import org.spongepowered.api.item.inventory.Inventory;
+import org.spongepowered.common.item.inventory.util.ContainerUtil;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -45,11 +46,15 @@ public class CustomInventoryListener implements EventListener<InteractInventoryE
 
     @Override
     public void handle(InteractInventoryEvent event) throws Exception {
-        if (!(event.getTargetInventory() == this.inventory || (event.getTargetInventory() instanceof CustomContainer && (((CustomContainer) event.getTargetInventory()).inv == this.inventory)))) {
-            return;
-        }
-        for (Consumer<InteractInventoryEvent> consumer: this.consumers) {
-            consumer.accept(event);
+        net.minecraft.inventory.Container nativeContainer = ContainerUtil.toNative(event.getTargetInventory());
+        for (net.minecraft.inventory.Slot slot : nativeContainer.inventorySlots) {
+            if (slot.inventory == this.inventory) {
+                // This container does contain our inventory
+                for (Consumer<InteractInventoryEvent> consumer: this.consumers) {
+                    consumer.accept(event);
+                }
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
In the old version of the implementation, the `CustomInventoryListener` checks if the target inventory is `CustomContainer`. However, a `CustomInventory` does not always create a `CustomContainer` as its container (See [CustomInventory.java](https://github.com/SpongePowered/SpongeCommon/blob/b4bf667e87e0adde1ade8843efa30b0b28430aeb/src/main/java/org/spongepowered/common/item/inventory/custom/CustomInventory.java#L134)), and the condition will usually return false, then the events won't be fired.

There is a new way to detect if the target container does contain our custom inventory. All of the slots will be iterated, and if one of the slots belongs to our inventory, all of those related events will be fired and everything works well.

I'm the author of a chest menu plugin ([ustc-zzzz/VirtualChest](https://github.com/ustc-zzzz/VirtualChest/)), and I'm trying to port my plugin to 1.12.x. It was not working until I made this commit and built a new jar for testing.