### PR TITLE
fix TeleportHelperFilter teleporting into non-passable blocks

### DIFF
--- a/src/main/java/org/spongepowered/common/world/teleport/DefaultTeleportHelperFilter.java
+++ b/src/main/java/org/spongepowered/common/world/teleport/DefaultTeleportHelperFilter.java
@@ -25,7 +25,13 @@
 package org.spongepowered.common.world.teleport;
 
 import com.google.common.collect.ImmutableSet;
+import net.minecraft.block.BlockAnvil;
+import net.minecraft.block.BlockCauldron;
+import net.minecraft.block.BlockChorusPlant;
+import net.minecraft.block.BlockFence;
+import net.minecraft.block.BlockGlass;
 import net.minecraft.block.BlockSlab;
+import net.minecraft.block.BlockSnow;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import org.spongepowered.api.block.BlockState;
@@ -59,7 +65,25 @@ public class DefaultTeleportHelperFilter implements TeleportHelperFilter {
         IBlockState state = BlockUtil.toNative(blockState);
         Material material = state.getMaterial();
 
-        // Also avoid slabs.
-        return !state.causesSuffocation() && material != Material.LAVA && !(state.getBlock() instanceof BlockSlab);
+        // Deny blocks that suffocate
+        if (state.causesSuffocation()) {
+            return false;
+        }
+        // Deny dangerous lava
+        if (material == Material.LAVA) {
+            return false;
+        }
+
+        // Sadly there is no easy way to check for this using vanilla right now as Blocks like Cauldron are technically marked as passable.
+
+        // Deny non-passable non "full" blocks
+        return !(state.getBlock() instanceof BlockSlab ||
+                 state.getBlock() instanceof BlockCauldron ||
+                 state.getBlock() instanceof BlockAnvil ||
+                 state.getBlock() instanceof BlockFence ||
+                 state.getBlock() instanceof BlockChorusPlant ||
+                 state.getBlock() instanceof BlockSnow ||
+                 material == Material.GLASS ||
+                 material == Material.LEAVES);
     }
 }


### PR DESCRIPTION
API promises to teleport into safe passable blocks.
It actually teleported you into all safe blocks except slabs.

This denies a few more blocks that you cannot pass through.

There might be more blocks that are not really passable.