### PR TITLE
Use the PotionID when creating the DataContainer (Close #1276)

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -41,6 +41,7 @@ import org.spongepowered.api.data.manipulator.mutable.block.*;
 import org.spongepowered.api.data.manipulator.mutable.entity.*;
 import org.spongepowered.api.data.manipulator.mutable.item.*;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.*;
+import org.spongepowered.api.effect.potion.PotionEffect;
 import org.spongepowered.api.item.enchantment.Enchantment;
 import org.spongepowered.api.data.meta.PatternLayer;
 import org.spongepowered.api.data.property.PropertyRegistry;
@@ -73,6 +74,7 @@ import org.spongepowered.common.data.builder.item.*;
 import org.spongepowered.common.data.builder.manipulator.InvisibilityDataAddVanishUpdater;
 import org.spongepowered.common.data.builder.manipulator.immutable.block.ImmutableSpongeTreeDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.immutable.item.ImmutableItemEnchantmentDataBuilder;
+import org.spongepowered.common.effect.potion.PotionEffectContentUpdater;
 import org.spongepowered.common.item.enchantment.SpongeEnchantmentBuilder;
 import org.spongepowered.common.data.builder.meta.SpongePatternLayerBuilder;
 import org.spongepowered.common.data.builder.util.weighted.BaseAndAdditionBuilder;
@@ -188,6 +190,12 @@ public class DataRegistrar {
         dataManager.registerContentUpdater(ImmutableInvisibilityData.class, invisibilityUpdater);
         dataManager.registerContentUpdater(SpongeInvisibilityData.class, invisibilityUpdater);
         dataManager.registerContentUpdater(ImmutableSpongeInvisibilityData.class, invisibilityUpdater);
+        final PotionEffectContentUpdater potionUpdater = new PotionEffectContentUpdater();
+        dataManager.registerContentUpdater(PotionEffect.class, potionUpdater);
+        dataManager.registerContentUpdater(PotionEffectData.class, potionUpdater);
+        dataManager.registerContentUpdater(ImmutablePotionEffectData.class, potionUpdater);
+        dataManager.registerContentUpdater(SpongePotionEffectData.class, potionUpdater);
+        dataManager.registerContentUpdater(ImmutableSpongePotionEffectData.class, potionUpdater);
 
         // Content Updaters for Custom Data
         dataManager.registerContentUpdater(DataManipulator.class, new LegacyCustomDataClassContentUpdater());

--- a/src/main/java/org/spongepowered/common/data/util/DataVersions.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataVersions.java
@@ -93,6 +93,17 @@ public final class DataVersions {
 
     }
 
+    public static final class Potion {
+
+        public static final int BROKEN_POTION_ID = 1;
+        public static final int POTION_V2 = 2;
+        public static final int CURRENT_VERSION = POTION_V2;
+
+        private Potion() {
+        }
+
+    }
+
     public static final class Data {
 
         public static final int INVISIBILITY_DATA_PRE_1_9 = 1;

--- a/src/main/java/org/spongepowered/common/effect/potion/PotionEffectContentUpdater.java
+++ b/src/main/java/org/spongepowered/common/effect/potion/PotionEffectContentUpdater.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.effect.potion;
+
+import com.google.common.collect.ImmutableMap;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.persistence.DataContentUpdater;
+import org.spongepowered.common.data.util.DataQueries;
+import org.spongepowered.common.data.util.DataVersions;
+import org.spongepowered.common.registry.type.effect.PotionEffectTypeRegistryModule;
+
+import java.util.stream.Collectors;
+
+public class PotionEffectContentUpdater implements DataContentUpdater {
+
+    private final static ImmutableMap<String, String> map = ImmutableMap.<String, String>builder().putAll(PotionEffectTypeRegistryModule.getInstance().getAll()
+            .stream().collect(Collectors.toMap(CatalogType::getName, CatalogType::getId))).build();
+
+    @Override
+    public int getInputVersion() {
+        return DataVersions.Potion.BROKEN_POTION_ID;
+    }
+
+    @Override
+    public int getOutputVersion() {
+        return DataVersions.Potion.POTION_V2;
+    }
+
+    @Override
+    public DataView update(DataView content) {
+        final String oldId = content.getString(DataQueries.POTION_TYPE).get();
+        final String newId = map.get(oldId);
+
+        content.remove(DataQueries.POTION_TYPE);
+        content.set(DataQueries.POTION_TYPE, newId);
+
+        return content;
+    }
+}

--- a/src/main/java/org/spongepowered/common/effect/potion/SpongePotionBuilder.java
+++ b/src/main/java/org/spongepowered/common/effect/potion/SpongePotionBuilder.java
@@ -36,6 +36,7 @@ import org.spongepowered.api.effect.potion.PotionEffect;
 import org.spongepowered.api.effect.potion.PotionEffectType;
 import org.spongepowered.api.data.persistence.AbstractDataBuilder;
 import org.spongepowered.common.data.util.DataQueries;
+import org.spongepowered.common.data.util.DataVersions;
 
 import java.util.Optional;
 
@@ -48,7 +49,7 @@ public class SpongePotionBuilder extends AbstractDataBuilder<PotionEffect> imple
     private boolean showParticles;
 
     public SpongePotionBuilder() {
-        super(PotionEffect.class, 1);
+        super(PotionEffect.class, DataVersions.Potion.CURRENT_VERSION);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/potion/MixinPotionEffect.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/potion/MixinPotionEffect.java
@@ -37,6 +37,7 @@ import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.data.util.DataQueries;
+import org.spongepowered.common.data.util.DataVersions;
 
 @NonnullByDefault
 @Mixin(net.minecraft.potion.PotionEffect.class)
@@ -76,14 +77,14 @@ public abstract class MixinPotionEffect implements PotionEffect {
 
     @Override
     public int getContentVersion() {
-        return 1;
+        return DataVersions.Potion.CURRENT_VERSION;
     }
 
     @Override
     public DataContainer toContainer() {
         return DataContainer.createNew()
                 .set(Queries.CONTENT_VERSION, getContentVersion())
-                .set(DataQueries.POTION_TYPE, this.potion.getName())
+                .set(DataQueries.POTION_TYPE, this.getType().getId())
                 .set(DataQueries.POTION_DURATION, this.duration)
                 .set(DataQueries.POTION_AMPLIFIER, this.amplifier)
                 .set(DataQueries.POTION_AMBIANCE, this.isAmbient)


### PR DESCRIPTION
When creating a `DataContainer` from a `PotionEffect`, we are using its name as the `DataQueries.POTION_TYPE`. However if you pass the container to the [PotionBuilder](https://github.com/SpongePowered/SpongeCommon/blob/bleeding/src/main/java/org/spongepowered/common/effect/potion/SpongePotionBuilder.java#L73) it uses the `DataQueries.POTION_TYPE` to search for the `PotionEffect` in the registry (which requires the PotionEffect id).

Fix #1276 