### PR TITLE
Add enderpearl thrower to cause and TeleportType to context

### DIFF
--- a/src/main/java/org/spongepowered/common/entity/EntityUtil.java
+++ b/src/main/java/org/spongepowered/common/entity/EntityUtil.java
@@ -191,7 +191,7 @@ public final class EntityUtil {
      * A relative copy paste of {@link EntityPlayerMP#changeDimension(int)} where instead we direct all processing
      * to the appropriate areas for throwing events and capturing world changes during the transfer.
      *
-     * @param mixinEntityPlayerMP The player being teleported
+     * @param entityPlayerMP The player being teleported
      * @param suggestedDimensionId The suggested dimension
      * @return The player object, not re-created
      */
@@ -318,9 +318,13 @@ public final class EntityUtil {
         final IPhaseState state = peek.state;
         final PhaseContext<?> context = peek.context;
 
-        MoveEntityEvent.Teleport event = SpongeEventFactory.createMoveEntityEventTeleport(Sponge.getCauseStackManager().getCurrentCause(), fromTransform, toTransform, (org.spongepowered.api.entity.Entity) entityIn);
-        SpongeImpl.postEvent(event);
-        return event;
+        try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+            frame.pushCause(entityIn);
+
+            MoveEntityEvent.Teleport event = SpongeEventFactory.createMoveEntityEventTeleport(Sponge.getCauseStackManager().getCurrentCause(), fromTransform, toTransform, (org.spongepowered.api.entity.Entity) entityIn);
+            SpongeImpl.postEvent(event);
+            return event;
+        }
     }
 
     @Nullable
@@ -383,14 +387,14 @@ public final class EntityUtil {
             Sponge.getCauseStackManager().pushCause(mixinEntity);
 
             Sponge.getCauseStackManager().addContext(EventContextKeys.TELEPORT_TYPE, TeleportTypes.PORTAL);
-    
+
             if (entityIn.isEntityAlive() && !(fromWorld.provider instanceof WorldProviderEnd)) {
                 fromWorld.profiler.startSection("placing");
                 // need to use placeInPortal to support mods
                 teleporter.placeInPortal(entityIn, entityIn.rotationYaw);
                 fromWorld.profiler.endSection();
             }
-    
+
             // Complete phases, just because we need to. The phases don't actually do anything, because the processing resides here.
 
             // Grab the exit location of entity after being placed into portal
@@ -453,7 +457,7 @@ public final class EntityUtil {
                 && !TrackingUtil.processBlockCaptures(capturedBlocks, EntityPhase.State.CHANGING_DIMENSION, context)) {
                 toMixinTeleporter.removePortalPositionFromCache(ChunkPos.asLong(chunkPosition.getX(), chunkPosition.getZ()));
             }
-    
+
             if (!event.getKeepsVelocity()) {
                 entityIn.motionX = 0;
                 entityIn.motionY = 0;
@@ -935,7 +939,7 @@ public final class EntityUtil {
             if (dropEvent.getDroppedItems().isEmpty()) {
                 return null;
             }
-    
+
             // SECOND throw the ConstructEntityEvent
             Transform<World> suggested = new Transform<>(mixinEntity.getWorld(), new Vector3d(posX, entity.posY + offsetY, posZ));
             Sponge.getCauseStackManager().addContext(EventContextKeys.SPAWN_TYPE, SpawnTypes.DROPPED_ITEM);
@@ -952,11 +956,11 @@ public final class EntityUtil {
             final PhaseData peek = PhaseTracker.getInstance().getCurrentPhaseData();
             final IPhaseState currentState = peek.state;
             final PhaseContext<?> phaseContext = peek.context;
-    
+
             if (item.isEmpty()) {
                 return null;
             }
-    
+
             if (!currentState.ignoresItemPreMerging() && SpongeImpl.getGlobalConfig().getConfig().getOptimizations().doDropsPreMergeItemDrops()) {
                 if (currentState.tracksEntitySpecificDrops()) {
                     final Multimap<UUID, ItemDropData> multimap = phaseContext.getCapturedEntityDropSupplier().get();
@@ -974,7 +978,7 @@ public final class EntityUtil {
             }
             EntityItem entityitem = new EntityItem(entity.world, posX, posY, posZ, item);
             entityitem.setDefaultPickupDelay();
-    
+
             // FIFTH - Capture the entity maybe?
             if (currentState.doesCaptureEntityDrops()) {
                 if (currentState.tracksEntitySpecificDrops()) {
@@ -1020,7 +1024,7 @@ public final class EntityUtil {
             if (dropEvent.getDroppedItems().isEmpty()) {
                 return null;
             }
-    
+
             // SECOND throw the ConstructEntityEvent
             Transform<World> suggested = new Transform<>(mixinPlayer.getWorld(), new Vector3d(posX, adjustedPosY, posZ));
             Sponge.getCauseStackManager().addContext(EventContextKeys.SPAWN_TYPE, SpawnTypes.DROPPED_ITEM);
@@ -1039,7 +1043,7 @@ public final class EntityUtil {
             final PhaseData peek = PhaseTracker.getInstance().getCurrentPhaseData();
             final IPhaseState currentState = peek.state;
             final PhaseContext<?> phaseContext = peek.context;
-    
+
             if (!currentState.ignoresItemPreMerging() && SpongeImpl.getGlobalConfig().getConfig().getOptimizations().doDropsPreMergeItemDrops()) {
                 final Collection<ItemDropData> itemStacks;
                 if (currentState.tracksEntitySpecificDrops()) {
@@ -1057,14 +1061,14 @@ public final class EntityUtil {
                         .build());
                 return null;
             }
-    
+
             EntityItem entityitem = new EntityItem(player.world, posX, adjustedPosY, posZ, droppedItem);
             entityitem.setPickupDelay(40);
-    
+
             if (traceItem) {
                 entityitem.setThrower(player.getName());
             }
-    
+
             final Random random = mixinPlayer.getRandom();
             if (dropAround) {
                 float f = random.nextFloat() * 0.5F;
@@ -1096,15 +1100,15 @@ public final class EntityUtil {
                 return entityitem;
             }
             ItemStack itemstack = dropItemAndGetStack(player, entityitem);
-    
+
             if (traceItem) {
                 if (!itemstack.isEmpty()) {
                     player.addStat(StatList.getDroppedObjectStats(itemstack.getItem()), droppedItem.getCount());
                 }
-    
+
                 player.addStat(StatList.DROP);
             }
-    
+
             return entityitem;
         }
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityEnderPearl.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityEnderPearl.java
@@ -61,7 +61,8 @@ public abstract class MixinEntityEnderPearl extends MixinEntityThrowable impleme
 
         try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
             frame.addContext(EventContextKeys.TELEPORT_TYPE, TeleportTypes.ENTITY_TELEPORT);
-            frame.addContext(EventContextKeys.THROWER, (Player) player).getCurrentCause();
+            frame.addContext(EventContextKeys.PROJECTILE_SOURCE, (Player) player);
+            frame.addContext(EventContextKeys.THROWER, (Player) player);
 
             MoveEntityEvent.Teleport event = EntityUtil.handleDisplaceEntityTeleportEvent(player, this.getLocation());
             if (event.isCancelled()) {


### PR DESCRIPTION
This is the fixed version of #1741 (cc @Zidane )

---

Everything is about the MoveEntityEvent.Teleport.
Corrects an issue of #1523 .

[Here is the content of a test class](https://gist.github.com/RedNesto/6ecd541e06d5f321f345eafbb8162335)