### PR TITLE
Fix for FireworkShape id being... really messed up.

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/common/FireworkUtils.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/FireworkUtils.java
@@ -49,11 +49,11 @@ import java.util.Optional;
 public class FireworkUtils {
 
     public static final BiMap<Byte, SpongeFireworkShape> shapeMapping = ImmutableBiMap.<Byte, SpongeFireworkShape>builder()
-            .put((byte) 0, new SpongeFireworkShape((byte) 0, "BALL"))
-            .put((byte) 1, new SpongeFireworkShape((byte) 1, "LARGE_BALL"))
-            .put((byte) 2, new SpongeFireworkShape((byte) 2, "STAR"))
-            .put((byte) 3, new SpongeFireworkShape((byte) 3, "CREEPER"))
-            .put((byte) 4, new SpongeFireworkShape((byte) 4, "BURST"))
+            .put((byte) 0, new SpongeFireworkShape("minecraft:ball", "Ball"))
+            .put((byte) 1, new SpongeFireworkShape("minecraft:large_ball", "Large Ball"))
+            .put((byte) 2, new SpongeFireworkShape("minecraft:star", "Star"))
+            .put((byte) 3, new SpongeFireworkShape("minecraft:creeper", "Creeper"))
+            .put((byte) 4, new SpongeFireworkShape("minecraft:burst", "Burst"))
             .build();
 
     public static ItemStack getItem(EntityFireworkRocket firework) {

--- a/src/main/java/org/spongepowered/common/item/SpongeFireworkShape.java
+++ b/src/main/java/org/spongepowered/common/item/SpongeFireworkShape.java
@@ -28,17 +28,17 @@ import org.spongepowered.api.item.FireworkShape;
 
 public class SpongeFireworkShape implements FireworkShape {
 
-    private final byte id;
+    private final String id;
     private final String name;
 
-    public SpongeFireworkShape(byte id, String name) {
+    public SpongeFireworkShape(String id, String name) {
         this.id = id;
         this.name = name;
     }
 
     @Override
     public String getId() {
-        return this.name;
+        return this.id;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/registry/type/item/FireworkShapeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/item/FireworkShapeRegistryModule.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.item.FireworkShapes;
 import org.spongepowered.api.registry.CatalogRegistryModule;
 import org.spongepowered.api.registry.util.RegisterCatalog;
 import org.spongepowered.common.data.processor.common.FireworkUtils;
+import org.spongepowered.common.item.SpongeFireworkShape;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -48,7 +49,11 @@ public class FireworkShapeRegistryModule implements CatalogRegistryModule<Firewo
 
     @Override
     public Optional<FireworkShape> getById(String id) {
-        return Optional.ofNullable(this.fireworkShapeMap.get(checkNotNull(id).toLowerCase(Locale.ENGLISH)));
+        id = checkNotNull(id).toLowerCase(Locale.ENGLISH);
+        if (id.contains(":")) {
+            id = "minecraft:" + id;
+        }
+        return Optional.ofNullable(this.fireworkShapeMap.get(id));
     }
 
     @Override
@@ -58,8 +63,7 @@ public class FireworkShapeRegistryModule implements CatalogRegistryModule<Firewo
 
     @Override
     public void registerDefaults() {
-        this.fireworkShapeMap.putAll(FireworkUtils.shapeMapping.values()
-        .stream()
-        .collect(Collectors.toMap(shape -> shape.getId().toLowerCase(Locale.ENGLISH), Function.identity())));
+        this.fireworkShapeMap.putAll(FireworkUtils.shapeMapping.values().stream()
+                .collect(Collectors.toMap(SpongeFireworkShape::getId, Function.identity())));
     }
 }

--- a/src/main/java/org/spongepowered/common/registry/type/item/FireworkShapeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/item/FireworkShapeRegistryModule.java
@@ -50,7 +50,7 @@ public class FireworkShapeRegistryModule implements CatalogRegistryModule<Firewo
     @Override
     public Optional<FireworkShape> getById(String id) {
         id = checkNotNull(id).toLowerCase(Locale.ENGLISH);
-        if (id.contains(":")) {
+        if (!id.contains(":")) {
             id = "minecraft:" + id;
         }
         return Optional.ofNullable(this.fireworkShapeMap.get(id));


### PR DESCRIPTION
The id for `SpongeFireworkShape` is currently stored as a `byte`, and the name is returned instead. This makes the following changes to fix this behavior:

 - Switches the id to a `String` consistent with the `CatalogType` field.
 - Changes the name to be a 'normal' name, not upper case.
 - Adds the `minecraft` namespace to the id
 - Adds the `minecraft` namespace (if necessary) when looking up the id.