### PR TITLE
Add support for DyeableData for concrete, concrete powder, and fixes it for carpet

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/data/DyeableDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/DyeableDataProcessor.java
@@ -63,12 +63,15 @@ public class DyeableDataProcessor extends AbstractSingleDataProcessor<DyeColor, 
             return true;
         }
 
-        Block block = Block.getBlockFromItem(item);
-        return block != null
-            && (block.equals(Blocks.WOOL)
+        final Block block = Block.getBlockFromItem(item);
+
+        return block.equals(Blocks.WOOL)
                 || block.equals(Blocks.STAINED_GLASS)
+                || block.equals(Blocks.CARPET)
                 || block.equals(Blocks.STAINED_GLASS_PANE)
-                || block.equals(Blocks.STAINED_HARDENED_CLAY));
+                || block.equals(Blocks.STAINED_HARDENED_CLAY)
+                || block.equals(Blocks.CONCRETE)
+                || block.equals(Blocks.CONCRETE_POWDER);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/block/MixinBlockConcretePowder.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/MixinBlockConcretePowder.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.block;
+
+import net.minecraft.block.BlockConcretePowder;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.interfaces.block.IMixinDyeableBlock;
+
+@Mixin(BlockConcretePowder.class)
+public abstract class MixinBlockConcretePowder extends MixinBlock implements IMixinDyeableBlock {
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    public void onInit(CallbackInfo ci) {
+        this.setProperty(BlockConcretePowder.COLOR);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/block/MixinDyeableBlock.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/MixinDyeableBlock.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.mixin.core.block;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.block.BlockCarpet;
 import net.minecraft.block.BlockColored;
+import net.minecraft.block.BlockConcretePowder;
 import net.minecraft.block.BlockStainedGlass;
 import net.minecraft.block.BlockStainedGlassPane;
 import net.minecraft.block.properties.PropertyEnum;
@@ -47,7 +48,7 @@ import org.spongepowered.common.interfaces.block.IMixinDyeableBlock;
 import java.util.List;
 import java.util.Optional;
 
-@Mixin({BlockCarpet.class, BlockColored.class, BlockStainedGlass.class, BlockStainedGlassPane.class})
+@Mixin({BlockCarpet.class, BlockColored.class, BlockStainedGlass.class, BlockStainedGlassPane.class, BlockConcretePowder.class})
 public abstract class MixinDyeableBlock extends MixinBlock implements IMixinDyeableBlock {
 
     private PropertyEnum<EnumDyeColor> property;

--- a/src/main/java/org/spongepowered/common/registry/provider/BlockPropertyIdProvider.java
+++ b/src/main/java/org/spongepowered/common/registry/provider/BlockPropertyIdProvider.java
@@ -273,6 +273,7 @@ public class BlockPropertyIdProvider implements TypeProvider<IProperty<?>, Strin
         register(BlockTrapDoor.HALF, "minecraft:trap_door_half");
         register(BlockRedstoneRepeater.DELAY, "minecraft:redstone_repeater_delay");
         register(BlockRedstoneRepeater.LOCKED, "minecraft:redstone_repeater_locked");
+        register(BlockConcretePowder.COLOR, "minecraft:concrete_powder_color");
     }
 
     private static final class Holder {

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -30,6 +30,7 @@
         "block.MixinBlockCocoa",
         "block.MixinBlockColored",
         "block.MixinBlockCommandBlock",
+        "block.MixinBlockConcretePowder",
         "block.MixinBlockCrops",
         "block.MixinBlockDaylightDetector",
         "block.MixinBlockDirectional",


### PR DESCRIPTION
Adds support for `DyeableData` to concrete and concrete powder, as well as fixing it for the carpet item.

Fixes #1588

_I would be nothing but a mere peasant without Sheriff @kashike_ 