### PR TITLE
SF-1836: Fallback optimzation to vanilla if null

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -239,7 +239,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
     @Shadow public abstract void onEntityRemoved(net.minecraft.entity.Entity entityIn);
     @Shadow public abstract void updateEntity(net.minecraft.entity.Entity ent);
     @Shadow public abstract boolean isBlockLoaded(BlockPos pos);
-    @Shadow public abstract void markChunkDirty(BlockPos pos, net.minecraft.tileentity.TileEntity unusedTileEntity);
+    @Shadow public void markChunkDirty(BlockPos pos, net.minecraft.tileentity.TileEntity unusedTileEntity){};
    // @Shadow public abstract List<Entity> getEntitiesInAABBexcluding(@Nullable net.minecraft.entity.Entity entityIn, AxisAlignedBB boundingBox, @Nullable Predicate <? super net.minecraft.entity.Entity > predicate);
     @Shadow public abstract boolean addWeatherEffect(net.minecraft.entity.Entity entityIn);
     @Shadow public abstract Biome getBiome(BlockPos pos);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
@@ -1929,6 +1929,10 @@ public abstract class MixinWorldServer extends MixinWorld implements IMixinWorld
     @Override
     public void markChunkDirty(BlockPos pos, net.minecraft.tileentity.TileEntity unusedTileEntity)
     {
+        if (unusedTileEntity == null) {
+            super.markChunkDirty(pos, unusedTileEntity);
+            return;
+        }
         final IMixinTileEntity spongeTileEntity = (IMixinTileEntity) unusedTileEntity;
         final IMixinChunk chunk = spongeTileEntity.getActiveChunk();
         if (chunk != null) {


### PR DESCRIPTION
Fixes: https://github.com/SpongePowered/SpongeForge/issues/1836

If marking the entity would fail with a NPE due to mods passing in null to the 'unused' variable in vanilla, do the calculations that would normally be bypassed.