### PR TITLE
Fix all ManipulatorTest failures

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -61,6 +61,7 @@ import org.spongepowered.api.text.BookView;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.serializer.BookViewDataBuilder;
 import org.spongepowered.api.text.serializer.TextConfigSerializer;
+import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.weighted.VariableAmount;
 import org.spongepowered.api.world.LocatableBlock;
 import org.spongepowered.api.world.Location;
@@ -185,6 +186,8 @@ public class DataRegistrar {
         dataManager.registerBuilder(SpongePlayerData.class, new SpongePlayerData.Builder());
 
         dataManager.registerBuilder(GameProfile.class, new SpongeGameProfileBuilder());
+
+        dataManager.registerBuilder(Color.class, new Color.Builder());
 
         // Content Updaters
         dataManager.registerContentUpdater(BlockState.class, new SpongeBlockStateMetaContentUpdater());

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeDamageableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeDamageableData.java
@@ -57,6 +57,7 @@ public class ImmutableSpongeDamageableData extends AbstractImmutableData<Immutab
         this.lastDamage = lastDamage;
         this.lastAttackerValue = new ImmutableSpongeOptionalValue<>(Keys.LAST_ATTACKER, Optional.ofNullable(this.lastAttacker));
         this.lastDamageValue = new ImmutableSpongeOptionalValue<>(Keys.LAST_DAMAGE, Optional.ofNullable(this.lastDamage));
+        this.registerGetters();
     }
 
     public ImmutableSpongeDamageableData(@Nullable Living lastAttacker, @Nullable Double lastDamage) {

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeInvisibilityData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeInvisibilityData.java
@@ -55,6 +55,7 @@ public class ImmutableSpongeInvisibilityData extends AbstractImmutableData<Immut
         this.vanishValue = ImmutableSpongeValue.cachedOf(Keys.VANISH, false, this.vanish);
         this.collisionValue = ImmutableSpongeValue.cachedOf(Keys.VANISH_IGNORES_COLLISION, false, this.collision);
         this.untargetableValue = ImmutableSpongeValue.cachedOf(Keys.VANISH_PREVENTS_TARGETING, false, this.untargetable);
+        this.registerGetters();
     }
 
     @Override
@@ -87,6 +88,9 @@ public class ImmutableSpongeInvisibilityData extends AbstractImmutableData<Immut
 
         registerFieldGetter(Keys.VANISH_PREVENTS_TARGETING, this::isUntargetable);
         registerKeyValue(Keys.VANISH_PREVENTS_TARGETING, this::untargetable);
+
+        registerFieldGetter(Keys.INVISIBLE, () -> this.invisible);
+        registerKeyValue(Keys.INVISIBLE, this::invisible);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeDamageableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeDamageableData.java
@@ -53,6 +53,7 @@ public class SpongeDamageableData extends AbstractData<DamageableData, Immutable
         super(DamageableData.class);
         this.lastAttacker = lastAttacker;
         this.lastDamage = lastDamage;
+        this.registerGettersAndSetters();
     }
 
     public SpongeDamageableData(@Nullable Living lastAttacker, @Nullable Double lastDamage) {

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeFuseData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeFuseData.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.data.manipulator.mutable.entity;
 
+import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableFuseData;
 import org.spongepowered.api.data.manipulator.mutable.entity.FuseData;
@@ -77,6 +78,13 @@ public class SpongeFuseData extends AbstractData<FuseData, ImmutableFuseData> im
     @Override
     public ImmutableFuseData asImmutable() {
         return new ImmutableSpongeFuseData(this.fuseDuration, this.ticksRemaining);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer()
+                .set(Keys.FUSE_DURATION, this.fuseDuration)
+                .set(Keys.TICKS_REMAINING, this.ticksRemaining);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeInvisibilityData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeInvisibilityData.java
@@ -52,6 +52,7 @@ public class SpongeInvisibilityData extends AbstractData<InvisibilityData, Immut
         this.collision = collision;
         this.untargetable = untargetable;
         this.invisible = invisible;
+        this.registerGettersAndSetters();
     }
 
     @Override
@@ -81,9 +82,11 @@ public class SpongeInvisibilityData extends AbstractData<InvisibilityData, Immut
         registerKeyValue(Keys.VANISH, this::vanish);
 
         registerFieldGetter(Keys.VANISH_IGNORES_COLLISION, this::isCollision);
+        registerFieldSetter(Keys.VANISH_IGNORES_COLLISION, (value) -> this.collision = value);
         registerKeyValue(Keys.VANISH_IGNORES_COLLISION, this::ignoresCollisionDetection);
 
         registerFieldGetter(Keys.VANISH_PREVENTS_TARGETING, this::isUntargetable);
+        registerFieldSetter(Keys.VANISH_PREVENTS_TARGETING, (value) -> this.untargetable = value);
         registerKeyValue(Keys.VANISH_PREVENTS_TARGETING, this::untargetable);
 
         registerFieldGetter(Keys.INVISIBLE, () -> this.invisible);

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/item/SpongeAuthorData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/item/SpongeAuthorData.java
@@ -51,12 +51,6 @@ public class SpongeAuthorData extends AbstractSingleData<Text, AuthorData, Immut
     }
 
     @Override
