### PR TITLE
Restore Forge Compat for PlayerSetSpawnEvent

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinPlayerList.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinPlayerList.java
@@ -529,7 +529,9 @@ public abstract class MixinPlayerList implements IMixinPlayerList {
         // Sponge - Vanilla does this before recreating the player entity. However, we need to determine the bed location
         // before respawning the player, so we know what dimension to spawn them into. This means that the bed location must be copied
         // over to the new player
-        newPlayer.setSpawnPoint(playerIn.getBedLocation(), playerIn.isSpawnForced());
+        if (playerIn.getBedLocation() != null) {
+            newPlayer.setSpawnPoint(playerIn.getBedLocation(), playerIn.isSpawnForced());
+        }
 
         for (String s : playerIn.getTags()) {
             newPlayer.addTag(s);


### PR DESCRIPTION
if playerIn never slept, don't give newPlayer a null bedposition, it will achieve nothing and just fire an event mods don't expect

as found by https://github.com/SpongePowered/SpongeForge/issues/1860