### PR TITLE
Include all captures in capture supplier toString(), not just counts

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/context/CapturedMultiMapSupplier.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/CapturedMultiMapSupplier.java
@@ -220,7 +220,7 @@ public abstract class CapturedMultiMapSupplier<K, V> implements Supplier<ArrayLi
     @Override
     public String toString() {
         return com.google.common.base.MoreObjects.toStringHelper(this)
-                .add("Captured", this.captured == null ? 0 : this.captured.size())
+                .add("Captured", this.captured)
                 .toString();
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/context/CapturedSupplier.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/CapturedSupplier.java
@@ -118,7 +118,7 @@ public abstract class CapturedSupplier<T> implements Supplier<List<T>>, ICapture
     @Override
     public String toString() {
         return com.google.common.base.MoreObjects.toStringHelper(this)
-                .add("Captured", this.captured == null ? 0 : this.captured.size())
+                .add("Captured", this.captured)
                 .toString();
     }
 }


### PR DESCRIPTION
Now that we have config settings to limit phase tracker error spam,
including the full contents of a capture supplier shouldn't make much of
a difference. This can be valuable for debugging, especially when
dealing with recursive capture processing issues (where the captured
blocks may provide a hint as to the cause of the issue).

@gabizou Does this look reasonable?