### PR TITLE
Ensure that all PhaseContext captures are fully processed

### DIFF
--- a/src/main/java/org/spongepowered/common/config/category/PhaseTrackerCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/PhaseTrackerCategory.java
@@ -73,6 +73,20 @@ public class PhaseTrackerCategory extends ConfigCategory {
         return this.isVerbose;
     }
 
+    @Setting(value = "max-block-processing-depth", comment = "The maximum number of times to recursively process transactions in a single phase.\n"
+                                                           + "Some mods may interact badly with Sponge's block capturing system, causing Sponge to\n"
+                                                           + "end up capturing block transactions every time it tries to process an existing batch.\n"
+                                                            + "Due to the recursive nature of the depth-first processing that Sponge uses to handle block transactions,\n"
+                                                            + "this can result in a stack overflow, which causes us to lose all infomration about the original cause of the issue.\n"
+                                                            + "To prevent a stack overflow, Sponge tracks the current processing depth, and aborts processing when it exceeds\n"
+                                                            + "this threshold.\n"
+                                                            + "The default value should almost always work properly -  it's unlikely you'll ever have to change it.")
+    private int maxBlockProcessingDepth = 100;
+
+    public int getMaxBlockProcessingDepth() {
+        return this.maxBlockProcessingDepth;
+    }
+
     public boolean verboseErrors() {
         return this.verboseErrors;
     }

--- a/src/main/java/org/spongepowered/common/event/tracking/IPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/IPhaseState.java
@@ -305,7 +305,7 @@ public interface IPhaseState<C extends PhaseContext<C>> {
                 return false; // Short circuit
             }
             // And now, proceed as normal.
-            return TrackingUtil.performTransactionProcess(transaction, this, context, false);
+            return TrackingUtil.performTransactionProcess(transaction, this, context, false, 0);
         }
     }
     /**
@@ -372,9 +372,16 @@ public interface IPhaseState<C extends PhaseContext<C>> {
      * easy machine that could create quantum redstone clocks where redstone would be flipped twice in a
      * "single" tick. It was pretty cool, but did not work out as it broke vanilla mechanics.
      *
+     * Due the recursive nature of the "depth first" strategy, certain mod blocks may
+     * cause this method to infinite recurse if they generate new transactions on every pass through.
+     * To avoid a StackOverflowError (which causes us to lose all of the associated context),
+     * we track the current depth . If the processing depth exceeeds a configurable threshold,
+     * processing is aborted, and the current tracker state and phase data are logged.
+     *
      * @param context The context to re-check for captures
+     * @param currentDepth The current processing depth, to prevenet stack overflows
      */
