### PR TITLE
Optimize and improve experience calculations.

### DIFF
--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeExperienceHolderData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeExperienceHolderData.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.common.data.manipulator.mutable.entity;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableExperienceHolderData;
@@ -120,11 +122,7 @@ public class SpongeExperienceHolderData extends AbstractData<ExperienceHolderDat
 
     public void setLevel(int level) {
         this.level = level;
-        int totalExp = 0;
-        for (int i = 0; i < level; i++) {
-            totalExp += ExperienceHolderUtils.getExpBetweenLevels(i);
-        }
-        this.totalExp = totalExp;
+        this.totalExp = ExperienceHolderUtils.xpAtLevel(level);
         this.expSinceLevel = 0;
         this.expBetweenLevels = ExperienceHolderUtils.getExpBetweenLevels(level);
     }
@@ -135,18 +133,9 @@ public class SpongeExperienceHolderData extends AbstractData<ExperienceHolderDat
 
     public void setTotalExp(int totalExp) {
         this.totalExp = totalExp;
-        int level = 0;
-        while (true) {
-            int expToNextLevel = ExperienceHolderUtils.getExpBetweenLevels(level);
-            if (totalExp < expToNextLevel) {
-                this.expSinceLevel = totalExp;
-                this.expBetweenLevels = expToNextLevel;
-                this.level = level;
-                break;
-            }
-            totalExp -= expToNextLevel;
-            level++;
-        }
+        this.level = ExperienceHolderUtils.getLevelForExp(totalExp);
+        this.expSinceLevel = totalExp - ExperienceHolderUtils.xpAtLevel(this.level);
+        this.expBetweenLevels = ExperienceHolderUtils.getExpBetweenLevels(this.level);
     }
 
     public int getExpSinceLevel() {
@@ -154,9 +143,8 @@ public class SpongeExperienceHolderData extends AbstractData<ExperienceHolderDat
     }
 
     public void setExpSinceLevel(int expSinceLevel) {
-        while (expSinceLevel >= this.expBetweenLevels) {
-            expSinceLevel -= this.expBetweenLevels;
-        }
+        checkArgument(0 <= expSinceLevel && expSinceLevel <= this.expBetweenLevels,
+                "expSinceLevel (" + expSinceLevel + ") must be between 0 and expBetweenLevels (" + this.expBetweenLevels + ")");
         this.expSinceLevel = expSinceLevel;
     }
 

--- a/src/main/java/org/spongepowered/common/data/processor/common/ExperienceHolderUtils.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/ExperienceHolderUtils.java
@@ -24,11 +24,61 @@
  */
 package org.spongepowered.common.data.processor.common;
 
