### PR TITLE
[WIP] Refactor and implement ChangeDataHolderEvent.ValueChange

### DIFF
--- a/DATA-CHANGE-TODO
+++ b/DATA-CHANGE-TODO
@@ -4,3 +4,4 @@
 * Should ChangeDataHolderEvent deal with only values, or manipulators too?
 * Should DataTransactionResult use a Map for each of 'successful, rejected, and replaced' data?
 * What form should the event filters take?
+* Should DataTransactionResult be a ValueContainer/something else, or expose three views into iteslf that implement ValueContainer/something else?

--- a/DATA-CHANGE-TODO
+++ b/DATA-CHANGE-TODO
@@ -1,0 +1,6 @@
+* Should we allow accessing the default underlying and default value directly through the API?
+* Should there be a (convenience) method for creating a value with a given underlying, in the context of a DataHolder?
+* Should it be easily possbile to go from a BaseValue to an ImmutableValue/Value without casting?
+* Should ChangeDataHolderEvent deal with only values, or manipulators too?
+* Should DataTransactionResult use a Map for each of 'successful, rejected, and replaced' data?
+* What form should the event filters take?

--- a/src/main/java/org/spongepowered/common/block/SpongeBlockSnapshot.java
+++ b/src/main/java/org/spongepowered/common/block/SpongeBlockSnapshot.java
@@ -378,6 +378,16 @@ public class SpongeBlockSnapshot implements BlockSnapshot {
         return Optional.empty();
     }
 
