### PR TITLE
Finish implementing WireAttachmentData.

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -671,6 +671,9 @@ public class DataRegistrar {
         DataUtil.registerDualProcessor(MoistureData.class, SpongeMoistureData.class, ImmutableMoistureData.class,
                 ImmutableSpongeMoistureData.class, new MoistureDataProcessor());
 
+        DataUtil.registerDataProcessorAndImpl(WireAttachmentData.class, SpongeWireAttachmentData.class, ImmutableWireAttachmentData.class,
+                ImmutableSpongeWireAttachmentData.class, new WireAttachmentDataProcessor());
+
         // TileEntity Processors
 
         DataUtil.registerDualProcessor(SkullData.class, SpongeSkullData.class, ImmutableSkullData.class,

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeWireAttachmentData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeWireAttachmentData.java
@@ -35,7 +35,7 @@ import org.spongepowered.api.data.value.immutable.ImmutableMapValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
-import org.spongepowered.common.data.manipulator.mutable.block.SpongeWireAttachementData;
+import org.spongepowered.common.data.manipulator.mutable.block.SpongeWireAttachmentData;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeMapValue;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
@@ -62,6 +62,7 @@ public class ImmutableSpongeWireAttachmentData extends AbstractImmutableData<Imm
         this.eastValue = ImmutableSpongeValue.cachedOf(Keys.WIRE_ATTACHMENT_EAST, WireAttachmentTypes.NONE, wireAttachmentMap.get(Direction.EAST));
         this.westValue = ImmutableSpongeValue.cachedOf(Keys.WIRE_ATTACHMENT_WEST, WireAttachmentTypes.NONE, wireAttachmentMap.get(Direction.WEST));
 
+        this.registerGetters();
     }
 
     @Override
@@ -91,7 +92,7 @@ public class ImmutableSpongeWireAttachmentData extends AbstractImmutableData<Imm
 
     @Override
     public WireAttachmentData asMutable() {
-        return new SpongeWireAttachementData(this.wireAttachmentMap);
+        return new SpongeWireAttachmentData(this.wireAttachmentMap);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeWireAttachmentData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeWireAttachmentData.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.data.manipulator.mutable.block;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.key.Keys;
@@ -41,11 +42,18 @@ import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 import java.util.Map;
 
-public class SpongeWireAttachementData extends AbstractData<WireAttachmentData, ImmutableWireAttachmentData> implements WireAttachmentData {
+public class SpongeWireAttachmentData extends AbstractData<WireAttachmentData, ImmutableWireAttachmentData> implements WireAttachmentData {
 
     private Map<Direction, WireAttachmentType> wireAttachmentMap;
 
-    public SpongeWireAttachementData(Map<Direction, WireAttachmentType> attachmentMap) {
+    public SpongeWireAttachmentData() {
+        this(ImmutableMap.of(Direction.NORTH, WireAttachmentTypes.NONE,
+                Direction.SOUTH, WireAttachmentTypes.NONE,
+                Direction.EAST, WireAttachmentTypes.NONE,
+                Direction.WEST, WireAttachmentTypes.NONE));
+    }
+
+    public SpongeWireAttachmentData(Map<Direction, WireAttachmentType> attachmentMap) {
         super(WireAttachmentData.class);
         this.wireAttachmentMap = Maps.newHashMap(attachmentMap);
         registerGettersAndSetters();
@@ -78,7 +86,7 @@ public class SpongeWireAttachementData extends AbstractData<WireAttachmentData, 
 
     @Override
     public WireAttachmentData copy() {
-        return new SpongeWireAttachementData(this.wireAttachmentMap);
+        return new SpongeWireAttachmentData(this.wireAttachmentMap);
     }
 
     @Override
@@ -99,6 +107,33 @@ public class SpongeWireAttachementData extends AbstractData<WireAttachmentData, 
     @Override
     protected void registerGettersAndSetters() {
         // north
-        // TODO register things
+        this.registerFieldGetter(Keys.WIRE_ATTACHMENT_NORTH, () -> this.wireAttachmentMap.get(Direction.NORTH));
+        this.registerFieldSetter(Keys.WIRE_ATTACHMENT_NORTH, x -> this.wireAttachmentMap.put(Direction.NORTH, x));
+        this.registerKeyValue(Keys.WIRE_ATTACHMENT_NORTH, this::wireAttachmentNorth);
+
+        // south
+        this.registerFieldGetter(Keys.WIRE_ATTACHMENT_SOUTH, () -> this.wireAttachmentMap.get(Direction.SOUTH));
+        this.registerFieldSetter(Keys.WIRE_ATTACHMENT_SOUTH, x -> this.wireAttachmentMap.put(Direction.SOUTH, x));
+        this.registerKeyValue(Keys.WIRE_ATTACHMENT_SOUTH, this::wireAttachmentSouth);
+
+        // east
+        this.registerFieldGetter(Keys.WIRE_ATTACHMENT_EAST, () -> this.wireAttachmentMap.get(Direction.EAST));
+        this.registerFieldSetter(Keys.WIRE_ATTACHMENT_EAST, x -> this.wireAttachmentMap.put(Direction.EAST, x));
+        this.registerKeyValue(Keys.WIRE_ATTACHMENT_EAST, this::wireAttachmentEast);
+
+        // west
+        this.registerFieldGetter(Keys.WIRE_ATTACHMENT_WEST, () -> this.wireAttachmentMap.get(Direction.WEST));
+        this.registerFieldSetter(Keys.WIRE_ATTACHMENT_WEST, x -> this.wireAttachmentMap.put(Direction.WEST, x));
+        this.registerKeyValue(Keys.WIRE_ATTACHMENT_WEST, this::wireAttachmentWest);
+
+        // all
+        this.registerFieldGetter(Keys.WIRE_ATTACHMENTS, () -> ImmutableMap.copyOf(this.wireAttachmentMap));
+        this.registerFieldSetter(Keys.WIRE_ATTACHMENTS, x -> {
+            this.wireAttachmentMap.put(Direction.NORTH, x.getOrDefault(Direction.NORTH, WireAttachmentTypes.NONE));
+            this.wireAttachmentMap.put(Direction.SOUTH, x.getOrDefault(Direction.SOUTH, WireAttachmentTypes.NONE));
+            this.wireAttachmentMap.put(Direction.EAST, x.getOrDefault(Direction.EAST, WireAttachmentTypes.NONE));
+            this.wireAttachmentMap.put(Direction.WEST, x.getOrDefault(Direction.WEST, WireAttachmentTypes.NONE));
+        });
+        this.registerKeyValue(Keys.WIRE_ATTACHMENTS, this::wireAttachments);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeWireAttachmentData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeWireAttachmentData.java
@@ -46,11 +46,13 @@ public class SpongeWireAttachmentData extends AbstractData<WireAttachmentData, I
 
     private Map<Direction, WireAttachmentType> wireAttachmentMap;
 
+    private static final Map<Direction, WireAttachmentType> DEFAULTS = ImmutableMap.of(Direction.NORTH, WireAttachmentTypes.NONE,
+            Direction.SOUTH, WireAttachmentTypes.NONE,
+            Direction.EAST, WireAttachmentTypes.NONE,
+            Direction.WEST, WireAttachmentTypes.NONE);
+
     public SpongeWireAttachmentData() {
-        this(ImmutableMap.of(Direction.NORTH, WireAttachmentTypes.NONE,
-                Direction.SOUTH, WireAttachmentTypes.NONE,
-                Direction.EAST, WireAttachmentTypes.NONE,
-                Direction.WEST, WireAttachmentTypes.NONE));
+        this(SpongeWireAttachmentData.DEFAULTS);
     }
 
     public SpongeWireAttachmentData(Map<Direction, WireAttachmentType> attachmentMap) {

--- a/src/main/java/org/spongepowered/common/data/processor/data/block/WireAttachmentDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/block/WireAttachmentDataProcessor.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.data.block;
+
+import com.google.common.collect.Maps;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.block.ImmutableWireAttachmentData;
+import org.spongepowered.api.data.manipulator.mutable.block.WireAttachmentData;
+import org.spongepowered.api.data.merge.MergeFunction;
+import org.spongepowered.api.data.type.WireAttachmentType;
+import org.spongepowered.api.data.type.WireAttachmentTypes;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.util.Direction;
+import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeWireAttachmentData;
+import org.spongepowered.common.data.manipulator.mutable.block.SpongeWireAttachmentData;
+import org.spongepowered.common.data.processor.common.AbstractMultiDataProcessor;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class WireAttachmentDataProcessor extends AbstractMultiDataProcessor<WireAttachmentData, ImmutableWireAttachmentData> {
+
+    @Override
+    protected WireAttachmentData createManipulator() {
+        return new SpongeWireAttachmentData();
+    }
+
+    @Override
+    public Optional<WireAttachmentData> fill(DataContainer container, WireAttachmentData data) {
+        if (container.contains(Keys.WIRE_ATTACHMENT_NORTH) && container.contains(Keys.WIRE_ATTACHMENT_SOUTH)
+                && container.contains(Keys.WIRE_ATTACHMENT_EAST) && container.contains(Keys.WIRE_ATTACHMENT_WEST)) {
+            data.set(Keys.WIRE_ATTACHMENT_NORTH, container.getCatalogType(Keys.WIRE_ATTACHMENT_NORTH.getQuery(), WireAttachmentType.class).get());
+            data.set(Keys.WIRE_ATTACHMENT_SOUTH, container.getCatalogType(Keys.WIRE_ATTACHMENT_SOUTH.getQuery(), WireAttachmentType.class).get());
+            data.set(Keys.WIRE_ATTACHMENT_EAST, container.getCatalogType(Keys.WIRE_ATTACHMENT_EAST.getQuery(), WireAttachmentType.class).get());
+            data.set(Keys.WIRE_ATTACHMENT_WEST, container.getCatalogType(Keys.WIRE_ATTACHMENT_WEST.getQuery(), WireAttachmentType.class).get());
+            return Optional.of(data);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public DataTransactionResult set(DataHolder dataHolder, WireAttachmentData manipulator, MergeFunction function) {
+        return DataTransactionResult.failNoData();
+    }
+
+    @Override
+    public Optional<ImmutableWireAttachmentData> with(Key<? extends BaseValue<?>> key, Object value, ImmutableWireAttachmentData immutable) {
+        Map<Direction, WireAttachmentType> map = Maps.newHashMap(((ImmutableSpongeWireAttachmentData) immutable).getWireAttachmentMap());
+        if (key == Keys.WIRE_ATTACHMENTS) {
+            for (Direction dir : map.keySet()) {
+                map.put(dir, ((Map<Direction, WireAttachmentType>) value).getOrDefault(dir, WireAttachmentTypes.NONE));
+            }
+        } else if (key == Keys.WIRE_ATTACHMENT_NORTH) {
+            map.put(Direction.NORTH, (WireAttachmentType) value);
+        } else if (key == Keys.WIRE_ATTACHMENT_SOUTH) {
+            map.put(Direction.SOUTH, (WireAttachmentType) value);
+        } else if (key == Keys.WIRE_ATTACHMENT_EAST) {
+            map.put(Direction.EAST, (WireAttachmentType) value);
+        } else if (key == Keys.WIRE_ATTACHMENT_WEST) {
+            map.put(Direction.WEST, (WireAttachmentType) value);
+        } else {
+            return Optional.empty();
+        }
+        return Optional.of(new ImmutableSpongeWireAttachmentData(map));
+    }
+
+    // This data only supports block states, which don't use DataProcessors.
+
+    @Override
+    public boolean supports(DataHolder dataHolder) {
+        return false;
+    }
+
+    @Override
+    public Optional<WireAttachmentData> from(DataHolder dataHolder) {
+        return Optional.empty();
+    }
+
+    @Override
+    public DataTransactionResult remove(DataHolder dataHolder) {
+        return DataTransactionResult.failNoData();
+    }
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/block/MixinBlockRedstoneWire.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/MixinBlockRedstoneWire.java
@@ -34,14 +34,19 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableConnectedDirectionData;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableRedstonePoweredData;
+import org.spongepowered.api.data.manipulator.immutable.block.ImmutableWireAttachmentData;
+import org.spongepowered.api.data.type.WireAttachmentType;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.common.data.ImmutableDataCachingUtil;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeConnectedDirectionData;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeRedstonePoweredData;
+import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeWireAttachmentData;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -50,12 +55,13 @@ public abstract class MixinBlockRedstoneWire extends MixinBlock {
 
     @Override
     public ImmutableList<ImmutableDataManipulator<?, ?>> getManipulators(IBlockState blockState) {
-        return ImmutableList.<ImmutableDataManipulator<?, ?>>of(getPowerFor(blockState), getConnectedDirectionData(blockState));
+        return ImmutableList.of(getPowerFor(blockState), getConnectedDirectionData(blockState), getWireAttachmentData(blockState));
     }
 
     @Override
     public boolean supports(Class<? extends ImmutableDataManipulator<?, ?>> immutable) {
-        return ImmutableRedstonePoweredData.class.isAssignableFrom(immutable) || ImmutableConnectedDirectionData.class.isAssignableFrom(immutable);
+        return ImmutableRedstonePoweredData.class.isAssignableFrom(immutable) || ImmutableConnectedDirectionData.class.isAssignableFrom(immutable)
+                || ImmutableWireAttachmentData.class.isAssignableFrom(immutable);
     }
 
     @Override
@@ -64,6 +70,9 @@ public abstract class MixinBlockRedstoneWire extends MixinBlock {
             return Optional.of((BlockState) blockState);
         }
         if (manipulator instanceof ImmutableConnectedDirectionData) {
+            return Optional.of((BlockState) blockState);
+        }
+        if (manipulator instanceof ImmutableWireAttachmentData) {
             return Optional.of((BlockState) blockState);
         }
         return super.getStateWithData(blockState, manipulator);
@@ -75,7 +84,9 @@ public abstract class MixinBlockRedstoneWire extends MixinBlock {
             return Optional.of((BlockState) blockState);
         }
         if (key.equals(Keys.CONNECTED_DIRECTIONS) || key.equals(Keys.CONNECTED_EAST) || key.equals(Keys.CONNECTED_NORTH)
-                || key.equals(Keys.CONNECTED_SOUTH) || key.equals(Keys.CONNECTED_WEST)) {
+                || key.equals(Keys.CONNECTED_SOUTH) || key.equals(Keys.CONNECTED_WEST) || key.equals(Keys.WIRE_ATTACHMENTS)
+                || key.equals(Keys.WIRE_ATTACHMENT_NORTH) || key.equals(Keys.WIRE_ATTACHMENT_SOUTH) || key.equals(Keys.WIRE_ATTACHMENT_EAST)
+                || key.equals(Keys.WIRE_ATTACHMENT_WEST)) {
             return Optional.of((BlockState) blockState);
         }
         return super.getStateWithValue(blockState, key, value);
@@ -104,5 +115,14 @@ public abstract class MixinBlockRedstoneWire extends MixinBlock {
             directions.add(Direction.SOUTH);
         }
         return ImmutableDataCachingUtil.getManipulator(ImmutableSpongeConnectedDirectionData.class, directions);
+    }
+
+    private ImmutableWireAttachmentData getWireAttachmentData(IBlockState blockState) {
+        Map<Direction, WireAttachmentType> data = new HashMap<>();
+        data.put(Direction.NORTH, (WireAttachmentType) (Object) blockState.getValue(BlockRedstoneWire.NORTH));
+        data.put(Direction.SOUTH, (WireAttachmentType) (Object) blockState.getValue(BlockRedstoneWire.SOUTH));
+        data.put(Direction.EAST, (WireAttachmentType) (Object) blockState.getValue(BlockRedstoneWire.EAST));
+        data.put(Direction.WEST, (WireAttachmentType) (Object) blockState.getValue(BlockRedstoneWire.WEST));
+        return new ImmutableSpongeWireAttachmentData(data);
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/data/types/MixinBlockRedstoneWireAttachPosition.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/data/types/MixinBlockRedstoneWireAttachPosition.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.data.types;
+
+import net.minecraft.block.BlockRedstoneWire;
+import org.spongepowered.api.data.type.WireAttachmentType;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Implements;
+import org.spongepowered.asm.mixin.Interface;
+import org.spongepowered.asm.mixin.Intrinsic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(BlockRedstoneWire.EnumAttachPosition.class)
+@Implements(@Interface(iface = WireAttachmentType.class, prefix = "type$"))
+public abstract class MixinBlockRedstoneWireAttachPosition implements WireAttachmentType {
+
+    @Shadow @Final private String name;
+
+    @Override
+    public String getId() {
+        return "minecraft:" + this.name;
+    }
+
+    @Intrinsic
+    public String type$getName() {
+        return this.name;
+    }
+}

--- a/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
@@ -473,6 +473,7 @@ public final class CommonModuleRegistry {
             .registerModule(StatisticType.class, new StatisticTypeRegistryModule())
             .registerModule(WallType.class, new WallTypeRegistryModule())
             .registerModule(Weather.class, new WeatherRegistryModule())
+            .registerModule(WireAttachmentType.class, new WireAttachmentRegistryModule())
             .registerModule(WorldGeneratorModifier.class, WorldGeneratorModifierRegistryModule.getInstance())
             .registerModule(TransactionType.class, new TransactionTypeRegistryModule())
             .registerModule(ChatVisibility.class, new ChatVisibilityRegistryModule())

--- a/src/main/java/org/spongepowered/common/registry/type/block/WireAttachmentRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/block/WireAttachmentRegistryModule.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.registry.type.block;
+
+import net.minecraft.block.BlockRedstoneWire;
+import org.spongepowered.api.data.type.WireAttachmentType;
+import org.spongepowered.api.data.type.WireAttachmentTypes;
+import org.spongepowered.common.registry.RegistryHelper;
+import org.spongepowered.common.registry.type.MinecraftEnumBasedCatalogTypeModule;
+
+public final class WireAttachmentRegistryModule extends MinecraftEnumBasedCatalogTypeModule<BlockRedstoneWire.EnumAttachPosition,
+        WireAttachmentType> {
+
+    @Override
+    protected BlockRedstoneWire.EnumAttachPosition[] getValues() {
+        return BlockRedstoneWire.EnumAttachPosition.values();
+    }
+
+    @Override
+    public void registerDefaults() {
+        RegistryHelper.mapFields(WireAttachmentTypes.class, this.catalogTypeMap);
+    }
+}

--- a/src/main/resources/META-INF/common_at.cfg
+++ b/src/main/resources/META-INF/common_at.cfg
@@ -11,6 +11,7 @@ public net.minecraft.block.BlockFlowerPot func_190951_a(Lnet/minecraft/item/Item
 public net.minecraft.block.BlockJukebox func_180678_e(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;)V # dropRecord
 public net.minecraft.block.BlockNote field_176434_a # INSTRUMENTS
 public net.minecraft.block.BlockRedstoneWire func_176343_a(Lnet/minecraft/block/state/IBlockState;Lnet/minecraft/util/EnumFacing;)Z # canConnectTo
+public net.minecraft.block.BlockRedstoneWire$EnumAttachPosition
 
 public net.minecraft.block.state.BlockStateContainer$StateImplementation
 
@@ -448,6 +449,7 @@ public-f org.spongepowered.api.data.type.StoneTypes *
 public-f org.spongepowered.api.data.type.StructureModes *
 public-f org.spongepowered.api.data.type.ToolTypes *
 public-f org.spongepowered.api.data.type.TreeTypes *
+public-f org.spongepowered.api.data.type.WireAttachmentTypes *
 public-f org.spongepowered.api.data.type.WallTypes *
 
 public-f org.spongepowered.api.effect.particle.ParticleOptions *

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -175,6 +175,7 @@
         "data.types.MixinBlockQuartzEnumType",
         "data.types.MixinBlockRailBaseEnumRailDirection",
         "data.types.MixinBlockRedstoneComparatorMode",
+        "data.types.MixinBlockRedstoneWireAttachPosition",
         "data.types.MixinBlockSandEnumType",
         "data.types.MixinBlockSandStoneEnumType",
         "data.types.MixinBlockSilverfishEnumType",


### PR DESCRIPTION
`WireAttachmentData` was partially implemented some time back. This should finish it.

Test code: (Drop this into a plugin. `source` should be a `Player`.)
```java
        source.getLocation().setBlock(BlockTypes.REDSTONE_WIRE.getDefaultState());
        ImmutableWireAttachmentData blockData = source.getLocation().getBlock().withExtendedProperties(source.getLocation())
                .get(ImmutableWireAttachmentData.class).get();
        source.sendMessage(Text.of("state: ", DataFormats.JSON.write(blockData.toContainer())));

        WireAttachmentData data = Sponge.getDataManager().getManipulatorBuilder(WireAttachmentData.class).get().create();
        data.set(Keys.WIRE_ATTACHMENT_NORTH, WireAttachmentTypes.SIDE);
        data.set(Keys.WIRE_ATTACHMENT_SOUTH, WireAttachmentTypes.UP);
        source.sendMessage(Text.of("individual set: ", DataFormats.JSON.write(data.toContainer())));

        data = Sponge.getDataManager().getManipulatorBuilder(WireAttachmentData.class).get().create();
        Map<Direction, WireAttachmentType> map = new HashMap<>();
        map.put(Direction.NORTH, WireAttachmentTypes.NONE);
        map.put(Direction.SOUTH, WireAttachmentTypes.SIDE);
        map.put(Direction.EAST, WireAttachmentTypes.UP);
        // skip west
        map.put(Direction.SOUTH_SOUTHEAST, WireAttachmentTypes.UP); // fake value
        data.set(Keys.WIRE_ATTACHMENTS, map);
        source.sendMessage(Text.of("bulk set: ", DataFormats.JSON.write(data.toContainer())));
```