### PR TITLE
delay opening/closing inventories during an InteractInventoryEvent

### DIFF
--- a/src/main/java/org/spongepowered/common/interfaces/IMixinContainer.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinContainer.java
@@ -66,4 +66,8 @@ public interface IMixinContainer extends IMixinInventory {
 
     @Nullable Location<World> getOpenLocation();
     void setOpenLocation(@Nullable Location<World> loc);
+
+    void setInUse(boolean inUse);
+    boolean isInUse();
+
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -691,6 +691,7 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
         // Create Close_Window to capture item drops
         try (PhaseContext<?> ctx = PacketPhase.General.CLOSE_WINDOW.createPhaseContext()
                 .source(this)
+                .packetPlayer(((EntityPlayerMP)(Object) this))
                 .openContainer(this.openContainer)
                 // intentionally missing the lastCursor to not double throw close event
                 .buildAndSwitch()) {

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -109,6 +109,7 @@ import org.spongepowered.api.entity.living.player.tab.TabList;
 import org.spongepowered.api.event.CauseStackManager.StackFrame;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.EventContextKey;
 import org.spongepowered.api.event.entity.DestructEntityEvent;
 import org.spongepowered.api.event.entity.MoveEntityEvent;
 import org.spongepowered.api.event.entity.living.humanoid.ChangeGameModeEvent;
@@ -168,6 +169,7 @@ import org.spongepowered.common.entity.living.human.EntityHuman;
 import org.spongepowered.common.entity.player.PlayerKickHelper;
 import org.spongepowered.common.entity.player.tab.SpongeTabList;
 import org.spongepowered.common.event.SpongeCommonEventFactory;
+import org.spongepowered.common.event.SpongeEventContextKey;
 import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseData;
@@ -657,10 +659,15 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     @Override
     public Optional<Container> openInventory(Inventory inventory) throws IllegalArgumentException {
         if (((IMixinContainer) this.openContainer).isInUse()) {
+            Cause cause = Sponge.getCauseStackManager().getCurrentCause();
             SpongeImpl.getLogger().warn("This player is currently modifying an open container. This action will be delayed.");
             Sponge.getScheduler().createTaskBuilder().delayTicks(0).execute(() -> {
-                this.closeInventory(); // Cause close event first. So cursor item is not lost.
-                this.openInventory(inventory); // Then open the inventory
+                try (StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+                    cause.all().forEach(frame::pushCause);
+                    cause.getContext().asMap().forEach((key, value) -> frame.addContext(((EventContextKey) key), value));
+                    this.closeInventory(); // Cause close event first. So cursor item is not lost.
+                    this.openInventory(inventory); // Then open the inventory
+                }
             }).submit(SpongeImpl.getPlugin());
             return this.getOpenInventory();
         }
@@ -670,8 +677,15 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     @Override
     public boolean closeInventory() throws IllegalArgumentException {
         if (((IMixinContainer) this.openContainer).isInUse()) {
+            Cause cause = Sponge.getCauseStackManager().getCurrentCause();
             SpongeImpl.getLogger().warn("This player is currently modifying an open container. This action will be delayed.");
-            Sponge.getScheduler().createTaskBuilder().delayTicks(0).execute(this::closeInventory).submit(SpongeImpl.getPlugin());
+            Sponge.getScheduler().createTaskBuilder().delayTicks(0).execute(() -> {
+                try (StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+                    cause.all().forEach(frame::pushCause);
+                    cause.getContext().asMap().forEach((key, value) -> frame.addContext(((EventContextKey) key), value));
+                    closeInventory();
+                }
+            }).submit(SpongeImpl.getPlugin());
             return false;
         }
         // Create Close_Window to capture item drops

--- a/src/main/java/org/spongepowered/common/mixin/core/item/inventory/MixinContainer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/inventory/MixinContainer.java
@@ -107,6 +107,7 @@ public abstract class MixinContainer implements org.spongepowered.api.item.inven
     @Nullable private CraftItemEvent.Craft lastCraft = null;
     private boolean firePreview;
     @Nullable private Location<org.spongepowered.api.world.World> lastOpenLocation;
+    private boolean inUse = false;
 
     @Shadow
     public abstract NonNullList<ItemStack> getInventory();
@@ -552,5 +553,15 @@ public abstract class MixinContainer implements org.spongepowered.api.item.inven
     @Override
     public void setOpenLocation(Location<org.spongepowered.api.world.World> loc) {
         this.lastOpenLocation = loc;
+    }
+
+    @Override
+    public void setInUse(boolean inUse) {
+        this.inUse = inUse;
+    }
+
+    @Override
+    public boolean isInUse() {
+        return this.inUse;
     }
 }

--- a/testplugins/src/main/java/org/spongepowered/test/InventoryOpenCloseTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/InventoryOpenCloseTest.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.filter.cause.First;
+import org.spongepowered.api.event.game.state.GameInitializationEvent;
+import org.spongepowered.api.event.item.inventory.ClickInventoryEvent;
+import org.spongepowered.api.event.item.inventory.InteractInventoryEvent;
+import org.spongepowered.api.item.inventory.Inventory;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.text.Text;
+
+import java.util.Optional;
+
+@Plugin(id = "inventoryopenclosetest", name = "Inventory Open/Close Test", description = "A plugin to test open and close during inventory events.")
+public class InventoryOpenCloseTest {
+
+    private final InventoryListener listener = new InventoryListener();
+    private boolean registered = false;
+
+    @Listener
+    public void onInit(GameInitializationEvent event) {
+        Sponge.getCommandManager().register(this,
+                CommandSpec.builder().executor((source, context) -> {
+                    if (this.registered) {
+                        this.registered = false;
+                        Sponge.getEventManager().unregisterListeners(this.listener);
+                    } else {
+                        this.registered = true;
+                        Sponge.getEventManager().registerListeners(this, this.listener);
+                    }
+                    return CommandResult.success();
+                }).build(), "toggleinventoryopenclosetest");
+    }
+
+    public class InventoryListener {
+
+        @Listener
+        public void onInventoryPrimary(ClickInventoryEvent.Primary event, @First Player player) {
+            Inventory inv = Inventory.builder().build(InventoryOpenCloseTest.this);
+            // This will open the inventory the next tick
+            player.openInventory(inv);
+        }
+
+        @Listener
+        public void onInventorySecondary(ClickInventoryEvent.Secondary event, @First Player player) {
+            // This will close the inventory the next tick
+            player.closeInventory();
+        }
+
+        @Listener
+        public void onInventoryClose(InteractInventoryEvent.Close event, @First Player player) {
+            Optional<PluginContainer> pc = event.getCause().first(PluginContainer.class);
+            player.sendMessage(Text.of("Inventory closed by " + pc.map(PluginContainer::getId).orElse(player.getName())));
+        }
+
+        @Listener
+        public void onInventoryOpen(InteractInventoryEvent.Open event, @First Player player) {
+            Optional<PluginContainer> pc = event.getCause().first(PluginContainer.class);
+            player.sendMessage(Text.of("Inventory opened by " + pc.map(PluginContainer::getId).orElse(player.getName())));
+        }
+    }
+}


### PR DESCRIPTION
Opening and closing an inventory during an event prevents us from correctly handling modified transactions and event cancel.

This PR delays open/close during InteractInventoryEvent to the next tick and also prints a warning.

In API 8 we may want to instead throw an exception 
and add a method on the events so you do not have to schedule the action yourself.