### PR TITLE
Delay config saving during startup to prevent Access Denied errors on Windows

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeImpl.java
+++ b/src/main/java/org/spongepowered/common/SpongeImpl.java
@@ -43,6 +43,7 @@ import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.game.state.GameStateEvent;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.common.config.SpongeConfig;
+import org.spongepowered.common.config.SpongeConfigSaveManager;
 import org.spongepowered.common.config.type.CustomDataConfig;
 import org.spongepowered.common.config.type.GlobalConfig;
 import org.spongepowered.common.data.SpongeDataManager;
@@ -83,6 +84,7 @@ public final class SpongeImpl {
     @Nullable private static SpongeConfig<GlobalConfig> globalConfig;
     @Nullable private static PluginContainer minecraftPlugin;
     @Nullable private static SpongeConfig<CustomDataConfig> customDataConfig;
+    @Nullable private static SpongeConfigSaveManager configSaveManager;
 
     @Inject private static SpongeGame game;
 
@@ -182,6 +184,14 @@ public final class SpongeImpl {
 
     public static Path getSpongeConfigDir() {
         return SpongeLaunch.getSpongeConfigDir();
+    }
+
+    public static SpongeConfigSaveManager getConfigSaveManager() {
+        if (configSaveManager == null) {
+            configSaveManager = new SpongeConfigSaveManager();
+        }
+
+        return configSaveManager;
     }
 
     public static SpongeConfig<GlobalConfig> getGlobalConfig() {

--- a/src/main/java/org/spongepowered/common/config/SpongeConfigSaveManager.java
+++ b/src/main/java/org/spongepowered/common/config/SpongeConfigSaveManager.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.config;
+
+import org.spongepowered.api.GameState;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.common.SpongeImpl;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+/**
+ * To avoid file saving issues with Windows and to allow some async file saving,
+ * this manager acts as a staging ground for file saves so that we can do them
+ * in batches.
+ *
+ * <p>This class is intended to be thread safe through the use of
+ * synchronisation.</p>
+ */
+public class SpongeConfigSaveManager {
+
+    private final Set<SpongeConfig<?>> stagedConfigs = new HashSet<>();
+
+    public void save(SpongeConfig<?> spongeConfig) {
+        synchronized (this) {
+            if (!SpongeImpl.isInitialized() || // if we're not initialised, then we're likely testing and should just pass on through.
+                    SpongeImpl.getGame().getState() == GameState.SERVER_STARTED || SpongeImpl.getGame().getState() == GameState.GAME_STOPPED) {
+                if (!this.stagedConfigs.isEmpty()) {
+                    // We want to save and flush now, but add this into the set in case it is already present.
+                    this.stagedConfigs.add(spongeConfig);
+                    flush();
+                } else {
+                    // just save
+                    spongeConfig.saveNow();
+                }
+            } else {
+                this.stagedConfigs.add(spongeConfig);
+            }
+        }
+    }
+
+    /**
+     * Flush a specific config. Returns true if successful or if the config was
+     * not in the set. False if there was an error on save.
+     *
+     * @param config The config to save now
+     * @return {@code true} if successful or unneeded, false otherwise.
+     */
+    public boolean flush(SpongeConfig<?> config) {
+        synchronized (this) {
+            if (this.stagedConfigs.remove(config)) {
+                return config.saveNow();
+            }
+        }
+
+        return true;
+    }
+
+    public void flush() {
+        if (!this.stagedConfigs.isEmpty()) {
+            synchronized (this) {
+                for (SpongeConfig spongeConfig : this.stagedConfigs) {
+                    spongeConfig.saveNow();
+                }
+
+                this.stagedConfigs.clear();
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/SpongeManipulatorRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeManipulatorRegistry.java
@@ -438,7 +438,6 @@ public class SpongeManipulatorRegistry implements SpongeAdditionalCatalogRegistr
         this.pluginBasedRegistrations = pluginBuilder.build();
 
         final SpongeConfig<CustomDataConfig> dataConfig = SpongeImpl.getDataConfig();
-        dataConfig.reload();
         final CustomDataRegistrationCategory config = dataConfig.getConfig().getDataRegistrationConfig();
         config.populateRegistrations(this.registrations);
         // Save the list of registered id's, this way the config can be re-understood.


### PR DESCRIPTION
**SpongeCommon** | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/2162) | [SpongeVanilla](https://github.com/SpongePowered/SpongeVanilla/pull/369) | [Original SC Issue](https://github.com/SpongePowered/SpongeCommon/issues/1906) | [Original Original SF Issue](https://github.com/SpongePowered/SpongeForge/issues/1991)

This works around file system locking that can cause Access Denied exceptions during file saves, particularly in Windows.

Currently, when Sponge loads, we load many config files. When the file is first loaded, we load and then immediately save. This allows the file to be generated if it doesn't already exist, or for the contents to be updated with new defaults (in theory at least).

During the loading process, the configuration may then be adapted and re-saved. This can result in files, particularly on the world management side, being **saved** upwards of five/six times during the load.

On Linux, this isn't so much of an issue, because of the way the file handling works. If a file is being loaded and written, the handle is held, even though the file might be overwritten. The file path doesn't matter once the inode is located ([good SO explanation here](https://stackoverflow.com/questions/2028874/what-happens-to-an-open-file-handler-on-linux-if-the-pointed-file-gets-moved-de/2031100#2031100)) because IO operations then work on the inode, not the file name, so even if the file name was redirected to a different inode, the loading or saving process doesn't care at that point (though is then dealing with obsolete data).

Windows is a different story. The file gets locked during the first save and cannot be overwritten at that time. It's the same cause as the infamous "this file is locked and cannot be removed" scenario. Not only is the file location locked, but the file name is locked. To be helpful, when Windows gets a write request, Windows takes the data and lets the calling process continue, performing a delayed write to the drive. This means that Sponge considers the first save a success and will continue on its merry way while Windows has not completed the write yet. Thus, when the second save operation then comes in and fails because the file is locked, which results in an AccessDenied exception.

What this PR does (with the SF and SV PRs) is introduce a save manager (which is the best name I could come up with, I'm not wedded to it) to try to reduce the number of save operations and avoid this issue. Now, what happens is:

* A config is requested for the first time. Sponge loads the file and saves it, as normal
* A save operation is requested on the config file. This operation occurs during INIT. The save manager stores the class in a set but does not request a save yet.
* At the end of POST_INIT (may move to LOAD_COMPLETE), the save manager performs a save to disc (using flush(), again, name is up for debate). This tries to bypass the issue when the data registration is completed by performing the write a little bit later.
* Worlds are loaded during game lifecycle events. Similar to above, the initial save is left. Future saves are held until GAME_STARTED, at which time, the saves are all performed.
* Saves during the GAME_STARTED phase are performed as normal
* Saves during the shutdown phase are held until GAME_STOPPED.

Could do with a couple of Windows users that were having this problem to test this. Once this is pulled, this should be backported to stable-7

Fixes #1906