+import net.minecraft.entity.player.EntityPlayer;
 
 public class ExperienceHolderUtils {
-    
+
+    private static final int XP_AT_LEVEL_30 = xpAtLevel(30);
+    private static final int XP_AT_LEVEL_15 = xpAtLevel(15);
+
+    // If these formulas change, make sure to change all these methods and then
+    // run ExperienceHolderUtilsTest to check your results.
+
+    /**
+     * A static version of {@link EntityPlayer#xpBarCap()}.
+     *
+     * @param level The player's level
+     * @return The amount of XP between the specified level and the next level
+     */
     public static int getExpBetweenLevels(int level) {
         return level >= 30 ? 112 + (level - 30) * 9 : (level >= 15 ? 37 + (level - 15) * 5 : 7 + level * 2);
     }
 
+    /**
+     * Utility method for getting the total experience at an arbitrary level.
+     * The formulas here are basically (slightly modified) integrals of those
+     * of {@link EntityPlayer#xpBarCap()}.
+     *
+     * @param level The player's level
+     * @return The total amount of XP a player would have if they are exactly
+     * at the start of the specified level
+     */
+    public static int xpAtLevel(int level) {
+        if (level > 30) {
+            return (int) (4.5 * level * level - 162.5 * level + 2220);
+        } else if (level > 15) {
+            return (int) (2.5 * level * level - 40.5 * level + 360);
+        } else {
+            return (int) (level * level + 6 * level);
+        }
+    }
+
+    /**
+     * Utility method for getting the level a player would have if they had the
+     * provided amount of experience. The formulas here are inverses of the
+     * integrals in {@link #xpAtLevel(int)} using the quadratic formula, with
+     * several values precomputed.
+     *
+     * @param experience The player's experience
+     * @return The level the player would be at
+     */
+    public static int getLevelForExp(int experience) {
+        if (experience >= XP_AT_LEVEL_30) {
+            return (int) ((162.5 + Math.sqrt(-13553.75 + 18 * experience)) / 9);
+        } else if (experience >= XP_AT_LEVEL_15) {
+            return (int) ((40.5 + Math.sqrt(-1959.75 + 10 * experience)) / 5);
+        } else {
+            return (int) (-3 + Math.sqrt(9 + experience));
+        }
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/processor/multi/entity/ExperienceHolderDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/entity/ExperienceHolderDataProcessor.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableExperien
 import org.spongepowered.api.data.manipulator.mutable.entity.ExperienceHolderData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeExperienceHolderData;
 import org.spongepowered.common.data.processor.common.AbstractEntityDataProcessor;
+import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayer;
 import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayerMP;
 
 import java.util.Map;
@@ -71,7 +72,7 @@ public class ExperienceHolderDataProcessor extends AbstractEntityDataProcessor<E
     protected Map<Key<?>, ?> getValues(EntityPlayer entity) {
         final int level = entity.experienceLevel;
         final int totalExp = entity.experienceTotal;
-        final int expSinceLevel = (int) (entity.experience * entity.xpBarCap());
+        final int expSinceLevel = ((IMixinEntityPlayer) entity).getExperienceSinceLevel();
         final int expBetweenLevels = entity.xpBarCap();
         return ImmutableMap.<Key<?>, Object>of(Keys.EXPERIENCE_LEVEL, level,
                 Keys.TOTAL_EXPERIENCE, totalExp,

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/ExperienceLevelValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/ExperienceLevelValueProcessor.java
@@ -49,11 +49,7 @@ public class ExperienceLevelValueProcessor extends AbstractSpongeValueProcessor<
         if (supports(container)) {
             final EntityPlayer player = (EntityPlayer) container;
             final Integer oldValue = player.experienceLevel;
-            int totalExp = 0;
-            for (int i = 0; i < value; i++) {
-                totalExp += ExperienceHolderUtils.getExpBetweenLevels(i);
-            }
-            player.experienceTotal = totalExp;
+            player.experienceTotal = ExperienceHolderUtils.xpAtLevel(value);
             player.experience = 0;
             player.experienceLevel = value;
             ((IMixinEntityPlayerMP) container).refreshExp();

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/ExperienceSinceLevelValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/ExperienceSinceLevelValueProcessor.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.SpongeValueFactory;
+import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayer;
 import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayerMP;
 
 import java.util.Optional;
@@ -62,14 +63,14 @@ public class ExperienceSinceLevelValueProcessor extends AbstractSpongeValueProce
         while (value >= container.xpBarCap()) {
             value -= container.xpBarCap();
         }
-        container.experience = (float) value / container.xpBarCap();
+        ((IMixinEntityPlayer) container).setExperienceSinceLevel(value);
         ((IMixinEntityPlayerMP) container).refreshExp();
         return true;
     }
 
     @Override
     protected Optional<Integer> getVal(EntityPlayer container) {
-        return Optional.of((int) (container.experience * container.xpBarCap()));
+        return Optional.of(((IMixinEntityPlayer) container).getExperienceSinceLevel());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/interfaces/entity/player/IMixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/player/IMixinEntityPlayer.java
@@ -53,4 +53,8 @@ public interface IMixinEntityPlayer extends IMixinEntity {
     void shouldRestoreInventory(boolean flag);
 
     boolean shouldRestoreInventory();
+
+    int getExperienceSinceLevel();
+
+    void setExperienceSinceLevel(int experience);
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -590,13 +590,6 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
         return NetworkUtil.getHostString(this.connection.netManager.getRemoteAddress());
     }
 
-    // this needs to be overridden from EntityPlayer so we can force a resend of the experience level
-    @Override
-    public void setLevel(int level) {
-        super.experienceLevel = level;
-        this.lastExperience = -1;
-    }
-
     @Override
     public String getSubjectCollectionIdentifier() {
         return ((IMixinSubject) this.user).getSubjectCollectionIdentifier();

--- a/src/test/java/org/spongepowered/common/data/util/ExperienceHolderUtilsTest.java
+++ b/src/test/java/org/spongepowered/common/data/util/ExperienceHolderUtilsTest.java
@@ -1,0 +1,124 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.util;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.profiler.Profiler;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldProviderSurface;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.storage.WorldInfo;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.spongepowered.common.data.processor.common.ExperienceHolderUtils;
+
+import java.util.Iterator;
+import java.util.UUID;
+
+@RunWith(Parameterized.class)
+public final class ExperienceHolderUtilsTest {
+
+    private final int level;
+    private final int startExp;
+    private final int expInLevel;
+
+    public ExperienceHolderUtilsTest(int level, int startExp, int expInLevel) {
+        this.level = level;
+        this.startExp = startExp;
+        this.expInLevel = expInLevel;
+    }
+
+    @Parameterized.Parameters
+    public static Iterable<Object[]> data() {
+        World world = new World(null, new WorldInfo(new NBTTagCompound()), new WorldProviderSurface(), new Profiler(), false) {
+
+            @Override
+            protected IChunkProvider createChunkProvider() {
+                return null;
+            }
+
+            @Override
+            protected boolean isChunkLoaded(int x, int z, boolean allowEmpty) {
+                return false;
+            }
+        };
+        //noinspection EntityConstructor
+        EntityPlayer player = new EntityPlayer(world, new GameProfile(UUID.randomUUID(), "Player")) {
+
+            @Override
+            public boolean isSpectator() {
+                return false;
+            }
+
+            @Override
+            public boolean isCreative() {
+                return false;
+            }
+        };
+        return () -> new Iterator<Object[]>() {
+
+            private int level;
+            private int startExp;
+
+            @Override
+            public boolean hasNext() {
+                return level < 50;
+            }
+
+            @Override
+            public Object[] next() {
+                player.experienceLevel = level;
+                Object[] data = {level, startExp, player.xpBarCap()};
+                startExp += player.xpBarCap();
+                level++;
+                return data;
+            }
+        };
+    }
+
+    @Test
+    public void testGetExpBetweenLevels() {
+        Assert.assertEquals(expInLevel, ExperienceHolderUtils.getExpBetweenLevels(level));
+    }
+
+    @Test
+    public void testXpAtLevel() {
+        Assert.assertEquals(startExp, ExperienceHolderUtils.xpAtLevel(level));
+    }
+
+    @Test
+    public void testGetLevelForXpStart() {
+        Assert.assertEquals(level, ExperienceHolderUtils.getLevelForExp(startExp));
+    }
+
+    @Test
+    public void testGetLevelForXpMiddle() {
+        Assert.assertEquals(level, ExperienceHolderUtils.getLevelForExp(startExp + 1));
+    }
+}


### PR DESCRIPTION
This PR has two primary changes. First, it replaces the float-based "experience since level" calculations with integer-based ones [to avoid rounding errors](https://github.com/SpongePowered/SpongeCommon/pull/1358). Second, it replaces the loops used to calculate experience in a given level with `Math.pow()` and `Math.sqrt()` for performance and ease of updating.