### PR TITLE
Re-Fix Chunk#getHighestYAt for correct order of operations

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinChunk.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinChunk.java
@@ -432,7 +432,7 @@ public abstract class MixinChunk implements Chunk, IMixinChunk, IMixinCachable {
 
     @Override
     public int getHighestYAt(int x, int z) {
-        return this.sponge_world.getHighestYAt(this.x << 4 + (x & 15), this.z << 4 + (z & 15));
+        return this.sponge_world.getHighestYAt((this.x << 4) + (x & 15), (this.z << 4) + (z & 15));
     }
 
     @Override


### PR DESCRIPTION
**Information**
Fixed the implementation of `Chunk#getHighestYAt(int, int)`. The function originally did not use the correct order of operations to obtain the chunks height y value in a given column position. I fixed the function to respect the chunks column range, instead of grabbing columns from other chunks.