-    default void performPostBlockNotificationsAndNeighborUpdates(C context) {
+    default void performPostBlockNotificationsAndNeighborUpdates(C context, int currentDepth) {
 
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/PhaseContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/PhaseContext.java
@@ -51,6 +51,7 @@ import org.spongepowered.common.event.tracking.context.CapturedSupplier;
 import org.spongepowered.common.event.tracking.context.EntityItemDropsSupplier;
 import org.spongepowered.common.event.tracking.context.EntityItemEntityDropsSupplier;
 import org.spongepowered.common.event.tracking.context.GeneralizedContext;
+import org.spongepowered.common.event.tracking.context.ICaptureSupplier;
 import org.spongepowered.common.event.tracking.context.ItemDropData;
 import org.spongepowered.common.event.tracking.phase.general.GeneralPhase;
 
@@ -296,6 +297,24 @@ public class PhaseContext<P extends PhaseContext<P>> implements AutoCloseable {
     }
 
 
+    public boolean notAllCapturesProcessed() {
+        return
+                isNonEmpty(this.blocksSupplier)
+                || isNonEmpty(this.blockItemDropsSupplier)
+                || isNonEmpty(this.blockItemEntityDropsSupplier)
+                || isNonEmpty(this.capturedItemsSupplier)
+                || isNonEmpty(this.capturedEntitiesSupplier)
+                || isNonEmpty(this.capturedItemStackSupplier)
+                || isNonEmpty(this.entityItemDropsSupplier)
+                || isNonEmpty(this.entityItemEntityDropsSupplier)
+                || isNonEmpty(this.blockEntitySpawnSupplier);
+    }
+
+    private boolean isNonEmpty(@Nullable ICaptureSupplier supplier) {
+        return supplier != null && !supplier.isEmpty();
+    }
+
+
     public boolean shouldProcessImmediately() {
         return this.processImmediately;
     }
@@ -501,4 +520,5 @@ public class PhaseContext<P extends PhaseContext<P>> implements AutoCloseable {
                 .add(this.stackTrace);
         }
     }
+
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/CapturedMultiMapSupplier.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/CapturedMultiMapSupplier.java
@@ -38,7 +38,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-public abstract class CapturedMultiMapSupplier<K, V> implements Supplier<ArrayListMultimap<K, V>> {
+public abstract class CapturedMultiMapSupplier<K, V> implements Supplier<ArrayListMultimap<K, V>>, ICaptureSupplier {
 
     @Nullable private ArrayListMultimap<K, V> captured;
 
@@ -55,16 +55,17 @@ public abstract class CapturedMultiMapSupplier<K, V> implements Supplier<ArrayLi
 
     /**
      * Returns {@code true} if there are no captured objects.
-     * 
+     *
      * @return {@code true} if empty
      */
+    @Override
     public final boolean isEmpty() {
         return this.captured == null || this.captured.isEmpty();
     }
 
     /**
      * If not empty, activates the consumer then clears all captures.
-     * 
+     *
      * @param consumer The consumer to activate
      */
     public final void acceptAndClearIfNotEmpty(Consumer<ListMultimap<K, V>> consumer) {
@@ -83,7 +84,7 @@ public abstract class CapturedMultiMapSupplier<K, V> implements Supplier<ArrayLi
 
     /**
      * If not empty, activates the {@link BiConsumer} with captures.
-     * 
+     *
      * @param biConsumer The consumer to activate
      */
     public final void acceptIfNotEmpty(BiConsumer<K, List<V>> biConsumer) {
@@ -101,7 +102,7 @@ public abstract class CapturedMultiMapSupplier<K, V> implements Supplier<ArrayLi
     /**
      * If not empty, activates the consumer with the captured
      * {@link ListMultimap}.
-     * 
+     *
      * @param consumer The consumer to activate
      */
     public final void acceptIfNotEmpty(Consumer<ListMultimap<K, V>> consumer) {
@@ -113,7 +114,7 @@ public abstract class CapturedMultiMapSupplier<K, V> implements Supplier<ArrayLi
     /**
      * If not empty and key is present, removes the key then activates
      * the consumer with the captured {@link ListMultimap}.
-     * 
+     *
      * @param key The key to process and remove
      * @param consumer The consumer to activate
      */
@@ -142,10 +143,10 @@ public abstract class CapturedMultiMapSupplier<K, V> implements Supplier<ArrayLi
 
     /**
      * If not empty, removes all values associated with key.
-     * 
+     *
      * Note: If you require the list of removals, use
      * {@link #acceptAndRemoveIfPresent}
-     * 
+     *
      * @param key The key to remove
      */
     public final void removeAllIfNotEmpty(K key) {
@@ -159,7 +160,7 @@ public abstract class CapturedMultiMapSupplier<K, V> implements Supplier<ArrayLi
     /**
      * If not empty, returns the captured {@link ListMultimap}.
      * Otherwise, this will return the passed list.
-     * 
+     *
      * @param list The fallback list
      * @return If not empty, the captured list otherwise the fallback list
      */
@@ -169,7 +170,7 @@ public abstract class CapturedMultiMapSupplier<K, V> implements Supplier<ArrayLi
 
     /**
      * If not empty, returns a sequential stream of values associated with key.
-     * 
+     *
      * @param key The key
      * @return A sequential stream of values
      */
@@ -180,7 +181,7 @@ public abstract class CapturedMultiMapSupplier<K, V> implements Supplier<ArrayLi
 
     /**
      * If not empty and key is present, applies the function to the resulting values.
-     * 
+     *
      * @param key The key
      * @param function The function to apply
      * @return The function result or null if no key was found

--- a/src/main/java/org/spongepowered/common/event/tracking/context/CapturedSupplier.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/CapturedSupplier.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-public abstract class CapturedSupplier<T> implements Supplier<List<T>> {
+public abstract class CapturedSupplier<T> implements Supplier<List<T>>, ICaptureSupplier {
     @Nullable private List<T> captured;
 
     CapturedSupplier() {
@@ -51,16 +51,17 @@ public abstract class CapturedSupplier<T> implements Supplier<List<T>> {
 
     /**
      * Returns {@code true} if there are no captured objects.
-     * 
+     *
      * @return {@code true} if empty
      */
+    @Override
     public final boolean isEmpty() {
         return this.captured == null || this.captured.isEmpty();
     }
 
     /**
      * If not empty, activates the consumer then clears all captures.
-     * 
+     *
      * @param consumer The consumer to activate
      */
     public final void acceptAndClearIfNotEmpty(Consumer<List<T>> consumer) {
@@ -74,7 +75,7 @@ public abstract class CapturedSupplier<T> implements Supplier<List<T>> {
     /**
      * If not empty, returns the captured {@link List}.
      * Otherwise, this will return the passed list.
-     * 
+     *
      * @param list The fallback list
      * @return If not empty, the captured list otherwise the fallback list
      */
@@ -88,7 +89,7 @@ public abstract class CapturedSupplier<T> implements Supplier<List<T>> {
 
     /**
      * If not empty, returns a sequential stream of values associated with key.
-     * 
+     *
      * @param key The key
      * @return A sequential stream of values
      */

--- a/src/main/java/org/spongepowered/common/event/tracking/context/ICaptureSupplier.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/ICaptureSupplier.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.event.tracking.context;
+
+public interface ICaptureSupplier {
+
+    boolean isEmpty();
+
+}

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/general/PostState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/general/PostState.java
@@ -35,6 +35,7 @@ import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseData;
+import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.TrackingUtil;
 import org.spongepowered.common.event.tracking.context.CapturedSupplier;
 import org.spongepowered.common.event.tracking.phase.TrackingPhases;
@@ -199,12 +200,15 @@ public final class PostState extends GeneralState<UnwindingPhaseContext> {
     }
 
     @Override
-    public void performPostBlockNotificationsAndNeighborUpdates(UnwindingPhaseContext context) {
+    public void performPostBlockNotificationsAndNeighborUpdates(UnwindingPhaseContext context, int depth) {
+        if (PhaseTracker.checkMaxBlockProcessingDepth(this, context, depth)) {
+            return;
+        }
         final CapturedSupplier<BlockSnapshot> capturedBlockSupplier = context.getCapturedBlockSupplier();
         capturedBlockSupplier.acceptAndClearIfNotEmpty(blocks -> {
             final List<BlockSnapshot> blockSnapshots = new ArrayList<>(blocks);
             blocks.clear();
-            TrackingUtil.processBlockCaptures(blockSnapshots, this, context);
+            TrackingUtil.processBlockCaptures(blockSnapshots, this, context, depth);
         });
     }
 


### PR DESCRIPTION
This commit checks that all PhaseContext capture suppliers are either
null or empty when a phase completes. This has been responsible for a
large number of bugs in the past, such as the one fixed by e8d394f3.