### PR TITLE
nbttranslator (de)serialize enum types

### DIFF
--- a/src/test/java/org/spongepowered/common/util/persistence/data/FakeSerializable.java
+++ b/src/test/java/org/spongepowered/common/util/persistence/data/FakeSerializable.java
@@ -29,6 +29,9 @@ import org.spongepowered.api.data.DataQuery;
 import org.spongepowered.api.data.DataSerializable;
 import org.spongepowered.api.data.Queries;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class FakeSerializable implements DataSerializable {
 
     public final String foo;
@@ -36,13 +39,16 @@ public class FakeSerializable implements DataSerializable {
     public final double theDouble;
     public final String nestedCompound;
     public final boolean aBoolean;
-
+    public final List<RandomEnum> randomEnumList;
+    public final RandomEnum randomEnum;
     public FakeSerializable(String foo, int myInt, double theDouble, String nestedCompound) {
         this.foo = foo;
         this.myInt = myInt;
         this.theDouble = theDouble;
         this.nestedCompound = nestedCompound;
         this.aBoolean = false;
+        randomEnum = RandomEnum.FOO;
+        randomEnumList = Arrays.asList(RandomEnum.FOO, RandomEnum.BAR, RandomEnum.BAR, RandomEnum.FOO);
     }
 
     @Override
@@ -59,6 +65,8 @@ public class FakeSerializable implements DataSerializable {
         container.set(DataQuery.of("theDouble"), this.theDouble);
         container.set(DataQuery.of("nested", "compound"), this.nestedCompound);
         container.set(DataQuery.of("MyBoolean"), this.aBoolean);
+        container.set(DataQuery.of("singleEnum"), this.randomEnum);
+        container.set(DataQuery.of("randomEnumList"), this.randomEnumList);
         return container;
     }
 }

--- a/src/test/java/org/spongepowered/common/util/persistence/data/NBTTranslationTest.java
+++ b/src/test/java/org/spongepowered/common/util/persistence/data/NBTTranslationTest.java
@@ -24,9 +24,6 @@
  */
 package org.spongepowered.common.util.persistence.data;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
-
 import net.minecraft.nbt.NBTTagCompound;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +37,9 @@ import org.spongepowered.common.data.persistence.NbtTranslator;
 import org.spongepowered.lwts.runner.LaunchWrapperTestRunner;
 
 import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 @RunWith(LaunchWrapperTestRunner.class)
 public class NBTTranslationTest {
@@ -65,5 +65,8 @@ public class NBTTranslationTest {
         DataView translatedContainer = NbtTranslator.getInstance().translateFrom(compound);
         assertEquals(container, translatedContainer);
     }
+
+
+
 
 }

--- a/src/test/java/org/spongepowered/common/util/persistence/data/RandomEnum.java
+++ b/src/test/java/org/spongepowered/common/util/persistence/data/RandomEnum.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.util.persistence.data;
+
+public enum  RandomEnum {
+    FOO, BAR
+}


### PR DESCRIPTION
More discussion here some code samples to reproduce this : https://github.com/SpongePowered/SpongeCommon/issues/1762#issuecomment-362869260

sample: https://pastebin.com/y3GFsxzr

Currently NBTTranslator cannot automatically (de)serialize enum type. 
This change will serialize enum as $Enum(classname)Value

[img](https://i.gyazo.com/081fc9bc4c4413d5549bf202382f753b.png "image")

- Downsides: 
   The user will encounter problems when the enum value will change name/or change class package
If the class is not found to be present at runtime the translator simply returns serialized string as described above. Now its up to developer to handle this inconsistence. 