### PR TITLE
Improve the way Sponge configuration files are loaded/saved

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeImpl.java
+++ b/src/main/java/org/spongepowered/common/SpongeImpl.java
@@ -196,7 +196,7 @@ public final class SpongeImpl {
 
     public static SpongeConfig<GlobalConfig> getGlobalConfig() {
         if (globalConfig == null) {
-            globalConfig = new SpongeConfig<>(GLOBAL, getSpongeConfigDir().resolve("global.conf"), ECOSYSTEM_ID);
+            globalConfig = new SpongeConfig<>(GLOBAL, getSpongeConfigDir().resolve("global.conf"), ECOSYSTEM_ID, null);
         }
 
         return globalConfig;
@@ -204,7 +204,7 @@ public final class SpongeImpl {
 
     public static SpongeConfig<CustomDataConfig> getDataConfig() {
         if (customDataConfig == null) {
-            customDataConfig = new SpongeConfig<>(CUSTOM_DATA, getSpongeConfigDir().resolve("custom_data.conf"), ECOSYSTEM_ID);
+            customDataConfig = new SpongeConfig<>(CUSTOM_DATA, getSpongeConfigDir().resolve("custom_data.conf"), ECOSYSTEM_ID, null);
         }
         return customDataConfig;
     }

--- a/src/main/java/org/spongepowered/common/config/SpongeConfig.java
+++ b/src/main/java/org/spongepowered/common/config/SpongeConfig.java
@@ -25,13 +25,16 @@
 package org.spongepowered.common.config;
 
 import com.google.common.reflect.TypeToken;
+import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
+import ninja.leaping.configurate.ValueType;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMapper;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializers;
+import ninja.leaping.configurate.util.ConfigurationNodeWalker;
 import org.spongepowered.api.util.Functional;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.config.type.ConfigBase;
@@ -44,8 +47,12 @@ import org.spongepowered.common.util.IpSet;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
+
+import javax.annotation.Nullable;
 
 public class SpongeConfig<T extends ConfigBase> {
 
@@ -70,18 +77,48 @@ public class SpongeConfig<T extends ConfigBase> {
             + "# IRC: #sponge @ irc.esper.net ( https://webchat.esper.net/?channel=sponge )\n"
             + "# Forums: https://forums.spongepowered.org/\n";
 
+    private static final ConfigurationOptions LOADER_OPTIONS = ConfigurationOptions.defaults()
+            .setHeader(HEADER)
+            .setSerializers(TypeSerializers.getDefaultSerializers().newChild()
+                    .registerType(TypeToken.of(IpSet.class), new IpSet.IpSetSerializer())
+            );
+
+    /**
+     * The type of this config instance
+     */
     private final Type type;
+
+    /**
+     * The parent configuration - values are inherited from this
+     */
+    @Nullable private final SpongeConfig<?> parent;
+
+    /**
+     * The loader (mapped to a file) used to read/write the config to disk
+     */
     private HoconConfigurationLoader loader;
-    private CommentedConfigurationNode root = SimpleCommentedConfigurationNode.root(ConfigurationOptions.defaults()
-            .setHeader(HEADER));
+
+    /**
+     * A node representation of "whats actually in the file".
+     */
+    private CommentedConfigurationNode fileData = SimpleCommentedConfigurationNode.root(LOADER_OPTIONS);
+
+    /**
+     * A node representation of {@link #fileData}, merged with the data of {@link #parent}.
+     */
+    private CommentedConfigurationNode data = SimpleCommentedConfigurationNode.root(LOADER_OPTIONS);
+
+    /**
+     * The mapper instance used to populate the config instance
+     */
     private ObjectMapper<T>.BoundInstance configMapper;
-    private T configBase;
+
     private final String modId;
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public SpongeConfig(Type type, Path path, String modId) {
-
+    public SpongeConfig(Type type, Path path, String modId, SpongeConfig<?> parent) {
         this.type = type;
+        this.parent = parent;
         this.modId = modId;
 
         try {
@@ -101,7 +138,7 @@ public class SpongeConfig<T extends ConfigBase> {
     }
 
     public T getConfig() {
-        return this.configBase;
+        return this.configMapper.getInstance();
     }
 
     public void save() {
@@ -110,8 +147,20 @@ public class SpongeConfig<T extends ConfigBase> {
 
     public boolean saveNow() {
         try {
-            this.configMapper.serialize(this.root.getNode(this.modId));
-            this.loader.save(this.root);
+            // save from the mapped object --> node
+            CommentedConfigurationNode saveNode = SimpleCommentedConfigurationNode.root(LOADER_OPTIONS);
+            this.configMapper.serialize(saveNode.getNode(this.modId));
+
+            // before saving this config, remove any values already declared with the same value on the parent
+            if (this.parent != null) {
+                removeDuplicates(saveNode);
+            }
+
+            // merge the values we need to write with the ones already declared in the file
+            saveNode.mergeValuesFrom(this.fileData);
+
+            // save the data to disk
+            this.loader.save(saveNode);
             return true;
         } catch (IOException | ObjectMappingException e) {
             SpongeImpl.getLogger().error("Failed to save configuration", e);
@@ -127,13 +176,112 @@ public class SpongeConfig<T extends ConfigBase> {
         }
 
         try {
-            this.root = this.loader.load(ConfigurationOptions.defaults()
-                    .setSerializers(
-                            TypeSerializers.getDefaultSerializers().newChild().registerType(TypeToken.of(IpSet.class), new IpSet.IpSetSerializer()))
-                    .setHeader(HEADER));
-            this.configBase = this.configMapper.populate(this.root.getNode(this.modId));
+            // load settings from file
+            CommentedConfigurationNode loadedNode = this.loader.load();
+
+            // attempt to strip duplicate settings from the file
+            // (this only happens on the first pass of the file - see javadocs below)
+            if (cleanupConfig(loadedNode)) {
+                this.loader.save(loadedNode);
+            }
+
+            // store "what's in the file" separately in memory
+            this.fileData = loadedNode;
+
+            // make a copy of the file data
+            this.data = this.fileData.copy();
+
+            // merge with settings from parent
+            if (this.parent != null) {
+                this.data.mergeValuesFrom(this.parent.data);
+            }
+
+            // populate the config object
+            populateInstance();
         } catch (Exception e) {
             SpongeImpl.getLogger().error("Failed to load configuration", e);
+        }
+    }
+
+    private void populateInstance() throws ObjectMappingException {
+        this.configMapper.populate(this.data.getNode(this.modId));
+    }
+
+    /**
+     * Performs a cleanup operation on the given configuration node, taking into
+     * account the legacy 'config-enabled' setting.
+     *
+     * See: https://github.com/SpongePowered/SpongeCommon/pull/1957#issuecomment-400761641
+     *
+     * @param root The node to cleanup
+     * @return If the cleanup was able to occur, depending on the state of the 'config-enabled' setting
+     */
+    private boolean cleanupConfig(CommentedConfigurationNode root) {
+        // we can't strip values from the global config, there won't be any duplicates there
+        if (this.parent == null) {
+            return false;
+        }
+
+        ConfigurationNode configEnabled = root.getNode(this.modId, "config-enabled");
+
+        // if the node is missing, don't strip anything from the file
+        // (this ensures the migration only happens on the first pass)
+        if (configEnabled.isVirtual()) {
+            return false;
+        }
+
+        boolean enabled = configEnabled.getBoolean(true);
+
+        // remove the enabled property so migration doesn't happen again
+        configEnabled.setValue(null);
+
+        if (!enabled) {
+            // config wasn't enabled, just clear it
+            // (we don't wish to take account for any of the settings defined here)
+            root.getNode(this.modId).setValue(null);
+        } else {
+            // config was enabled, but we want to strip out duplicated values
+            // but keep any overrides
+            removeDuplicates(root);
+        }
+
+        return true;
+    }
+
+    /**
+     * Traverses the given {@code root} config node, removing any values which
+     * are also present and set to the same value on this configs "parent".
+     *
+     * @param root The node to process
+     */
+    private void removeDuplicates(CommentedConfigurationNode root) {
+        if (this.parent == null) {
+            throw new IllegalStateException("parent is null");
+        }
+
+        Iterator<ConfigurationNodeWalker.VisitedNode<CommentedConfigurationNode>> it = ConfigurationNodeWalker.DEPTH_FIRST_POST_ORDER.walkWithPath(root);
+        while (it.hasNext()) {
+            ConfigurationNodeWalker.VisitedNode<CommentedConfigurationNode> next = it.next();
+            CommentedConfigurationNode node = next.getNode();
+
+            // remove empty maps
+            if (node.hasMapChildren()) {
+                if (node.getChildrenMap().isEmpty()) {
+                    node.setValue(null);
+                }
+                continue;
+            }
+
+            // ignore list values
+            if (node.getParent() != null && node.getParent().getValueType() == ValueType.LIST) {
+                continue;
+            }
+
+            // if the node already exists in the parent config, remove it
+            CommentedConfigurationNode parentValue = this.parent.data.getNode(next.getPath().getArray());
+            if (Objects.equals(node.getValue(), parentValue.getValue())) {
+                node.setValue(null);
+            }
         }
     }
 
@@ -141,16 +289,17 @@ public class SpongeConfig<T extends ConfigBase> {
         return Functional.asyncFailableFuture(() -> {
             CommentedConfigurationNode upd = getSetting(key);
             upd.setValue(value);
-            this.configBase = this.configMapper.populate(this.root.getNode(this.modId));
-            this.loader.save(this.root);
+            populateInstance();
+            saveNow();
             return upd;
         }, ForkJoinPool.commonPool());
     }
 
     public CommentedConfigurationNode getRootNode() {
-        return this.root.getNode(this.modId);
+        return this.data.getNode(this.modId);
     }
 
+    @Nullable
     public CommentedConfigurationNode getSetting(String key) {
         if (key.equalsIgnoreCase("config-enabled")) {
             return getRootNode().getNode(key);
@@ -159,7 +308,7 @@ public class SpongeConfig<T extends ConfigBase> {
         } else {
             String category = key.substring(0, key.indexOf('.'));
             String prop = key.substring(key.indexOf('.') + 1);
-            return getRootNode().getNode(category).getNode(prop);
+            return getRootNode().getNode(category, prop);
         }
     }
 

--- a/src/main/java/org/spongepowered/common/config/type/GeneralConfigBase.java
+++ b/src/main/java/org/spongepowered/common/config/type/GeneralConfigBase.java
@@ -42,9 +42,6 @@ public class GeneralConfigBase extends ConfigBase {
 
     @Setting
     protected WorldCategory world = new WorldCategory();
-    @Setting(value = "config-enabled", comment = "This setting does nothing in the global config. In dimension/world configs, it allows the config \n"
-                                               + "to override config(s) that it inherits from")
-    protected boolean configEnabled = false;
     @Setting(value = "block-tracking")
     private BlockTrackingCategory blockTracking = new BlockTrackingCategory();
     @Setting(value = "block-capturing")
@@ -115,13 +112,5 @@ public class GeneralConfigBase extends ConfigBase {
 
     public TimingsCategory getTimings() {
         return this.timings;
-    }
-
-    public boolean isConfigEnabled() {
-        return this.configEnabled;
-    }
-
-    public void setConfigEnabled(boolean configEnabled) {
-        this.configEnabled = configEnabled;
     }
 }

--- a/src/main/java/org/spongepowered/common/config/type/GlobalConfig.java
+++ b/src/main/java/org/spongepowered/common/config/type/GlobalConfig.java
@@ -141,12 +141,6 @@ public class GlobalConfig extends GeneralConfigBase {
         return this.world;
     }
 
-    @Override
-    public boolean isConfigEnabled() {
-        // always return true as there is only 1 global config
-        return true;
-    }
-
     public PhaseTrackerCategory getPhaseTracker() {
         return this.causeTracker;
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinDimensionType.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinDimensionType.java
@@ -71,7 +71,7 @@ public abstract class MixinDimensionType implements IMixinDimensionType {
         this.enumName = dimName;
         this.modId = SpongeImplHooks.getModIdFromClass(clazzIn);
         this.configPath = SpongeImpl.getSpongeConfigDir().resolve("worlds").resolve(this.modId).resolve(this.enumName);
-        this.config = new SpongeConfig<>(SpongeConfig.Type.DIMENSION, this.configPath.resolve("dimension.conf"), SpongeImpl.ECOSYSTEM_ID);
+        this.config = new SpongeConfig<>(SpongeConfig.Type.DIMENSION, this.configPath.resolve("dimension.conf"), SpongeImpl.ECOSYSTEM_ID, SpongeImpl.getGlobalConfig());
         this.generateSpawnOnLoad = idIn == 0;
         this.loadSpawn = this.generateSpawnOnLoad;
         this.config.getConfig().getWorld().setGenerateSpawnOnLoad(this.generateSpawnOnLoad);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinWorldInfo.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinWorldInfo.java
@@ -246,7 +246,8 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
                 new SpongeConfig<>(SpongeConfig.Type.WORLD, ((IMixinDimensionType) this.dimensionType).getConfigPath()
                                 .resolve(this.levelName)
                                 .resolve("world.conf"),
-                        SpongeImpl.ECOSYSTEM_ID);
+                        SpongeImpl.ECOSYSTEM_ID,
+                        ((IMixinDimensionType) getDimensionType()).getDimensionConfig());
         return true;
     }
 
@@ -603,17 +604,7 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
 
     @Override
     public boolean isEnabled() {
-        boolean isEnabled = true;
-        if (!this.getOrCreateWorldConfig().getConfig().isConfigEnabled()) {
-            DimensionConfig dimConfig = ((IMixinDimensionType) this.dimensionType).getDimensionConfig().getConfig();
-            if (dimConfig.isConfigEnabled()) {
-                isEnabled = dimConfig.getWorld().isWorldEnabled();
-            }
-        } else {
-            isEnabled = this.getOrCreateWorldConfig().getConfig().getWorld().isWorldEnabled();
-        }
-
-        return isEnabled;
+        return this.getOrCreateWorldConfig().getConfig().getWorld().isWorldEnabled();
     }
 
     @Override
@@ -623,17 +614,7 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
 
     @Override
     public boolean loadOnStartup() {
-        Boolean loadOnStartup;
-        if (!this.getOrCreateWorldConfig().getConfig().isConfigEnabled()) {
-            DimensionConfig dimConfig = ((IMixinDimensionType) this.dimensionType).getDimensionConfig().getConfig();
-            if (dimConfig.isConfigEnabled()) {
-                loadOnStartup = dimConfig.getWorld().loadOnStartup();
-            } else {
-                loadOnStartup = this.getOrCreateWorldConfig().getConfig().getWorld().loadOnStartup();
-            }
-        } else {
-            loadOnStartup = this.getOrCreateWorldConfig().getConfig().getWorld().loadOnStartup();
-        }
+        Boolean loadOnStartup = this.getOrCreateWorldConfig().getConfig().getWorld().loadOnStartup();
         if (loadOnStartup == null) {
            loadOnStartup = ((IMixinDimensionType) this.dimensionType).shouldGenerateSpawnOnLoad();
            this.setLoadOnStartup(loadOnStartup);
@@ -654,23 +635,10 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
 
     @Override
     public boolean doesKeepSpawnLoaded() {
-        Boolean keepSpawnLoaded;
-        // World config isn't enabled
-        if (!this.getOrCreateWorldConfig().getConfig().isConfigEnabled()) {
-            DimensionConfig dimConfig = ((IMixinDimensionType) this.dimensionType).getDimensionConfig().getConfig();
-            if (dimConfig.isConfigEnabled()) {
-                keepSpawnLoaded = dimConfig.getWorld().getKeepSpawnLoaded();
-            } else {
-                keepSpawnLoaded = this.getOrCreateWorldConfig().getConfig().getWorld().getKeepSpawnLoaded();
-            }
-        } else {
-            keepSpawnLoaded = this.getOrCreateWorldConfig().getConfig().getWorld().getKeepSpawnLoaded();
-        }
-
+        Boolean keepSpawnLoaded = this.getOrCreateWorldConfig().getConfig().getWorld().getKeepSpawnLoaded();
         if (keepSpawnLoaded == null) {
             keepSpawnLoaded = ((IMixinDimensionType) this.dimensionType).shouldLoadSpawn();
         }
-
         return keepSpawnLoaded;
     }
 
@@ -682,17 +650,7 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
 
     @Override
     public boolean doesGenerateSpawnOnLoad() {
-        Boolean shouldGenerateSpawn;
-        if (!this.getOrCreateWorldConfig().getConfig().isConfigEnabled()) {
-            DimensionConfig dimConfig = ((IMixinDimensionType) this.dimensionType).getDimensionConfig().getConfig();
-            if (dimConfig.isConfigEnabled()) {
-                shouldGenerateSpawn = dimConfig.getWorld().getGenerateSpawnOnLoad();
-            } else {
-                shouldGenerateSpawn = this.getOrCreateWorldConfig().getConfig().getWorld().getGenerateSpawnOnLoad();
-            }
-        } else {
-            shouldGenerateSpawn = this.getOrCreateWorldConfig().getConfig().getWorld().getGenerateSpawnOnLoad();
-        }
+        Boolean shouldGenerateSpawn = this.getOrCreateWorldConfig().getConfig().getWorld().getGenerateSpawnOnLoad();
         if (shouldGenerateSpawn == null) {
             shouldGenerateSpawn = ((IMixinDimensionType) this.dimensionType).shouldGenerateSpawnOnLoad();
             this.setGenerateSpawnOnLoad(shouldGenerateSpawn);
@@ -708,7 +666,7 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
 
     @Override
     public boolean isPVPEnabled() {
-        return !this.getOrCreateWorldConfig().getConfig().isConfigEnabled() || this.getOrCreateWorldConfig().getConfig().getWorld().getPVPEnabled();
+        return this.getOrCreateWorldConfig().getConfig().getWorld().getPVPEnabled();
     }
 
     @Override
@@ -916,8 +874,6 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
     }
 
     private void saveConfig() {
-        if (this.getOrCreateWorldConfig().getConfig().isConfigEnabled()) {
-            this.getOrCreateWorldConfig().save();
-        }
+        this.getOrCreateWorldConfig().save();
     }
 }

--- a/src/main/java/org/spongepowered/common/util/SpongeHooks.java
+++ b/src/main/java/org/spongepowered/common/util/SpongeHooks.java
@@ -441,15 +441,7 @@ public class SpongeHooks {
         final IMixinWorldServer mixinWorldServer = (IMixinWorldServer) world;
         SpongeConfig<? extends GeneralConfigBase> activeConfig = mixinWorldServer.getActiveConfig();
         if (activeConfig == null || refresh) {
-            final SpongeConfig<WorldConfig> worldConfig = mixinWorldServer.getWorldConfig();
-            final SpongeConfig<DimensionConfig> dimensionConfig = ((IMixinDimensionType) ((Dimension) world.provider).getType()).getDimensionConfig();
-            if (worldConfig != null && worldConfig.getConfig().isConfigEnabled()) {
-                activeConfig = worldConfig;
-            } else if (dimensionConfig != null && dimensionConfig.getConfig().isConfigEnabled()) {
-                activeConfig = dimensionConfig;
-            } else {
-                activeConfig = SpongeImpl.getGlobalConfig();
-            }
+            activeConfig = mixinWorldServer.getWorldConfig();
             mixinWorldServer.setActiveConfig(activeConfig);
         }
 
@@ -477,23 +469,14 @@ public class SpongeHooks {
 
         // No in-memory config objects, lookup from disk.
         final Path dimConfPath = dimensionPath.resolve("dimension.conf");
+        final SpongeConfig<DimensionConfig> dimConfig = new SpongeConfig<>(SpongeConfig.Type.DIMENSION, dimConfPath, SpongeImpl.ECOSYSTEM_ID, SpongeImpl.getGlobalConfig());
 
         if (worldFolder != null) {
             final Path worldConfPath = dimensionPath.resolve(worldFolder).resolve("world.conf");
-
-            final SpongeConfig<WorldConfig> worldConfig = new SpongeConfig<>(SpongeConfig.Type.WORLD, worldConfPath, SpongeImpl.ECOSYSTEM_ID);
-            if (worldConfig.getConfig().isConfigEnabled()) {
-                return worldConfig;
-            }
+            return new SpongeConfig<>(SpongeConfig.Type.WORLD, worldConfPath, SpongeImpl.ECOSYSTEM_ID, dimConfig);
         }
 
-        final SpongeConfig<DimensionConfig> dimConfig = new SpongeConfig<>(SpongeConfig.Type.DIMENSION, dimConfPath, SpongeImpl.ECOSYSTEM_ID);
-        if (dimConfig.getConfig().isConfigEnabled()) {
-            return dimConfig;
-        }
-
-        // Neither in-memory or on-disk enabled configs. Go global.
-        return SpongeImpl.getGlobalConfig();
+        return dimConfig;
     }
 
     public static void refreshActiveConfigs() {


### PR DESCRIPTION
* World and dimension configurations are now merged with their "parent" config on load
* Each value within a config file is not written to the file if the setting is also present in the parent config with the same value
* The 'config-enabled' property is no longer needed, values from world/dimension configs will always override.