### PR TITLE
Add simplistic frame pooling

### DIFF
--- a/src/main/java/org/spongepowered/common/event/SpongeCauseStackManager.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCauseStackManager.java
@@ -60,17 +60,31 @@ import javax.annotation.Nullable;
 public final class SpongeCauseStackManager implements CauseStackManager {
 
     private static final boolean DEBUG_CAUSE_FRAMES = Boolean.parseBoolean(System.getProperty("sponge.debugcauseframes", "false"));
-    public static final int MAX_POOL_SIZE;
+    private static final String INITIAL_POOL_SIZE_PROPERTY =  "sponge.cause.initialFramePoolSize";
+    private static final String MAX_POOL_SIZE_PROPERTY =  "sponge.cause.maxFramePoolSize";
+
+    private static final int INITIAL_POOL_SIZE;
+    private static final int MAX_POOL_SIZE;
 
     static {
-        int maxPoolSize = 50;
+        int initialPoolSize = 50;
+        int maxPoolSize = 100;
         try {
-            maxPoolSize = Integer.parseInt(System.getProperty("sponge.cause.framePoolSize", "50"));
+            initialPoolSize = Integer.parseInt(System.getProperty(INITIAL_POOL_SIZE_PROPERTY, "50"));
         } catch (NumberFormatException ex) {
-            SpongeImpl.getLogger().warn("sponge.cause.framePoolSize must be an integer, was set to {}. Defaulting to 50.",
-                    System.getProperty("sponge.cause.framePoolSize"));
+            SpongeImpl.getLogger().warn("{} must be an integer, was set to {}. Defaulting to 50.",
+                    INITIAL_POOL_SIZE_PROPERTY,
+                    System.getProperty(INITIAL_POOL_SIZE_PROPERTY));
+        }
+        try {
+            maxPoolSize = Integer.parseInt(System.getProperty(MAX_POOL_SIZE_PROPERTY, "100"));
+        } catch (NumberFormatException ex) {
+            SpongeImpl.getLogger().warn("{} must be an integer, was set to {}. Defaulting to 100.",
+                    MAX_POOL_SIZE_PROPERTY,
+                    System.getProperty(MAX_POOL_SIZE_PROPERTY));
         }
         MAX_POOL_SIZE = Math.max(0, maxPoolSize);
+        INITIAL_POOL_SIZE = Math.max(0, Math.min(MAX_POOL_SIZE, initialPoolSize));
     }
 
     private final Deque<Object> cause = Queues.newArrayDeque();
@@ -96,7 +110,7 @@ public final class SpongeCauseStackManager implements CauseStackManager {
 
     @Inject
     private SpongeCauseStackManager() {
-        for (int i = 0; i < MAX_POOL_SIZE; i++) {
+        for (int i = 0; i < INITIAL_POOL_SIZE; i++) {
             this.framePool.push(new CauseStackFrameImpl());
         }
     }

--- a/src/test/java/org/spongepowered/common/event/CauseStackManagerTest.java
+++ b/src/test/java/org/spongepowered/common/event/CauseStackManagerTest.java
@@ -34,7 +34,7 @@ import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.lwts.runner.LaunchWrapperTestRunner;
 
 @RunWith(LaunchWrapperTestRunner.class)
-public class PhaseStackManagerTest {
+public class CauseStackManagerTest {
 
     @Test
     public void testPoppingFramePopsCauses() throws Exception {

--- a/testplugins/src/main/java/org/spongepowered/test/CauseFramesTimingTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/CauseFramesTimingTest.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.EventContextKey;
+import org.spongepowered.api.event.game.state.GameInitializationEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+
+import java.util.Stack;
+
+import javax.annotation.Nullable;
+
+@Plugin(id = "frames-timing")
+public class CauseFramesTimingTest {
+
+    private final Text numberOfFrames = Text.of("number of frames");
+    private final Text numberOfRepeats = Text.of("repetitions");
+    @Nullable private EventContextKey<Integer> testContextKey;
+
+    @Listener
+    public void init(GameInitializationEvent event) {
+        testContextKey = EventContextKey.builder(Integer.class)
+                .id("frames-timing:test")
+                .name("Test numberOfFrames")
+                .type(Integer.class)
+                .build();
+
+        Sponge.getCommandManager().register(
+                this,
+                CommandSpec.builder()
+                        .arguments(
+                                GenericArguments.flags()
+                                        .valueFlag(GenericArguments.integer(this.numberOfFrames), "-frames", "f")
+                                        .valueFlag(GenericArguments.integer(this.numberOfRepeats), "-repeats", "r")
+                                        .buildWith(GenericArguments.none()))
+                        .executor((src, context) -> {
+                            int noOfFrames = context.<Integer>getOne(this.numberOfFrames).orElse(50);
+                            if (noOfFrames < 1) {
+                                throw new CommandException(Text.of("There must be a positive number of frames!"));
+                            }
+
+                            int noOfRepeats = context.<Integer>getOne(this.numberOfRepeats).orElse(1);
+                            if (noOfRepeats < 1) {
+                                throw new CommandException(Text.of("There must be a positive number of repeats!"));
+                            }
+
+                            // create the objects for putting on the stack, this is not part of the test.
+                            // We'll put 5 objects into each frame.
+                            Stack<Object> causes = new Stack<>();
+                            for (int i = 0; i < noOfFrames * noOfRepeats * 5; ++i) {
+                                causes.push(new Object());
+                            }
+
+                            CauseStackManager csm = Sponge.getCauseStackManager();
+                            long startTime = System.nanoTime();
+                            for (int r = 0; r < noOfRepeats; ++r) {
+                                CauseStackManager.StackFrame[] frames = new CauseStackManager.StackFrame[noOfFrames];
+                                for (int i = 0; i < noOfFrames; ++i) {
+                                    frames[i] = csm.pushCauseFrame();
+                                    for (int j = 0; j < 5; ++j) {
+                                        csm.pushCause(causes.pop());
+                                    }
+                                    csm.addContext(testContextKey, i);
+                                }
+
+                                // Create a cause
+                                Cause cause = csm.getCurrentCause();
+                                for (int i = noOfFrames - 1; i >= 0; --i) {
+                                    csm.popCauseFrame(frames[i]);
+                                }
+                            }
+                            long endTime = System.nanoTime();
+
+                            src.sendMessage(Text.of("Test completed in: ", endTime - startTime, "ns."));
+                            return CommandResult.success();
+                        }).build(),
+                "timecsm"
+        );
+    }
+
+}


### PR DESCRIPTION
As we potentially create hundreds of frames a tick, this can mean that a lot of objects are created. To reduce the number of objects that we create and destroy during cause creation, we pool the frames themselves. We pool up to 50.

This isn't yet ready for pulling, I need to do some profiling on this first. This might be slower! Just looking for any feedback - if this is no good, it's not good!

This also cleans up some of the calls for the CSM to reduce the number of calls needed. The included tests verify that the functionality is the same.