### PR TITLE
Allow plugins to use a separate implementation class for custom data.

### DIFF
--- a/src/main/java/org/spongepowered/common/data/SpongeDataManager.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeDataManager.java
@@ -223,18 +223,6 @@ public final class SpongeDataManager implements DataManager {
         SpongeManipulatorRegistry.getInstance().registerLegacyId(legacyId, registration);
     }
 
-    public <T extends DataManipulator<T, I>, I extends ImmutableDataManipulator<I, T>> void register(DataRegistration<T, I> registration) {
-        checkState(allowRegistrations, "Registrations are no longer allowed!");
-        final Class<T> manipulatorClass = registration.getManipulatorClass();
-        final Class<I> immutableManipulatorClass = registration.getImmutableManipulatorClass();
-        final DataManipulatorBuilder<T, I> builder = registration.getDataManipulatorBuilder();
-        final String manipulatorId = registration.getId();
-        final PluginContainer pluginContainer = registration.getPluginContainer();
-        final String pluginId = pluginContainer.getId().toLowerCase();
-
-        // TODO ???
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     public <T extends DataManipulator<T, I>, I extends ImmutableDataManipulator<I, T>> Optional<DataManipulatorBuilder<T, I>>
@@ -299,7 +287,9 @@ public final class SpongeDataManager implements DataManager {
         SpongeDataRegistrationBuilder<M, I> builder) {
         checkState(allowRegistrations);
         final Class<M> manipulatorClass = builder.manipulatorClass;
+        final Class<? extends M> implementationClass = builder.implementationData;
         final Class<I> immutableClass = builder.immutableClass;
+        final Class<? extends I> immutableImplementation = builder.immutableImplementation;
         final DataManipulatorBuilder<M, I> manipulatorBuilder = builder.manipulatorBuilder;
         checkState(!this.builders.containsKey(manipulatorClass), "DataManipulator already registered!");
         checkState(!this.builderMap.containsKey(manipulatorClass), "DataManipulator already registered!");
@@ -308,7 +298,14 @@ public final class SpongeDataManager implements DataManager {
         checkState(!this.immutableBuilderMap.containsKey(immutableClass), "ImmutableDataManipulator already registered!");
         checkState(!this.immutableBuilderMap.containsValue(manipulatorBuilder), "DataManipulatorBuilder already registered!");
 
-
+        if (implementationClass != null) {
+            checkState(!this.builders.containsKey(implementationClass), "DataManipulator implementation already registered!");
+            checkState(!this.builderMap.containsKey(implementationClass), "DataManipulator implementation already registered!");
+        }
+        if (immutableImplementation != null) {
+            checkState(!this.builders.containsKey(immutableImplementation), "ImmutableDataManipulator implementation already registered!");
+            checkState(!this.immutableBuilderMap.containsKey(immutableImplementation), "ImmutableDataManipulator implementation already registered!");
+        }
     }
 
     public static boolean areRegistrationsComplete() {
@@ -319,6 +316,13 @@ public final class SpongeDataManager implements DataManager {
         SpongeDataRegistration<M, I> registration) {
         this.builders.put(registration.getManipulatorClass(), registration.getDataManipulatorBuilder());
         this.builderMap.put(registration.getManipulatorClass(), registration.getDataManipulatorBuilder());
+        if (!registration.getImplementationClass().equals(registration.getManipulatorClass())) {
+            this.builders.put(registration.getImplementationClass(), registration.getDataManipulatorBuilder());
+            this.builderMap.put(registration.getImplementationClass(), registration.getDataManipulatorBuilder());
+        }
         this.immutableBuilderMap.put(registration.getImmutableManipulatorClass(), registration.getDataManipulatorBuilder());
+        if (!registration.getImmutableImplementationClass().equals(registration.getImmutableManipulatorClass())) {
+            this.immutableBuilderMap.put(registration.getImmutableImplementationClass(), registration.getDataManipulatorBuilder());
+        }
     }
 }

--- a/src/main/java/org/spongepowered/common/data/SpongeDataRegistration.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeDataRegistration.java
@@ -39,7 +39,9 @@ public final class SpongeDataRegistration<M extends DataManipulator<M, I>, I ext
 
 
     private final Class<M> manipulatorClass;
+    private final Class<? extends M> implementationClass;
     private final Class<I> immutableClass;
+    private final Class<? extends I> immutableImplementationClass;
     private final DataManipulatorBuilder<M, I> manipulatorBuilder;
     private final PluginContainer container;
     private final String id;
@@ -48,6 +50,8 @@ public final class SpongeDataRegistration<M extends DataManipulator<M, I>, I ext
     SpongeDataRegistration(SpongeDataRegistrationBuilder<M, I> builder) {
         this.manipulatorClass = checkNotNull(builder.manipulatorClass, "DataManipulator class is null!");
         this.immutableClass = checkNotNull(builder.immutableClass, "ImmutableDataManipulator class is null!");
+        this.implementationClass = builder.implementationData == null ? this.manipulatorClass : builder.implementationData;
+        this.immutableImplementationClass = builder.immutableImplementation == null ? this.immutableClass : builder.immutableImplementation;
         this.manipulatorBuilder = checkNotNull(builder.manipulatorBuilder, "DataManipulatorBuilder is null!");
         this.container = checkNotNull(builder.container, "PluginContainer is null!");
         this.id = this.container.getId() + ":" + checkNotNull(builder.id, "Data ID is null!");
@@ -59,9 +63,17 @@ public final class SpongeDataRegistration<M extends DataManipulator<M, I>, I ext
         return this.manipulatorClass;
     }
 
+    public Class<? extends M> getImplementationClass() {
+        return this.implementationClass;
+    }
+
     @Override
     public Class<I> getImmutableManipulatorClass() {
         return this.immutableClass;
+    }
+
+    public Class<? extends I> getImmutableImplementationClass() {
+        return this.immutableImplementationClass;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/SpongeDataRegistrationBuilder.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeDataRegistrationBuilder.java
@@ -94,12 +94,20 @@ public final class SpongeDataRegistrationBuilder<M extends DataManipulator<M, I>
         return this;
     }
 
-    SpongeDataRegistrationBuilder<M, I> implementationClass(Class<? extends M> implementation) {
+    @Override
+    public SpongeDataRegistrationBuilder<M, I> dataImplementation(Class<? extends M> implementation) {
+        checkState(this.manipulatorClass != null, "DataManipulator class must be set prior to setting the immutable variant!");
+        checkArgument(this.manipulatorClass.isAssignableFrom(implementation),
+                "Manipulator implementation class must be a subtype of the manipulator interface!");
         this.implementationData = implementation;
         return this;
     }
 
-    SpongeDataRegistrationBuilder<M, I> immutableImplementation(Class<? extends I> immutable) {
+    @Override
+    public SpongeDataRegistrationBuilder<M, I> immutableImplementation(Class<? extends I> immutable) {
+        checkState(this.immutableClass != null, "ImmutableDataManipulator class must be set prior to setting the immutable variant!");
+        checkArgument(this.immutableClass.isAssignableFrom(immutable),
+                "Immutable manipulator implementation class must be a subtype of the immutable manipulator interface!");
         this.immutableImplementation = checkNotNull(immutable);
         return this;
     }

--- a/src/main/java/org/spongepowered/common/data/SpongeManipulatorRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeManipulatorRegistry.java
@@ -125,7 +125,7 @@ public class SpongeManipulatorRegistry {
             .concurrencyLevel(4)
             .makeMap();
 
-        private final ConcurrentSkipListSet<DataRegistration<?, ?>> registrations = new ConcurrentSkipListSet<>(
+        private final ConcurrentSkipListSet<SpongeDataRegistration<?, ?>> registrations = new ConcurrentSkipListSet<>(
             Comparator.comparing(DataRegistration::getId));
 
     }
@@ -190,19 +190,13 @@ public class SpongeManipulatorRegistry {
             .collect(Collectors.toList());
     }
 
-    <T extends DataManipulator<T, I>, I extends ImmutableDataManipulator<I, T>> void registerLegacyId(DataRegistration<T, I> registration) {
-        this.legacyRegistrationIds.put(registration.getManipulatorClass().getName(), registration);
-        this.legacyRegistrationIds.put(registration.getImmutableManipulatorClass().getName(), registration);
-
-    }
-
     public Optional<DataRegistration<?, ?>> getRegistrationForLegacyId(String id) {
         return Optional.ofNullable(this.legacyRegistrationIds.get(id));
     }
 
 
     public <M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>> DataRegistration<M, I> register(
-        DataRegistration<M, I> registration) {
+        SpongeDataRegistration<M, I> registration) {
         checkState(this.tempRegistry != null);
         if (this.tempRegistry.registrations.contains(registration)) {
             throw new IllegalStateException("Existing DataRegistration exists for id: " + registration);
@@ -370,7 +364,13 @@ public class SpongeManipulatorRegistry {
         this.tempRegistry.registrations.forEach(registration -> {
                 registrationBuilder.add(registration);
                 manipulatorBuilder.put(registration.getManipulatorClass(), registration);
+                if (!registration.getImplementationClass().equals(registration.getManipulatorClass())) {
+                    manipulatorBuilder.put(registration.getImplementationClass(), registration);
+                }
                 immutableBuilder.put(registration.getImmutableManipulatorClass(), registration);
+                if (!registration.getImmutableImplementationClass().equals(registration.getImmutableManipulatorClass())) {
+                    immutableBuilder.put(registration.getImmutableImplementationClass(), registration);
+                }
                 idBuilder.put(registration.getId(), registration);
                 pluginBuilder.put(registration.getPluginContainer(), registration);
             });


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1723) | **SpongeCommon**

Sponge uses an interface and a separate implementing class for its `DataManipulator`s, and a few plugin developers have been [trying to use that model](https://forums.spongepowered.org/t/custom-data-not-working/21832?u=jbyoshi). However, `DataRegistration` doesn't allow multiple classes to be registered to it. This PR adds that option. (However, it remains optional for any plugins that don't currently use it, or don't want to use it.)