### PR TITLE
Fix a Phase IllegalStateException during a teleportation

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -473,7 +473,7 @@ public abstract class MixinEntity implements IMixinEntity {
             return false;
         }
 
-        try (final BasicPluginContext context = PluginPhase.State.TELEPORT.createPhaseContext().buildAndSwitch()) {
+        try (final BasicPluginContext context = PluginPhase.State.TELEPORT.createPhaseContext().addEntityCaptures().buildAndSwitch()) {
 
             // TODO Add a 'Move' plugin phase or just keep it under Teleport?
             try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame();) {


### PR DESCRIPTION
It seems it's only occurring when a plugin teleports an entity under some conditions (only tested with a Player though)

Fixes #1744 