### PR TITLE
Implements @ContextValue annotation

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/data/item/ItemDyeColorDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/ItemDyeColorDataProcessor.java
@@ -59,6 +59,7 @@ public class ItemDyeColorDataProcessor extends AbstractItemSingleDataProcessor<D
         final Block block = Block.getBlockFromItem(item);
 
         return block.equals(Blocks.WOOL)
+                || block.equals(Blocks.STANDING_BANNER)
                 || block.equals(Blocks.STAINED_GLASS)
                 || block.equals(Blocks.CARPET)
                 || block.equals(Blocks.STAINED_GLASS_PANE)
@@ -74,7 +75,9 @@ public class ItemDyeColorDataProcessor extends AbstractItemSingleDataProcessor<D
 
     @Override
     protected boolean set(ItemStack container, DyeColor value) {
-        if(container.getItem().equals(Items.DYE)) {
+        Item item = container.getItem();
+
+        if(item.equals(Items.DYE) || item.equals(Items.BANNER)) {
             container.setItemDamage(((EnumDyeColor) (Object) value).getDyeDamage());
         } else {
             container.setItemDamage(((EnumDyeColor) (Object) value).getMetadata());
@@ -84,7 +87,9 @@ public class ItemDyeColorDataProcessor extends AbstractItemSingleDataProcessor<D
 
     @Override
     protected Optional<DyeColor> getVal(ItemStack container) {
-        if(container.getItem().equals(Items.DYE)) {
+        Item item = container.getItem();
+
+        if(item.equals(Items.DYE) || item.equals(Items.BANNER)) {
             return Optional.of((DyeColor) (Object) EnumDyeColor.byDyeDamage(container.getItemDamage()));
         }
         return Optional.of((DyeColor) (Object) EnumDyeColor.byMetadata(container.getItemDamage()));

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/ItemDyeColorDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/ItemDyeColorDataProcessor.java
@@ -59,7 +59,6 @@ public class ItemDyeColorDataProcessor extends AbstractItemSingleDataProcessor<D
         final Block block = Block.getBlockFromItem(item);
 
         return block.equals(Blocks.WOOL)
-                || block.equals(Blocks.STANDING_BANNER)
                 || block.equals(Blocks.STAINED_GLASS)
                 || block.equals(Blocks.CARPET)
                 || block.equals(Blocks.STAINED_GLASS_PANE)
@@ -75,9 +74,7 @@ public class ItemDyeColorDataProcessor extends AbstractItemSingleDataProcessor<D
 
     @Override
     protected boolean set(ItemStack container, DyeColor value) {
-        Item item = container.getItem();
-
-        if(item.equals(Items.DYE) || item.equals(Items.BANNER)) {
+        if(container.getItem().equals(Items.DYE)) {
             container.setItemDamage(((EnumDyeColor) (Object) value).getDyeDamage());
         } else {
             container.setItemDamage(((EnumDyeColor) (Object) value).getMetadata());
@@ -87,9 +84,7 @@ public class ItemDyeColorDataProcessor extends AbstractItemSingleDataProcessor<D
 
     @Override
     protected Optional<DyeColor> getVal(ItemStack container) {
-        Item item = container.getItem();
-
-        if(item.equals(Items.DYE) || item.equals(Items.BANNER)) {
+        if(container.getItem().equals(Items.DYE)) {
             return Optional.of((DyeColor) (Object) EnumDyeColor.byDyeDamage(container.getItemDamage()));
         }
         return Optional.of((DyeColor) (Object) EnumDyeColor.byMetadata(container.getItemDamage()));

--- a/src/main/java/org/spongepowered/common/event/filter/FilterGenerator.java
+++ b/src/main/java/org/spongepowered/common/event/filter/FilterGenerator.java
@@ -51,6 +51,7 @@ import org.spongepowered.api.event.filter.IsCancelled;
 import org.spongepowered.api.event.filter.cause.After;
 import org.spongepowered.api.event.filter.cause.All;
 import org.spongepowered.api.event.filter.cause.Before;
+import org.spongepowered.api.event.filter.cause.ContextValue;
 import org.spongepowered.api.event.filter.cause.First;
 import org.spongepowered.api.event.filter.cause.Last;
 import org.spongepowered.api.event.filter.cause.Root;
@@ -65,6 +66,7 @@ import org.spongepowered.common.event.filter.delegate.AfterCauseFilterSourceDele
 import org.spongepowered.common.event.filter.delegate.AllCauseFilterSourceDelegate;
 import org.spongepowered.common.event.filter.delegate.BeforeCauseFilterSourceDelegate;
 import org.spongepowered.common.event.filter.delegate.CancellationEventFilterDelegate;
+import org.spongepowered.common.event.filter.delegate.ContextValueFilterSourceDelegate;
 import org.spongepowered.common.event.filter.delegate.ExcludeSubtypeFilterDelegate;
 import org.spongepowered.common.event.filter.delegate.FilterDelegate;
 import org.spongepowered.common.event.filter.delegate.FirstCauseFilterSourceDelegate;
@@ -317,6 +319,7 @@ public class FilterGenerator {
         CAUSE_ALL(All.class),
         CAUSE_ROOT(Root.class),
         GETTER(Getter.class),
+        CONTEXT_VALUE(ContextValue.class)
         ;
 
         private final Class<? extends Annotation> cls;
@@ -347,6 +350,10 @@ public class FilterGenerator {
             if (this == GETTER) {
                 return new GetterFilterSourceDelegate((Getter) anno);
             }
+            if (this == CONTEXT_VALUE) {
+                return new ContextValueFilterSourceDelegate((ContextValue) anno);
+            }
+
             throw new UnsupportedOperationException();
         }
 

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/CauseFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/CauseFilterSourceDelegate.java
@@ -41,7 +41,7 @@ import java.lang.reflect.Parameter;
 public abstract class CauseFilterSourceDelegate implements ParameterFilterSourceDelegate {
 
     @Override
-    public Tuple<Integer, Integer> write(ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local) {
+    public Tuple<Integer, Integer> write(String name, ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local) {
         // Get the cause
         mv.visitVarInsn(ALOAD, 1);
         mv.visitMethodInsn(INVOKEINTERFACE, Type.getInternalName(Event.class), "getCause",

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/ContextFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/ContextFilterSourceDelegate.java
@@ -45,6 +45,9 @@ public abstract class ContextFilterSourceDelegate implements ParameterFilterSour
 
     @Override
     public Tuple<Integer, Integer> write(String name, ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local) {
+        this.createFields(cw);
+        this.writeCtor(name, cw, mv);
+
         // Get the context
         mv.visitVarInsn(ALOAD, 1);
         mv.visitMethodInsn(INVOKEINTERFACE, Type.getInternalName(Event.class), "getContext",

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/ContextFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/ContextFilterSourceDelegate.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.event.filter.delegate;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.EventContext;
+import org.spongepowered.api.util.Tuple;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
+
+public abstract class ContextFilterSourceDelegate implements ParameterFilterSourceDelegate {
+
+    @Override
+    public Tuple<Integer, Integer> write(ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local) {
+        // Get the context
+        mv.visitVarInsn(ALOAD, 1);
+        mv.visitMethodInsn(INVOKEINTERFACE, Type.getInternalName(Event.class), "getContext",
+                "()" + Type.getDescriptor(EventContext.class), true);
+
+        Class<?> targetType = param.getType();
+
+        insertContextCall(mv, param, targetType, local);
+        int paramLocal = local + 2;
+        mv.visitVarInsn(ASTORE, paramLocal);
+
+        insertTransform(mv, param, targetType, paramLocal);
+
+        return new Tuple<>(local, paramLocal);
+    }
+
+    protected abstract void insertContextCall(MethodVisitor mv, Parameter param, Class<?> targetType, int local);
+
+    protected abstract void insertTransform(MethodVisitor mv, Parameter param, Class<?> targetType, int local);
+}

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/ContextFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/ContextFilterSourceDelegate.java
@@ -28,7 +28,6 @@ import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
 import org.spongepowered.api.event.Event;
-import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.EventContext;
 import org.spongepowered.api.util.Tuple;
 
@@ -50,8 +49,8 @@ public abstract class ContextFilterSourceDelegate implements ParameterFilterSour
 
         Class<?> targetType = param.getType();
 
-        insertContextCall(mv, param, targetType, local);
-        int paramLocal = local + 2;
+        insertContextCall(mv, param, targetType);
+        int paramLocal = local++;
         mv.visitVarInsn(ASTORE, paramLocal);
 
         insertTransform(mv, param, targetType, paramLocal);
@@ -59,7 +58,7 @@ public abstract class ContextFilterSourceDelegate implements ParameterFilterSour
         return new Tuple<>(local, paramLocal);
     }
 
-    protected abstract void insertContextCall(MethodVisitor mv, Parameter param, Class<?> targetType, int local);
+    protected abstract void insertContextCall(MethodVisitor mv, Parameter param, Class<?> targetType);
 
     protected abstract void insertTransform(MethodVisitor mv, Parameter param, Class<?> targetType, int local);
 }

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/ContextFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/ContextFilterSourceDelegate.java
@@ -40,8 +40,11 @@ import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
 
 public abstract class ContextFilterSourceDelegate implements ParameterFilterSourceDelegate {
 
+    public abstract void createFields(ClassWriter cw);
+    public abstract void writeCtor(String name, ClassWriter cw, MethodVisitor mv);
+
     @Override
-    public Tuple<Integer, Integer> write(ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local) {
+    public Tuple<Integer, Integer> write(String name, ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local) {
         // Get the context
         mv.visitVarInsn(ALOAD, 1);
         mv.visitMethodInsn(INVOKEINTERFACE, Type.getInternalName(Event.class), "getContext",
@@ -49,7 +52,7 @@ public abstract class ContextFilterSourceDelegate implements ParameterFilterSour
 
         Class<?> targetType = param.getType();
 
-        insertContextCall(mv, param, targetType);
+        insertContextCall(name, mv, param, targetType);
         int paramLocal = local++;
         mv.visitVarInsn(ASTORE, paramLocal);
 
@@ -58,7 +61,7 @@ public abstract class ContextFilterSourceDelegate implements ParameterFilterSour
         return new Tuple<>(local, paramLocal);
     }
 
-    protected abstract void insertContextCall(MethodVisitor mv, Parameter param, Class<?> targetType);
+    protected abstract void insertContextCall(String name, MethodVisitor mv, Parameter param, Class<?> targetType);
 
     protected abstract void insertTransform(MethodVisitor mv, Parameter param, Class<?> targetType, int local);
 }

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/ContextValueFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/ContextValueFilterSourceDelegate.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.event.filter.delegate;
+
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+import org.spongepowered.api.event.cause.EventContext;
+import org.spongepowered.api.event.filter.cause.ContextValue;
+
+import java.lang.reflect.Parameter;
+
+import static org.objectweb.asm.Opcodes.ACONST_NULL;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.GOTO;
+import static org.objectweb.asm.Opcodes.IFEQ;
+import static org.objectweb.asm.Opcodes.IFNE;
+import static org.objectweb.asm.Opcodes.INSTANCEOF;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+
+public class ContextValueFilterSourceDelegate extends ContextFilterSourceDelegate {
+
+    private final ContextValue anno;
+
+    public ContextValueFilterSourceDelegate(ContextValue anno) {
+        this.anno = anno;
+    }
+
+    @Override
+    protected void insertContextCall(MethodVisitor mv, Parameter param, Class<?> targetType, int local) {
+        // Sponge.getRegistry().getType(EventContextKey.class, anno.value()).get())
+
+        mv.visitMethodInsn(INVOKEVIRTUAL, Type.getInternalName(EventContext.class), "get",
+                "()Ljava/lang/Object;", false);
+    }
+
+    @Override
+    protected void insertTransform(MethodVisitor mv, Parameter param, Class<?> targetType, int local) {
+        Label failure = new Label();
+        Label success = new Label();
+
+        mv.visitVarInsn(ALOAD, local);
+        mv.visitTypeInsn(INSTANCEOF, Type.getInternalName(targetType));
+
+        if (this.anno.typeFilter().length != 0) {
+            mv.visitJumpInsn(IFEQ, failure);
+            mv.visitVarInsn(ALOAD, local);
+            // For each type we do an instance check and jump to either failure or success if matched
+            for (int i = 0; i < this.anno.typeFilter().length; i++) {
+                Class<?> filter = this.anno.typeFilter()[i];
+                if (i < this.anno.typeFilter().length - 1) {
+                    mv.visitInsn(DUP);
+                }
+                mv.visitTypeInsn(INSTANCEOF, Type.getInternalName(filter));
+                if (this.anno.inverse()) {
+                    mv.visitJumpInsn(IFNE, failure);
+                } else {
+                    mv.visitJumpInsn(IFNE, success);
+                }
+            }
+            if (this.anno.inverse()) {
+                mv.visitJumpInsn(GOTO, success);
+            }
+            // If the annotation was not reversed then we fall into failure as no types were matched
+        } else {
+            mv.visitJumpInsn(IFNE, success);
+        }
+        mv.visitLabel(failure);
+        mv.visitInsn(ACONST_NULL);
+        mv.visitInsn(ARETURN);
+
+        mv.visitLabel(success);
+    }
+}

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/GetterFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/GetterFilterSourceDelegate.java
@@ -58,7 +58,7 @@ public class GetterFilterSourceDelegate implements ParameterFilterSourceDelegate
     }
 
     @Override
-    public Tuple<Integer, Integer> write(ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local) {
+    public Tuple<Integer, Integer> write(String name, ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local) {
         Class<?> targetType = param.getType();
         Class<?> eventClass = method.getParameterTypes()[0];
         String targetMethod = this.anno.value();

--- a/src/main/java/org/spongepowered/common/event/filter/delegate/ParameterFilterSourceDelegate.java
+++ b/src/main/java/org/spongepowered/common/event/filter/delegate/ParameterFilterSourceDelegate.java
@@ -33,5 +33,5 @@ import java.lang.reflect.Parameter;
 
 public interface ParameterFilterSourceDelegate {
 
-    Tuple<Integer, Integer> write(ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local);
+    Tuple<Integer, Integer> write(String name, ClassWriter cw, MethodVisitor mv, Method method, Parameter param, int local);
 }

--- a/src/test/java/org/spongepowered/common/event/listener/ContextValueListener.java
+++ b/src/test/java/org/spongepowered/common/event/listener/ContextValueListener.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.event.listener;
+
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.filter.cause.ContextValue;
+import org.spongepowered.common.event.EventFilterTest;
+
+public class ContextValueListener {
+
+    public boolean contextListenerCalled;
+    public boolean contextListenerCalledInc;
+    public boolean contextListenerCalledEx;
+
+    @Listener
+    public void contextListener(EventFilterTest.SubEvent event,
+            @ContextValue("OWNER") User user) {
+
+        this.contextListenerCalled = true;
+    }
+
+    @Listener
+    public void contextListenerInclude(EventFilterTest.SubEvent event,
+            @ContextValue(value = "OWNER", typeFilter = User.class) Object user) {
+
+        this.contextListenerCalledInc = true;
+    }
+
+    @Listener
+    public void contextListenerExclude(EventFilterTest.SubEvent event,
+            @ContextValue(value = "OWNER", typeFilter = User.class, inverse = true) Object user) {
+
+        this.contextListenerCalledEx = true;
+    }
+
+}


### PR DESCRIPTION
The `@ContextValue` annotation for event parameters is now fully implemented, example code:

```java
@Listener
public void onEntitySpawn(SpawnEntityEvent event,
                          @ContextValue("SPAWN_TYPE") SpawnType type) {

    logger.info(type.getName());
}
```