### PR TITLE
Fix NPE when mods use world transfer methods

### DIFF
--- a/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
@@ -29,6 +29,7 @@ import com.flowpowered.math.vector.Vector3d;
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.entity.Transform;
@@ -148,5 +149,9 @@ public interface IMixinEntity extends org.spongepowered.api.entity.Entity {
     boolean shouldTick();
 
     void setInvulnerable(boolean value);
+
+    boolean inPortal();
+
+    void setInPortal(boolean inPortal);
 
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -57,6 +57,7 @@ import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.WorldServer;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
@@ -254,6 +255,10 @@ public abstract class MixinEntity implements IMixinEntity {
     @Shadow public abstract void setItemStackToSlot(EntityEquipmentSlot slotIn, ItemStack stack);
 
     @Shadow private boolean invulnerable;
+
+    @Shadow protected Vec3d lastPortalVec;
+
+    @Shadow protected boolean inPortal;
 
     @Redirect(method = "<init>", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/Entity;dimension:I", opcode = Opcodes.PUTFIELD))
     private void onSet(net.minecraft.entity.Entity self, int dimensionId, net.minecraft.world.World worldIn) {
@@ -1360,4 +1365,15 @@ public abstract class MixinEntity implements IMixinEntity {
     public void setInvulnerable(boolean value) {
         this.invulnerable = value;
     }
+
+    @Override
+    public boolean inPortal() {
+        return this.inPortal;
+    }
+
+    @Override
+    public void setInPortal(boolean inPortal) {
+        this.inPortal = inPortal;
+    }
+
 }


### PR DESCRIPTION
Fixes SpongePowered/SpongeForge#1973

@bloodmc I haven't merged this yet because I'm not entirely sure that this is the way to go with Forge mods and would like your input to make sure I don't break anything.

The problem is that forge's world transfer methods run through Minecraft teleporters (while Sponge's API methods don't). The default minecraft overworld/nether teleporter code assumes that the player has touched a portal block and thus `Entity#getLastPortalVec()` returns a `null` if the player is yet to do so. What this does is if the player is not in a portal, it sets the fields in question as if the player _is_ in the portal at that very block, then immediately tells the server that the player isn't really in a portal.

What confuses me is that the Forge methods seem to work fine, even though the Sponge methods pretty much mirror what Forge does. I would expect the Forge methods without Sponge to also fail in this way, but apparently they don't.

Anyway, if you have a better solution or if I'm missing something totally trivial, feel free to close this. I just thought it was better to get something in a PR that you can look at and suggest whether or not it's a good idea. It works, but I can only say that for the limited cases I've tried.