### PR TITLE
Cancel Mesa Terrain only if constructed from SpongeForge 

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/biome/MixinBiomeMesa.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/biome/MixinBiomeMesa.java
@@ -52,9 +52,11 @@ public abstract class MixinBiomeMesa extends MixinBiome {
 
     @Shadow @Final private boolean brycePillars;
     @Shadow @Final private boolean hasForest;
+    private boolean vanillaCompat = true;
 
     @Override
     public void buildPopulators(World world, SpongeBiomeGenerationSettings gensettings) {
+        this.vanillaCompat = false;
         gensettings.getGenerationPopulators().add(new MesaBiomeGenerationPopulator(this.brycePillars, this.hasForest));
         super.buildPopulators(world, gensettings);
         String s = world.getWorldInfo().getGeneratorOptions();
@@ -95,7 +97,9 @@ public abstract class MixinBiomeMesa extends MixinBiome {
      */
     @Inject(method = "genTerrainBlocks(Lnet/minecraft/world/World;Ljava/util/Random;Lnet/minecraft/world/chunk/ChunkPrimer;IID)V", at = @At("HEAD") , cancellable = true)
     public void genTerrainBlocks(World world, Random rand, ChunkPrimer chunk, int x, int z, double stoneNoise, CallbackInfo ci) {
-        ci.cancel();
+        if (this.vanillaCompat) {
+            ci.cancel();
+        }
     }
 
 }


### PR DESCRIPTION
Fixes SpongePowered/SpongeForge#1834

This restores vanilla behavior if BiomeMesa is constructed without MixinBiome::buildPopulators being called, which to my knowledge, only gets called under Sponge world generators.

If this is bypassed e.g. mods not knowing about us extracting the Mesa biome into a decorator/populator then it defaults to vanilla's.