### PR TITLE
Fix cause for natural entity spawns.

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/CauseTracker.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/CauseTracker.java
@@ -623,6 +623,7 @@ public final class CauseTracker {
             // capture all entities until the phase is marked for completion.
             if (!isForced) {
                 try {
+                    Sponge.getCauseStackManager().pushCause(world);
                     return ((IPhaseState) phaseState).spawnEntityOrCapture(context, entity, chunkX, chunkZ);
                 } catch (Exception | NoClassDefFoundError e) {
                     // Just in case something really happened, we should print a nice exception for people to

--- a/src/main/java/org/spongepowered/common/event/tracking/CauseTracker.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/CauseTracker.java
@@ -623,7 +623,6 @@ public final class CauseTracker {
             // capture all entities until the phase is marked for completion.
             if (!isForced) {
                 try {
-                    Sponge.getCauseStackManager().pushCause(world);
                     return ((IPhaseState) phaseState).spawnEntityOrCapture(context, entity, chunkX, chunkZ);
                 } catch (Exception | NoClassDefFoundError e) {
                     // Just in case something really happened, we should print a nice exception for people to

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GeneralGenerationPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GeneralGenerationPhaseState.java
@@ -116,11 +116,9 @@ abstract class GeneralGenerationPhaseState<G extends GenerationContext<G>> imple
             return;
         }
         try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
-            Sponge.getCauseStackManager().addContext(EventContextKeys.SPAWN_TYPE, SpawnTypes.WORLD_SPAWNER);
+            frame.addContext(EventContextKeys.SPAWN_TYPE, SpawnTypes.WORLD_SPAWNER);
     
-            final SpawnEntityEvent.Spawner
-                    event =
-                    SpongeEventFactory.createSpawnEntityEventSpawner(Sponge.getCauseStackManager().getCurrentCause(), spawnedEntities);
+            final SpawnEntityEvent.Spawner event = SpongeEventFactory.createSpawnEntityEventSpawner(frame.getCurrentCause(), spawnedEntities);
             SpongeImpl.postEvent(event);
             if (!event.isCancelled()) {
                 for (Entity entity : event.getEntities()) {
@@ -135,10 +133,10 @@ abstract class GeneralGenerationPhaseState<G extends GenerationContext<G>> imple
         final ArrayList<Entity> entities = new ArrayList<>(1);
         entities.add(entity);
         try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+            frame.pushCause(entity.getLocation().getExtent());
             frame.addContext(EventContextKeys.SPAWN_TYPE, SpawnTypes.WORLD_SPAWNER);
 
-            final SpawnEntityEvent event = SpongeEventFactory.createSpawnEntityEventSpawner(Sponge.getCauseStackManager().getCurrentCause(),
-                    entities);
+            final SpawnEntityEvent event = SpongeEventFactory.createSpawnEntityEventSpawner(frame.getCurrentCause(), entities);
             SpongeImpl.postEvent(event);
             if (!event.isCancelled() && event.getEntities().size() > 0) {
                 for (Entity item : event.getEntities()) {

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GeneralGenerationPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GeneralGenerationPhaseState.java
@@ -134,16 +134,20 @@ abstract class GeneralGenerationPhaseState<G extends GenerationContext<G>> imple
     public boolean spawnEntityOrCapture(G context, Entity entity, int chunkX, int chunkZ) {
         final ArrayList<Entity> entities = new ArrayList<>(1);
         entities.add(entity);
-        final SpawnEntityEvent event = SpongeEventFactory.createSpawnEntityEventSpawner(Sponge.getCauseStackManager().getCurrentCause(),
-            entities);
-        SpongeImpl.postEvent(event);
-        if (!event.isCancelled() && event.getEntities().size() > 0) {
-            for (Entity item : event.getEntities()) {
-                ((IMixinWorldServer) item.getWorld()).forceSpawnEntity(item);
+        try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+            frame.addContext(EventContextKeys.SPAWN_TYPE, SpawnTypes.WORLD_SPAWNER);
+
+            final SpawnEntityEvent event = SpongeEventFactory.createSpawnEntityEventSpawner(Sponge.getCauseStackManager().getCurrentCause(),
+                    entities);
+            SpongeImpl.postEvent(event);
+            if (!event.isCancelled() && event.getEntities().size() > 0) {
+                for (Entity item : event.getEntities()) {
+                    ((IMixinWorldServer) item.getWorld()).forceSpawnEntity(item);
+                }
+                return true;
             }
-            return true;
+            return false;
         }
-        return false;
     }
 
     @Override


### PR DESCRIPTION
Before no cause was present so the game object would report. Now the
World object is pushed as a cause before processing any phases for
entity spawns.

Also, for triggering spawns in GeneralGenerationPhase we weren't passing
the world spawner as the context of the spawn.

@gabizou please review this.

Signed-off-by: Chris Sanders <zidane@spongepowered.org>