### PR TITLE
Refactoring and implementation of the LaunchProjectileEvent

### DIFF
--- a/src/main/java/org/spongepowered/common/entity/projectile/ProjectileLauncher.java
+++ b/src/main/java/org/spongepowered/common/entity/projectile/ProjectileLauncher.java
@@ -78,6 +78,8 @@ import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.registry.type.entity.EntityTypeRegistryModule;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
@@ -163,7 +165,9 @@ public class ProjectileLauncher {
     }
 
     static <P extends Projectile> Optional<P> doLaunch(Extent extent, P projectile) {
-        LaunchProjectileEvent event = SpongeEventFactory.createLaunchProjectileEvent(Sponge.getCauseStackManager().getCurrentCause(), projectile);
+        List<P> projectiles = new ArrayList<>();
+        projectiles.add(projectile);
+        LaunchProjectileEvent event = SpongeEventFactory.createLaunchProjectileEvent(Sponge.getCauseStackManager().getCurrentCause(), projectiles);
         SpongeImpl.getGame().getEventManager().post(event);
         if (!event.isCancelled() && extent.spawnEntity(projectile)) {
             return Optional.of(projectile);

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/block/DispensePhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/block/DispensePhaseState.java
@@ -113,7 +113,6 @@ final class DispensePhaseState extends BlockPhaseState {
                             frame.addContext(EventContextKeys.SPAWN_TYPE, InternalSpawnTypes.PROJECTILE);
                             Dispenser dispenser = (Dispenser) blockSnapshot.getLocation().get().getExtent().getTileEntity(blockSnapshot.getLocation().get().getPosition().toInt()).get();
                             frame.addContext(EventContextKeys.PROJECTILE_SOURCE, dispenser);
-                            frame.addContext(EventContextKeys.THROWER, dispenser);
 
                             LaunchProjectileEvent launchProjectileEvent =
                                     SpongeEventFactory.createLaunchProjectileEvent(Sponge.getCauseStackManager().getCurrentCause(), projectiles);

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/InteractionPacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/InteractionPacketState.java
@@ -78,6 +78,7 @@ final class InteractionPacketState extends BasicPacketState {
 
     @Override
     public void populateContext(EntityPlayerMP playerMP, Packet<?> packet, BasicPacketContext context) {
+        ContainerUtil.toMixin(playerMP.inventoryContainer).setCaptureInventory(true);
         final ItemStack stack = ItemStackUtil.cloneDefensive(playerMP.getHeldItemMainhand());
         if (stack != null) {
             context.itemUsed(stack);
@@ -118,6 +119,8 @@ final class InteractionPacketState extends BasicPacketState {
     @Override
     public void unwind(BasicPacketContext phaseContext) {
         final EntityPlayerMP player = phaseContext.getPacketPlayer();
+        final IMixinContainer mixinContainer = ContainerUtil.toMixin(player.inventoryContainer);
+        mixinContainer.detectAndSendChanges(false);
         final ItemStack usedStack = phaseContext.getItemUsed();
         final ItemStackSnapshot usedSnapshot = ItemStackUtil.snapshotOf(usedStack);
         final Entity spongePlayer = EntityUtil.fromNative(player);
@@ -294,7 +297,6 @@ final class InteractionPacketState extends BasicPacketState {
                 }
             });
 
-            final IMixinContainer mixinContainer = ContainerUtil.toMixin(player.openContainer);
             mixinContainer.setCaptureInventory(false);
             mixinContainer.getCapturedTransactions().clear();
         }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/InteractionPacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/InteractionPacketState.java
@@ -199,14 +199,14 @@ final class InteractionPacketState extends BasicPacketState {
                         printer.trace(System.err);
                     });
             phaseContext.getCapturedEntitySupplier().acceptAndClearIfNotEmpty(entities -> {
-                final List<Entity> projectiles = new ArrayList<>(entities.size());
+                final List<Projectile> projectiles = new ArrayList<>(entities.size());
                 final List<Entity> spawnEggs = new ArrayList<>(entities.size());
                 final List<Entity> xpOrbs = new ArrayList<>(entities.size());
                 final List<Entity> normalPlacement = new ArrayList<>(entities.size());
                 final List<Entity> items = new ArrayList<>(entities.size());
                 for (Entity entity : entities) {
                     if (entity instanceof Projectile || entity instanceof EntityThrowable) {
-                        projectiles.add(entity);
+                        projectiles.add((Projectile) entity);
                     } else if (usedSnapshot.getType() == ItemTypes.SPAWN_EGG) {
                         spawnEggs.add(entity);
                     } else if (entity instanceof EntityItem) {
@@ -218,19 +218,8 @@ final class InteractionPacketState extends BasicPacketState {
                     }
                 }
                 if (!projectiles.isEmpty()) {
-                    if (ShouldFire.SPAWN_ENTITY_EVENT) {
-                        try (CauseStackManager.StackFrame frame2 = Sponge.getCauseStackManager().pushCauseFrame()) {
-                            Sponge.getCauseStackManager().addContext(EventContextKeys.SPAWN_TYPE, InternalSpawnTypes.PROJECTILE);
-                            Sponge.getCauseStackManager().pushCause(usedSnapshot);
-                            final SpawnEntityEvent event =
-                                SpongeEventFactory.createSpawnEntityEvent(Sponge.getCauseStackManager().getCurrentCause(),
-                                    projectiles);
-                            if (!SpongeImpl.postEvent(event)) {
-                                processSpawnedEntities(player, event);
-                            }
-                        }
-                    } else {
-                        processEntities(player, projectiles);
+                    try (CauseStackManager.StackFrame frame2 = Sponge.getCauseStackManager().pushCauseFrame()) {
+                        PacketPhaseUtil.fireProjectileLaunchEvent(frame2, player, projectiles);
                     }
                 }
                 if (!spawnEggs.isEmpty()) {

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/InteractionPacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/InteractionPacketState.java
@@ -50,8 +50,8 @@ import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.entity.EntityUtil;
 import org.spongepowered.common.event.ShouldFire;
 import org.spongepowered.common.event.tracking.IPhaseState;
-import org.spongepowered.common.event.tracking.context.ItemDropData;
 import org.spongepowered.common.event.tracking.TrackingUtil;
+import org.spongepowered.common.event.tracking.context.ItemDropData;
 import org.spongepowered.common.event.tracking.phase.block.BlockPhase;
 import org.spongepowered.common.interfaces.IMixinContainer;
 import org.spongepowered.common.item.inventory.util.ContainerUtil;
@@ -117,7 +117,6 @@ final class InteractionPacketState extends BasicPacketState {
 
     @Override
     public void unwind(BasicPacketContext phaseContext) {
-
         final EntityPlayerMP player = phaseContext.getPacketPlayer();
         final ItemStack usedStack = phaseContext.getItemUsed();
         final ItemStackSnapshot usedSnapshot = ItemStackUtil.snapshotOf(usedStack);
@@ -145,7 +144,7 @@ final class InteractionPacketState extends BasicPacketState {
                             if (!entityItems.isEmpty()) {
                                 final List<Entity> items = entityItems.stream().map(EntityUtil::fromNative).collect(Collectors.toList());
                                 final DropItemEvent.Destruct event =
-                                    SpongeEventFactory.createDropItemEventDestruct(Sponge.getCauseStackManager().getCurrentCause(), items);
+                                        SpongeEventFactory.createDropItemEventDestruct(Sponge.getCauseStackManager().getCurrentCause(), items);
                                 SpongeImpl.postEvent(event);
                                 if (!event.isCancelled()) {
                                     processSpawnedEntities(player, event);
@@ -168,34 +167,34 @@ final class InteractionPacketState extends BasicPacketState {
             }
 
             phaseContext.getCapturedItemsSupplier()
-                .acceptAndClearIfNotEmpty(items -> {
-                    final ArrayList<Entity> entities = new ArrayList<>();
-                    for (EntityItem item : items) {
-                        entities.add(EntityUtil.fromNative(item));
-                    }
-                    final DropItemEvent.Dispense dispense =
-                        SpongeEventFactory.createDropItemEventDispense(Sponge.getCauseStackManager().getCurrentCause(), entities);
-                    SpongeImpl.postEvent(dispense);
-                    if (!dispense.isCancelled()) {
-                        processSpawnedEntities(player, dispense);
-                    }
-                });
-            phaseContext.getCapturedEntityDropSupplier()
-                .acceptIfNotEmpty(map -> {
-                    if (map.isEmpty()) {
-                        return;
-                    }
-                    final PrettyPrinter printer = new PrettyPrinter(80);
-                    printer.add("Processing Interaction").centre().hr();
-                    printer.add("The item stacks captured are: ");
-                    for (Map.Entry<UUID, Collection<ItemDropData>> entry : map.asMap().entrySet()) {
-                        printer.add("  - Entity with UUID: %s", entry.getKey());
-                        for (ItemDropData stack : entry.getValue()) {
-                            printer.add("    - %s", stack);
+                    .acceptAndClearIfNotEmpty(items -> {
+                        final ArrayList<Entity> entities = new ArrayList<>();
+                        for (EntityItem item : items) {
+                            entities.add(EntityUtil.fromNative(item));
                         }
-                    }
-                    printer.trace(System.err);
-                });
+                        final DropItemEvent.Dispense dispense =
+                                SpongeEventFactory.createDropItemEventDispense(Sponge.getCauseStackManager().getCurrentCause(), entities);
+                        SpongeImpl.postEvent(dispense);
+                        if (!dispense.isCancelled()) {
+                            processSpawnedEntities(player, dispense);
+                        }
+                    });
+            phaseContext.getCapturedEntityDropSupplier()
+                    .acceptIfNotEmpty(map -> {
+                        if (map.isEmpty()) {
+                            return;
+                        }
+                        final PrettyPrinter printer = new PrettyPrinter(80);
+                        printer.add("Processing Interaction").centre().hr();
+                        printer.add("The item stacks captured are: ");
+                        for (Map.Entry<UUID, Collection<ItemDropData>> entry : map.asMap().entrySet()) {
+                            printer.add("  - Entity with UUID: %s", entry.getKey());
+                            for (ItemDropData stack : entry.getValue()) {
+                                printer.add("    - %s", stack);
+                            }
+                        }
+                        printer.trace(System.err);
+                    });
             phaseContext.getCapturedEntitySupplier().acceptAndClearIfNotEmpty(entities -> {
                 final List<Entity> projectiles = new ArrayList<>(entities.size());
                 final List<Entity> spawnEggs = new ArrayList<>(entities.size());
@@ -237,8 +236,8 @@ final class InteractionPacketState extends BasicPacketState {
                             Sponge.getCauseStackManager().addContext(EventContextKeys.SPAWN_TYPE, InternalSpawnTypes.PROJECTILE);
                             Sponge.getCauseStackManager().pushCause(usedSnapshot);
                             final SpawnEntityEvent event =
-                                SpongeEventFactory.createSpawnEntityEvent(Sponge.getCauseStackManager().getCurrentCause(),
-                                    spawnEggs);
+                                    SpongeEventFactory.createSpawnEntityEvent(Sponge.getCauseStackManager().getCurrentCause(),
+                                            spawnEggs);
                             if (!SpongeImpl.postEvent(event)) {
                                 processSpawnedEntities(player, event);
                             }
@@ -250,7 +249,7 @@ final class InteractionPacketState extends BasicPacketState {
                 if (!items.isEmpty()) {
                     if (ShouldFire.DROP_ITEM_EVENT_DISPENSE) {
                         final DropItemEvent.Dispense dispense = SpongeEventFactory
-                            .createDropItemEventDispense(Sponge.getCauseStackManager().getCurrentCause(), items);
+                                .createDropItemEventDispense(Sponge.getCauseStackManager().getCurrentCause(), items);
                         if (!SpongeImpl.postEvent(dispense)) {
                             processSpawnedEntities(player, dispense);
                         }
@@ -265,8 +264,9 @@ final class InteractionPacketState extends BasicPacketState {
                                 stackFrame.pushCause(firstBlockChange);
                             }
                             stackFrame.addContext(EventContextKeys.SPAWN_TYPE, InternalSpawnTypes.EXPERIENCE);
-                            final SpawnEntityEvent event = SpongeEventFactory.createSpawnEntityEvent(Sponge.getCauseStackManager().getCurrentCause(),
-                                    xpOrbs);
+                            final SpawnEntityEvent event =
+                                    SpongeEventFactory.createSpawnEntityEvent(Sponge.getCauseStackManager().getCurrentCause(),
+                                            xpOrbs);
                             if (!SpongeImpl.postEvent(event)) {
                                 processSpawnedEntities(player, event);
                             }
@@ -281,8 +281,9 @@ final class InteractionPacketState extends BasicPacketState {
                             if (firstBlockChange != null) {
                                 stackFrame.pushCause(firstBlockChange);
                             }
-                            final SpawnEntityEvent event = SpongeEventFactory.createSpawnEntityEvent(Sponge.getCauseStackManager().getCurrentCause(),
-                                normalPlacement);
+                            final SpawnEntityEvent event =
+                                    SpongeEventFactory.createSpawnEntityEvent(Sponge.getCauseStackManager().getCurrentCause(),
+                                            normalPlacement);
                             if (!SpongeImpl.postEvent(event)) {
                                 processSpawnedEntities(player, event);
                             }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -158,7 +158,6 @@ public final class PacketPhaseUtil {
 
         frame.addContext(EventContextKeys.SPAWN_TYPE, InternalSpawnTypes.PROJECTILE);
         frame.addContext(EventContextKeys.PROJECTILE_SOURCE, (ProjectileSource) player);
-        frame.addContext(EventContextKeys.THROWER, (ProjectileSource) player);
 
         LaunchProjectileEvent
                 launchProjectileEvent = SpongeEventFactory.createLaunchProjectileEvent(Sponge.getCauseStackManager().getCurrentCause(), projectiles);

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PlaceBlockPacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PlaceBlockPacketState.java
@@ -80,6 +80,7 @@ class PlaceBlockPacketState extends BasicPacketState {
 
     @Override
     public void populateContext(EntityPlayerMP playerMP, Packet<?> packet, BasicPacketContext context) {
+        ContainerUtil.toMixin(playerMP.inventoryContainer).setCaptureInventory(true);
         final CPacketPlayerTryUseItemOnBlock placeBlock = (CPacketPlayerTryUseItemOnBlock) packet;
         final net.minecraft.item.ItemStack itemUsed = playerMP.getHeldItem(placeBlock.getHand());
         final ItemStack itemstack = ItemStackUtil.cloneDefensive(itemUsed);
@@ -121,6 +122,8 @@ class PlaceBlockPacketState extends BasicPacketState {
     public void unwind(BasicPacketContext context) {
         final Packet<?> packet = context.getPacket();
         final EntityPlayerMP player = context.getPacketPlayer();
+        final IMixinContainer mixinContainer = ContainerUtil.toMixin(player.inventoryContainer);
+        mixinContainer.detectAndSendChanges(false);
         final IMixinWorldServer mixinWorld = (IMixinWorldServer) player.world;
 
         final ItemStack itemStack = context.getItemUsed();
@@ -190,7 +193,6 @@ class PlaceBlockPacketState extends BasicPacketState {
 
         });
 
-        final IMixinContainer mixinContainer = ContainerUtil.toMixin(player.openContainer);
         mixinContainer.setCaptureInventory(false);
         mixinContainer.getCapturedTransactions().clear();
     }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/BlockTickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/BlockTickPhaseState.java
@@ -94,11 +94,13 @@ class BlockTickPhaseState extends LocationBasedTickPhaseState<BlockTickContext> 
                         final SpawnEntityEvent spawnEntityEvent =
                                 SpongeEventFactory.createSpawnEntityEvent(Sponge.getCauseStackManager().getCurrentCause(), capturedEntities);
                         SpongeImpl.postEvent(spawnEntityEvent);
-                        for (Entity entity : spawnEntityEvent.getEntities()) {
-                            if (entityCreator != null) {
-                                EntityUtil.toMixin(entity).setCreator(entityCreator.getUniqueId());
+                        if(!spawnEntityEvent.isCancelled()) {
+                            for (Entity entity : spawnEntityEvent.getEntities()) {
+                                if (entityCreator != null) {
+                                    EntityUtil.toMixin(entity).setCreator(entityCreator.getUniqueId());
+                                }
+                                EntityUtil.getMixinWorld(entity).forceSpawnEntity(entity);
                             }
-                            EntityUtil.getMixinWorld(entity).forceSpawnEntity(entity);
                         }
                     });
         }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/EntityTickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/EntityTickPhaseState.java
@@ -152,7 +152,6 @@ class EntityTickPhaseState extends TickPhaseState<EntityTickContext> {
                         if (!projectile.isEmpty()) {
                             frame.addContext(EventContextKeys.SPAWN_TYPE, InternalSpawnTypes.PROJECTILE);
                             frame.addContext(EventContextKeys.PROJECTILE_SOURCE, (ProjectileSource) tickingEntity);
-                            frame.addContext(EventContextKeys.THROWER, (ProjectileSource) tickingEntity);
 
                             LaunchProjectileEvent
                                     launchProjectileEvent = SpongeEventFactory.createLaunchProjectileEvent(Sponge.getCauseStackManager().getCurrentCause(), projectile);

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/EntityTickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/EntityTickPhaseState.java
@@ -410,21 +410,8 @@ class EntityTickPhaseState extends TickPhaseState<EntityTickContext> {
                 }
                 return false;
             } else if (entity instanceof Projectile) {
-                Sponge.getCauseStackManager().addContext(EventContextKeys.SPAWN_TYPE, InternalSpawnTypes.PROJECTILE);
-                final List<Entity> projectile = new ArrayList<Entity>(1);
-                projectile.add(entity);
-                final SpawnEntityEvent event = SpongeEventFactory.createSpawnEntityEvent(Sponge.getCauseStackManager().getCurrentCause(), projectile);
-                SpongeImpl.postEvent(event);
-                if (!event.isCancelled()) {
-                    for (Entity anEntity : event.getEntities()) {
-                        if (entityCreator != null) {
-                            anEntity.setCreator(entityCreator.getUniqueId());
-                        }
-                        EntityUtil.getMixinWorld(entity).forceSpawnEntity(anEntity);
-                    }
-                    return true;
-                }
-                return false;
+                context.getCapturedEntities().add(entity);
+                return true;
             }
             final List<Entity> nonExp = new ArrayList<Entity>(1);
             nonExp.add(entity);

--- a/src/main/java/org/spongepowered/common/interfaces/block/tile/IMixinBlockDispenser.java
+++ b/src/main/java/org/spongepowered/common/interfaces/block/tile/IMixinBlockDispenser.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.common.interfaces.block.tile;
 
 public interface IMixinBlockDispenser {

--- a/src/main/java/org/spongepowered/common/interfaces/block/tile/IMixinBlockDispenser.java
+++ b/src/main/java/org/spongepowered/common/interfaces/block/tile/IMixinBlockDispenser.java
@@ -1,0 +1,6 @@
+package org.spongepowered.common.interfaces.block.tile;
+
+public interface IMixinBlockDispenser {
+
+    void restoreDispensedItem();
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/block/MixinBehaviorProjectileDispense.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/MixinBehaviorProjectileDispense.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.mixin.core.block;
 import net.minecraft.dispenser.BehaviorDefaultDispenseItem;
 import net.minecraft.dispenser.BehaviorProjectileDispense;
 import net.minecraft.dispenser.IBlockSource;
+import net.minecraft.dispenser.IPosition;
 import net.minecraft.entity.IProjectile;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -59,7 +60,8 @@ public class MixinBehaviorProjectileDispense extends BehaviorDefaultDispenseItem
 
     @Inject(method = "dispenseStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntity(Lnet/minecraft/entity/Entity;)Z"),
             locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true)
-    public void onspawnEntity(IBlockSource source, ItemStack stack, CallbackInfoReturnable<ItemStack> cir, EnumFacing enumfacing, IProjectile iprojectile) {
+    public void onspawnEntity(IBlockSource source, ItemStack stack, CallbackInfoReturnable<ItemStack> cir,
+            World world, IPosition position, EnumFacing enumfacing, IProjectile iprojectile) {
         TileEntity tileEntity = source.getBlockTileEntity();
         if (tileEntity instanceof ProjectileSource) {
             try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
@@ -68,8 +70,7 @@ public class MixinBehaviorProjectileDispense extends BehaviorDefaultDispenseItem
                 ((Projectile) iprojectile).setShooter((ProjectileSource) tileEntity);
                 List<Projectile> projectiles = new ArrayList<>();
                 projectiles.add((Projectile) iprojectile);
-                LaunchProjectileEvent event =
-                        SpongeEventFactory.createLaunchProjectileEvent(Sponge.getCauseStackManager().getCurrentCause(), projectiles);
+                LaunchProjectileEvent event = SpongeEventFactory.createLaunchProjectileEvent(Sponge.getCauseStackManager().getCurrentCause(), projectiles);
                 if (SpongeImpl.postEvent(event)) {
                     cir.setReturnValue(stack);
                 }

--- a/src/main/java/org/spongepowered/common/mixin/core/block/MixinBehaviorProjectileDispense.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/MixinBehaviorProjectileDispense.java
@@ -66,7 +66,6 @@ public class MixinBehaviorProjectileDispense extends BehaviorDefaultDispenseItem
         if (tileEntity instanceof ProjectileSource) {
             try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
                 frame.addContext(EventContextKeys.PROJECTILE_SOURCE, (ProjectileSource) tileEntity);
-                frame.addContext(EventContextKeys.THROWER, (ProjectileSource) tileEntity);
                 ((Projectile) iprojectile).setShooter((ProjectileSource) tileEntity);
                 List<Projectile> projectiles = new ArrayList<>();
                 projectiles.add((Projectile) iprojectile);

--- a/src/main/java/org/spongepowered/common/mixin/core/block/MixinBlockDispenser.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/MixinBlockDispenser.java
@@ -62,6 +62,7 @@ import org.spongepowered.common.event.tracking.PhaseData;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.phase.block.BlockPhase;
 import org.spongepowered.common.interfaces.IMixinChunk;
+import org.spongepowered.common.interfaces.block.tile.IMixinBlockDispenser;
 import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 import org.spongepowered.common.item.inventory.util.ItemStackUtil;
 
@@ -72,8 +73,10 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 @Mixin(BlockDispenser.class)
-public abstract class MixinBlockDispenser extends MixinBlock {
+public abstract class MixinBlockDispenser extends MixinBlock implements IMixinBlockDispenser {
 
+    private ItemStack originalStack;
+    private int originalStackSize;
     private ItemStackSnapshot originalItem;
     private PhaseContext<?> context;
 
@@ -129,6 +132,8 @@ public abstract class MixinBlockDispenser extends MixinBlock {
 
     @Redirect(method = "dispense", at = @At(value = "INVOKE", target = "Lnet/minecraft/dispenser/IBehaviorDispenseItem;dispense(Lnet/minecraft/dispenser/IBlockSource;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;"))
     public ItemStack onSpongeDispense(IBehaviorDispenseItem ibehaviordispenseitem, IBlockSource source, ItemStack stack) {
+        this.originalStack = stack;
+        this.originalStackSize = stack.getCount();
         this.originalItem = ItemStackUtil.snapshotOf(stack);
         return ibehaviordispenseitem.dispense(source, stack);
     }
@@ -164,4 +169,8 @@ public abstract class MixinBlockDispenser extends MixinBlock {
         }
     }
 
+    @Override
+    public void restoreDispensedItem() {
+        this.originalStack.setCount(this.originalStackSize);
+    }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityFireworkRocket.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityFireworkRocket.java
@@ -156,7 +156,7 @@ public abstract class MixinEntityFireworkRocket extends MixinEntity implements F
         // post an event regardless and if the radius is zero the explosion
         // won't be triggered (the default behavior).
         Sponge.getCauseStackManager().pushCause(this);
-        Sponge.getCauseStackManager().addContext(EventContextKeys.THROWER, getShooter());
+        Sponge.getCauseStackManager().addContext(EventContextKeys.PROJECTILE_SOURCE, getShooter());
         detonate(Explosion.builder()
                 .sourceExplosive(this)
                 .location(getLocation())
@@ -170,7 +170,7 @@ public abstract class MixinEntityFireworkRocket extends MixinEntity implements F
         if (this.fireworkAge == 1 && !this.world.isRemote) {
             try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
                 Sponge.getCauseStackManager().pushCause(this);
-                Sponge.getCauseStackManager().addContext(EventContextKeys.THROWER, getShooter());
+                Sponge.getCauseStackManager().addContext(EventContextKeys.PROJECTILE_SOURCE, getShooter());
                 postPrime();
             }
         }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityLargeFireball.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityLargeFireball.java
@@ -85,7 +85,7 @@ public abstract class MixinEntityLargeFireball extends MixinEntityFireball imple
         boolean griefer = ((IMixinGriefer) this).canGrief();
         try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
             Sponge.getCauseStackManager().pushCause(this);
-            Sponge.getCauseStackManager().addContext(EventContextKeys.THROWER, getShooter());
+            Sponge.getCauseStackManager().addContext(EventContextKeys.PROJECTILE_SOURCE, getShooter());
             Sponge.getCauseStackManager().pushCause(getShooter());
             Optional<net.minecraft.world.Explosion> ex = detonate(Explosion.builder()
                 .location(new Location<>((World) worldObj, new Vector3d(x, y, z)))

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityWitherSkull.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityWitherSkull.java
@@ -124,7 +124,7 @@ public abstract class MixinEntityWitherSkull extends MixinEntityFireball impleme
         boolean griefer = ((IMixinGriefer) this).canGrief();
         try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
             Sponge.getCauseStackManager().pushCause(this);
-            Sponge.getCauseStackManager().addContext(EventContextKeys.THROWER, getShooter());
+            Sponge.getCauseStackManager().addContext(EventContextKeys.PROJECTILE_SOURCE, getShooter());
             Sponge.getCauseStackManager().pushCause(getShooter());
             return detonate(Explosion.builder()
                 .location(new Location<>((World) worldObj, new Vector3d(x, y, z)))


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1766) | **SpongeCommon**

This PR implement its SpongeAPI counterpart.

### When is the event fired ?

Here are each cases I tested:
- [x] A non-player entity shoots a projectile (skeletons shooting arrows, llamas spitting, ghasts shooting fireballs, snowmans shooting snowballs, blaze shooting small fireballs)
- [x] A player shoots arrows (with a bow heh)
- [x] A player throws projectiles (snowballs, eggs, potions - splash and lingering -, enderpearls, eyes of ender, using fishing rod, experience bottle)
- [x] A dispenser dispenses projectiles (arrows, snowballs, eggs, potions - splash and lingering -, experience bottle)
- [x] A plugin shoots a projectile
- [x] A player uses a firework.
- [x] A dispenser dispenses a firework.
- [x] A Wither attacks.
- [x] The dragon shoots a fireball

Tell me if you see a case of projectile I missed.

[And there is the content of a test plugin](https://gist.github.com/RedNesto/a1c45a36bf79e190dae512ee867daeac)

~Note: It seems that there are two projectile-related `EventContextKeys`, `PROJECTILE_SOURCE` and `THROWER`, from what I saw, only one would be necessary, I may address this issue later if it is considered as one.~
Fixed in 5d0184de3b1eeba951c5873d9c20c919c7a8d307
