### PR TITLE
Add feature to reload individual plugins

### DIFF
--- a/src/main/java/org/spongepowered/common/command/SpongeCommandFactory.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommandFactory.java
@@ -91,6 +91,7 @@ import org.spongepowered.common.config.type.GlobalConfig;
 import org.spongepowered.common.config.type.TrackerConfig;
 import org.spongepowered.common.config.type.WorldConfig;
 import org.spongepowered.common.entity.EntityUtil;
+import org.spongepowered.common.event.SpongeEventManager;
 import org.spongepowered.common.interfaces.IMixinChunk;
 import org.spongepowered.common.interfaces.IMixinMinecraftServer;
 import org.spongepowered.common.interfaces.entity.IMixinEntity;
@@ -560,9 +561,15 @@ public class SpongeCommandFactory {
                 .arguments(optionalWeak(literal(Text.of("reload"), "reload")), optional(plugin(Text.of("plugin"))))
                 .executor((src, args) -> {
                     if (args.hasAny("reload") && src.hasPermission("sponge.command.plugins.reload")) {
-                        src.sendMessage(Text.of("Sending reload event to all plugins. Please wait."));
                         Sponge.getCauseStackManager().pushCause(src);
-                        SpongeImpl.postEvent(SpongeEventFactory.createGameReloadEvent(Sponge.getCauseStackManager().getCurrentCause()));
+                        if (args.hasAny("plugin")) {
+                            PluginContainer plugin = args.<PluginContainer>getOne("plugin").get();
+                            src.sendMessage(Text.of("Sending reload event to " + plugin.getId() + ". Please wait."));
+                            ((SpongeEventManager) Sponge.getEventManager()).post(SpongeEventFactory.createGameReloadEvent(Sponge.getCauseStackManager().getCurrentCause()), plugin);
+                        } else {
+                            src.sendMessage(Text.of("Sending reload event to all plugins. Please wait."));
+                            SpongeImpl.postEvent(SpongeEventFactory.createGameReloadEvent(Sponge.getCauseStackManager().getCurrentCause()));
+                        }
                         Sponge.getCauseStackManager().popCause();
                         src.sendMessage(Text.of("Reload complete!"));
                     } else if (args.hasAny("plugin")) {

--- a/src/main/java/org/spongepowered/common/event/SpongeEventManager.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeEventManager.java
@@ -461,6 +461,8 @@ public class SpongeEventManager implements EventManager {
     }
 
     public boolean post(Event event, PluginContainer plugin) {
-        return post(event, getHandlerCache(event).getListeners().stream().filter(l -> l.getPlugin().equals(plugin)).collect(Collectors.toList()));
+        return post(event, getHandlerCache(event).getListeners().stream()
+                .filter(l -> l.getPlugin().equals(plugin))
+                .collect(Collectors.toList()));
     }
 }

--- a/src/main/java/org/spongepowered/common/event/SpongeEventManager.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeEventManager.java
@@ -76,6 +76,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -457,7 +458,9 @@ public class SpongeEventManager implements EventManager {
 
     public boolean post(Event event, boolean allowClientThread) {
         return post(event, getHandlerCache(event).getListeners());
+    }
 
-
+    public boolean post(Event event, PluginContainer plugin) {
+        return post(event, getHandlerCache(event).getListeners().stream().filter(l -> l.getPlugin().equals(plugin)).collect(Collectors.toList()));
     }
 }

--- a/testplugins/src/main/java/org/spongepowered/test/IndividualPluginReloadTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/IndividualPluginReloadTest.java
@@ -1,0 +1,22 @@
+package org.spongepowered.test;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.game.GameReloadEvent;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id="individual-plugin-reload-test",
+        name="Individual Plugin Reload Test",
+        description = "Tests sending GameReloadEvent to specific plugins.",
+        version = "1.0.0")
+public class IndividualPluginReloadTest {
+
+    @Inject private Logger logger;
+
+    @Listener
+    public void onReload(GameReloadEvent event) {
+        this.logger.info("GameReloadEvent: " + event);
+    }
+
+}

--- a/testplugins/src/main/java/org/spongepowered/test/IndividualPluginReloadTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/IndividualPluginReloadTest.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.test;
 
 import com.google.inject.Inject;


### PR DESCRIPTION
This PR allows the `/sponge plugins reload` command to specify a plugin to be reloaded.

 - This requires a way to send an event to listeners registered by a particular plugin. To do this, I added `SpongeEventManager#post(Event, PluginContainer)` that runs a filter operation on the available listeners.
 - The command syntax already supports `/sponge plugins reload <pluginid>`, however it does not verify that the plugin id is valid (if it's not, all plugins will be reloaded). Changing this requires a redesign to Sponge's commands and is beyond the scope of this PR.

Please let me know if there's a better way to handle posting an event to listeners for a specific plugin.