### PR TITLE
Add "minecraft.force-gamemode.override" permission for overriding force gamemode

### DIFF
--- a/src/main/java/org/spongepowered/common/interfaces/entity/player/IMixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/player/IMixinEntityPlayerMP.java
@@ -82,4 +82,7 @@ public interface IMixinEntityPlayerMP extends IMixinEntityPlayer {
     void injectScaledHealth(Collection<IAttributeInstance> set, boolean b);
 
     void updateDataManagerForScaledHealth();
+
+    boolean hasForcedGamemodeOverridePermission();
+
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandDefaultGameMode.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandDefaultGameMode.java
@@ -22,43 +22,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.mixin.command.multiworld;
+package org.spongepowered.common.mixin.core.command;
 
 import net.minecraft.command.CommandDefaultGameMode;
-import net.minecraft.command.ICommandSender;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.server.MinecraftServer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.world.GameType;
-import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayerMP;
 
 @Mixin(CommandDefaultGameMode.class)
-public abstract class MixinCommandDefaultGameMode  {
+public abstract class MixinCommandDefaultGameMode {
 
-    /**
-     * @author Minecrell - September 28, 2016
-     * @author dualspiral - December 29, 2017
-     * @reason Change game mode only in the world the command was executed in
-     *         Only apply game mode to those without the override permission
-     */
-    @Redirect(method = "execute", at = @At(value = "INVOKE", target = "Lnet/minecraft/command/CommandDefaultGameMode;"
-            + "setDefaultGameType(Lnet/minecraft/world/GameType;Lnet/minecraft/server/MinecraftServer;)V"))
-    private void onSetDefaultGameType(CommandDefaultGameMode self, GameType type, MinecraftServer server, MinecraftServer server2,
-            ICommandSender sender, String[] args) {
-
-        World world = sender.getEntityWorld();
-        world.getWorldInfo().setGameType(type);
-
-        if (server.getForceGamemode()) {
-            for (EntityPlayer player : world.playerEntities) {
-                if (!((IMixinEntityPlayerMP) player).hasForcedGamemodeOverridePermission()) {
-                    player.setGameType(type);
-                }
-            }
+    @Redirect(method = "setDefaultGameType",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;setGameType(Lnet/minecraft/world/GameType;)V"))
+    private void onSetGameType(EntityPlayerMP entityPlayerMP, GameType gameType) {
+        if (!((IMixinEntityPlayerMP) entityPlayerMP).hasForcedGamemodeOverridePermission()) {
+            entityPlayerMP.setGameType(gameType);
         }
     }
 
 }
+

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -1158,4 +1158,15 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     public CooldownTracker getCooldownTracker() {
         return (CooldownTracker) shadow$getCooldownTracker();
     }
+
+    @Redirect(method = "readEntityFromNBT", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;getForceGamemode()Z"))
+    private boolean onCheckForcedGameMode(MinecraftServer minecraftServer) {
+        return minecraftServer.getForceGamemode() && !hasForcedGamemodeOverridePermission();
+    }
+
+    @Override
+    public boolean hasForcedGamemodeOverridePermission() {
+        return this.hasPermission(getActiveContexts(), "minecraft.force-gamemode.override");
+    }
+
 }

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -123,6 +123,7 @@
         "command.MixinBlockCommandBlockSender",
         "command.MixinCommandBase",
         "command.MixinCommandBlockSource",
+        "command.MixinCommandDefaultGameMode",
         "command.MixinCommandExecuteAt",
         "command.MixinCommandHandler",
         "command.MixinCommandScoreboard",


### PR DESCRIPTION
This allows for players to bypass the `force-gamemode` setting in server.properties on login. I've opted for `minecraft.force-gamemode.override` as the permission to try to be consistent with the spawn protection permission.

I looked for forced gamemodes when transferring worlds, couldn't see it, indeed, it seems that world gamemodes seem to be ignored for the most part. I imagine it's not there, but if it is, I'd appreciate it being pointed out! Similarly, if there is a better suggestion for the permission itself, that'd be dandy.

This came about because @Inscrutable asked me (in the Nucleus discord)

> Is it possible to bypass the forced gamemode of a server? I'd like to let admin staff and camera crews to stay in creative, but I have the server forcing survival mode. I can't see any way around it with either nucleus or sponge. Am I missing something, or is it not possible?

> it's sorta mission critical to camerabots in gamemode 3 to stay that way without interruption. I guess OP is a good enough solution. Amazing, OP is some use again at last