+    @Override
+    public <E> Optional<E> getDefault(Key<? extends BaseValue<E>> key) {
+        if (this.keyValueMap.containsKey(key)) {
+            return Optional.of((E) this.keyValueMap.get(key).getDefault());
+        } else if (getKeyValueMap().containsKey(key)) {
+            return Optional.of((E) this.blockKeyValueMap.get(key).getDefault());
+        }
+        return Optional.empty();
+    }
+
     private ImmutableMap<Key<?>, ImmutableValue<?>> getKeyValueMap() {
         if (this.blockKeyValueMap == null) {
             final ImmutableMap.Builder<Key<?>, ImmutableValue<?>> mapBuilder = ImmutableMap.builder();
@@ -430,6 +440,18 @@ public class SpongeBlockSnapshot implements BlockSnapshot {
             return Optional.of((V) this.keyValueMap.get(key).asMutable());
         } else if (getKeyValueMap().containsKey(key)) {
             return Optional.of((V) this.blockKeyValueMap.get(key).asMutable());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getDefaultValue(Key<V> key) {
+        if (this.keyValueMap.containsKey(key)) {
+            ImmutableValue<V> val = (ImmutableValue) this.keyValueMap.get(key);
+            return Optional.of((V) val.with(val.getDefault()).asMutable());
+        } else if (getKeyValueMap().containsKey(key)) {
+            ImmutableValue<V> val = (ImmutableValue) this.blockKeyValueMap.get(key);
+            return Optional.of((V) val.with(val.getDefault()).asMutable());
         }
         return Optional.empty();
     }

--- a/src/main/java/org/spongepowered/common/data/AbstractArchetype.java
+++ b/src/main/java/org/spongepowered/common/data/AbstractArchetype.java
@@ -199,10 +199,22 @@ public abstract class AbstractArchetype<C extends CatalogType, S extends Locatab
                 .flatMap(processor -> processor.readValue(this.data));
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R> Optional<R> getDefault(Key<? extends BaseValue<R>> key) {
+        return DataUtil.getNbtProcessor(this.getDataType(), key)
+                .flatMap(processor -> processor.readFrom(this.data).map(v -> v.getDefault()));
+    }
+
     @Override
     public <R, V extends BaseValue<R>> Optional<V> getValue(Key<V> key) {
         return DataUtil.getNbtProcessor(this.getDataType(), key)
                 .flatMap(processor -> processor.readFrom(this.data));
+    }
+
+    @Override
+    public <R, V extends BaseValue<R>> Optional<V> getDefaultValue(Key<V> key) {
+        throw new UnsupportedOperationException(); // TODO - can we construct a new value here?
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/AbstractArchetype.java
+++ b/src/main/java/org/spongepowered/common/data/AbstractArchetype.java
@@ -42,6 +42,8 @@ import org.spongepowered.api.data.persistence.InvalidDataException;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.data.ChangeDataHolderEvent;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.data.nbt.CustomDataNbtUtil;
 import org.spongepowered.common.data.nbt.NbtDataType;
@@ -120,6 +122,11 @@ public abstract class AbstractArchetype<C extends CatalogType, S extends Locatab
         return DataUtil.getNbtProcessor(this.getDataType(), key)
                 .map(processor -> processor.offer(this.data, value))
                 .orElseGet(DataTransactionResult::failNoData);
+    }
+
+    @Override
+    public <E> Optional<ChangeDataHolderEvent.ValueChange> offerWithEvent(Key<? extends BaseValue<E>> key, E value, Cause cause) {
+        throw new UnsupportedOperationException();
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/src/main/java/org/spongepowered/common/data/DataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/DataProcessor.java
@@ -33,6 +33,7 @@ import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.merge.MergeFunction;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.event.cause.Cause;
 
 import java.util.Optional;
 
@@ -96,6 +97,8 @@ public interface DataProcessor<M extends DataManipulator<M, I>, I extends Immuta
      * @return The transaction result
      */
     DataTransactionResult set(DataHolder dataHolder, M manipulator, MergeFunction function);
+
+    //void setWithEvent(DataHolder container, M manipulator, Cause cause);
 
     Optional<I> with(Key<? extends BaseValue<?>> key, Object value, I immutable);
 

--- a/src/main/java/org/spongepowered/common/data/ValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/ValueProcessor.java
@@ -160,7 +160,7 @@ public interface ValueProcessor<E, V extends BaseValue<E>> {
      * @param value
      * @return
      */
-    Optional<ChangeDataHolderEvent.ValueChange> offerWithEvent(DataHolder container, E value, Cause cause);
+    //Optional<ChangeDataHolderEvent.ValueChange> offerWithEvent(DataHolder container, E value, Cause cause);
 
     /**
      * Attempts to remove the known keyed data associated with this

--- a/src/main/java/org/spongepowered/common/data/ValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/ValueProcessor.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.data;
 
+import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
@@ -35,6 +36,8 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.mutable.CollectionValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.data.ChangeDataHolderEvent;
 
 import java.util.Optional;
 
@@ -149,6 +152,15 @@ public interface ValueProcessor<E, V extends BaseValue<E>> {
      * @return The transaction result
      */
     DataTransactionResult offerToStore(ValueContainer<?> container, E value);
+
+    /**
+     * Offers the provided value to the value container, firing an appropriate
+     * {@link ChangeDataHolderEvent.ValueChange}. The returned value should be
+     * @param container
+     * @param value
+     * @return
+     */
+    Optional<ChangeDataHolderEvent.ValueChange> offerWithEvent(DataHolder container, E value, Cause cause);
 
     /**
      * Attempts to remove the known keyed data associated with this

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableData.java
@@ -163,11 +163,28 @@ public abstract class AbstractImmutableData<I extends ImmutableDataManipulator<I
     }
 
     @Override
+    public <E> Optional<E> getDefault(Key<? extends BaseValue<E>> key) {
+        if (!supports(key)) {
+            return Optional.empty();
+        }
+        return Optional.of((E) this.keyValueMap.get(key).get().getDefault());
+    }
+
+    @Override
     public <E, V extends BaseValue<E>> Optional<V> getValue(Key<V> key) {
         if (!this.keyValueMap.containsKey(key)) {
             return Optional.empty();
         }
         return Optional.of((V) checkNotNull(this.keyValueMap.get(key).get()));
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getDefaultValue(Key<V> key) {
+        if (!this.keyValueMap.containsKey(key)) {
+            return Optional.empty();
+        }
+        ImmutableValue<V> val = (ImmutableValue) this.keyValueMap.get(key).get();
+        return Optional.of((V) checkNotNull(val.with(val.getDefault())));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableSingleData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableSingleData.java
@@ -70,6 +70,12 @@ public abstract class AbstractImmutableSingleData<T, I extends ImmutableDataMani
         return checkNotNull(key).equals(this.usedKey) ? Optional.of((E) this.value) : Optional.<E>empty();
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E> Optional<E> getDefault(Key<? extends BaseValue<E>> key) {
+        return checkNotNull(key).equals(this.usedKey) ? Optional.of((E) this.value) : Optional.<E>empty();
+    }
+
     @Override
     public boolean supports(Key<?> key) {
         return checkNotNull(key) == this.usedKey;

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/AbstractData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/AbstractData.java
@@ -204,11 +204,28 @@ public abstract class AbstractData<M extends DataManipulator<M, I>, I extends Im
     }
 
     @Override
+    public <E> Optional<E> getDefault(Key<? extends BaseValue<E>> key) {
+        if (!supports(key)) {
+            return Optional.empty();
+        }
+        return Optional.of((E) this.keyValueMap.get(key).get().getDefault());
+    }
+
+    @Override
     public <E, V extends BaseValue<E>> Optional<V> getValue(Key<V> key) {
         if (!this.keyValueMap.containsKey(key)) {
             return Optional.empty();
         }
         return Optional.of((V) checkNotNull(this.keyValueMap.get(key).get()));
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getDefaultValue(Key<V> key) {
+        if (!this.keyValueMap.containsKey(key)) {
+            return Optional.empty();
+        }
+        ImmutableValue<V> val = (ImmutableValue) this.keyValueMap.get(key).get();
+        return Optional.of((V) checkNotNull(val.with(val.getDefault())));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/common/AbstractBlockOnlyDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/AbstractBlockOnlyDataProcessor.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.data.processor.common;
 
 import net.minecraft.item.ItemStack;
+import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
@@ -32,6 +33,8 @@ import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.data.ChangeDataHolderEvent;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 import java.util.Optional;
@@ -63,6 +66,11 @@ public abstract class AbstractBlockOnlyDataProcessor<T, V extends BaseValue<T>, 
     @Override
     protected ImmutableValue<T> constructImmutableValue(T value) {
         return ImmutableSpongeValue.cachedOf(this.key, getDefaultValue(), value);
+    }
+
+    @Override
+    public Optional<ChangeDataHolderEvent.ValueChange> offerWithEvent(DataHolder container, T value, Cause cause) {
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/processor/common/AbstractBlockOnlyDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/AbstractBlockOnlyDataProcessor.java
@@ -68,9 +68,4 @@ public abstract class AbstractBlockOnlyDataProcessor<T, V extends BaseValue<T>, 
         return ImmutableSpongeValue.cachedOf(this.key, getDefaultValue(), value);
     }
 
-    @Override
-    public Optional<ChangeDataHolderEvent.ValueChange> offerWithEvent(DataHolder container, T value, Cause cause) {
-        throw new UnsupportedOperationException();
-    }
-
 }

--- a/src/main/java/org/spongepowered/common/data/processor/common/AbstractSingleDataSingleTargetProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/AbstractSingleDataSingleTargetProcessor.java
@@ -195,7 +195,7 @@ public abstract class AbstractSingleDataSingleTargetProcessor<Holder, T, V exten
         return DataTransactionResult.failResult(newValue);
     }
 
-    @SuppressWarnings("unchecked")
+    /*@SuppressWarnings("unchecked")
     @Override
     public Optional<ChangeDataHolderEvent.ValueChange> offerWithEvent(DataHolder container, T value, Cause cause) {
         if (supports(container)) {
@@ -216,7 +216,7 @@ public abstract class AbstractSingleDataSingleTargetProcessor<Holder, T, V exten
             return Optional.of(event);
         }
         return Optional.empty();
-    }
+    }*/
 
     @Override
     public final DataTransactionResult remove(DataHolder dataHolder) {

--- a/src/main/java/org/spongepowered/common/data/processor/common/AbstractSpongeDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/AbstractSpongeDataProcessor.java
@@ -24,10 +24,20 @@
  */
 package org.spongepowered.common.data.processor.common;
 
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.data.ChangeDataHolderEvent;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.data.DataProcessor;
+
+import java.util.List;
+import java.util.Optional;
 
 public abstract class AbstractSpongeDataProcessor<M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>> implements DataProcessor<M, I> {
 
@@ -40,4 +50,23 @@ public abstract class AbstractSpongeDataProcessor<M extends DataManipulator<M, I
     public boolean supports(EntityType entityType) {
         return false;
     }
+
+    /*@Override
+    public void setWithEvent(DataHolder container, M manipulator, Cause cause) {
+        if (supports(container)) {
+            final DataTransactionResult.Builder builder = DataTransactionResult.builder()
+                    .result(DataTransactionResult.Type.SUCCESS)
+                    .success(manipulator.getValues());
+
+
+            Optional<M> old = this.from(container);
+            old.ifPresent(m -> builder.replace(m.getValues()));
+
+            ChangeDataHolderEvent.ValueChange event = SpongeEventFactory.createChangeDataHolderEventValueChange(cause, builder.build(), container);
+            if (!SpongeImpl.postEvent(event) && event.getEndResult().getType() == DataTransactionResult.Type.SUCCESS) {
+                ImmutableValue<?> val = event.getEndResult().get(DataTransactionResult.DataCategory.SUCCESSFUL, this.key).orElseThrow(() -> new IllegalStateException(String.format("Event %s no longer has value with key %s", event, this.key)));
+                set((C) container, (E) val.get());
+            }
+        }
+    }*/
 }

--- a/src/main/java/org/spongepowered/common/data/processor/common/AbstractSpongeValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/AbstractSpongeValueProcessor.java
@@ -130,7 +130,7 @@ public abstract class AbstractSpongeValueProcessor<C, E, V extends BaseValue<E>>
         return DataTransactionResult.failResult(newValue);
     }
 
-    @SuppressWarnings("unchecked")
+    /*@SuppressWarnings("unchecked")
     @Override
     public Optional<ChangeDataHolderEvent.ValueChange> offerWithEvent(DataHolder container, E value, Cause cause) {
         if (supports(container)) {
@@ -152,6 +152,6 @@ public abstract class AbstractSpongeValueProcessor<C, E, V extends BaseValue<E>>
             return Optional.of(event);
         }
         return Optional.empty();
-    }
+    }*/
 
 }

--- a/src/main/java/org/spongepowered/common/data/processor/multi/entity/FoodDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/entity/FoodDataProcessor.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableFoodData
 import org.spongepowered.api.data.manipulator.mutable.entity.FoodData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeFoodData;
 import org.spongepowered.common.data.processor.common.AbstractEntityDataProcessor;
+import org.spongepowered.common.interfaces.IMixinFoodStats;
 
 import java.util.Map;
 import java.util.Optional;
@@ -59,7 +60,7 @@ public class FoodDataProcessor extends AbstractEntityDataProcessor<EntityPlayer,
 
     @Override
     protected boolean set(EntityPlayer entity, Map<Key<?>, Object> keyValues) {
-        entity.getFoodStats().setFoodLevel((Integer) keyValues.get(Keys.FOOD_LEVEL));
+        ((IMixinFoodStats) entity.getFoodStats()).setFoodLevelDirect((Integer) keyValues.get(Keys.FOOD_LEVEL));
         entity.getFoodStats().foodSaturationLevel = ((Double) keyValues.get(Keys.SATURATION)).floatValue();
         entity.getFoodStats().foodExhaustionLevel = ((Double) keyValues.get(Keys.EXHAUSTION)).floatValue();
         return true;

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodLevelValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodLevelValueProcessor.java
@@ -33,6 +33,7 @@ import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.SpongeValueFactory;
+import org.spongepowered.common.interfaces.IMixinFoodStats;
 
 import java.util.Optional;
 
@@ -54,7 +55,7 @@ public class FoodLevelValueProcessor extends AbstractSpongeValueProcessor<Entity
 
     @Override
     protected boolean set(EntityPlayer container, Integer value) {
-        container.getFoodStats().setFoodLevel(value);
+        ((IMixinFoodStats) container.getFoodStats()).setFoodLevelDirect(value);
         return true;
     }
 

--- a/src/main/java/org/spongepowered/common/data/util/ValueProcessorDelegate.java
+++ b/src/main/java/org/spongepowered/common/data/util/ValueProcessorDelegate.java
@@ -25,11 +25,14 @@
 package org.spongepowered.common.data.util;
 
 import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.data.ChangeDataHolderEvent;
 import org.spongepowered.common.data.ValueProcessor;
 
 import java.util.Optional;
@@ -119,6 +122,22 @@ public final class ValueProcessorDelegate<E, V extends BaseValue<E>> implements 
         }
         return DataTransactionResult.failNoData();
     }
+
+    @Override
+    public Optional<ChangeDataHolderEvent.ValueChange> offerWithEvent(DataHolder container, E value, Cause cause) {
+        for (ValueProcessor<E, V> processor : this.processors) {
+            if (processor.supports(container)) {
+                final Optional<ChangeDataHolderEvent.ValueChange> result = processor.offerWithEvent(container, value, cause);
+                if (result.isPresent()) {
+                    return result;
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+
 
     @Override
     public DataTransactionResult removeFrom(ValueContainer<?> container) {

--- a/src/main/java/org/spongepowered/common/data/util/ValueProcessorDelegate.java
+++ b/src/main/java/org/spongepowered/common/data/util/ValueProcessorDelegate.java
@@ -123,7 +123,7 @@ public final class ValueProcessorDelegate<E, V extends BaseValue<E>> implements 
         return DataTransactionResult.failNoData();
     }
 
-    @Override
+    /*@Override
     public Optional<ChangeDataHolderEvent.ValueChange> offerWithEvent(DataHolder container, E value, Cause cause) {
         for (ValueProcessor<E, V> processor : this.processors) {
             if (processor.supports(container)) {
@@ -135,7 +135,7 @@ public final class ValueProcessorDelegate<E, V extends BaseValue<E>> implements 
         }
 
         return Optional.empty();
-    }
+    }*/
 
 
 

--- a/src/main/java/org/spongepowered/common/entity/SpongeEntitySnapshot.java
+++ b/src/main/java/org/spongepowered/common/entity/SpongeEntitySnapshot.java
@@ -343,11 +343,35 @@ public class SpongeEntitySnapshot implements EntitySnapshot {
 
     @SuppressWarnings("unchecked")
     @Override
+    public <E> Optional<E> getDefault(Key<? extends BaseValue<E>> key) {
+        checkNotNull(key);
+        for (ImmutableValue<?> value : this.values) {
+            if (value.getKey().equals(key)) {
+                return Optional.of((E) value.getDefault());
+            }
+        }
+        return Optional.empty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
     public <E, V extends BaseValue<E>> Optional<V> getValue(Key<V> key) {
         checkNotNull(key);
         for (ImmutableValue<?> value : this.values) {
             if (value.getKey().equals(key)) {
                 return Optional.of((V) value.asMutable());
+            }
+        }
+        return Optional.empty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getDefaultValue(Key<V> key) {
+        checkNotNull(key);
+        for (ImmutableValue<?> value : this.values) {
+            if (value.getKey().equals(key)) {
+                return Optional.of((V) ((ImmutableValue) value).with(value.getDefault()).asMutable());
             }
         }
         return Optional.empty();
@@ -435,7 +459,7 @@ public class SpongeEntitySnapshot implements EntitySnapshot {
                 if (this.compound != null) {
                     nmsEntity.readFromNBT(this.compound);
                 }
-    
+
                 boolean spawnResult = world.get().spawnEntity((Entity) nmsEntity);
                 if (spawnResult) {
                     return Optional.of((Entity) nmsEntity);

--- a/src/main/java/org/spongepowered/common/event/filter/FilterGenerator.java
+++ b/src/main/java/org/spongepowered/common/event/filter/FilterGenerator.java
@@ -107,7 +107,7 @@ public class FilterGenerator {
         name = name.replace('.', '/');
         Parameter[] params = method.getParameters();
 
-        ClassWriter cw = new ClassWriter(/*ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS*/0);
+        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
         MethodVisitor mv;
 
         cw.visit(V1_6, ACC_PUBLIC + ACC_FINAL + ACC_SUPER, name, null, "java/lang/Object", new String[] { Type.getInternalName(EventFilter.class) });

--- a/src/main/java/org/spongepowered/common/event/filter/FilterGenerator.java
+++ b/src/main/java/org/spongepowered/common/event/filter/FilterGenerator.java
@@ -202,7 +202,7 @@ public class FilterGenerator {
 
             // Finalize constructor after the delegates have all had a chance to modify it
             constructorMv.visitInsn(RETURN);
-            constructorMv.visitMaxs(100, 100);
+            constructorMv.visitMaxs(0,0 );
             constructorMv.visitEnd();
 
             // create the return array
@@ -227,7 +227,7 @@ public class FilterGenerator {
                 mv.visitInsn(AASTORE);
             }
             mv.visitInsn(ARETURN);
-            mv.visitMaxs(100, 100);
+            mv.visitMaxs(0, 0);
             mv.visitEnd();
         }
         cw.visitEnd();

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/CauseFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/CauseFilterSourceDelegate.java
@@ -41,7 +41,7 @@ import java.lang.reflect.Parameter;
 public abstract class CauseFilterSourceDelegate implements ParameterFilterSourceDelegate {
 
     @Override
-    public Tuple<Integer, Integer> write(ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local) {
+    public Tuple<Integer, Integer> write(String name, ClassWriter cw, MethodVisitor constructorMv, MethodVisitor mv, Method method, Parameter param, int local) {
         // Get the cause
         mv.visitVarInsn(ALOAD, 1);
         mv.visitMethodInsn(INVOKEINTERFACE, Type.getInternalName(Event.class), "getCause",

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/GetKeyFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/GetKeyFilterSourceDelegate.java
@@ -1,0 +1,201 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.event.filter.delegate;
+
+import static org.objectweb.asm.Opcodes.AALOAD;
+import static org.objectweb.asm.Opcodes.ACONST_NULL;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.CHECKCAST;
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.GETFIELD;
+import static org.objectweb.asm.Opcodes.GETSTATIC;
+import static org.objectweb.asm.Opcodes.GOTO;
+import static org.objectweb.asm.Opcodes.IFEQ;
+import static org.objectweb.asm.Opcodes.IFNE;
+import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.PUTFIELD;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+import org.spongepowered.api.GameRegistry;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.event.data.ChangeDataHolderEvent;
+import org.spongepowered.api.event.filter.data.GetKey;
+import org.spongepowered.api.util.Tuple;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Optional;
+
+public class GetKeyFilterSourceDelegate implements ParameterFilterSourceDelegate {
+
+    private final GetKey getKey;
+    private final String keyId;
+    private final Key<?> key;
+    private String fieldName;
+
+    public GetKeyFilterSourceDelegate(GetKey getKey) {
+        this.getKey = getKey;
+        if (!this.getKey.value().contains(":")) {
+            this.keyId = "sponge:" + this.getKey.value();
+        } else {
+            this.keyId = this.getKey.value();
+        }
+
+        this.key = Sponge.getRegistry().getType(Key.class, this.keyId).orElseThrow(() -> new IllegalStateException(String.format("No key found with id %s! If the key is created by a plugin with custom data,"
+                + "make sure that it is registered before registering yoru event listener", this.getKey.value())));
+    }
+
+    public void createFields(ClassWriter cw, int local) {
+        this.fieldName = "key" + local;
+        FieldVisitor fv = cw.visitField(0, this.fieldName, Type.getDescriptor(Key.class), null, null);
+        fv.visitEnd();
+    }
+
+    public void writeCtor(String name, MethodVisitor mv) {
+        mv.visitVarInsn(ALOAD, 0);
+
+        // Call Sponge.getRegistry()
+        mv.visitMethodInsn(INVOKESTATIC, Type.getInternalName(Sponge.class), "getRegistry", "()" + Type.getDescriptor(GameRegistry.class), false);
+
+        // Load the arguments for GameRegistry#getType
+        mv.visitLdcInsn(Type.getType(Key.class));
+        mv.visitLdcInsn(this.keyId);
+
+        // Call GameRegistry#getType
+        mv.visitMethodInsn(INVOKEINTERFACE, Type.getInternalName(GameRegistry.class), "getType", "(" + Type.getDescriptor(Class.class) + Type.getDescriptor(String.class) + ")" + Type.getDescriptor(Optional.class), true);
+
+        // Call Optional#get, since we've already checked that the key exists
+        this.optionalGet(mv);
+        // Cast the returned Object to Key
+        mv.visitTypeInsn(CHECKCAST, Type.getInternalName(Key.class));
+
+        // Store the Key in the field
+        mv.visitFieldInsn(PUTFIELD, name, this.fieldName, Type.getDescriptor(Key.class));
+    }
+
+    @Override
+    public Tuple<Integer, Integer> write(String name, ClassWriter cw, MethodVisitor constructorMv, MethodVisitor mv, Method method, Parameter param, int local) {
+
+        this.createFields(cw, local);
+        this.writeCtor(name, constructorMv);
+
+        Class<?> paramType = param.getType();
+
+        Label success = new Label();
+
+        // The parameter type must be a supertype of either the value wrapper or the underlying value
+        if (!((paramType.isAssignableFrom(this.key.getElementToken().getRawType()) || paramType.isAssignableFrom(this.key.getValueToken().getRawType()) || ImmutableValue.class.isAssignableFrom(paramType)))) {
+            throw new IllegalStateException(String.format("Parameter '%s' must be of type %s or %s", param, key.getElementToken(), key.getValueToken()));
+        }
+
+        Class<?> eventClass = method.getParameterTypes()[0];
+
+        if (!(ChangeDataHolderEvent.ValueChange.class.isAssignableFrom(eventClass))) {
+            throw new IllegalStateException(String.format("@GetKey was used with event %s, which does not extend ChangeDataHolderEvent.ValueChange", eventClass));
+        }
+
+        int temp = local++;
+        int paramLocal = local++;
+
+
+        // Load the key into a temp local
+        mv.visitVarInsn(ALOAD, 0);
+        mv.visitFieldInsn(GETFIELD, name, this.fieldName, Type.getDescriptor(Key.class));
+        mv.visitVarInsn(ASTORE, temp);
+
+        mv.visitVarInsn(ALOAD, 1);
+        mv.visitMethodInsn(INVOKEINTERFACE, Type.getInternalName(ChangeDataHolderEvent.ValueChange.class), "getChanges", "()" + Type.getDescriptor(
+                DataTransactionResult.class), true);
+
+        for (DataTransactionResult.DataCategory category: this.getKey.from()) {
+            // Dup the DataTransactionResult
+            mv.visitInsn(DUP);
+            // Load enum value
+            mv.visitFieldInsn(GETSTATIC, Type.getInternalName(DataTransactionResult.DataCategory.class), category.name(), Type.getDescriptor(DataTransactionResult.DataCategory.class));
+            // Load key
+            mv.visitVarInsn(ALOAD, temp);
+
+            // Call DataTransactionResult#get
+            mv.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(DataTransactionResult.class), "get", "(" + Type.getDescriptor(
+                    DataTransactionResult.DataCategory.class) + Type.getDescriptor(Key.class) + ")" + Type.getDescriptor(Optional.class), false);
+
+            mv.visitInsn(DUP);
+            mv.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(Optional.class), "isPresent", "()Z", false);
+
+            // If the Optional is present, we're done
+            mv.visitJumpInsn(IFNE, success);
+        }
+        // If we get to here, then the key wasn't present in any of the DataCategories.
+        mv.visitInsn(ACONST_NULL);
+        mv.visitInsn(ARETURN);
+
+        // If we jump to success, the Optional is present, so unwrap it
+        mv.visitLabel(success);
+        this.optionalGet(mv);
+        mv.visitTypeInsn(CHECKCAST, Type.getInternalName(ImmutableValue.class));
+
+        // If the parameter's type is the underlying value, we need to unwrap the ImmutableValue.
+        if (paramType.equals(key.getElementToken().getRawType())) {
+            mv.visitMethodInsn(INVOKEINTERFACE, Type.getInternalName(BaseValue.class), "get", "()Ljava/lang/Object;", true);
+
+            // Cast and store the underlying value into the parameter local
+            mv.visitTypeInsn(CHECKCAST, Type.getInternalName(paramType));
+        } else {
+            // The parameter is the wrapping Value type (e.g. MutableBoundedValue). If the wrapper type is immutable,
+            // we just need to cast it. If it's mutable, we need to call isMutable, then cast it
+            if (Value.class.isAssignableFrom(paramType)) {
+                mv.visitMethodInsn(INVOKEINTERFACE, Type.getInternalName(ImmutableValue.class), "asMutable", "()" +  Type.getDescriptor(Value.class), true);
+            }
+            mv.visitTypeInsn(CHECKCAST, Type.getInternalName(paramType));
+        }
+        // Store the final value into the parameter local
+        mv.visitVarInsn(ASTORE, paramLocal);
+
+        return new Tuple<>(local, paramLocal);
+
+    }
+
+    private void optionalGet(MethodVisitor mv) {
+        mv.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(Optional.class), "get", "()" + Type.getDescriptor(Object.class), false);
+    }
+
+    public void foo() {
+        DataTransactionResult.DataCategory myVar = DataTransactionResult.DataCategory.SUCCESSFUL;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/GetKeyFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/GetKeyFilterSourceDelegate.java
@@ -41,6 +41,7 @@ import static org.objectweb.asm.Opcodes.POP;
 import static org.objectweb.asm.Opcodes.PUTFIELD;
 
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Primitives;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Label;
@@ -212,7 +213,7 @@ public class GetKeyFilterSourceDelegate implements ParameterFilterSourceDelegate
 
         this.paramType = param.getType();
         this.name = name;
-        this.boxedParamType = this.paramType.isPrimitive() ? GeneratorUtils.boxClass(this.paramType) : this.paramType;
+        this.boxedParamType = Primitives.wrap(this.paramType);
         this.fieldName = "key" + local;
         this.parameterIsSpongeValue = BaseValue.class.isAssignableFrom(this.paramType);
 

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/GetterFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/GetterFilterSourceDelegate.java
@@ -53,12 +53,13 @@ public class GetterFilterSourceDelegate implements ParameterFilterSourceDelegate
 
     private final Getter anno;
 
-    public GetterFilterSourceDelegate(Getter a) {
+    public GetterFilterSourceDelegate(Getter a)
+    {
         this.anno = a;
     }
 
     @Override
-    public Tuple<Integer, Integer> write(ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local) {
+    public Tuple<Integer, Integer> write(String name, ClassWriter cw, MethodVisitor constructorMv, MethodVisitor mv, Method method, Parameter param, int local) {
         Class<?> targetType = param.getType();
         Class<?> eventClass = method.getParameterTypes()[0];
         String targetMethod = this.anno.value();

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/ParameterFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/ParameterFilterSourceDelegate.java
@@ -32,6 +32,5 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 
 public interface ParameterFilterSourceDelegate {
-
-    Tuple<Integer, Integer> write(ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local);
+    Tuple<Integer, Integer> write(String name, ClassWriter cw, MethodVisitor constructorMv, MethodVisitor mv, Method method, Parameter param, int local);
 }

--- a/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStack.java
+++ b/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStack.java
@@ -39,6 +39,8 @@ import org.spongepowered.api.data.merge.MergeFunction;
 import org.spongepowered.api.data.persistence.InvalidDataException;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.data.ChangeDataHolderEvent;
 import org.spongepowered.api.extra.fluid.FluidStack;
 import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
 import org.spongepowered.api.extra.fluid.FluidType;
@@ -134,9 +136,16 @@ public class SpongeFluidStack implements FluidStack {
     }
 
     @Override
+    public <E> Optional<ChangeDataHolderEvent.ValueChange> offerWithEvent(Key<? extends BaseValue<E>> key, E value, Cause cause) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public DataTransactionResult offer(DataManipulator<?, ?> valueContainer, MergeFunction function) {
         return DataTransactionResult.failNoData();
     }
+
+
 
     @Override
     public DataTransactionResult remove(Class<? extends DataManipulator<?, ?>> containerClass) {

--- a/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStack.java
+++ b/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStack.java
@@ -205,7 +205,17 @@ public class SpongeFluidStack implements FluidStack {
     }
 
     @Override
+    public <E> Optional<E> getDefault(Key<? extends BaseValue<E>> key) {
+        return Optional.empty();
+    }
+
+    @Override
     public <E, V extends BaseValue<E>> Optional<V> getValue(Key<V> key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getDefaultValue(Key<V> key) {
         return Optional.empty();
     }
 

--- a/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStackSnapshot.java
+++ b/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStackSnapshot.java
@@ -175,7 +175,17 @@ public class SpongeFluidStackSnapshot implements FluidStackSnapshot {
     }
 
     @Override
+    public <E> Optional<E> getDefault(Key<? extends BaseValue<E>> key) {
+        return Optional.empty();
+    }
+
+    @Override
     public <E, V extends BaseValue<E>> Optional<V> getValue(Key<V> key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getDefaultValue(Key<V> key) {
         return Optional.empty();
     }
 

--- a/src/main/java/org/spongepowered/common/interfaces/IMixinFoodStats.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinFoodStats.java
@@ -22,36 +22,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.test;
+package org.spongepowered.common.interfaces;
 
-import org.slf4j.Logger;
-import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.event.Listener;
-import org.spongepowered.api.event.game.state.GameStartingServerEvent;
-import org.spongepowered.api.network.ChannelBinding;
-import org.spongepowered.api.network.ChannelId;
-import org.spongepowered.api.plugin.Plugin;
+import net.minecraft.entity.player.EntityPlayer;
 
-import javax.inject.Inject;
+public interface IMixinFoodStats {
 
-@Plugin(id = "injection-test", authors = "kashike")
-public class InjectionTest {
+    void setPlayer(EntityPlayer player);
 
-    private final Logger logger;
-    private final ChannelBinding.RawDataChannel channel;
+    void setFoodLevelDirect(int foodLevel);
 
-    @Inject
-    private InjectionTest(
-            final Logger logger,
-            @ChannelId("injection") ChannelBinding.RawDataChannel channel
-    ) {
-        this.logger = logger;
-        this.channel = channel;
-    }
-
-    @Listener
-    public void starting(final GameStartingServerEvent event) {
-        this.logger.info("Channel: {}", this.channel);
-    }
 }

--- a/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackSnapshot.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackSnapshot.java
@@ -304,8 +304,18 @@ public class SpongeItemStackSnapshot implements ItemStackSnapshot {
     }
 
     @Override
+    public <E> Optional<E> getDefault(Key<? extends BaseValue<E>> key) {
+        return this.privateStack.getDefault(key);
+    }
+
+    @Override
     public <E, V extends BaseValue<E>> Optional<V> getValue(Key<V> key) {
         return this.privateStack.getValue(key);
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getDefaultValue(Key<V> key) {
+        return this.privateStack.getDefaultValue(key);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/data/MixinDataHolder.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/data/MixinDataHolder.java
@@ -482,8 +482,8 @@ public abstract class MixinDataHolder implements DataHolder {
             oldVal.ifPresent(v -> builder.replace(newVal.with(v)));
 
             ChangeDataHolderEvent.ValueChange event = SpongeEventFactory.createChangeDataHolderEventValueChange(cause, builder.build(), this);
-            if (!SpongeImpl.postEvent(event) && event.getEndResult().getType() == DataTransactionResult.Type.SUCCESS) {
-                for (ImmutableValue<?> val: event.getEndResult().getSuccessfulData()) {
+            if (!SpongeImpl.postEvent(event) && event.getChanges().getType() == DataTransactionResult.Type.SUCCESS) {
+                for (ImmutableValue<?> val: event.getChanges().getSuccessfulData()) {
                     this.offer(val);
                 }
             }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayer.java
@@ -98,6 +98,7 @@ import org.spongepowered.common.interfaces.ITargetedLocation;
 import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayer;
 import org.spongepowered.common.item.inventory.util.ItemStackUtil;
 import org.spongepowered.common.mixin.core.entity.MixinEntityLivingBase;
+import org.spongepowered.common.interfaces.IMixinFoodStats;
 import org.spongepowered.common.registry.type.event.DamageSourceRegistryModule;
 import org.spongepowered.common.text.SpongeTexts;
 import org.spongepowered.common.text.serializer.LegacyTexts;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -162,6 +162,7 @@ import org.spongepowered.common.event.tracking.phase.entity.EntityPhase;
 import org.spongepowered.common.interfaces.IMixinCommandSender;
 import org.spongepowered.common.interfaces.IMixinCommandSource;
 import org.spongepowered.common.interfaces.IMixinContainer;
+import org.spongepowered.common.interfaces.IMixinFoodStats;
 import org.spongepowered.common.interfaces.IMixinPacketResourcePackSend;
 import org.spongepowered.common.interfaces.IMixinServerScoreboard;
 import org.spongepowered.common.interfaces.IMixinSubject;
@@ -244,6 +245,11 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     @Nullable private Vector3d velocityOverride = null;
     private boolean healthScaling = false;
     private double healthScale = 20;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void onInit(CallbackInfo ci) {
+        ((IMixinFoodStats) this.foodStats).setPlayer((EntityPlayer) (Object) this);
+    }
 
     @Override
     public void writeToNbt(NBTTagCompound compound) {

--- a/src/main/java/org/spongepowered/common/mixin/core/util/MixinFoodStats.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/util/MixinFoodStats.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.util;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemFood;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.FoodStats;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.cause.EventContextKeys;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.interfaces.IMixinFoodStats;
+
+@Mixin(FoodStats.class)
+public abstract class MixinFoodStats implements IMixinFoodStats {
+
+    @Shadow private int foodLevel;
+    private Player player; // Null when on client
+
+    @Override
+    public void setPlayer(EntityPlayer player) {
+        this.player = (Player) player;
+    }
+
+    @Inject(method = "addStats(Lnet/minecraft/item/ItemFood;Lnet/minecraft/item/ItemStack;)V", at = @At(value = "HEAD"))
+    private void onStatsItemStart(ItemFood food, ItemStack stack, CallbackInfo ci) {
+        if (this.player == null) {
+            return;
+        }
+
+        Sponge.getCauseStackManager().addContext(EventContextKeys.USED_ITEM, ((org.spongepowered.api.item.inventory.ItemStack) stack).createSnapshot());
+    }
+
+    @Inject(method = "addStats(Lnet/minecraft/item/ItemFood;Lnet/minecraft/item/ItemStack;)V", at = @At(value = "RETURN"))
+    private void onStatsItemReturn(CallbackInfo ci) {
+        if (this.player == null) {
+            return;
+        }
+
+        Sponge.getCauseStackManager().removeContext(EventContextKeys.USED_ITEM);
+    }
+
+    @Redirect(method = "addStats(IF)V", at = @At(value = "FIELD", target = "Lnet/minecraft/util/FoodStats;foodLevel:I", opcode = Opcodes.PUTFIELD))
+    private void onAddStatsSetFoodLevel(FoodStats this$0, int newLevel) {
+        this.changeFoodLevelImpl(newLevel);
+    }
+
+    @Redirect(method = "setFoodLevel", at = @At(value = "FIELD", target = "Lnet/minecraft/util/FoodStats;foodLevel:I", opcode = Opcodes.PUTFIELD))
+    private void onSetFoodLevelMethod(FoodStats this$0, int newLevel) {
+        this.changeFoodLevelImpl(newLevel);
+    }
+
+    @Redirect(method = "onUpdate", at = @At(value = "FIELD", target = "Lnet/minecraft/util/FoodStats;foodLevel:I", opcode = Opcodes.PUTFIELD))
+    private void onOnUpdateSetFoodLevel(FoodStats this$0, int newLevel) {
+        this.changeFoodLevelImpl(newLevel);
+    }
+
+    private void changeFoodLevelImpl(int newLevel) {
+        if (this.player == null) {
+            this.foodLevel = newLevel;
+            return;
+        }
+
+        Sponge.getCauseStackManager().pushCause(this.player);
+        this.player.offerWithEvent(Keys.FOOD_LEVEL, newLevel, Sponge.getCauseStackManager().getCurrentCause());
+        Sponge.getCauseStackManager().popCause();
+
+        /*Sponge.getCauseStackManager().pushCause(this.player);
+        ImmutableValue<Integer> oldVal = this.player.getValue(Keys.FOOD_LEVEL).get().asImmutable();
+        ImmutableValue<Integer> newVal = oldVal.with(newLevel);
+
+        DataTransactionResult result = DataTransactionResult.successReplaceResult(newVal, oldVal);
+        ChangeDataHolderEvent.ValueChange event = SpongeEventFactory.createChangeDataHolderEventValueChange(Sponge.getCauseStackManager().getCurrentCause(), result, this.player);
+        if (!SpongeImpl.postEvent(event)) {
+            this.foodLevel = ((Optional<ImmutableValue<Integer>>) (Optional) event.getEndResult().get(DataTransactionResult.DataCategory.SUCCESSFUL, Keys.FOOD_LEVEL)).map(BaseValue::get).orElse(this.foodLevel);
+        }*/
+
+    }
+
+    @Override
+    public void setFoodLevelDirect(int foodLevel) {
+        this.foodLevel = foodLevel;
+    }
+}

--- a/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
@@ -90,15 +90,15 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
 
         this.fieldMap.put("velocity", makeSingleKey(TypeTokens.VECTOR_3D_TOKEN, TypeTokens.VECTOR_3D_VALUE_TOKEN, of("Velocity"), "sponge:velocity", "Velocity"));
 
-        this.fieldMap.put("food_level", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.INTEGER_VALUE_TOKEN, of("FoodLevel"), "sponge:food_level", "Food Level"));
+        this.fieldMap.put("food_level", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("FoodLevel"), "sponge:food_level", "Food Level"));
 
         this.fieldMap.put("saturation", makeSingleKey(TypeTokens.DOUBLE_TOKEN, TypeTokens.DOUBLE_VALUE_TOKEN, of("FoodSaturationLevel"), "sponge:food_saturation_level", "Food Saturation Level"));
 
         this.fieldMap.put("exhaustion", makeSingleKey(TypeTokens.DOUBLE_TOKEN, TypeTokens.DOUBLE_VALUE_TOKEN, of("FoodExhaustionLevel"), "sponge:food_exhaustion_level", ""));
 
-        this.fieldMap.put("max_air", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.INTEGER_VALUE_TOKEN, of("MaxAir"), "sponge:max_air", "Max Air"));
+        this.fieldMap.put("max_air", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("MaxAir"), "sponge:max_air", "Max Air"));
 
-        this.fieldMap.put("remaining_air", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.INTEGER_VALUE_TOKEN, of("RemainingAir"), "sponge:remaining_air", "Remaining Air"));
+        this.fieldMap.put("remaining_air", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("RemainingAir"), "sponge:remaining_air", "Remaining Air"));
 
         this.fieldMap.put("fire_ticks", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("FireTicks"), "sponge:fire_ticks", "Fire Ticks"));
 
@@ -134,7 +134,7 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
 
         this.fieldMap.put("command", makeSingleKey(TypeTokens.STRING_TOKEN, TypeTokens.STRING_VALUE_TOKEN, of("Command"), "sponge:command", "Command"));
 
-        this.fieldMap.put("success_count", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.INTEGER_VALUE_TOKEN, of("SuccessCount"), "sponge:success_count", "SuccessCount"));
+        this.fieldMap.put("success_count", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("SuccessCount"), "sponge:success_count", "SuccessCount"));
 
         this.fieldMap.put("tracks_output", makeSingleKey(TypeTokens.BOOLEAN_TOKEN, TypeTokens.BOOLEAN_VALUE_TOKEN, of("TracksOutput"), "sponge:tracks_output", "Tracks Output"));
 
@@ -266,7 +266,7 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
 
         this.fieldMap.put("max_cook_time", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("MaxCookTime"), "sponge:max_cook_time", "Max Cook Time"));
 
-        this.fieldMap.put("contained_experience", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.INTEGER_VALUE_TOKEN, of("ContainedExperience"), "sponge:contained_experience", "Contained Experience"));
+        this.fieldMap.put("contained_experience", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("ContainedExperience"), "sponge:contained_experience", "Contained Experience"));
 
         this.fieldMap.put("remaining_brew_time", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("RemainingBrewTime"), "sponge:remaining_brew_time", "Remaining Brew Time"));
 
@@ -316,7 +316,7 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
 
         this.fieldMap.put("fall_distance", makeSingleKey(TypeTokens.FLOAT_TOKEN, TypeTokens.FLOAT_VALUE_TOKEN, of("FallDistance"), "sponge:fall_distance", "Fall Distance"));
 
-        this.fieldMap.put("cooldown", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.INTEGER_VALUE_TOKEN, of("Cooldown"), "sponge:cooldown", "Cooldown"));
+        this.fieldMap.put("cooldown", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN, of("Cooldown"), "sponge:cooldown", "Cooldown"));
 
         this.fieldMap.put("note_pitch", makeSingleKey(TypeTokens.NOTE_TOKEN, TypeTokens.NOTE_VALUE_TOKEN, of("Note"), "sponge:note", "Note"));
 
@@ -474,7 +474,7 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
 
         this.fieldMap.put("ticks_remaining", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.INTEGER_VALUE_TOKEN, of("TicksRemaining"), "sponge:ticks_remaining", "Ticks Remaining"));
 
-        this.fieldMap.put("explosion_radius", makeSingleKey(TypeTokens.INTEGER_TOKEN, TypeTokens.INTEGER_VALUE_TOKEN, of("ExplosionRadius"), "sponge:explosion_radius", "Explosion Radius"));
+        this.fieldMap.put("explosion_radius", makeSingleKey(TypeTokens.OPTIONAL_INTEGER_TOKEN, TypeTokens.OPTIONAL_INTEGER_VALUE_TOKEN, of("ExplosionRadius"), "sponge:explosion_radius", "Explosion Radius"));
 
         this.fieldMap.put("armor_stand_has_arms", makeSingleKey(TypeTokens.BOOLEAN_TOKEN, TypeTokens.BOOLEAN_VALUE_TOKEN, of("HasArms"), "sponge:has_arms", "Has Arms"));
 

--- a/src/main/java/org/spongepowered/common/world/SpongeLocatableBlock.java
+++ b/src/main/java/org/spongepowered/common/world/SpongeLocatableBlock.java
@@ -112,8 +112,18 @@ public class SpongeLocatableBlock implements LocatableBlock {
     }
 
     @Override
+    public <E> Optional<E> getDefault(Key<? extends BaseValue<E>> key) {
+        return this.blockState.getDefault(key);
+    }
+
+    @Override
     public <E, V extends BaseValue<E>> Optional<V> getValue(Key<V> key) {
         return this.blockState.getValue(key);
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getDefaultValue(Key<V> key) {
+        return this.blockState.getDefaultValue(key);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/extent/ExtentViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/ExtentViewDownsize.java
@@ -271,6 +271,12 @@ public class ExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override
+    public <E> Optional<E> getDefault(int x, int y, int z, Key<? extends BaseValue<E>> key) {
+        checkBlockRange(x, y, z);
+        return this.extent.getDefault(x, y, z, key);
+    }
+
+    @Override
     public <T extends DataManipulator<?, ?>> Optional<T> get(int x, int y, int z, Class<T> manipulatorClass) {
         checkBlockRange(x, y, z);
         return this.extent.get(x, y, z, manipulatorClass);
@@ -292,6 +298,12 @@ public class ExtentViewDownsize implements DefaultedExtent {
     public <E, V extends BaseValue<E>> Optional<V> getValue(int x, int y, int z, Key<V> key) {
         checkBlockRange(x, y, z);
         return this.extent.getValue(x, y, z, key);
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getDefaultValue(int x, int y, int z, Key<V> key) {
+        checkBlockRange(x, y, z);
+        return this.extent.getDefaultValue(x, y, z, key);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/extent/SoftBufferExtentViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/SoftBufferExtentViewDownsize.java
@@ -278,6 +278,12 @@ public class SoftBufferExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override
+    public <E> Optional<E> getDefault(int x, int y, int z, Key<? extends BaseValue<E>> key) {
+        checkBlockRange(x, y, z);
+        return this.extent.getDefault(x, y, z, key);
+    }
+
+    @Override
     public <T extends DataManipulator<?, ?>> Optional<T> get(int x, int y, int z, Class<T> manipulatorClass) {
         checkBlockRange(x, y, z);
         return this.extent.get(x, y, z, manipulatorClass);
@@ -299,6 +305,12 @@ public class SoftBufferExtentViewDownsize implements DefaultedExtent {
     public <E, V extends BaseValue<E>> Optional<V> getValue(int x, int y, int z, Key<V> key) {
         checkBlockRange(x, y, z);
         return this.extent.getValue(x, y, z, key);
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getDefaultValue(int x, int y, int z, Key<V> key) {
+        checkBlockRange(x, y, z);
+        return this.extent.getDefaultValue(x, y, z, key);
     }
 
     @Override

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -446,6 +446,7 @@
         "util.MixinDamageSource",
         "util.MixinEntityDamageSource",
         "util.MixinEnumHand",
+        "util.MixinFoodStats",
         "util.MixinIndirectEntityDamageSource",
         "util.MixinPacketThreadUtil",
         "util.datafix.MixinDataFixer",

--- a/src/test/java/org/spongepowered/common/event/listener/GetKeyListener.java
+++ b/src/test/java/org/spongepowered/common/event/listener/GetKeyListener.java
@@ -24,34 +24,107 @@
  */
 package org.spongepowered.common.event.listener;
 
+import static org.spongepowered.api.data.DataTransactionResult.DataCategory.REPLACED;
+import static org.spongepowered.api.data.DataTransactionResult.DataCategory.SUCCESSFUL;
+
 import org.junit.Assert;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.DataTransactionResult.DataCategory;
 import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.type.RabbitType;
+import org.spongepowered.api.data.type.RabbitTypes;
+import org.spongepowered.api.data.type.RailDirection;
+import org.spongepowered.api.data.type.RailDirections;
+import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.block.InteractBlockEvent;
 import org.spongepowered.api.event.data.ChangeDataHolderEvent;
 import org.spongepowered.api.event.filter.cause.First;
 import org.spongepowered.api.event.filter.data.GetKey;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.common.data.util.DataVersions;
 
 public class GetKeyListener {
 
     public boolean getKeyListenerCalled;
     public boolean dataHolderListenerCalled;
+    public boolean rejectedDataListenerCalled;
+    public boolean multipleCategoriesCalled;
 
     @Listener
-    public void getKeyListener(ChangeDataHolderEvent.ValueChange event, @GetKey("FOOD_LEVEL") Integer foodLevel, @GetKey("FOOD_LEVEL") MutableBoundedValue<Integer> foodValue, @GetKey("FOOD_LEVEL") ImmutableValue<Integer> foodImmut) {
+    public void getKeyListener(ChangeDataHolderEvent.ValueChange event, @GetKey("FOOD_LEVEL") int foodLevel, @GetKey("FOOD_LEVEL") MutableBoundedValue<Integer> foodValue, @GetKey("FOOD_LEVEL") ImmutableValue<Integer> foodImmut) {
         this.getKeyListenerCalled = true;
-        Assert.assertEquals(foodLevel, foodValue.get());
-        Assert.assertEquals(foodLevel, foodImmut.get());
+        Assert.assertEquals(foodLevel, foodValue.get().intValue());
+        Assert.assertEquals(foodLevel, foodImmut.get().intValue());
         Assert.assertEquals((long) foodLevel, 15);
     }
 
     @Listener
-    public void dataHolderListener(ChangeDataHolderEvent.ValueChange event, @First(tag = "foo") Player player, @GetKey(value = "FOOD_LEVEL", tag = "foo") Integer taggedFood) {
+    public void dataHolderListener(ChangeDataHolderEvent.ValueChange event,
+            @GetKey(value = "FOOD_LEVEL", from = REPLACED) int oldFood,
+            @GetKey(value = "FOOD_LEVEL", from = SUCCESSFUL) MutableBoundedValue<Integer> newFood,
+            @First(tag = "a") Player player,
+            @GetKey(value = "FOOD_LEVEL", tag = "a") int playerFood) {
+
         this.dataHolderListenerCalled = true;
-        Assert.assertEquals(taggedFood, player.get(Keys.FOOD_LEVEL).get());
-        Assert.assertEquals((long) taggedFood, 15);
+
+        Assert.assertEquals(playerFood, player.get(Keys.FOOD_LEVEL).get().intValue());
+        Assert.assertEquals((long) newFood.get(), 15);
+        Assert.assertEquals(oldFood, 16);
+    }
+
+    @Listener
+    public void rejectedDataListener(ChangeDataHolderEvent.ValueChange event, @GetKey(value = "RAIL_DIRECTION", from = {DataCategory.REJECTED}) RailDirection rail) {
+        this.rejectedDataListenerCalled = true;
+        Assert.assertEquals(RailDirections.ASCENDING_EAST, rail);
+    }
+
+    @Listener
+    public void multipleCategories(ChangeDataHolderEvent.ValueChange event,
+            @GetKey(value = "RAIL_DIRECTION", from = { DataCategory.REPLACED, DataCategory.REJECTED}) RailDirection direction,
+            @GetKey(value = "RABBIT_TYPE", from = { DataCategory.SUCCESSFUL, DataCategory.REPLACED}) RabbitType rabbitType) {
+
+        this.multipleCategoriesCalled = true;
+        Assert.assertEquals(RailDirections.ASCENDING_EAST, direction);
+        Assert.assertEquals(RabbitTypes.BLACK_AND_WHITE, rabbitType);
+    }
+
+    @Listener
+    public void invalidKeyListener(ChangeDataHolderEvent.ValueChange event, @GetKey("NOT_A_REAL_KEY") Integer blah) {
+    }
+
+    @Listener
+    public void invalidImmutableParameterType(ChangeDataHolderEvent.ValueChange event, @GetKey("REPRESENTED_BLOCK") ImmutableBoundedValue<DataVersions.BlockState> val) {
+
+    }
+
+    @Listener
+    public void invalidMutableParameterType(ChangeDataHolderEvent.ValueChange event, @GetKey("REPRESENTED_BLOCK") MutableBoundedValue<DataVersions.BlockState> val) {
+
+    }
+
+    @Listener
+    public void invalidParamType(ChangeDataHolderEvent.ValueChange event, @GetKey("REPRESENTED_BLOCK") String val) {
+
+    }
+
+    @Listener
+    public void invalidTagType(InteractBlockEvent event, @First Text text, @GetKey("REPRESENTED_BLOCK") BlockState block) {
+
+    }
+
+    @Listener
+    public void multipleMatches(ChangeDataHolderEvent.ValueChange event, @First Text text, @GetKey("REPRESENTED_BLOCK") BlockState block) {
+
+    }
+
+    @Listener
+    public void noMatches(ChangeDataHolderEvent.ValueChange event, @GetKey(value = "REPRESENTED_BLOCK", tag = "foo") BlockState block) {
+
     }
 
 }

--- a/src/test/java/org/spongepowered/common/event/listener/GetKeyListener.java
+++ b/src/test/java/org/spongepowered/common/event/listener/GetKeyListener.java
@@ -25,22 +25,33 @@
 package org.spongepowered.common.event.listener;
 
 import org.junit.Assert;
+import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.data.ChangeDataHolderEvent;
+import org.spongepowered.api.event.filter.cause.First;
 import org.spongepowered.api.event.filter.data.GetKey;
 
 public class GetKeyListener {
 
     public boolean getKeyListenerCalled;
+    public boolean dataHolderListenerCalled;
 
     @Listener
     public void getKeyListener(ChangeDataHolderEvent.ValueChange event, @GetKey("FOOD_LEVEL") Integer foodLevel, @GetKey("FOOD_LEVEL") MutableBoundedValue<Integer> foodValue, @GetKey("FOOD_LEVEL") ImmutableValue<Integer> foodImmut) {
         this.getKeyListenerCalled = true;
         Assert.assertEquals(foodLevel, foodValue.get());
         Assert.assertEquals(foodLevel, foodImmut.get());
-        Assert.assertEquals((long) foodLevel, 12);
+        Assert.assertEquals((long) foodLevel, 15);
+    }
+
+    @Listener
+    public void dataHolderListener(ChangeDataHolderEvent.ValueChange event, @First(tag = "foo") Player player, @GetKey(value = "FOOD_LEVEL", tag = "foo") Integer taggedFood) {
+        this.dataHolderListenerCalled = true;
+        Assert.assertEquals(taggedFood, player.get(Keys.FOOD_LEVEL).get());
+        Assert.assertEquals((long) taggedFood, 15);
     }
 
 }

--- a/src/test/java/org/spongepowered/common/event/listener/GetKeyListener.java
+++ b/src/test/java/org/spongepowered/common/event/listener/GetKeyListener.java
@@ -22,17 +22,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.event.filter.delegate;
+package org.spongepowered.common.event.listener;
 
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.MethodVisitor;
+import org.junit.Assert;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.data.ChangeDataHolderEvent;
+import org.spongepowered.api.event.filter.data.GetKey;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
+public class GetKeyListener {
 
-public interface ParameterFilterDelegate {
+    public boolean getKeyListenerCalled;
 
-    void write(ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int localParam);
-
+    @Listener
+    public void getKeyListener(ChangeDataHolderEvent.ValueChange event, @GetKey("FOOD_LEVEL") Integer foodLevel, @GetKey("FOOD_LEVEL") MutableBoundedValue<Integer> foodValue, @GetKey("FOOD_LEVEL") ImmutableValue<Integer> foodImmut) {
+        this.getKeyListenerCalled = true;
+        Assert.assertEquals(foodLevel, foodValue.get());
+        Assert.assertEquals(foodLevel, foodImmut.get());
+        Assert.assertEquals((long) foodLevel, 12);
+    }
 
 }

--- a/testplugins/src/main/java/org/spongepowered/test/FoodChangeTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/FoodChangeTest.java
@@ -9,6 +9,7 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.Order;
 import org.spongepowered.api.event.data.ChangeDataHolderEvent;
 import org.spongepowered.api.event.filter.cause.First;
 import org.spongepowered.api.event.filter.data.GetKey;
@@ -16,30 +17,25 @@ import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.channel.MessageChannel;
 
+import java.util.Optional;
+
 @Plugin(id = "food-change-test", authors = "Aaron1011")
 public class FoodChangeTest {
 
-    @Listener
-    public void onChange(ChangeDataHolderEvent.ValueChange event) {
-        int oldFood = 0;
-        int newFood = 0;
-        for (ImmutableValue<?> val: event.getChanges().getReplacedData()) {
-            if (val.getKey().equals(Keys.FOOD_LEVEL)) {
-                oldFood = (Integer) val.get();
-            }
+    @Listener(order = Order.EARLY)
+    public void simpleListener(ChangeDataHolderEvent.ValueChange event) {
+        Optional<ImmutableValue<?>> oldFood = event.getChanges().get(DataTransactionResult.DataCategory.REPLACED, Keys.FOOD_LEVEL);
+        Optional<ImmutableValue<?>> newFood = event.getChanges().get(DataTransactionResult.DataCategory.SUCCESSFUL, Keys.FOOD_LEVEL);
+
+        if (!oldFood.isPresent() || !newFood.isPresent()) {
+            return;
         }
 
-        for (ImmutableValue<?> val: event.getChanges().getSuccessfulData()) {
-            if (val.getKey().equals(Keys.FOOD_LEVEL)) {
-                newFood = (Integer) val.get();
-            }
-        }
-
-        MessageChannel.TO_ALL.send(Text.of(String.format("Simple listener: %s %s", oldFood, newFood)));
+        MessageChannel.TO_ALL.send(Text.of(String.format("Simple listener: %s %s", oldFood.get().get(), newFood.get().get())));
     }
 
     @Listener
-    public void onChange(ChangeDataHolderEvent.ValueChange event,
+    public void getKeyListener(ChangeDataHolderEvent.ValueChange event,
             @GetKey(value = "FOOD_LEVEL", from = REPLACED) int oldFood,
             @GetKey(value = "FOOD_LEVEL", from = SUCCESSFUL) MutableBoundedValue<Integer> newFood,
             @First(tag = "a") Player player,

--- a/testplugins/src/main/java/org/spongepowered/test/FoodChangeTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/FoodChangeTest.java
@@ -1,0 +1,35 @@
+package org.spongepowered.test;
+
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.data.ChangeDataHolderEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.channel.MessageChannel;
+
+@Plugin(id = "food-change-test", authors = "Aaron1011")
+public class FoodChangeTest {
+
+    @Listener
+    public void onChange(ChangeDataHolderEvent.ValueChange event) {
+        ImmutableValue<Integer> food = null;
+        for (ImmutableValue<?> val: event.getEndResult().getReplacedData()) {
+            if (val.getKey().equals(Keys.FOOD_LEVEL)) {
+                MessageChannel.TO_ALL.send(Text.of("Old food " + val.getDirect().get()));
+            }
+        }
+
+        for (ImmutableValue<?> val: event.getEndResult().getSuccessfulData()) {
+            if (val.getKey().equals(Keys.FOOD_LEVEL)) {
+                MessageChannel.TO_ALL.send(Text.of("New food: " + val.getDirect().get()));
+                food = (ImmutableValue) val;
+            }
+        }
+
+        event.proposeChanges(DataTransactionResult.successResult(food.with(20)));
+
+    }
+
+}

--- a/testplugins/src/main/java/org/spongepowered/test/FoodChangeTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/FoodChangeTest.java
@@ -5,6 +5,7 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.data.ChangeDataHolderEvent;
+import org.spongepowered.api.event.filter.data.GetKey;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.channel.MessageChannel;
@@ -13,15 +14,15 @@ import org.spongepowered.api.text.channel.MessageChannel;
 public class FoodChangeTest {
 
     @Listener
-    public void onChange(ChangeDataHolderEvent.ValueChange event) {
+    public void onChange(ChangeDataHolderEvent.ValueChange event, @GetKey("FOOD_LEVEL") int foodLevel) {
         ImmutableValue<Integer> food = null;
-           for (ImmutableValue<?> val: event.getEndResult().getReplacedData()) {
+           for (ImmutableValue<?> val: event.getChanges().getReplacedData()) {
             if (val.getKey().equals(Keys.FOOD_LEVEL)) {
                 MessageChannel.TO_ALL.send(Text.of("Old food " + val.getDirect().get()));
             }
         }
 
-        for (ImmutableValue<?> val: event.getEndResult().getSuccessfulData()) {
+        for (ImmutableValue<?> val: event.getChanges().getSuccessfulData()) {
             if (val.getKey().equals(Keys.FOOD_LEVEL)) {
                 MessageChannel.TO_ALL.send(Text.of("New food: " + val.getDirect().get()));
                 food = (ImmutableValue) val;

--- a/testplugins/src/main/java/org/spongepowered/test/FoodChangeTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/FoodChangeTest.java
@@ -1,10 +1,16 @@
 package org.spongepowered.test;
 
+import static org.spongepowered.api.data.DataTransactionResult.DataCategory.REPLACED;
+import static org.spongepowered.api.data.DataTransactionResult.DataCategory.SUCCESSFUL;
+
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.data.ChangeDataHolderEvent;
+import org.spongepowered.api.event.filter.cause.First;
 import org.spongepowered.api.event.filter.data.GetKey;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.text.Text;
@@ -14,23 +20,34 @@ import org.spongepowered.api.text.channel.MessageChannel;
 public class FoodChangeTest {
 
     @Listener
-    public void onChange(ChangeDataHolderEvent.ValueChange event, @GetKey("FOOD_LEVEL") int foodLevel) {
-        ImmutableValue<Integer> food = null;
-           for (ImmutableValue<?> val: event.getChanges().getReplacedData()) {
+    public void onChange(ChangeDataHolderEvent.ValueChange event) {
+        int oldFood = 0;
+        int newFood = 0;
+        for (ImmutableValue<?> val: event.getChanges().getReplacedData()) {
             if (val.getKey().equals(Keys.FOOD_LEVEL)) {
-                MessageChannel.TO_ALL.send(Text.of("Old food " + val.getDirect().get()));
+                oldFood = (Integer) val.get();
             }
         }
 
         for (ImmutableValue<?> val: event.getChanges().getSuccessfulData()) {
             if (val.getKey().equals(Keys.FOOD_LEVEL)) {
-                MessageChannel.TO_ALL.send(Text.of("New food: " + val.getDirect().get()));
-                food = (ImmutableValue) val;
+                newFood = (Integer) val.get();
             }
         }
 
-        //event.proposeChanges(DataTransactionResult.successResult(food.with(20)));
+        MessageChannel.TO_ALL.send(Text.of(String.format("Simple listener: %s %s", oldFood, newFood)));
+    }
 
+    @Listener
+    public void onChange(ChangeDataHolderEvent.ValueChange event,
+            @GetKey(value = "FOOD_LEVEL", from = REPLACED) int oldFood,
+            @GetKey(value = "FOOD_LEVEL", from = SUCCESSFUL) MutableBoundedValue<Integer> newFood,
+            @First(tag = "a") Player player,
+            @GetKey(value = "DISPLAY_NAME", tag = "a") Text name) {
+
+        MessageChannel.TO_ALL.send(Text.of(String.format("GetKey listener: %s %s from player ", oldFood, newFood.get())).concat(name));
+
+        event.setChanges(DataTransactionResult.builder().from(event.getChanges()).absorbResult(DataTransactionResult.successResult(newFood.asImmutable().with(newFood.getMaxValue()))).build());
     }
 
 }

--- a/testplugins/src/main/java/org/spongepowered/test/FoodChangeTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/FoodChangeTest.java
@@ -15,7 +15,7 @@ public class FoodChangeTest {
     @Listener
     public void onChange(ChangeDataHolderEvent.ValueChange event) {
         ImmutableValue<Integer> food = null;
-        for (ImmutableValue<?> val: event.getEndResult().getReplacedData()) {
+           for (ImmutableValue<?> val: event.getEndResult().getReplacedData()) {
             if (val.getKey().equals(Keys.FOOD_LEVEL)) {
                 MessageChannel.TO_ALL.send(Text.of("Old food " + val.getDirect().get()));
             }
@@ -28,7 +28,7 @@ public class FoodChangeTest {
             }
         }
 
-        event.proposeChanges(DataTransactionResult.successResult(food.with(20)));
+        //event.proposeChanges(DataTransactionResult.successResult(food.with(20)));
 
     }
 


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1695) | **SpongeCommon** | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/1866)

See the SpongeAPI PR for more details.

This is the basic pattern for firing a `ChangeDataHolderEvent.ValueChange` event for a given key:


1. Redirect all locations in Vanilla/Forge where the value is set. Ideally, there will be a public setter method for you to inject into.
2. Instead of setting the underlying field (or `DataParameter, etc`), call `offerWithEvent` on the appropriate `DataHolder`, putting any relevant objects into the `Cause`
3. In the `ValueProcessor` for the key in question, **bypass** the setter you redirected before, if applicable. This ensures that setting the value does not end up recursing infinitely between your redirected setter and the value processor.

Basically, the idea is to ensure that all changes done by mods/vanilla/forge end up firing an event, while API changes (e.g. anything going through the value processor) does **not**. The decision as to whether or not to fire an event for a plugin change is handled on the API side, and is not the implementation's concern.