### PR TITLE
Implements spawn load methods in MixinDimensionType

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinDimensionType.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinDimensionType.java
@@ -62,6 +62,7 @@ public abstract class MixinDimensionType implements IMixinDimensionType {
     private SpongeConfig<DimensionConfig> config;
     private volatile Context context;
     private boolean generateSpawnOnLoad;
+    private boolean loadSpawn;
 
     @Inject(method = "<init>", at = @At("RETURN"))
     public void onConstruct(String enumName, int ordinal, int idIn, String nameIn, String suffixIn, Class <? extends WorldProvider > clazzIn,
@@ -72,6 +73,7 @@ public abstract class MixinDimensionType implements IMixinDimensionType {
         this.configPath = SpongeImpl.getSpongeConfigDir().resolve("worlds").resolve(this.modId).resolve(this.enumName);
         this.config = new SpongeConfig<>(SpongeConfig.Type.DIMENSION, this.configPath.resolve("dimension.conf"), SpongeImpl.ECOSYSTEM_ID);
         this.generateSpawnOnLoad = idIn == 0;
+        this.loadSpawn = this.generateSpawnOnLoad;
         this.config.getConfig().getWorld().setGenerateSpawnOnLoad(this.generateSpawnOnLoad);
         this.sanitizedId = this.modId + ":" + dimName;
         String contextId = this.sanitizedId.replace(":", ".");
@@ -84,6 +86,16 @@ public abstract class MixinDimensionType implements IMixinDimensionType {
     @Override
     public boolean shouldGenerateSpawnOnLoad() {
         return this.generateSpawnOnLoad;
+    }
+
+    @Override
+    public boolean shouldLoadSpawn() {
+        return this.loadSpawn;
+    }
+
+    @Override
+    public void setShouldLoadSpawn(boolean keepSpawnLoaded) {
+        this.loadSpawn = keepSpawnLoaded;
     }
 
     public String dimensionType$getId() {


### PR DESCRIPTION
Before this, it caused a crash on SpongeVanilla when making a completely brand new server with a newly generated configuration and world, as it does not mixin the implemented method for `shouldLoadSpawn` like SpongeForge does. 

Original Crash: https://gist.github.com/connorhartley/dce0285cc1d8f22434e06de03463ad81

https://github.com/SpongePowered/SpongeForge/blob/bleeding/src/main/java/org/spongepowered/mod/mixin/core/world/MixinDimensionType.java - It is overriden by this for Forge (this PR fixes it for SV mainly).

I've tested this fix for Forge and Vanilla and it works.