### PR TITLE
Fix potential tab desync during login

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinPlayerList.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinPlayerList.java
@@ -801,7 +801,7 @@ public abstract class MixinPlayerList implements IMixinPlayerList {
                 viewer.connection.sendPacket(noSpecificViewerPacket);
             }
 
-            if (((Player) player).canSee((Player) viewer)) {
+            if (player == viewer || ((Player) player).canSee((Player) viewer)) {
                 player.connection.sendPacket(new SPacketPlayerListItem(SPacketPlayerListItem.Action.ADD_PLAYER, viewer));
             }
         }


### PR DESCRIPTION
A bit of context: We needed a quick fix for https://github.com/SpongePowered/SpongeCommon/issues/1880 so we created a new event (something like ClientConnectionEvent.Join.Pre) and we're firing it before `playerloggedin` https://github.com/SpongePowered/SpongeCommon/blob/2f855eea9052eb51b4e9e22399e8262e67e0aca8/src/main/java/org/spongepowered/common/mixin/core/server/MixinPlayerList.java#L349
(See the linked issue for additional info on the method)

Now keep in mind that even if you're in vanish and your name doesn't appear in other players' tab, you need an entry in your tab list or else you'd not be able to change gamemode (spectator wouldn't work for you), you'd get a steve skin (this is probably what dual was talking about) and all hell could break loose.

Here's the thing, playerloggedin is using `canSee` to send `SPacketPlayerListItem` (ADD_PLAYER) thus adding players to the tablist when you join the server. However if you are in vanish, `player.canSee(player)` is false and you're not added to your own tab.

https://github.com/SpongePowered/SpongeCommon/blob/2f855eea9052eb51b4e9e22399e8262e67e0aca8/src/main/java/org/spongepowered/common/mixin/core/server/MixinPlayerList.java#L802

As of now, this bug can't be reproduced (unless you play with tasks during the loginevent) but it's nonetheless a problem that should be addressed.

Note: I'm using `==` because the playerLoggedIn injection takes place after `this.playerEntityList.add(playerIn);` so player and viewer are the same object. Just let me know if you want me to use `equals` for whatever reason.