### PR TITLE
Include both custom and vanilla DataManipulators in BlockSnapshots.

### DIFF
--- a/src/main/java/org/spongepowered/common/block/SpongeBlockSnapshotBuilder.java
+++ b/src/main/java/org/spongepowered/common/block/SpongeBlockSnapshotBuilder.java
@@ -50,7 +50,6 @@ import org.spongepowered.api.world.BlockChangeFlags;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.storage.WorldProperties;
-import org.spongepowered.common.bridge.data.CustomDataHolderBridge;
 import org.spongepowered.common.data.persistence.NbtTranslator;
 import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.util.Constants;
@@ -153,7 +152,7 @@ public class SpongeBlockSnapshotBuilder extends AbstractDataBuilder<BlockSnapsho
                 this.compound = new NBTTagCompound();
                 final org.spongepowered.api.block.tileentity.TileEntity te = location.getTileEntity().get();
                 ((TileEntity) te).writeToNBT(this.compound);
-                this.manipulators = ((CustomDataHolderBridge) te).bridge$getCustomManipulators().stream()
+                this.manipulators = te.getContainers().stream()
                         .map(DataManipulator::asImmutable)
                         .collect(Collectors.toList());
             }

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/block/state/StateImplementationMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/block/state/StateImplementationMixin_API.java
@@ -120,7 +120,7 @@ public abstract class StateImplementationMixin_API extends BlockStateBase implem
         if (this.block.hasTileEntity() && location.getBlockType().equals(this.block)) {
             final TileEntity tileEntity = location.getTileEntity()
                 .orElseThrow(() -> new IllegalStateException("Unable to retrieve a TileEntity for location: " + location));
-            for (final DataManipulator<?, ?> manipulator : ((CustomDataHolderBridge) tileEntity).bridge$getCustomManipulators()) {
+            for (final DataManipulator<?, ?> manipulator : tileEntity.getContainers()) {
                 builder.add(manipulator);
             }
             final NBTTagCompound compound = new NBTTagCompound();

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/world/WorldMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/world/WorldMixin_API.java
@@ -613,7 +613,7 @@ public abstract class WorldMixin_API implements World {
         }
         if (te.isPresent()) {
             final TileEntity tileEntity = te.get();
-            for (DataManipulator<?, ?> manipulator : ((CustomDataHolderBridge) tileEntity).bridge$getCustomManipulators()) {
+            for (DataManipulator<?, ?> manipulator : tileEntity.getContainers()) {
                 builder.add(manipulator);
             }
             final NBTTagCompound compound = new NBTTagCompound();


### PR DESCRIPTION
> "Include ALL the manipulators!" - Quote from someone or something, or maybe no one

Fixes https://forums.spongepowered.org/t/getting-sign-lines-from-changeblockevent-break/23461.
Fixes #2416.

I'm worried about side effects, though (for example, if the custom data gets saved off and conflicts with NBT data), so this may need quite a bit of testing.