### PR TITLE
Improve ManipulatorTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,8 @@ dependencies {
     }
 
     testCompile 'org.spongepowered:lwts:1.0.0'
+    // Taken from https://stackoverflow.com/a/7969292
+    testCompile api.sourceSets.test.output
 }
 
 uploadArchives {

--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -57,6 +57,7 @@ import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidItemData;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.item.merchant.TradeOffer;
 import org.spongepowered.api.profile.GameProfile;
 import org.spongepowered.api.text.BookView;
 import org.spongepowered.api.text.Text;
@@ -125,6 +126,7 @@ import org.spongepowered.common.effect.particle.SpongeParticleEffectBuilder;
 import org.spongepowered.common.entity.SpongeEntitySnapshotBuilder;
 import org.spongepowered.common.item.inventory.SpongeItemStackBuilder;
 import org.spongepowered.common.item.inventory.ItemStackSnapshotDuplicateManipulatorUpdater;
+import org.spongepowered.common.item.merchant.SpongeTradeOfferBuilder;
 import org.spongepowered.common.world.SpongeLocatableBlockBuilder;
 import org.spongepowered.common.world.storage.SpongePlayerData;
 
@@ -193,6 +195,7 @@ public class DataRegistrar {
         dataManager.registerBuilder(GameProfile.class, new SpongeGameProfileBuilder());
 
         dataManager.registerBuilder(Color.class, new Color.Builder());
+        dataManager.registerBuilder(TradeOffer.class, new SpongeTradeOfferBuilder());
 
         dataManager.registerBuilder(PotionEffect.class, new SpongePotionBuilder());
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeTradeOfferData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeTradeOfferData.java
@@ -37,20 +37,12 @@ import java.util.List;
 
 public class SpongeTradeOfferData extends AbstractListData<TradeOffer, TradeOfferData, ImmutableTradeOfferData> implements TradeOfferData {
 
-    private List<TradeOffer> offers = Lists.newArrayList();
-
     public SpongeTradeOfferData() {
         this(Lists.newArrayList());
     }
 
     public SpongeTradeOfferData(List<TradeOffer> tradeOffers) {
         super(TradeOfferData.class, tradeOffers, Keys.TRADE_OFFERS, ImmutableSpongeTradeOfferData.class);
-    }
-
-    @Override
-    public DataContainer toContainer() {
-        return super.toContainer()
-            .set(Keys.TRADE_OFFERS.getQuery(), this.offers);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/item/SpongeFireworkEffect.java
+++ b/src/main/java/org/spongepowered/common/item/SpongeFireworkEffect.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.util.Color;
 import org.spongepowered.common.data.util.DataQueries;
 
 import java.util.List;
+import java.util.Objects;
 
 public class SpongeFireworkEffect implements FireworkEffect {
 
@@ -49,6 +50,28 @@ public class SpongeFireworkEffect implements FireworkEffect {
         this.colors = ImmutableList.copyOf(colors);
         this.fades = ImmutableList.copyOf(fades);
         this.shape = shape;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SpongeFireworkEffect that = (SpongeFireworkEffect) o;
+        return flicker == that.flicker &&
+                trails == that.trails &&
+                Objects.equals(colors, that.colors) &&
+                Objects.equals(fades, that.fades) &&
+                Objects.equals(shape, that.shape);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(flicker, trails, colors, fades, shape);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/item/merchant/MixinMerchantRecipe.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/merchant/MixinMerchantRecipe.java
@@ -28,6 +28,7 @@ import net.minecraft.village.MerchantRecipe;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.Queries;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackComparators;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.merchant.TradeOffer;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -110,5 +111,25 @@ public abstract class MixinMerchantRecipe implements TradeOffer {
                 .set(DataQueries.TRADE_OFFER_GRANTS_EXPERIENCE, this.doesGrantExperience())
                 .set(DataQueries.TRADE_OFFER_MAX_USES, this.getMaxTradeUses())
                 .set(DataQueries.TRADE_OFFER_USES, this.getUses());
+    }
+
+    // This is a little questionable, since we're mixing into a Mixnecraft class.
+    // However, Vanill adoesn't override equals(), so no one except plugins
+    // should be calling it,
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MerchantRecipe other = (MerchantRecipe) o;
+        return ItemStackComparators.ALL.compare((ItemStack) this.getItemToBuy(), (ItemStack) other.getItemToBuy()) == 0
+                && ItemStackComparators.ALL.compare((ItemStack) this.getSecondItemToBuy(), (ItemStack) other.getSecondItemToBuy()) == 0
+                && ItemStackComparators.ALL.compare((ItemStack) this.getItemToSell(), (ItemStack) other.getItemToSell()) == 0
+                && this.getToolUses() == other.getToolUses()
+                && this.getMaxTradeUses() == other.getMaxTradeUses()
+                && this.getRewardsExp() == other.getRewardsExp();
     }
 }

--- a/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
@@ -510,7 +510,7 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
 
         this.register("exit_position", Key.builder().type(TypeTokens.VECTOR_3I_VALUE_TOKEN).id("exit_position").name("Exit Position").query(of("ExitPosition")).build());
 
-        this.register("exact_teleport", Key.builder().type(TypeTokens.VECTOR_3I_VALUE_TOKEN).id("exact_teleport").name("Exact Teleport").query(of("ExactTeleport")).build());
+        this.register("exact_teleport", Key.builder().type(TypeTokens.BOOLEAN_VALUE_TOKEN).id("exact_teleport").name("Exact Teleport").query(of("ExactTeleport")).build());
 
         this.register("structure_author", Key.builder().type(TypeTokens.STRING_VALUE_TOKEN).id("structure_author").name("Structure Author").query(of("StructureAuthor")).build());
 

--- a/src/main/java/org/spongepowered/common/util/TypeTokenHelper.java
+++ b/src/main/java/org/spongepowered/common/util/TypeTokenHelper.java
@@ -39,6 +39,10 @@ import javax.annotation.Nullable;
 @SuppressWarnings({"unchecked", "rawtypes", "WeakerAccess"})
 public final class TypeTokenHelper {
 
+    public static Class<?>  getGenericParam(TypeToken<?> token, int typeIndex) {
+        return (Class) ((ParameterizedType) token.getType()).getActualTypeArguments()[typeIndex];
+    }
+
     public static boolean isAssignable(TypeToken<?> type, TypeToken<?> toType) {
         return isAssignable(type.getType(), toType.getType());
     }

--- a/src/test/java/org/spongepowered/common/data/manipulator/DataTestUtil.java
+++ b/src/test/java/org/spongepowered/common/data/manipulator/DataTestUtil.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 final class DataTestUtil {
 
@@ -46,7 +47,13 @@ final class DataTestUtil {
         final Map<Class<? extends DataManipulator<?, ?>>, DataProcessorDelegate<?, ?>> delegateMap = getDelegateMap();
         return delegateMap.entrySet().stream()
                 .filter(entry -> isValidForTesting(entry.getKey()))
-                .map(entry -> new Object[]{entry.getKey().getSimpleName(), entry.getKey(), manipulatorBuilderMap.get(entry.getKey())})
+                .flatMap(entry -> {
+                    String name = entry.getKey().getSimpleName();
+                    Class<? extends DataManipulator<?, ?>> key = entry.getKey();
+                    DataManipulatorBuilder<?, ?> builder = manipulatorBuilderMap.get(key);
+
+                    return Stream.of(new Object[]{name, key, builder, false}, new Object[]{name, key, builder, true});
+                })
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
+++ b/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
@@ -234,7 +234,7 @@ public class ManipulatorTest {
                     continue;
                 }
                 Class<?> paramType = builderSetter.getParameterTypes()[0];
-                Object param = this.createBuilderParam(builderType, builderSetter);
+                Object param = this.createBuilderParam(paramType);
 
                 builderSetter.invoke(builderObject, param);
             }
@@ -247,18 +247,18 @@ public class ManipulatorTest {
         }
     }
 
-    private Object createBuilderParam(Class<?> builderType, Method builderSetter) {
+    private Object createBuilderParam(Class<?> paramType) {
         // Many builder methods require that that integer parameters be greater than 0
-        if (builderType.equals(int.class) || builderType.equals(Integer.class)) {
+        if (paramType.equals(int.class) || paramType.equals(Integer.class)) {
             return 1;
         }
-        return this.createType(builderSetter.getParameterTypes()[0]);
+        return this.createType(paramType);
     }
 
     private boolean isBuilderSetter(Class<?> builderType, Class<?> type, Method method) {
         if (method.getReturnType().equals(builderType) && method.getParameterCount() == 1) {
             // Don't try to call any methods that take the type we're building
-            return !method.getParameterTypes()[0].equals(type) && !method.getName().equals("from");
+            return !method.getParameterTypes()[0].equals(type) && !method.getName().startsWith("from");
         }
         return false;
     }

--- a/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
+++ b/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import org.checkerframework.checker.nullness.Opt;
 import org.junit.Test;
@@ -177,12 +178,20 @@ public class ManipulatorTest {
     private <T> Optional<T> createValueElement(Key<?> type) {
         Class<T> elementClass = (Class<T>) type.getElementToken().getRawType();
         if (Optional.class.isAssignableFrom(elementClass)) {
-            Class<?> wrappedType = (Class) ((ParameterizedType) type.getElementToken().getType()).getActualTypeArguments()[0];
+            Class<?> wrappedType = this.getGenericParam(type.getElementToken(), 0);
             // The innermost optional is the actual type of the Key. The outer optional
             // indicates to the caller that we were able to create something for this key.
             return (Optional) Optional.of(Optional.of(createType(wrappedType)));
+        } else if (List.class.isAssignableFrom(elementClass)) {
+            Class<?> wrappedType = this.getGenericParam(type.getElementToken(), 0);
+
+            return (Optional) Optional.of(Lists.newArrayList(createType(wrappedType)));
         }
         return Optional.empty();
+    }
+
+    private Class<?>  getGenericParam(TypeToken<?> token, int typeIndex) {
+        return (Class) ((ParameterizedType) token.getType()).getActualTypeArguments()[typeIndex];
     }
 
     private <T> T createType(Class<T> type) {

--- a/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
+++ b/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
@@ -227,7 +227,7 @@ public class ManipulatorTest {
                 if (!equals) {
                     printNonEqual(container, manipulator, deserialized);
                 }
-                assertThat(equals, is(true));
+                assertThat(manipulator, equalTo(deserialized));
             }
         } catch (Exception e) {
             throw new RuntimeException("There was an unknown exception trying to test " + this.dataName

--- a/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
+++ b/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
@@ -258,7 +258,12 @@ public class ManipulatorTest {
     private boolean isBuilderSetter(Class<?> builderType, Class<?> type, Method method) {
         if (method.getReturnType().equals(builderType) && method.getParameterCount() == 1) {
             // Don't try to call any methods that take the type we're building
-            return !method.getParameterTypes()[0].equals(type) && !method.getName().startsWith("from");
+            Class<?> paramType = method.getParameterTypes()[0];
+            return !paramType.equals(type)
+                    && !paramType.equals(Class.class)
+                    && !paramType.equals(DataManipulator.class)
+                    && !paramType.equals(ImmutableDataManipulator.class)
+                    && !method.getName().startsWith("from");
         }
         return false;
     }

--- a/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
+++ b/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
@@ -49,6 +49,7 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.effect.potion.PotionEffect;
 import org.spongepowered.api.event.SpongeEventFactoryTest;
 import org.spongepowered.api.item.merchant.TradeOffer;
+import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.PEBKACException;
 import org.spongepowered.asm.util.PrettyPrinter;
 import org.spongepowered.common.util.TypeTokenHelper;
@@ -208,6 +209,11 @@ public class ManipulatorTest {
     }
 
     private boolean isBuildable(Class<?> type) {
+        // The 'child' methods on Text.Builder interact oddly
+        // with our code, so skip building Text for now
+        if (type == Text.class) {
+            return false;
+        }
         try {
             type.getMethod("builder");
             return true;

--- a/src/test/java/org/spongepowered/common/test/inject/TestImplementationModule.java
+++ b/src/test/java/org/spongepowered/common/test/inject/TestImplementationModule.java
@@ -53,6 +53,7 @@ public class TestImplementationModule extends SpongeImplementationModule {
         this.bind(Server.class).to(TestServer.class);
         this.bind(SpongeGame.class).to(TestGame.class);
         Platform platform = mock(Platform.class);
+        when(platform.getExecutionType()).thenReturn(Platform.Type.SERVER);
         PluginContainer mock = mock(PluginContainer.class);
         when(platform.getContainer(any())).thenReturn(mock);
         this.bind(Platform.class).toInstance(platform);


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1859) | **SpongeCommon**

Currently, `ManipulatorTest` attempts to construct, manipulate, and serialize all registered `DataManipulators`. While this is able to catch many bugs, it suffers from a significant limitation: it is unable to set any new values. Whenever a `DataManipulator` is constructed, the default values for every associated `Key` are always (implicitly) used. When a `Key` represents a wrapper or container type (e.g. `Optional` or `List`), the corresponding default value will always be 'empty' (e.g. `Optional.empty()`, `Lists.newArrayList()`).

This often results in code paths not being exercised at all by `ManipulatorTest`, leaving bugs like https://github.com/SpongePowered/SpongeCommon/issues/1276 uncaught.

This PR greatly expands the amount of code that `ManipulatorTest` is able to cover, by creating and setting values for each of a `DataManipulator`'s `Key`s whenever possible. Several different strategies are used to accomplish this:

* `CatalogType`s are creating by retrieving the first instance from `GameRegistry#getAllOf`
* Types with a `builder` static method  are created by walking the methods of the `Builder` class. Any setter methods (defined as methods taking a single parameter and returning the `Builder` instance) are called with parameters created recursively through this process.
* If all else fails, types are created using `SpongeEventFactoryTest.mockParam`. This returns default values for a number of Java and Sponge types (`int`, `Text`, `Color`, etc). Otherwise, it falls back to a special 'recursive mock', which use `SpongeEventFactoryTest.mockParam` to create return values for all methods of the target type.

With these three value-creation strategies, I was able to uncover quite a few new bugs, which are fixed in this PR. These include:

* A missing registration for `SpongeTradeOfferBuilder`
* Broken serialization for `SpongeTradeOfferData`
* Invalid deserialization of lists of `DataContainers` in `DataUtil`
* Missing `equals` overrides in classes used in data values,
* An incorrect `TypeToken` registered in `KeyRegistryModule.java`

To ensure that dynamically creating values does not reduce our test coverage, all tests in `ManipulatorTest` are run twice - once with the previous behavior (default values only), and once with the new behavior (dynamically created values for applicable `Key`s).

There's still room to improve and add to the value-creation strategies included in this PR. However, these strategies will always be implemented on a 'best-effort' basis. It's simply impossible to create an instance of an arbitrary Java type, and have things work out sanely every time. As new `DataManipulator`s are added, it will likely be necessary to add rules for instantiating new types (`final` API types in particular)