### PR TITLE
Implement ChangeEntityEquipmentEvents

### DIFF
--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -71,6 +71,7 @@ import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.Item;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.entity.living.Agent;
+import org.spongepowered.api.entity.living.Human;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
@@ -86,6 +87,7 @@ import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.EventContext;
 import org.spongepowered.api.event.cause.EventContextKeys;
 import org.spongepowered.api.event.cause.entity.spawn.SpawnTypes;
+import org.spongepowered.api.event.entity.ChangeEntityEquipmentEvent;
 import org.spongepowered.api.event.entity.CollideEntityEvent;
 import org.spongepowered.api.event.entity.DestructEntityEvent;
 import org.spongepowered.api.event.entity.InteractEntityEvent;
@@ -137,6 +139,7 @@ import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayerMP;
 import org.spongepowered.common.interfaces.entity.player.IMixinInventoryPlayer;
 import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 import org.spongepowered.common.item.inventory.adapter.InventoryAdapter;
+import org.spongepowered.common.item.inventory.adapter.impl.slots.SlotAdapter;
 import org.spongepowered.common.item.inventory.custom.CustomInventory;
 import org.spongepowered.common.item.inventory.util.ContainerUtil;
 import org.spongepowered.common.item.inventory.util.InventoryUtil;
@@ -1414,6 +1417,24 @@ public class SpongeCommonEventFactory {
         UpdateAnvilEventCost costs = new UpdateAnvilEventCost(levelCost, materialCost);
         UpdateAnvilEvent event = SpongeEventFactory.createUpdateAnvilEvent(Sponge.getCauseStackManager().getCurrentCause(),
                 new Transaction<>(costs, costs), name, ItemStackUtil.snapshotOf(slot1), transaction, ItemStackUtil.snapshotOf(slot2), (Inventory)anvil);
+        SpongeImpl.postEvent(event);
+        return event;
+    }
+
+    public static ChangeEntityEquipmentEvent callChangeEntityEquipmentEvent(EntityLivingBase entity, ItemStackSnapshot before, ItemStackSnapshot after, SlotAdapter slot) {
+        ChangeEntityEquipmentEvent event;
+        Cause currentCause = Sponge.getCauseStackManager().getCurrentCause();
+        Transaction<ItemStackSnapshot> transaction = new Transaction<>(before, after);
+        if (entity instanceof EntityPlayerMP) {
+            Player player = EntityUtil.toPlayer((EntityPlayerMP) entity);
+            event = SpongeEventFactory.createChangeEntityEquipmentEventTargetPlayer(currentCause, player, slot, transaction);
+        } else if (entity instanceof Human) {
+            Human humanoid = (Human) entity;
+            event = SpongeEventFactory.createChangeEntityEquipmentEventTargetHumanoid(currentCause, humanoid, slot, transaction);
+        } else {
+            Living living = EntityUtil.fromNativeToLiving(entity);
+            event = SpongeEventFactory.createChangeEntityEquipmentEventTargetLiving(currentCause, living, slot, transaction);
+        }
         SpongeImpl.postEvent(event);
         return event;
     }

