### PR TITLE
Fix a race condition with resource packs.

### DIFF
--- a/src/main/java/org/spongepowered/common/interfaces/network/IMixinNetHandlerPlayServer.java
+++ b/src/main/java/org/spongepowered/common/interfaces/network/IMixinNetHandlerPlayServer.java
@@ -24,15 +24,19 @@
  */
 package org.spongepowered.common.interfaces.network;
 
-import net.minecraft.network.play.server.SPacketResourcePackSend;
+import org.spongepowered.api.resourcepack.ResourcePack;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
-import java.util.Deque;
+import javax.annotation.Nullable;
 
 public interface IMixinNetHandlerPlayServer {
 
-    Deque<SPacketResourcePackSend> getPendingResourcePackQueue();
+    @Nullable
+    ResourcePack popReceivedResourcePack(boolean markAccepted);
+
+    @Nullable
+    ResourcePack popAcceptedResourcePack();
 
     void resendLatestResourcePackRequest();
 

--- a/src/main/java/org/spongepowered/common/resourcepack/SpongeResourcePack.java
+++ b/src/main/java/org/spongepowered/common/resourcepack/SpongeResourcePack.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.resourcepack;
 
+import com.google.common.base.MoreObjects;
 import org.spongepowered.api.resourcepack.ResourcePack;
 
 import java.net.URI;
@@ -54,6 +55,11 @@ public abstract class SpongeResourcePack implements ResourcePack {
     @Override
     public Optional<String> getHash() {
         return this.hash;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("id", this.getId()).add("uri", this.getUri()).toString();
     }
 
     public static SpongeResourcePack create(String uri, String hash) throws URISyntaxException {


### PR DESCRIPTION
If the client sends certain packets while the server is sending a resource pack, the server currently interprets those as "the client has closed the resource pack prompt" before the client shows the prompt, prompting it to resend the resource pack request. This prevents that lag by sending custom keep-alive packets after sending the resource pack request. Only after the client acknowledges the keep-alive packet (and, therefore, has shown the resource pack request) does the server begin to assume the resource pack prompt was closed.

And just in case a malicious/poorly-written client decides to send fake "resource pack accepted" packets to the server, this PR just logs a warning and skips processing.

Fixes #1721.