-    public DataContainer toContainer() {
-        return super.toContainer()
-                .set(Keys.BOOK_AUTHOR.getQuery(), TextSerializers.PLAIN.serialize(this.getValue()));
-    }
-
-    @Override
     public Value<Text> author() {
         return new SpongeValue<>(Keys.BOOK_AUTHOR, Text.of(), this.getValue());
     }

--- a/src/main/java/org/spongepowered/common/data/processor/multi/entity/DespawnDelayDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/entity/DespawnDelayDataProcessor.java
@@ -78,7 +78,6 @@ public final class DespawnDelayDataProcessor extends AbstractEntityDataProcessor
     @Override
     public Optional<DespawnDelayData> fill(DataContainer container, DespawnDelayData data) {
         data.set(Keys.DESPAWN_DELAY, getData(container, Keys.DESPAWN_DELAY));
-        data.set(Keys.INFINITE_DESPAWN_DELAY, getData(container, Keys.INFINITE_DESPAWN_DELAY));
         return Optional.of(data);
     }
 

--- a/src/main/java/org/spongepowered/common/data/processor/multi/entity/PickupDelayDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/entity/PickupDelayDataProcessor.java
@@ -78,7 +78,6 @@ public final class PickupDelayDataProcessor extends AbstractEntityDataProcessor<
     @Override
     public Optional<PickupDelayData> fill(DataContainer container, PickupDelayData data) {
         data.set(Keys.PICKUP_DELAY, getData(container, Keys.PICKUP_DELAY));
-        data.set(Keys.INFINITE_PICKUP_DELAY, getData(container, Keys.INFINITE_PICKUP_DELAY));
         return Optional.of(data);
     }
 

--- a/src/main/java/org/spongepowered/common/data/util/DataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataUtil.java
@@ -72,6 +72,7 @@ import org.spongepowered.common.data.processor.common.AbstractSingleDataSingleTa
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -126,6 +127,8 @@ public final class DataUtil {
             final HashSet<Object> set = new HashSet<>();
             set.addAll(dataView.getList(key.getQuery()).orElse(Collections.emptyList()));
             object = set;
+        } else if (elementToken.isSubtypeOf(TypeToken.of(Map.class))) {
+            object = dataView.getMap(key.getQuery()).orElseThrow(() -> new InvalidDataException("Missing value for key: " + key.getId()));
         } else if (elementToken.isSubtypeOf(TypeToken.of(Enum.class))) {
             object = Enum.valueOf((Class<Enum>) elementToken.getRawType(), dataView.getString(key.getQuery())
                 .orElseThrow(() -> new InvalidDataException("Missing value for key: " + key.getId())));

--- a/src/main/java/org/spongepowered/common/data/util/DataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataUtil.java
@@ -135,7 +135,7 @@ public final class DataUtil {
         } else {
             final Optional<? extends DataTranslator<?>> translator = SpongeDataManager.getInstance().getTranslator(elementToken.getRawType());
             if (translator.isPresent()) {
-                object = translator.map(trans -> trans.translate(dataView))
+                object = translator.map(trans -> trans.translate(dataView.getView(key.getQuery()).orElseThrow(() -> new InvalidDataException("Missing value for key: " + key.getId()))))
                     .orElseThrow(() -> new InvalidDataException("Could not translate translateable: " + key.getId()));
             } else {
                 object = dataView.get(key.getQuery())

--- a/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
+++ b/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
@@ -196,7 +196,7 @@ public class ManipulatorTest {
                 try {
                      optional = (Optional<DataManipulator<?, ?>>) this.builder.build(container);
                 } catch (Exception e) {
-                    printExceptionBuildingData(container);
+                    printExceptionBuildingData(container, e);
                     return;
                 }
                 if (!optional.isPresent()) {
@@ -236,8 +236,9 @@ public class ManipulatorTest {
         printRemaining(container, printer);
     }
 
-    private void printExceptionBuildingData(DataContainer container) {
+    private void printExceptionBuildingData(DataContainer container, Exception exception) {
         final PrettyPrinter printer = new PrettyPrinter(60).centre().add("Could not build data!").hr()
+            .add(exception)
             .add("Something something data....")
             .add()
             .add("Here's the provided container:");

--- a/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
+++ b/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
@@ -197,7 +197,7 @@ public class ManipulatorTest {
                      optional = (Optional<DataManipulator<?, ?>>) this.builder.build(container);
                 } catch (Exception e) {
                     printExceptionBuildingData(container, e);
-                    return;
+                    throw e;
                 }
                 if (!optional.isPresent()) {
                     printEmptyBuild(container);

--- a/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
+++ b/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.data.manipulator;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -145,7 +146,7 @@ public class ManipulatorTest {
                 + "key/values as the ImmutableDataManipulator and vice versa.\n"
                 + "The mutable manipulator in question: " + this.dataName +"\n"
                 + "The immutable manipulator in question: " + immutableDataManipulator.getClass().getSimpleName(),
-                mutableKeys.equals(immutableKeys), is(true));
+                immutableKeys, equalTo(mutableKeys));
         } catch (NoSuchMethodException e) {
             throw new UnsupportedOperationException("All Sponge provided DataManipulator implementations require a no-args constructor! \n"
                                                     + "If the manipulator needs to be parametarized, please understand that there needs to "


### PR DESCRIPTION
To prevent any future regressions, any exception thrown from ManipulatorTest causes a test failure in addition to a pretty-printed message.

Pinging @gabizou for review.