### PR TITLE
Implement chorus fruit teleport type

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemChorusFruit.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemChorusFruit.java
@@ -1,0 +1,25 @@
+package org.spongepowered.common.mixin.core.item;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemChorusFruit;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.api.event.cause.EventContextKeys;
+import org.spongepowered.api.event.cause.entity.teleport.TeleportTypes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ItemChorusFruit.class)
+public class MixinItemChorusFruit extends Item {
+
+    @Redirect(method = "onItemUseFinish", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;attemptTeleport(DDD)Z"))
+    private boolean onAttemptTeleport(EntityLivingBase entity, double x, double y, double z) {
+        try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+            Sponge.getCauseStackManager().addContext(EventContextKeys.TELEPORT_TYPE, TeleportTypes.CHORUS_FRUIT);
+            return entity.attemptTeleport(x, y, z);
+        }
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/registry/type/event/TeleportTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/event/TeleportTypeRegistryModule.java
@@ -76,6 +76,7 @@ public final class TeleportTypeRegistryModule implements AlternateCatalogRegistr
         this.teleportTypeMappings.put("minecraft:command", new SpongeTeleportType("minecraft:command", "Command"));
         this.teleportTypeMappings.put("minecraft:entity_teleport", new SpongeTeleportType("minecraft:entity_teleport", "Entity Teleport"));
         this.teleportTypeMappings.put("minecraft:portal", new SpongeTeleportType("minecraft:portal", "Portal"));
+        this.teleportTypeMappings.put("minecraft:chorus_fruit", new SpongeTeleportType("minecraft:chorus_fruit", "Chorus Fruit"));
         this.teleportTypeMappings.put("sponge:plugin", new SpongeTeleportType("sponge:plugin", "Plugin"));
         this.teleportTypeMappings.put("sponge:unknown", new SpongeTeleportType("sponge:unknown", "Unknown"));
     }

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -333,6 +333,7 @@
         "item.MixinItem",
         "item.MixinItemArmorMaterial",
         "item.MixinItemBlock",
+        "item.MixinItemChorusFruit",
         "item.MixinItemEnderEye",
         "item.MixinItemFirework",
         "item.MixinItemFishingRod",


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1709) | **SpongeCommon**

Not actually sure if this is the complete correct way to do this as I haven't worked much with this before, but with this code `TeleportTypes.CHORUS_FRUIT` was in the context for the key `EventContextKeys.TELEPORT_TYPES`. So please give feedback where you can, thanks!

Tested with: 

```Java
@Listener
public void onTeleport(MoveEntityEvent.Teleport event, @Root Player player) {
    event.getContext().get(EventContextKeys.TELEPORT_TYPE).ifPresent(t -> player.sendMessage(Text.of(TextColors.GOLD, "TeleportType: ", TextColors.GRAY, t.getId())));
}
```