### PR TITLE
Implement DamageEntityEvent for armor stands.

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java
@@ -184,6 +184,9 @@ public abstract class MixinEntityLivingBase extends MixinEntity implements Livin
         return false; // SHADOWED
     }
     @Shadow public abstract AbstractAttributeMap getAttributeMap();
+    @Shadow public void onKillCommand() {
+        // Non-abstract for MixinEntityArmorStand
+    }
     @Shadow protected abstract int getExperiencePoints(EntityPlayer attackingPlayer);
 
     @Shadow @Nullable public abstract EntityLivingBase getRevengeTarget();

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityArmorStand.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityArmorStand.java
@@ -27,7 +27,9 @@ package org.spongepowered.common.mixin.core.entity.item;
 import com.flowpowered.math.vector.Vector3d;
 import com.google.common.collect.Maps;
 import net.minecraft.entity.item.EntityArmorStand;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.math.Rotations;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.entity.ArmorStandData;
@@ -36,16 +38,29 @@ import org.spongepowered.api.data.type.BodyPart;
 import org.spongepowered.api.data.type.BodyParts;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.living.ArmorStand;
+import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.entity.DamageEntityEvent;
+import org.spongepowered.asm.lib.Opcodes;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeArmorStandData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeBodyPartRotationalData;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.event.damage.DamageEventHandler;
 import org.spongepowered.common.mixin.core.entity.MixinEntityLivingBase;
 import org.spongepowered.common.util.VecHelper;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -64,6 +79,8 @@ public abstract class MixinEntityArmorStand extends MixinEntityLivingBase implem
     @Shadow public abstract boolean shadow$isSmall();
     @Shadow public abstract Rotations shadow$getHeadRotation();
     @Shadow public abstract Rotations getBodyRotation();
+
+    @Shadow protected abstract void damageArmorStand(float damage);
 
     @Override
     public Value<Boolean> marker() {
@@ -107,5 +124,95 @@ public abstract class MixinEntityArmorStand extends MixinEntityLivingBase implem
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getBodyPartRotationalData());
         manipulators.add(getArmorStandData());
+    }
+
+    /**
+     * The return value is set to false if the entity should not be completely
+     * destroyed.
+     */
+    private void fireDestroyDamageEvent(DamageSource source, CallbackInfoReturnable<Boolean> cir) {
+        try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+            DamageEventHandler.generateCauseFor(source);
+            DamageEntityEvent event = SpongeEventFactory.createDamageEntityEvent(Sponge.getCauseStackManager().getCurrentCause(), new ArrayList<>(),
+                    this, Math.max(1000, this.getHealth()));
+            if (SpongeImpl.postEvent(event)) {
+                cir.setReturnValue(false);
+            }
+            if (event.getFinalDamage() < this.getHealth()) {
+                this.damageArmorStand((float) event.getFinalDamage());
+                cir.setReturnValue(false);
+            }
+        }
+    }
+
+    @Inject(method = "attackEntityFrom",
+            slice = @Slice(from = @At(value = "FIELD", target = "Lnet/minecraft/util/DamageSource;OUT_OF_WORLD:Lnet/minecraft/util/DamageSource;")),
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityArmorStand;setDead()V", ordinal = 0),
+            cancellable = true)
+    private void fireDamageEventOutOfWorld(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        fireDestroyDamageEvent(source, cir);
+    }
+
+    @Inject(method = "attackEntityFrom",
+            slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/util/DamageSource;isExplosion()Z")),
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityArmorStand;dropContents()V"),
+            cancellable = true)
+    private void fireDamageEventExplosion(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        fireDestroyDamageEvent(source, cir);
+    }
+
+    @Redirect(method = "attackEntityFrom", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityArmorStand;damageArmorStand(F)V"))
+    private void fireDamageEventDamage(EntityArmorStand self, float effectiveAmount, DamageSource source, float originalAmount) {
+        try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+            DamageEventHandler.generateCauseFor(source);
+            DamageEntityEvent event = SpongeEventFactory.createDamageEntityEvent(Sponge.getCauseStackManager().getCurrentCause(), new ArrayList<>(),
+                    this, effectiveAmount);
+            if (!SpongeImpl.postEvent(event)) {
+                this.damageArmorStand((float) event.getFinalDamage());
+            }
+        }
+    }
+
+    @Inject(method = "attackEntityFrom", slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/util/DamageSource;isCreativePlayer()Z")),
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityArmorStand;playBrokenSound()V"), cancellable = true)
+    private void fireDamageEventCreativePunch(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        fireDestroyDamageEvent(source, cir);
+    }
+
+    @Inject(method = "attackEntityFrom",
+            slice = @Slice(
+                    from = @At(value = "FIELD", target = "Lnet/minecraft/entity/item/EntityArmorStand;punchCooldown:J", opcode = Opcodes.GETFIELD)),
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setEntityState(Lnet/minecraft/entity/Entity;B)V"),
+            cancellable = true)
+    private void fireDamageEventFirstPunch(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        // While this doesn't technically "damage" the armor stand, it feels
+        // like damage in other respects, so fire an event.
+        try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+            DamageEventHandler.generateCauseFor(source);
+            DamageEntityEvent event = SpongeEventFactory.createDamageEntityEvent(Sponge.getCauseStackManager().getCurrentCause(), new ArrayList<>(),
+                    this, 0);
+            if (SpongeImpl.postEvent(event)) {
+                cir.setReturnValue(false);
+            }
+        }
+    }
+
+    @Inject(method = "attackEntityFrom", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityArmorStand;dropBlock()V"),
+            cancellable = true)
+    private void fireDamageEventSecondPunch(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        fireDestroyDamageEvent(source, cir);
+    }
+
+    /**
+     * @author JBYoshi
+     * @reason EntityArmorStand "simplifies" this method to simply call {@link
+     * #setDead()}. However, this ignores our custom event. Instead, delegate
+     * to the superclass and use {@link
+     * EntityArmorStand#attackEntityFrom(DamageSource, float)}.
+     */
+    @Overwrite
+    @Override
+    public void onKillCommand() {
+        super.onKillCommand();
     }
 }


### PR DESCRIPTION
Input wanted because armor stands don't use the regular health system for damage, but it seems like the regular damage system to users.

In vanilla:
* Armor stands are immediately destroyed upon taking damage from the void or an explosion. I implement this by firing an event with a very large damage value (1000) and then changing it to fire damage if someone reduces it.
* Armor stands take regular damage from fire, but use a custom method for that damage. I pass the damage specified for that through an event and then pull the final value back from the event.
* Armor stands are usually destroyed from two punches or arrow hits from a player within 5 ticks of each other (EDIT: only one in creative), but the first push or arrow hit does not affect the armor stand's health. For the first punch, I fire a damage event with 0 damage and then ignore the resulting value. For the second, I do the same procedure as explosions/void damage.

Fixes #1644.