### PR TITLE
Implements damageabledata

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -205,6 +205,9 @@ public class DataRegistrar {
         DataUtil.registerDataProcessorAndImpl(InvulnerabilityData.class, SpongeInvulnerabilityData.class,
                 ImmutableInvulnerabilityData.class, ImmutableSpongeInvulnerabilityData.class, new InvulnerabilityDataProcessor());
 
+        DataUtil.registerDataProcessorAndImpl(DamageableData.class, SpongeDamageableData.class,
+                ImmutableDamageableData.class, ImmutableSpongeDamageableData.class, new DamageableDataProcessor());
+
         DataUtil.registerDataProcessorAndImpl(FuseData.class, SpongeFuseData.class, ImmutableFuseData.class,
                 ImmutableSpongeFuseData.class, new FuseDataProcessor());
 
@@ -825,6 +828,8 @@ public class DataRegistrar {
         DataUtil.registerValueProcessor(Keys.AGE, new AgeableAgeValueProcessor());
         DataUtil.registerValueProcessor(Keys.INVULNERABILITY_TICKS, new InvulnerabilityTicksValueProcessor());
         DataUtil.registerValueProcessor(Keys.INVULNERABLE, new InvulnerableValueProcessor());
+        DataUtil.registerValueProcessor(Keys.LAST_ATTACKER, new LastAttackerValueProcessor());
+        DataUtil.registerValueProcessor(Keys.LAST_DAMAGE, new LastDamageValueProcessor());
 
         // Properties
         final PropertyRegistry propertyRegistry = Sponge.getPropertyRegistry();

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeDamageableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeDamageableData.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableDamageableData;
+import org.spongepowered.api.data.manipulator.mutable.entity.DamageableData;
+import org.spongepowered.api.data.value.immutable.ImmutableOptionalValue;
+import org.spongepowered.api.entity.EntitySnapshot;
+import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeDamageableData;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeOptionalValue;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+public class ImmutableSpongeDamageableData extends AbstractImmutableData<ImmutableDamageableData, DamageableData> implements ImmutableDamageableData {
+
+    @Nullable private final EntitySnapshot lastAttacker;
+    @Nullable private final Double lastDamage;
+
+    private final ImmutableOptionalValue<EntitySnapshot> lastAttackerValue;
+    private final ImmutableOptionalValue<Double> lastDamageValue;
+
+    public ImmutableSpongeDamageableData() {
+        this((EntitySnapshot) null, null);
+    }
+
+    public ImmutableSpongeDamageableData(@Nullable EntitySnapshot lastAttacker, @Nullable Double lastDamage) {
+        super(ImmutableDamageableData.class);
+        this.lastAttacker = lastAttacker;
+        this.lastDamage = lastDamage;
+        this.lastAttackerValue = new ImmutableSpongeOptionalValue<>(Keys.LAST_ATTACKER, Optional.ofNullable(this.lastAttacker));
+        this.lastDamageValue = new ImmutableSpongeOptionalValue<>(Keys.LAST_DAMAGE, Optional.ofNullable(this.lastDamage));
+    }
+
+    public ImmutableSpongeDamageableData(@Nullable Living lastAttacker, @Nullable Double lastDamage) {
+        this(lastAttacker == null ? null : lastAttacker.createSnapshot(), lastDamage);
+    }
+
+    @Override
+    public ImmutableOptionalValue<EntitySnapshot> lastAttacker() {
+        return this.lastAttackerValue;
+    }
+
+    @Override
+    public ImmutableOptionalValue<Double> lastDamage() {
+        return this.lastDamageValue;
+    }
+
+    @Override
+    protected void registerGetters() {
+        registerFieldGetter(Keys.LAST_ATTACKER, () -> Optional.ofNullable(this.lastAttacker));
+        registerKeyValue(Keys.LAST_ATTACKER, () -> this.lastAttackerValue);
+
+        registerFieldGetter(Keys.LAST_DAMAGE, () -> Optional.ofNullable(this.lastDamage));
+        registerKeyValue(Keys.LAST_DAMAGE, () -> this.lastDamageValue);
+    }
+
+    @Override
+    public DamageableData asMutable() {
+        return new SpongeDamageableData(this.lastAttacker, this.lastDamage);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer()
+                .set(Keys.LAST_ATTACKER, Optional.ofNullable(this.lastAttacker))
+                .set(Keys.LAST_DAMAGE, Optional.ofNullable(this.lastDamage));
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeDamageableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeDamageableData.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableDamageableData;
+import org.spongepowered.api.data.manipulator.mutable.entity.DamageableData;
+import org.spongepowered.api.data.value.mutable.OptionalValue;
+import org.spongepowered.api.entity.EntitySnapshot;
+import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.common.data.ImmutableDataCachingUtil;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeDamageableData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractData;
+import org.spongepowered.common.data.value.mutable.SpongeOptionalValue;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+public class SpongeDamageableData extends AbstractData<DamageableData, ImmutableDamageableData> implements DamageableData {
+
+    @Nullable private EntitySnapshot lastAttacker;
+    @Nullable private Double lastDamage;
+
+    public SpongeDamageableData() {
+        this((EntitySnapshot) null, null);
+    }
+
+    public SpongeDamageableData(@Nullable EntitySnapshot lastAttacker, @Nullable Double lastDamage) {
+        super(DamageableData.class);
+        this.lastAttacker = lastAttacker;
+        this.lastDamage = lastDamage;
+    }
+
+    public SpongeDamageableData(@Nullable Living lastAttacker, @Nullable Double lastDamage) {
+        this(lastAttacker == null ? null : lastAttacker.createSnapshot(), lastDamage);
+    }
+
+    @Override
+    public OptionalValue<EntitySnapshot> lastAttacker() {
+        return new SpongeOptionalValue<>(Keys.LAST_ATTACKER, Optional.empty(), Optional.ofNullable(this.lastAttacker));
+    }
+
+    @Override
+    public OptionalValue<Double> lastDamage() {
+        return new SpongeOptionalValue<>(Keys.LAST_DAMAGE, Optional.empty(), Optional.ofNullable(this.lastAttacker == null ? null : this.lastDamage));
+    }
+
+    @Override
+    protected void registerGettersAndSetters() {
+        registerFieldGetter(Keys.LAST_ATTACKER, () -> Optional.ofNullable(this.lastAttacker));
+        registerFieldSetter(Keys.LAST_ATTACKER, lastAttacker -> this.lastAttacker = lastAttacker == null ? null : lastAttacker.orElse(null));
+        registerKeyValue(Keys.LAST_ATTACKER, this::lastAttacker);
+
+        registerFieldGetter(Keys.LAST_DAMAGE, () -> Optional.ofNullable(this.lastDamage));
+        registerFieldSetter(Keys.LAST_DAMAGE, lastDamage -> this.lastDamage = lastDamage == null ? null : lastDamage.orElse(null));
+        registerKeyValue(Keys.LAST_DAMAGE, this::lastDamage);
+    }
+
+    @Override
+    public DamageableData copy() {
+        return new SpongeDamageableData(this.lastAttacker, this.lastDamage);
+    }
+
+    @Override
+    public ImmutableDamageableData asImmutable() {
+        return ImmutableDataCachingUtil.getManipulator(ImmutableSpongeDamageableData.class, this.lastAttacker, this.lastDamage);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer()
+                .set(Keys.LAST_ATTACKER, Optional.ofNullable(this.lastAttacker))
+                .set(Keys.LAST_DAMAGE, Optional.ofNullable(this.lastDamage));
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/LastAttackerValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/LastAttackerValueProcessor.java
@@ -60,7 +60,7 @@ public class LastAttackerValueProcessor
             return true;
         }
         if (lastAttacker.get().getUniqueId().isPresent()) {
-            final Optional<Entity> optionalEntity = ((World) dataHolder.getEntityWorld()).getEntity(lastAttacker.get().getUniqueId().get());
+            final Optional<Entity> optionalEntity = lastAttacker.get().restore();
             if (optionalEntity.isPresent()) {
                 final Entity entity = optionalEntity.get();
                 if (entity.isLoaded() && entity instanceof EntityLivingBase) {

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/LastAttackerValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/LastAttackerValueProcessor.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.entity;
+
+import net.minecraft.entity.EntityLivingBase;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.OptionalValue;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntitySnapshot;
+import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.api.world.World;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.SpongeValueFactory;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+public class LastAttackerValueProcessor
+        extends AbstractSpongeValueProcessor<EntityLivingBase, Optional<EntitySnapshot>, OptionalValue<EntitySnapshot>> {
+
+    public LastAttackerValueProcessor() {
+        super(EntityLivingBase.class, Keys.LAST_ATTACKER);
+    }
+
+    @Override
+    protected OptionalValue<EntitySnapshot> constructValue(Optional<EntitySnapshot> actualValue) {
+        return SpongeValueFactory.getInstance().createOptionalValue(Keys.LAST_ATTACKER, actualValue.orElse(null));
+    }
+
+    @Override
+    protected boolean set(EntityLivingBase dataHolder, @Nullable Optional<EntitySnapshot> lastAttacker) {
+        if (lastAttacker == null || !lastAttacker.isPresent()) {
+            dataHolder.setRevengeTarget(null);
+            return true;
+        }
+        if (lastAttacker.get().getUniqueId().isPresent()) {
+            final Optional<Entity> optionalEntity = ((World) dataHolder.getEntityWorld()).getEntity(lastAttacker.get().getUniqueId().get());
+            if (optionalEntity.isPresent()) {
+                final Entity entity = optionalEntity.get();
+                if (entity.isLoaded() && entity instanceof EntityLivingBase) {
+                    dataHolder.setRevengeTarget((EntityLivingBase) entity);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected Optional<Optional<EntitySnapshot>> getVal(EntityLivingBase container) {
+        final EntityLivingBase entityLivingBase = container.getRevengeTarget();
+        return Optional.of(Optional.ofNullable(entityLivingBase == null ? null : ((Living) entityLivingBase).createSnapshot()));
+    }
+
+    @Override
+    protected ImmutableValue<Optional<EntitySnapshot>> constructImmutableValue(Optional<EntitySnapshot> value) {
+        return constructValue(value).asImmutable();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionResult.failNoData();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/LastDamageValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/LastDamageValueProcessor.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.entity;
+
+import net.minecraft.entity.EntityLivingBase;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.OptionalValue;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.SpongeValueFactory;
+import org.spongepowered.common.interfaces.entity.IMixinEntityLivingBase;
+
+import java.util.Optional;
+
+public class LastDamageValueProcessor extends AbstractSpongeValueProcessor<EntityLivingBase, Optional<Double>, OptionalValue<Double>> {
+
+    public LastDamageValueProcessor() {
+        super(EntityLivingBase.class, Keys.LAST_DAMAGE);
+    }
+
+    @Override
+    protected OptionalValue<Double> constructValue(Optional<Double> actualValue) {
+        return SpongeValueFactory.getInstance().createOptionalValue(Keys.LAST_DAMAGE, actualValue.orElse(null));
+    }
+
+    @Override
+    protected boolean set(EntityLivingBase container, Optional<Double> value) {
+        if (value.isPresent()) {
+            ((IMixinEntityLivingBase) container).setLastDamage(value.get());
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected Optional<Optional<Double>> getVal(EntityLivingBase container) {
+        return Optional.of(Optional.ofNullable(container.getRevengeTarget() == null ?
+                null : ((IMixinEntityLivingBase) container).getLastDamageTaken()));
+    }
+
+    @Override
+    protected ImmutableValue<Optional<Double>> constructImmutableValue(Optional<Double> value) {
+        return constructValue(value).asImmutable();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionResult.failNoData();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntityLivingBase.java
@@ -61,4 +61,8 @@ public interface IMixinEntityLivingBase {
         return false;
     }
 
+    double getLastDamageTaken();
+
+    void setRevengeTarget(EntityLivingBase entityLivingBase);
+
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java
@@ -54,6 +54,7 @@ import net.minecraft.world.WorldServer;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.entity.DamageableData;
 import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.data.value.mutable.OptionalValue;
@@ -78,6 +79,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeDamageableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeHealthData;
 import org.spongepowered.common.data.value.SpongeValueFactory;
 import org.spongepowered.common.data.value.mutable.SpongeOptionalValue;
@@ -123,7 +125,7 @@ public abstract class MixinEntityLivingBase extends MixinEntity implements Livin
     @Shadow public boolean potionsNeedUpdate;
     @Shadow public boolean dead;
     @Shadow public CombatTracker _combatTracker;
-    @Shadow public EntityLivingBase revengeTarget;
+    @Shadow @Nullable public EntityLivingBase revengeTarget;
     @Shadow protected AbstractAttributeMap attributeMap;
     @Shadow protected int idleTime;
     @Shadow protected int recentlyHit;
@@ -182,6 +184,8 @@ public abstract class MixinEntityLivingBase extends MixinEntity implements Livin
         return false; // SHADOWED
     }
     @Shadow public abstract AbstractAttributeMap getAttributeMap();
+
+    @Shadow @Nullable public abstract EntityLivingBase getRevengeTarget();
 
     @Override
     public Vector3d getHeadRotation() {
@@ -891,20 +895,26 @@ public abstract class MixinEntityLivingBase extends MixinEntity implements Livin
                 .build();
     }
 
-    // TODO uncomment when the processor is implemented
-//    @Override
-//    public DamageableData getMortalData() {
-//        return null;
-//    }
+    @Override
+    public DamageableData getDamageableData() {
+        return new SpongeDamageableData((Living) this.revengeTarget, (double) this.lastDamage);
+    }
 
     @Override
     public OptionalValue<EntitySnapshot> lastAttacker() {
-        return new SpongeOptionalValue<>(Keys.LAST_ATTACKER, Optional.ofNullable(EntityUtil.createSnapshot(this.getLastAttackedEntity())));
+        return new SpongeOptionalValue<>(Keys.LAST_ATTACKER, Optional.empty(), Optional.ofNullable(this.revengeTarget == null ?
+                null : ((Living) this.revengeTarget).createSnapshot()));
     }
 
     @Override
     public OptionalValue<Double> lastDamage() {
-        return new SpongeOptionalValue<>(Keys.LAST_DAMAGE, Optional.ofNullable(this.getLastAttackedEntity() == null ? null : (double) this.lastDamage));
+        return new SpongeOptionalValue<>(Keys.LAST_DAMAGE, Optional.empty(), Optional.ofNullable(this.revengeTarget == null ?
+                null : (double) (this.lastDamage)));
+    }
+
+    @Override
+    public double getLastDamageTaken() {
+        return this.lastDamage;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
@@ -570,9 +570,9 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
         // Deprecated
         register("johnny_vindicator", Key.builder().type(TypeTokens.BOOLEAN_VALUE_TOKEN).id("sponge:johnny_vindicator").name("Johnny Vindicator").query(of("JohnnyVindicator")).build());
 
-        register("last_attacker", Key.builder().type(TypeTokens.OPTIONAL_ENTITY_SNAPSHOT_VALUE_TOKEN).id("sponge_last_attacker").name("Last Attacker").build());
+        register("last_attacker", Key.builder().type(TypeTokens.OPTIONAL_ENTITY_SNAPSHOT_VALUE_TOKEN).id("sponge:last_attacker").name("Last Attacker").query(of("LastAttacker")).build());
 
-        register("last_damage", Key.builder().type(TypeTokens.OPTIONAL_DOUBLE_VALUE_TOKEN).id("sponge:last_damage").name("Last Damage Taken").build());
+        register("last_damage", Key.builder().type(TypeTokens.OPTIONAL_DOUBLE_VALUE_TOKEN).id("sponge:last_damage").name("Last Damage Taken").query(of("LastDamage")).build());
 
         register("llama_strength", Key.builder().type(TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN).id("sponge:llama_strength").name("Llama Strength").query(of("LlamaStrength")).build());
 

--- a/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
@@ -570,7 +570,9 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
         // Deprecated
         register("johnny_vindicator", Key.builder().type(TypeTokens.BOOLEAN_VALUE_TOKEN).id("sponge:johnny_vindicator").name("Johnny Vindicator").query(of("JohnnyVindicator")).build());
 
-        register("last_attacker", Key.builder().type(TypeTokens.LAST_ATTACKER_VALUE_TOKEN).id("sponge:last_attacker").name("Last Attacking Entity").query(of("LastAttacker")).build());
+        register("last_attacker", Key.builder().type(TypeTokens.OPTIONAL_ENTITY_SNAPSHOT_VALUE_TOKEN).id("sponge_last_attacker").name("Last Attacker").build());
+
+        register("last_damage", Key.builder().type(TypeTokens.OPTIONAL_DOUBLE_VALUE_TOKEN).id("sponge:last_damage").name("Last Damage Taken").build());
 
         register("llama_strength", Key.builder().type(TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN).id("sponge:llama_strength").name("Llama Strength").query(of("LlamaStrength")).build());
 

--- a/testplugins/src/main/java/org/spongepowered/test/DamageableDataTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/DamageableDataTest.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntitySnapshot;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+
+import java.util.Optional;
+
+@Plugin(id = "damageabledatatest", name = "Damageable Data Test", description = "A plugin to test damageable data.")
+public class DamageableDataTest {
+
+    @Listener
+    public void onGamePreInitialization(GamePreInitializationEvent event) {
+        Sponge.getCommandManager().register(this,
+                CommandSpec.builder()
+                        .arguments(GenericArguments.onlyOne(GenericArguments.entityOrSource(Text.of("target"))))
+                        .executor((src, args) -> {
+                            final Entity entity = args.<Entity>getOne("target").get();
+
+                            final Optional<EntitySnapshot> optionalAttacker = entity.get(Keys.LAST_ATTACKER).get();
+                            final Optional<Double> lastDamage = entity.get(Keys.LAST_DAMAGE).get();
+                            if (optionalAttacker.isPresent() && lastDamage.isPresent()) {
+                                final EntitySnapshot attacker = optionalAttacker.get();
+                                src.sendMessage(Text.of(attacker.get(Keys.DISPLAY_NAME).orElse(Text.of(attacker.getUniqueId())) + " dealt "
+                                        + lastDamage.get() + " damage to " + entity.get(Keys.DISPLAY_NAME).orElse(Text.of(entity.getUniqueId()))));
+                            } else {
+                                src.sendMessage(Text.of(TextColors.RED, "This target does not have a last attacker."));
+                            }
+
+                            return CommandResult.success();
+                        })
+                        .build(),
+                "lastattackertest");
+    }
+
+}


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1716) | **SpongeCommon**

Implements `DamageableData`.

Needs heavy review in API changes as well as implementation. Read API pull request for more information.