### PR TITLE
Fix off-by-one error in MixinWorldServer.isAreaLoaded().

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
@@ -1912,7 +1912,7 @@ public abstract class MixinWorldServer extends MixinWorld implements IMixinWorld
                 return false;
             }
 
-            IMixinChunk currentRow = (IMixinChunk) currentColumn.getNeighborChunk(1);
+            IMixinChunk currentRow = currentColumn;
             for (int j = zStart; j <= zEnd; j++) {
                 if (currentRow == null) {
                     return false;


### PR DESCRIPTION
The original code moves one chunk sideways before checking the chunks in the area. This uses the proper positions.

Fixes #1815.