--- a/src/main/java/org/spongepowered/common/item/inventory/lens/impl/fabric/EquipmentSlotFabric.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/lens/impl/fabric/EquipmentSlotFabric.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.item.inventory.lens.impl.fabric;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.api.text.translation.Translation;
+import org.spongepowered.common.entity.EntityUtil;
+import org.spongepowered.common.item.inventory.lens.Fabric;
+import org.spongepowered.common.item.inventory.lens.impl.slots.SlotLensImpl;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class EquipmentSlotFabric implements Fabric {
+    private static final EntityEquipmentSlot[] SLOTS;
+    private static final int MAX_STACK_SIZE = 64;
+
+    static {
+        EntityEquipmentSlot[] values = EntityEquipmentSlot.values();
+        SLOTS = new EntityEquipmentSlot[values.length];
+        for (EntityEquipmentSlot slot : values) {
+            SLOTS[slot.getSlotIndex()] = slot;
+        }
+    }
+
+    private final Living living;
+
+    public EquipmentSlotFabric(Living living) {
+        this.living = living;
+    }
+
+    @Override
+    public Collection<Living> allInventories() {
+        return Collections.singleton(this.living);
+    }
+
+    @Override
+    public Living get(int index) {
+        return this.living;
+    }
+
+    @Override
+    public ItemStack getStack(int index) {
+        return EntityUtil.toNative(this.living).getItemStackFromSlot(SLOTS[index]);
+    }
+
+    @Override
+    public void setStack(int index, ItemStack stack) {
+        EntityUtil.toNative(this.living).setItemStackToSlot(SLOTS[index], stack);
+    }
+
+    @Override
+    public int getMaxStackSize() {
+        return MAX_STACK_SIZE;
+    }
+
+    @Override
+    public Translation getDisplayName() {
+        return SlotLensImpl.SLOT_NAME;
+    }
+
+    @Override
+    public int getSize() {
+        return SLOTS.length;
+    }
+
+    @Override
+    public void clear() {
+        EntityLivingBase entity = EntityUtil.toNative(this.living);
+        for (EntityEquipmentSlot slot : SLOTS) {
+            entity.setItemStackToSlot(slot, ItemStack.EMPTY);
+        }
+    }
+
+    @Override
+    public void markDirty() {
+    }
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java
@@ -923,15 +923,15 @@ public abstract class MixinEntityLivingBase extends MixinEntity implements Livin
                 IMixinInventoryPlayer inventory = (IMixinInventoryPlayer) ((EntityPlayerMP) entity).inventory;
                 PlayerInventoryLens inventoryLens = (PlayerInventoryLens) inventory.getRootLens();
                 switch (entityEquipmentSlot) {
-                case OFFHAND:
-                    slotLens = inventoryLens.getOffhandLens();
-                    break;
-                case MAINHAND:
-                    HotbarLens hotbarLens = inventoryLens.getMainLens().getHotbar();
-                    slotLens = hotbarLens.getSlot(hotbarLens.getSelectedSlotIndex(inventory.getFabric()));
-                    break;
-                default:
-                    slotLens = inventoryLens.getEquipmentLens().getSlot(entityEquipmentSlot.getIndex());
+                    case OFFHAND:
+                        slotLens = inventoryLens.getOffhandLens();
+                        break;
+                    case MAINHAND:
+                        HotbarLens hotbarLens = inventoryLens.getMainLens().getHotbar();
+                        slotLens = hotbarLens.getSlot(hotbarLens.getSelectedSlotIndex(inventory.getFabric()));
+                        break;
+                    default:
+                        slotLens = inventoryLens.getEquipmentLens().getSlot(entityEquipmentSlot.getIndex());
                 }
                 slotAdapter = slotLens.getAdapter(inventory.getFabric(), inventory);
             } else {

--- a/testplugins/src/main/java/org/spongepowered/test/ChangeEntityEquipmentTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/ChangeEntityEquipmentTest.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.Humanoid;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.entity.ChangeEntityEquipmentEvent;
+import org.spongepowered.api.event.game.state.GameInitializationEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nullable;
+
+@Plugin(id = "changeentityequipmenttest", name = "Entity Equipment Change Test", description = ChangeEntityEquipmentTest.DESCRIPTION, version = "0.0.0")
+public class ChangeEntityEquipmentTest {
+    public static final String DESCRIPTION = "A plugin for testing ChangeEntityEquipmentEvents.";
+
+    @Nullable
+    private TestListener listener = null;
+
+    @Listener
+    public void onGameInitialization(GameInitializationEvent event) {
+        CommandSpec command = CommandSpec.builder().executor(this::onCommand).build();
+        Sponge.getCommandManager().register(this, command, "togglechangeentityequipmenttest");
+    }
+
+    private CommandResult onCommand(CommandSource source, CommandContext context) {
+        if (this.listener != null) {
+            Sponge.getEventManager().unregisterListeners(this.listener);
+            this.listener = null;
+        } else {
+            this.listener = new TestListener();
+            Sponge.getEventManager().registerListeners(this, this.listener);
+        }
+        return CommandResult.success();
+    }
+
+    public class TestListener {
+        private TestListener() {}
+
+        @Listener
+        public void onChangeEntityEquipment(ChangeEntityEquipmentEvent event) {
+            Entity entity = event.getTargetEntity();
+            String name = entity instanceof Humanoid ? ((Humanoid) entity).getName() : entity.getUniqueId().toString();
+            Text text = Text.builder()
+                    .append(Text.of("[", name, "]", " ChangeEntityEquipmentEvent is fired")).append(Text.NEW_LINE)
+                    .append(Text.of("[", name, "]", " ", event.getCause().toString())).append(Text.NEW_LINE)
+                    .append(Text.of("[", name, "]", " ", event.getTransaction().toString())).build();
+            Sponge.getServer().getConsole().sendMessage(text);
+        }
+    }
+}


### PR DESCRIPTION
[SpongeAPI](//github.com/SpongePowered/SpongeAPI/pull/1819) | **SpongeCommon**

The purpose of this PR is the same as what is expressed in the title.

There are only two questions I found when I was implementing the events:
* What do the `Optional`s mean in the return values of [`getOriginalItemStack`](https://github.com/SpongePowered/SpongeAPI/blob/bleeding/src/main/java/org/spongepowered/api/event/entity/ChangeEntityEquipmentEvent.java#L66) and [`getItemStack`](https://github.com/SpongePowered/SpongeAPI/blob/bleeding/src/main/java/org/spongepowered/api/event/entity/ChangeEntityEquipmentEvent.java#L76) of the event interface? I didn't see the need for the existence. The two `Optional`s could never be empty.
* All the implementations of those `Lens` (`OrderedInventoryLensImpl`, `EquipmentInventoryLensImpl`) are based on the `IInventory` while general creatures (such as zombies, skeletons, etc.) never have their inventories so I cannot reuse those codes. Is it needed to extract generics in those implementations?

Besides, would this PR be merged into the `stable` branch and be available in the artifacts of stable builds?