### PR TITLE
Use setupCIWorkspace on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ git:
   submodules: false
 before_install: scripts/travis-initialize-submodules
 
-install: ./gradlew setupDecompWorkspace
+install: ./gradlew setupCIWorkspace
 script: ./gradlew build
 
 notifications:


### PR DESCRIPTION
SpongeCommon | SpongeForge | SpongeVanilla

According to this commit: https://github.com/SpongePowered/SpongeCommon/commit/0801d5ccaeaf7655ef5a3861fca8fa814a5df6ff#diff-354f30a63fb0907d4ad57269548329e3

> Compiling with setupCIWorkspace on 1.9.4 is broken because of a
> class file the Java compiler can't read for some special reason.
> 
> bad class file: SPacketPlayerListItem$AddPlayerData.class

That should be fixed now. (See https://github.com/MinecraftForge/ForgeGradle/issues/472)

This should speed up travis build.

EDIT: Wait something went wrong
