### PR TITLE
Use active config, instead of always world config

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLiving.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLiving.java
@@ -179,7 +179,7 @@ public abstract class MixinEntityLiving extends MixinEntityLivingBase implements
     @ModifyConstant(method = "despawnEntity", constant = @Constant(doubleValue = 16384.0D))
     private double getHardDespawnRange(double value) {
         if (!this.world.isRemote) {
-            return Math.pow(((IMixinWorldServer) this.world).getWorldConfig().getConfig().getEntity().getHardDespawnRange(), 2);
+            return Math.pow(((IMixinWorldServer) this.world).getActiveConfig().getConfig().getEntity().getHardDespawnRange(), 2);
         }
         return value;
     }
@@ -188,7 +188,7 @@ public abstract class MixinEntityLiving extends MixinEntityLivingBase implements
     @ModifyConstant(method = "despawnEntity", constant = @Constant(doubleValue = 1024.0D), expect = 2)
     private double getSoftDespawnRange(double value) {
         if (!this.world.isRemote) {
-            return Math.pow(((IMixinWorldServer) this.world).getWorldConfig().getConfig().getEntity().getSoftDespawnRange(), 2);
+            return Math.pow(((IMixinWorldServer) this.world).getActiveConfig().getConfig().getEntity().getSoftDespawnRange(), 2);
         }
         return value;
     }
@@ -196,7 +196,7 @@ public abstract class MixinEntityLiving extends MixinEntityLivingBase implements
     @ModifyConstant(method = "despawnEntity", constant = @Constant(intValue = 600))
     private int getMinimumLifetime(int value) {
         if (!this.world.isRemote) {
-            return ((IMixinWorldServer) this.world).getWorldConfig().getConfig().getEntity().getMinimumLife() * 20;
+            return ((IMixinWorldServer) this.world).getActiveConfig().getConfig().getEntity().getMinimumLife() * 20;
         }
         return value;
     }

--- a/src/main/java/org/spongepowered/common/mixin/entityactivation/MixinEntityItem_Activation.java
+++ b/src/main/java/org/spongepowered/common/mixin/entityactivation/MixinEntityItem_Activation.java
@@ -46,7 +46,7 @@ public abstract class MixinEntityItem_Activation extends MixinEntity_Activation 
             --this.pickupDelay;
         }
 
-        if (!this.world.isRemote && this.age >= ((IMixinWorldServer) this.world).getWorldConfig().getConfig().getEntity().getItemDespawnRate()) {
+        if (!this.world.isRemote && this.age >= ((IMixinWorldServer) this.world).getActiveConfig().getConfig().getEntity().getItemDespawnRate()) {
             this.setDead();
         }
     }


### PR DESCRIPTION
Use active config like everywhere else where it isn't currently used.
Fixes SpongePowered/SpongeForge#1201