### PR TITLE
Fix despawn delay issues and make it work as expected - Fixes #1867

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/DespawnDelayValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/DespawnDelayValueProcessor.java
@@ -55,13 +55,13 @@ public class DespawnDelayValueProcessor extends AbstractSpongeValueProcessor<Ent
 
     @Override
     protected boolean set(EntityItem container, Integer value) {
-        container.setPickupDelay(value);
+        ((IMixinEntityItem) container).setDespawnDelay(value);
         return true;
     }
 
     @Override
     protected Optional<Integer> getVal(EntityItem container) {
-        return Optional.of(((IMixinEntityItem) container).getPickupDelay());
+        return Optional.of(((IMixinEntityItem) container).getDespawnDelay());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/interfaces/entity/item/IMixinEntityItem.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/item/IMixinEntityItem.java
@@ -34,6 +34,8 @@ public interface IMixinEntityItem {
 
     boolean infiniteDespawnDelay();
 
+    void setDespawnDelay(int delay);
+
     int getDespawnDelay();
 
     void setDespawnDelay(int delay, boolean infinite);

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityItem.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityItem.java
@@ -122,12 +122,17 @@ public abstract class MixinEntityItem extends MixinEntity implements Item, IMixi
 
     @Override
     public int getDespawnDelay() {
-        return this.infiniteDespawnDelay ? this.previousDespawnDelay : this.age;
+        return 6000 - (this.infiniteDespawnDelay ? this.previousDespawnDelay : this.age);
+    }
+
+    @Override
+    public void setDespawnDelay(int delay) {
+        this.age = 6000 - delay;
     }
 
     @Override
     public void setDespawnDelay(int delay, boolean infinite) {
-        this.age = delay;
+        this.age = 6000 - delay;
         boolean previous = this.infiniteDespawnDelay;
         this.infiniteDespawnDelay = infinite;
         if (infinite && !previous) {


### PR DESCRIPTION
We were setting the pickup delay for one, and also users expect despawn delay to be the amount of ticks until the item despawns, but the item really lasted from the ticks they specified until 6000 ticks(age of 6000). So I have switched this behavior so developers can set it in a sense of how many ticks until they want it to despawn, and that is also what it returns as well.

Fixes #1867 