### PR TITLE
Implements direct invulnerable to invulnerability data

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -205,6 +205,9 @@ public class DataRegistrar {
         DataUtil.registerDataProcessorAndImpl(ArmorStandData.class, SpongeArmorStandData.class,
                 ImmutableArmorStandData.class, ImmutableSpongeArmorStandData.class, new ArmorStandDataProcessor());
 
+        DataUtil.registerDataProcessorAndImpl(InvulnerabilityData.class, SpongeInvulnerabilityData.class,
+                ImmutableInvulnerabilityData.class, ImmutableSpongeInvulnerabilityData.class, new InvulnerabilityDataProcessor());
+
         DataUtil.registerDataProcessorAndImpl(FuseData.class, SpongeFuseData.class, ImmutableFuseData.class,
                 ImmutableSpongeFuseData.class, new FuseDataProcessor());
 
@@ -414,9 +417,6 @@ public class DataRegistrar {
 
         DataUtil.registerDualProcessor(CustomNameVisibleData.class, SpongeCustomNameVisibleData.class, ImmutableCustomNameVisibleData.class,
                 ImmutableSpongeCustomNameVisibleData.class, new CustomNameVisibleProcessor());
-
-        DataUtil.registerDualProcessor(InvulnerabilityData.class, SpongeInvulnerabilityData.class, ImmutableInvulnerabilityData.class,
-                ImmutableSpongeInvulnerabilityData.class, new InvulnerabilityDataProcessor());
 
         DataUtil.registerDualProcessor(GlowingData.class, SpongeGlowingData.class, ImmutableGlowingData.class, ImmutableSpongeGlowingData.class,
                 new GlowingDataProcessor());
@@ -812,6 +812,8 @@ public class DataRegistrar {
         DataUtil.registerValueProcessor(Keys.IS_ADULT, new IsAdultValueProcessor());
         DataUtil.registerValueProcessor(Keys.IS_ADULT, new IsAdultZombieValueProcessor());
         DataUtil.registerValueProcessor(Keys.AGE, new AgeableAgeValueProcessor());
+        DataUtil.registerValueProcessor(Keys.INVULNERABILITY_TICKS, new InvulnerabilityTicksValueProcessor());
+        DataUtil.registerValueProcessor(Keys.INVULNERABLE, new InvulnerableValueProcessor());
 
         // Properties
         final PropertyRegistry propertyRegistry = Sponge.getPropertyRegistry();

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeInvulnerabilityData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeInvulnerabilityData.java
@@ -24,24 +24,73 @@
  */
 package org.spongepowered.common.data.manipulator.immutable.entity;
 
+import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableInvulnerabilityData;
 import org.spongepowered.api.data.manipulator.mutable.entity.InvulnerabilityData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
-import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableIntData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeInvulnerabilityData;
+import org.spongepowered.common.data.value.SpongeValueFactory;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
-public class ImmutableSpongeInvulnerabilityData extends AbstractImmutableIntData<ImmutableInvulnerabilityData, InvulnerabilityData>
+public class ImmutableSpongeInvulnerabilityData extends AbstractImmutableData<ImmutableInvulnerabilityData, InvulnerabilityData>
         implements ImmutableInvulnerabilityData {
 
-    public ImmutableSpongeInvulnerabilityData(Integer value) {
-        super(ImmutableInvulnerabilityData.class, value, Keys.INVULNERABILITY_TICKS, SpongeInvulnerabilityData.class,
-                0, Integer.MAX_VALUE, 0);
+    private final int invulnerabilityTicks;
+    private final boolean invulnerable;
+
+    private final ImmutableBoundedValue<Integer> invulnerabilityTicksValue;
+    private final ImmutableValue<Boolean> invulnerableValue;
+
+    public ImmutableSpongeInvulnerabilityData() {
+        this(0, false);
+    }
+
+    public ImmutableSpongeInvulnerabilityData(int invulnerabilityTicks, boolean invulnerable) {
+        super(ImmutableInvulnerabilityData.class);
+        this.invulnerabilityTicks = invulnerabilityTicks;
+        this.invulnerable = invulnerable;
+        this.invulnerabilityTicksValue = SpongeValueFactory.boundedBuilder(Keys.INVULNERABILITY_TICKS)
+                .actualValue(this.invulnerabilityTicks)
+                .defaultValue(0)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .build()
+                .asImmutable();
+        this.invulnerableValue = ImmutableSpongeValue.cachedOf(Keys.INVULNERABLE, false, this.invulnerable);
+        registerGetters();
     }
 
     @Override
     public ImmutableBoundedValue<Integer> invulnerableTicks() {
-        return getValueGetter();
+        return this.invulnerabilityTicksValue;
     }
 
+    @Override
+    public ImmutableValue<Boolean> invulnerable() {
+        return this.invulnerableValue;
+    }
+
+    @Override
+    protected void registerGetters() {
+        registerFieldGetter(Keys.INVULNERABILITY_TICKS, () -> this.invulnerabilityTicks);
+        registerKeyValue(Keys.INVULNERABILITY_TICKS, () -> this.invulnerabilityTicksValue);
+
+        registerFieldGetter(Keys.INVULNERABLE, () -> this.invulnerable);
+        registerKeyValue(Keys.INVULNERABLE, () -> this.invulnerableValue);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer()
+                .set(Keys.INVULNERABILITY_TICKS, this.invulnerabilityTicks)
+                .set(Keys.INVULNERABLE, this.invulnerable);
+    }
+
+    @Override
+    public InvulnerabilityData asMutable() {
+        return new SpongeInvulnerabilityData(this.invulnerabilityTicks, this.invulnerable);
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeInvulnerabilityData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeInvulnerabilityData.java
@@ -24,49 +24,74 @@
  */
 package org.spongepowered.common.data.manipulator.mutable.entity;
 
+import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableInvulnerabilityData;
 import org.spongepowered.api.data.manipulator.mutable.entity.InvulnerabilityData;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.ImmutableDataCachingUtil;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeInvulnerabilityData;
-import org.spongepowered.common.data.manipulator.mutable.common.AbstractBoundedComparableData;
-import org.spongepowered.common.data.util.ComparatorUtil;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractData;
 import org.spongepowered.common.data.value.SpongeValueFactory;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
 
-public class SpongeInvulnerabilityData extends AbstractBoundedComparableData<Integer, InvulnerabilityData, ImmutableInvulnerabilityData>
-        implements InvulnerabilityData {
+public class SpongeInvulnerabilityData extends AbstractData<InvulnerabilityData, ImmutableInvulnerabilityData> implements InvulnerabilityData {
 
-    public SpongeInvulnerabilityData(int value, int minValue, int maxValue, int defaultValue) {
-        super(InvulnerabilityData.class, value, Keys.INVULNERABILITY_TICKS, ComparatorUtil.intComparator(),
-                ImmutableSpongeInvulnerabilityData.class, minValue, maxValue, defaultValue);
-    }
-
-    public SpongeInvulnerabilityData(int value) {
-        this(value, 0, Integer.MAX_VALUE, 0);
-    }
+    private int invulnerabilityTicks;
+    private boolean invulnerable;
 
     public SpongeInvulnerabilityData() {
-        this(0);
+        this(0, false);
+    }
+
+    public SpongeInvulnerabilityData(int invulnerabilityTicks, boolean invulnerable) {
+        super(InvulnerabilityData.class);
+        this.invulnerabilityTicks = invulnerabilityTicks;
+        this.invulnerable = invulnerable;
+        registerGettersAndSetters();
     }
 
     @Override
     public MutableBoundedValue<Integer> invulnerableTicks() {
         return SpongeValueFactory.boundedBuilder(Keys.INVULNERABILITY_TICKS)
-                .actualValue(getValue())
-                .defaultValue(0)
                 .minimum(0)
                 .maximum(Integer.MAX_VALUE)
+                .defaultValue(0)
+                .actualValue(this.invulnerabilityTicks)
                 .build();
     }
 
     @Override
-    protected MutableBoundedValue<Integer> getValueGetter() {
-        return invulnerableTicks();
+    public Value<Boolean> invulnerable() {
+        return new SpongeValue<>(Keys.INVULNERABLE, false, this.invulnerable);
+    }
+
+    @Override
+    protected void registerGettersAndSetters() {
+        registerFieldGetter(Keys.INVULNERABILITY_TICKS, () -> this.invulnerabilityTicks);
+        registerFieldSetter(Keys.INVULNERABILITY_TICKS, (invulnerabilityTicks) -> this.invulnerabilityTicks = invulnerabilityTicks);
+        registerKeyValue(Keys.INVULNERABILITY_TICKS, this::invulnerableTicks);
+
+        registerFieldGetter(Keys.INVULNERABLE, () -> this.invulnerable);
+        registerFieldSetter(Keys.INVULNERABLE, (invulnerable) -> this.invulnerable = invulnerable);
+        registerKeyValue(Keys.INVULNERABLE, this::invulnerable);
+    }
+
+    @Override
+    public InvulnerabilityData copy() {
+        return new SpongeInvulnerabilityData(this.invulnerabilityTicks, this.invulnerable);
     }
 
     @Override
     public ImmutableInvulnerabilityData asImmutable() {
-        return new ImmutableSpongeInvulnerabilityData(getValue());
+        return ImmutableDataCachingUtil.getManipulator(ImmutableSpongeInvulnerabilityData.class, this.invulnerabilityTicks, this.invulnerable);
     }
 
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer()
+                .set(Keys.INVULNERABILITY_TICKS, this.invulnerabilityTicks)
+                .set(Keys.INVULNERABLE, this.invulnerable);
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/processor/multi/entity/InvulnerabilityDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/entity/InvulnerabilityDataProcessor.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.multi.entity;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableInvulnerabilityData;
+import org.spongepowered.api.data.manipulator.mutable.entity.InvulnerabilityData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeInvulnerabilityData;
+import org.spongepowered.common.data.processor.common.AbstractEntityDataProcessor;
+import org.spongepowered.common.interfaces.entity.IMixinEntity;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class InvulnerabilityDataProcessor extends AbstractEntityDataProcessor<Entity, InvulnerabilityData, ImmutableInvulnerabilityData> {
+
+    public InvulnerabilityDataProcessor() {
+        super(Entity.class);
+    }
+
+    @Override
+    protected boolean doesDataExist(Entity dataHolder) {
+        return true;
+    }
+
+    @Override
+    protected boolean set(Entity dataHolder, Map<Key<?>, Object> keyValues) {
+        final int invulnerabilityTicks = (Integer) keyValues.get(Keys.INVULNERABILITY_TICKS);
+        final boolean invulnerable = (Boolean) keyValues.get(Keys.INVULNERABLE);
+        dataHolder.hurtResistantTime = invulnerabilityTicks;
+        if (dataHolder instanceof EntityLivingBase) {
+            ((EntityLivingBase) dataHolder).hurtTime = invulnerabilityTicks;
+        }
+        ((IMixinEntity) dataHolder).setInvulnerable(invulnerable);
+        return false;
+    }
+
+    @Override
+    protected Map<Key<?>, ?> getValues(Entity dataHolder) {
+        return ImmutableMap.<Key<?>, Object>builder()
+                .put(Keys.INVULNERABILITY_TICKS, dataHolder.hurtResistantTime)
+                .put(Keys.INVULNERABLE, dataHolder.getIsInvulnerable())
+                .build();
+    }
+
+    @Override
+    protected InvulnerabilityData createManipulator() {
+        return new SpongeInvulnerabilityData();
+    }
+
+    @Override
+    public Optional<InvulnerabilityData> fill(DataContainer container, InvulnerabilityData invulnerabilityData) {
+        if (container.contains(Keys.INVULNERABILITY_TICKS)) {
+            invulnerabilityData.set(Keys.INVULNERABILITY_TICKS, container.getInt(Keys.INVULNERABILITY_TICKS.getQuery()).get());
+        }
+        if (container.contains(Keys.INVULNERABLE)) {
+            invulnerabilityData.set(Keys.INVULNERABLE, container.getBoolean(Keys.INVULNERABLE.getQuery()).get());
+        }
+        return Optional.of(invulnerabilityData);
+    }
+
+    @Override
+    public DataTransactionResult remove(DataHolder dataHolder) {
+        return DataTransactionResult.failNoData();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/InvulnerabilityTicksValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/InvulnerabilityTicksValueProcessor.java
@@ -22,35 +22,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.data.processor.data.entity;
+package org.spongepowered.common.data.processor.value.entity;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableInvulnerabilityData;
-import org.spongepowered.api.data.manipulator.mutable.entity.InvulnerabilityData;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.common.data.manipulator.mutable.entity.SpongeInvulnerabilityData;
-import org.spongepowered.common.data.processor.common.AbstractEntitySingleDataProcessor;
-import org.spongepowered.common.data.util.ComparatorUtil;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.SpongeValueFactory;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 
 import java.util.Optional;
 
-public final class InvulnerabilityDataProcessor
-        extends AbstractEntitySingleDataProcessor<Entity, Integer, MutableBoundedValue<Integer>, InvulnerabilityData, ImmutableInvulnerabilityData> {
+public class InvulnerabilityTicksValueProcessor extends AbstractSpongeValueProcessor<Entity, Integer, MutableBoundedValue<Integer>> {
 
-    public InvulnerabilityDataProcessor() {
+    public InvulnerabilityTicksValueProcessor() {
         super(Entity.class, Keys.INVULNERABILITY_TICKS);
-    }
-
-    @Override
-    public DataTransactionResult removeFrom(ValueContainer<?> container) {
-        return DataTransactionResult.failNoData();
     }
 
     @Override
@@ -64,27 +53,26 @@ public final class InvulnerabilityDataProcessor
     }
 
     @Override
-    protected boolean set(Entity dataHolder, Integer value) {
-        dataHolder.hurtResistantTime = value;
-        if (dataHolder instanceof EntityLivingBase) {
-            ((EntityLivingBase) dataHolder).hurtTime = value;
+    protected boolean set(Entity container, Integer value) {
+        container.hurtResistantTime = value;
+        if (container instanceof EntityLivingBase) {
+            ((EntityLivingBase) container).hurtTime = value;
         }
         return true;
     }
 
     @Override
-    protected Optional<Integer> getVal(Entity dataHolder) {
-        return Optional.of(dataHolder.hurtResistantTime);
+    protected Optional<Integer> getVal(Entity container) {
+        return Optional.of(container.hurtResistantTime);
     }
 
     @Override
     protected ImmutableValue<Integer> constructImmutableValue(Integer value) {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.INVULNERABILITY_TICKS, 0, value, ComparatorUtil.intComparator(), 0, Integer.MAX_VALUE);
+        return constructValue(value).asImmutable();
     }
 
     @Override
-    protected InvulnerabilityData createManipulator() {
-        return new SpongeInvulnerabilityData();
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionResult.failNoData();
     }
-
 }

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/InvulnerableValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/InvulnerableValueProcessor.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.entity;
+
+import net.minecraft.entity.Entity;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.interfaces.entity.IMixinEntity;
+
+import java.util.Optional;
+
+public class InvulnerableValueProcessor extends AbstractSpongeValueProcessor<Entity, Boolean, Value<Boolean>> {
+
+    public InvulnerableValueProcessor() {
+        super(Entity.class, Keys.INVULNERABLE);
+    }
+
+    @Override
+    protected Value<Boolean> constructValue(Boolean actualValue) {
+        return new SpongeValue<>(Keys.INVULNERABLE, false, actualValue);
+    }
+
+    @Override
+    protected boolean set(Entity container, Boolean value) {
+        ((IMixinEntity) container).setInvulnerable(value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Boolean> getVal(Entity container) {
+        return Optional.of(container.getIsInvulnerable());
+    }
+
+    @Override
+    protected ImmutableValue<Boolean> constructImmutableValue(Boolean value) {
+        return constructValue(value).asImmutable();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionResult.failNoData();
+    }
+}

--- a/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
@@ -146,4 +146,7 @@ public interface IMixinEntity extends org.spongepowered.api.entity.Entity {
     void setActiveChunk(IMixinChunk chunk);
 
     boolean shouldTick();
+
+    void setInvulnerable(boolean value);
+
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -253,6 +253,8 @@ public abstract class MixinEntity implements IMixinEntity {
 
     @Shadow public abstract void setItemStackToSlot(EntityEquipmentSlot slotIn, ItemStack stack);
 
+    @Shadow private boolean invulnerable;
+
     @Redirect(method = "<init>", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/Entity;dimension:I", opcode = Opcodes.PUTFIELD))
     private void onSet(net.minecraft.entity.Entity self, int dimensionId, net.minecraft.world.World worldIn) {
         if (worldIn instanceof IMixinWorldServer) {
@@ -1352,5 +1354,10 @@ public abstract class MixinEntity implements IMixinEntity {
         }
 
         return true;
+    }
+
+    @Override
+    public void setInvulnerable(boolean value) {
+        this.invulnerable = value;
     }
 }

--- a/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
@@ -491,6 +491,7 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
         this.fieldMap.put("pickup_rule", makeSingleKey(TypeTokens.PICKUP_TOKEN, TypeTokens.PICKUP_VALUE_TOKEN, of("PickupRule"), "sponge:pickup_rule", "Pickup Rule"));
 
         this.fieldMap.put("invulnerability_ticks", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("HurtTime"), "sponge:invulnerability_ticks", "Invulnerability Ticks"));
+        this.fieldMap.put("invulnerable", makeSingleKey(TypeTokens.BOOLEAN_TOKEN, TypeTokens.BOOLEAN_VALUE_TOKEN, of("Invulnerable"), "sponge:invulnerable", "Invulnerable"));
 
         this.fieldMap.put("has_gravity", makeSingleKey(TypeTokens.BOOLEAN_TOKEN, TypeTokens.BOOLEAN_VALUE_TOKEN, of("HasGravity"), "sponge:has_gravity", "Has Gravity"));
 

--- a/testplugins/src/main/java/org/spongepowered/test/InvulnerabilityTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/InvulnerabilityTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.entity.InteractEntityEvent;
+import org.spongepowered.api.event.filter.cause.Root;
+import org.spongepowered.api.event.game.state.GameInitializationEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Plugin(id = "invulnerabilitytest", name = "InvulnerabilityTest", description = "Tests invulnerability data.")
+public final class InvulnerabilityTest {
+
+    private final Map<UUID, Boolean> invulnerable = new HashMap<>();
+
+    @Listener
+    public void onInit(final GameInitializationEvent event) {
+        Sponge.getCommandManager().register(this,
+                CommandSpec.builder()
+                        .arguments(GenericArguments.bool(Text.of("value")))
+                        .executor((src, args) ->  {
+                            if (!(src instanceof Player)) {
+                                throw new CommandException(Text.of(TextColors.RED, "You must be a player to execute this command."));
+                            }
+                            final boolean value = args.<Boolean>getOne("value").orElse(false);
+                            this.invulnerable.put(((Player) src).getUniqueId(), value);
+                            src.sendMessage(Text.of(TextColors.GOLD,
+                                    "The next entity you right click will have the invulnerability value of: " + value));
+                            return CommandResult.success();
+                        })
+                        .build(),
+                "invulntest");
+    }
+
+    @Listener
+    public void onEntityInteract(final InteractEntityEvent.Secondary event, @Root Player player) {
+        if (this.invulnerable.containsKey(player.getUniqueId())) {
+            final Entity target = event.getTargetEntity();
+            if (target.supports(Keys.INVULNERABLE)) {
+                final boolean value = this.invulnerable.remove(player.getUniqueId());
+                target.offer(Keys.INVULNERABLE, value);
+                player.sendMessage(Text.of(TextColors.GOLD,
+                        "You have successfully set the invulnerability of the entity you interacted with to: " + value));
+                player.sendMessage(Text.of(target.get(Keys.INVULNERABLE).orElse(false)));
+            } else {
+                player.sendMessage(Text.of(TextColors.RED, "This entity does not support invulnerability data."));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1688) | **SpongeCommon**

This implements control of direct invulnerability without timing to `InvulnerabilityData` alongside the ticks(being hurt). This allows entities to be impervious to damage **BESIDES damage from `DamageSources.VOID` and from a creative player.** 

**NEED INPUT:** Relating to the lack of protection of damage from creative players(due to this being used for armor stands I'm assuming?), I could change this check, removing the check if it is from a creative player from entity and moving that to armor stand instead. I'm open to feedback on this and please point out if it is used elsewhere in this manner. 