### PR TITLE
Fixes EntityArchetype deserialization error

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -42,6 +42,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.*;
 import org.spongepowered.api.data.manipulator.mutable.item.*;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.*;
 import org.spongepowered.api.effect.potion.PotionEffect;
+import org.spongepowered.api.entity.EntityArchetype;
 import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
 import org.spongepowered.api.item.enchantment.Enchantment;
 import org.spongepowered.api.data.meta.PatternLayer;
@@ -76,6 +77,7 @@ import org.spongepowered.common.data.builder.manipulator.InvisibilityDataAddVani
 import org.spongepowered.common.data.builder.manipulator.immutable.block.ImmutableSpongeTreeDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.immutable.item.ImmutableItemEnchantmentDataBuilder;
 import org.spongepowered.common.effect.potion.PotionEffectContentUpdater;
+import org.spongepowered.common.entity.SpongeEntityArchetypeBuilder;
 import org.spongepowered.common.extra.fluid.SpongeFluidStackSnapshotBuilder;
 import org.spongepowered.common.item.enchantment.SpongeEnchantmentBuilder;
 import org.spongepowered.common.data.builder.meta.SpongePatternLayerBuilder;
@@ -159,6 +161,7 @@ public class DataRegistrar {
 
         // Entity stuff
         dataManager.registerBuilder(EntitySnapshot.class, new SpongeEntitySnapshotBuilder());
+        dataManager.registerBuilder(EntityArchetype.class, new SpongeEntityArchetypeBuilder());
 
         // ItemStack stuff
         dataManager.registerBuilder(ItemStack.class, new SpongeItemStackBuilder());


### PR DESCRIPTION
Fixes this: https://github.com/SpongePowered/SpongeCommon/issues/1964

Test code:
```java
        StringWriter stringWriter = new StringWriter();
        YAMLConfigurationLoader build = YAMLConfigurationLoader.builder()
                .setSink(() -> new BufferedWriter(stringWriter))
                .setSource(() -> new BufferedReader(new StringReader("")))
                .build();
        ConfigurationNode load1 = build.load();
        load1.getNode("key").setValue(TypeToken.of(EntityArchetype.class), EntityArchetype.of(EntityTypes.VILLAGER));
        build.save(load1);
        BufferedReader reader = new BufferedReader(new StringReader(stringWriter.toString()));
        YAMLConfigurationLoader build2 = YAMLConfigurationLoader.builder()
                .setSink(() -> new BufferedWriter(new StringWriter()))
                .setSource(() -> reader)
                .build();
        ConfigurationNode load2 = build2.load();
        System.out.println(load2.getNode("key").getValue(TypeToken.of(EntityArchetype.class)));
        System.out.println("==================");
```

Not tested, but should work.