### PR TITLE
Fix missing vanilla manipulators

### DIFF
--- a/src/main/java/org/spongepowered/common/entity/SpongeEntitySnapshotBuilder.java
+++ b/src/main/java/org/spongepowered/common/entity/SpongeEntitySnapshotBuilder.java
@@ -198,8 +198,11 @@ public class SpongeEntitySnapshotBuilder extends AbstractDataBuilder<EntitySnaps
             this.rotation = optional.get().getRotation();
             this.scale = optional.get().getScale();
         }
-        for (ImmutableDataManipulator<?, ?> manipulator : holder.getContainers()) {
-            add(manipulator);
+        if (!holder.getContainers().isEmpty()) {
+            if (this.customManipulators == null) {
+                this.customManipulators = new ArrayList<>();
+            }
+            this.customManipulators.addAll(holder.getContainers());
         }
         if (holder instanceof SpongeEntitySnapshot) {
             this.compound = ((SpongeEntitySnapshot) holder).getCompound().orElse(null);

--- a/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
@@ -45,6 +45,7 @@ import org.spongepowered.common.event.tracking.phase.tick.EntityTickContext;
 import org.spongepowered.common.interfaces.IMixinChunk;
 import org.spongepowered.common.interfaces.IMixinTrackable;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -96,7 +97,7 @@ public interface IMixinEntity extends org.spongepowered.api.entity.Entity, IMixi
         return data.getCompoundTag(NbtDataUtil.SPONGE_DATA);
     }
 
-    default void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    default void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -66,6 +66,7 @@ import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataView;
 import org.spongepowered.api.data.Queries;
+import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.entity.IgniteableData;
@@ -142,6 +143,7 @@ import org.spongepowered.common.util.SpongeHooks;
 import org.spongepowered.common.util.VecHelper;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
@@ -1045,6 +1047,14 @@ public abstract class MixinEntity implements org.spongepowered.api.entity.Entity
         final Collection<DataManipulator<?, ?>> manipulators = ((IMixinCustomDataHolder) this).getCustomManipulators();
         if (!manipulators.isEmpty()) {
             container.set(DataQueries.DATA_MANIPULATORS, DataUtil.getSerializedManipulatorList(manipulators));
+        }
+        final List<DataManipulator<?, ?>> vanilla = new ArrayList<>();
+        this.supplyVanillaManipulators(vanilla);
+        if (!vanilla.isEmpty()) {
+            vanilla.forEach(m -> m.getKeys().forEach(k -> {
+                Optional<?> val = m.get((Key) k);
+                val.ifPresent(value -> container.set(k.getQuery(), value));
+            }));
         }
         return container;
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityHanging.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityHanging.java
@@ -57,6 +57,7 @@ import org.spongepowered.common.interfaces.entity.IMixinEntityHanging;
 import org.spongepowered.common.interfaces.world.IMixinWorld;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -152,7 +153,7 @@ public abstract class MixinEntityHanging extends MixinEntity implements Hanging,
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getDirectionalData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLiving.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLiving.java
@@ -70,6 +70,7 @@ import org.spongepowered.common.interfaces.entity.IMixinGriefer;
 import org.spongepowered.common.interfaces.world.IMixinWorld;
 import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -293,7 +294,7 @@ public abstract class MixinEntityLiving extends MixinEntityLivingBase implements
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getAgentData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java
@@ -976,7 +976,7 @@ public abstract class MixinEntityLivingBase extends MixinEntity implements Livin
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getHealthData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityMinecartCommandBlock.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityMinecartCommandBlock.java
@@ -35,6 +35,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.interfaces.IMixinCommandSource;
 import org.spongepowered.common.mixin.core.entity.item.MixinEntityMinecart;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityMinecartCommandBlock.class)
@@ -48,7 +49,8 @@ public abstract class MixinEntityMinecartCommandBlock extends MixinEntityMinecar
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
+        super.supplyVanillaManipulators(manipulators);
         manipulators.add(getCommandData());
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/ai/MixinEntityMinecartMobSpawner.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/ai/MixinEntityMinecartMobSpawner.java
@@ -36,6 +36,7 @@ import org.spongepowered.common.interfaces.IMixinMobSpawner;
 import org.spongepowered.common.mixin.core.entity.item.MixinEntityMinecart;
 import org.spongepowered.asm.mixin.Shadow;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityMinecartMobSpawner.class)
@@ -63,7 +64,7 @@ public abstract class MixinEntityMinecartMobSpawner extends MixinEntityMinecart 
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getSpawnerData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/effect/MixinEntityLightningBolt.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/effect/MixinEntityLightningBolt.java
@@ -58,6 +58,7 @@ import org.spongepowered.common.interfaces.entity.IMixinEntityLightningBolt;
 import org.spongepowered.common.interfaces.world.IMixinLocation;
 import org.spongepowered.common.util.VecHelper;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityLightningBolt.class)
@@ -182,7 +183,7 @@ public abstract class MixinEntityLightningBolt extends MixinEntityWeatherEffect 
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getExpiringData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityArmorStand.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityArmorStand.java
@@ -61,6 +61,7 @@ import org.spongepowered.common.mixin.core.entity.MixinEntityLivingBase;
 import org.spongepowered.common.util.VecHelper;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -120,7 +121,7 @@ public abstract class MixinEntityArmorStand extends MixinEntityLivingBase implem
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getBodyPartRotationalData());
         manipulators.add(getArmorStandData());

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityBoat.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityBoat.java
@@ -33,6 +33,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.common.data.util.NbtDataUtil;
 import org.spongepowered.common.mixin.core.entity.MixinEntity;
 
+import java.util.Collection;
 import java.util.List;
 
 // TODO 1.9: Refactor this for boat overhaul
@@ -116,7 +117,7 @@ public abstract class MixinEntityBoat extends MixinEntity implements Boat {
     }*/
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(get(TreeData.class).get());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityItem.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityItem.java
@@ -57,6 +57,7 @@ import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 import org.spongepowered.common.item.inventory.util.ItemStackUtil;
 import org.spongepowered.common.mixin.core.entity.MixinEntity;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityItem.class)
@@ -238,7 +239,7 @@ public abstract class MixinEntityItem extends MixinEntity implements Item, IMixi
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getItemData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityPainting.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityPainting.java
@@ -38,6 +38,7 @@ import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.mixin.core.entity.MixinEntityHanging;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityPainting.class)
@@ -56,7 +57,7 @@ public abstract class MixinEntityPainting extends MixinEntityHanging implements 
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getArtData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityXPOrb.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityXPOrb.java
@@ -37,6 +37,7 @@ import org.spongepowered.common.data.value.SpongeValueFactory;
 import org.spongepowered.common.interfaces.entity.IMixinEntityXPOrb;
 import org.spongepowered.common.mixin.core.entity.MixinEntity;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityXPOrb.class)
@@ -70,7 +71,7 @@ public abstract class MixinEntityXPOrb extends MixinEntity implements Experience
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(experienceHeld());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/monster/MixinEntityBlaze.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/monster/MixinEntityBlaze.java
@@ -34,6 +34,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeFlammableData;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityBlaze.class)
@@ -47,7 +48,7 @@ public abstract class MixinEntityBlaze extends MixinEntityMob implements Blaze {
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(new SpongeFlammableData(this.isBurning()));
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/monster/MixinEntityEnderman.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/monster/MixinEntityEnderman.java
@@ -39,6 +39,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.common.event.tracking.phase.tick.EntityTickContext;
 
+import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -63,7 +64,7 @@ public abstract class MixinEntityEnderman extends MixinEntityMob implements Ende
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(get(ScreamingData.class).get());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/monster/MixinEntityEndermite.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/monster/MixinEntityEndermite.java
@@ -43,6 +43,7 @@ import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeExpirableData;
 import org.spongepowered.common.data.value.SpongeValueFactory;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityEndermite.class)
@@ -66,7 +67,7 @@ public abstract class MixinEntityEndermite extends MixinEntityMob implements End
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getExpirableData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/monster/MixinEntityPigZombie.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/monster/MixinEntityPigZombie.java
@@ -41,6 +41,7 @@ import org.spongepowered.common.data.value.SpongeValueFactory;
 import org.spongepowered.common.interfaces.entity.IMixinAggressive;
 import org.spongepowered.common.interfaces.entity.IMixinAnger;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityPigZombie.class)
@@ -90,7 +91,7 @@ public abstract class MixinEntityPigZombie extends MixinEntityZombie implements 
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getAngerData());
         manipulators.add(new SpongeAggressiveData(isAngry()));

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/monster/MixinEntitySlime.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/monster/MixinEntitySlime.java
@@ -36,6 +36,7 @@ import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSlimeData;
 import org.spongepowered.common.data.value.SpongeValueFactory;
 import org.spongepowered.common.mixin.core.entity.MixinEntityLiving;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntitySlime.class)
@@ -59,7 +60,7 @@ public abstract class MixinEntitySlime extends MixinEntityLiving implements Slim
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getSlimeData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/monster/MixinEntityVindicator.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/monster/MixinEntityVindicator.java
@@ -35,6 +35,7 @@ import org.spongepowered.common.data.manipulator.mutable.entity.SpongeJohnnyData
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.interfaces.entity.monster.IMixinVindicator;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityVindicator.class)
@@ -48,7 +49,7 @@ public abstract class MixinEntityVindicator extends MixinEntityMob implements IM
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(new SpongeJohnnyData(this.johnny));
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityHorse.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityHorse.java
@@ -41,6 +41,7 @@ import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.registry.type.entity.HorseColorRegistryModule;
 import org.spongepowered.common.registry.type.entity.HorseStyleRegistryModule;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityHorse.class)
@@ -63,7 +64,7 @@ public abstract class MixinEntityHorse extends MixinAbstractHorse implements Rid
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getHorseData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityOcelot.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityOcelot.java
@@ -52,6 +52,7 @@ import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.registry.type.entity.OcelotTypeRegistryModule;
 import org.spongepowered.common.text.translation.SpongeTranslation;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 
@@ -99,7 +100,7 @@ public abstract class MixinEntityOcelot extends MixinEntityTameable implements O
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(new SpongeSittingData(this.shadow$isSitting()));
         manipulators.add(getOcelotData());

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityParrot.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityParrot.java
@@ -48,6 +48,7 @@ import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.registry.type.entity.ParrotVariantRegistryModule;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 
@@ -84,7 +85,7 @@ public abstract class MixinEntityParrot extends MixinEntityTameable implements P
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(new SpongeSittingData(this.shadow$isSitting()));
         manipulators.add(getParrotData());

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityPig.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityPig.java
@@ -35,6 +35,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongePigSaddleData;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityPig.class)
@@ -53,7 +54,7 @@ public abstract class MixinEntityPig extends MixinEntityAnimal implements Pig {
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(this.getPigSaddleData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityRabbit.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityRabbit.java
@@ -38,6 +38,7 @@ import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.registry.type.entity.RabbitTypeRegistryModule;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntityRabbit.class)
@@ -56,7 +57,7 @@ public abstract class MixinEntityRabbit extends MixinEntityAnimal implements Rab
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getRabbitData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntitySheep.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntitySheep.java
@@ -39,6 +39,7 @@ import org.spongepowered.common.data.manipulator.mutable.entity.SpongeShearedDat
 import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
+import java.util.Collection;
 import java.util.List;
 
 @Mixin(EntitySheep.class)
@@ -58,7 +59,7 @@ public abstract class MixinEntitySheep extends MixinEntityAnimal implements Shee
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getDyeData());
         manipulators.add(new SpongeShearedData(getSheared()));

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityVillager.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityVillager.java
@@ -72,6 +72,7 @@ import org.spongepowered.common.item.inventory.lens.impl.fabric.IInventoryFabric
 import org.spongepowered.common.mixin.core.entity.MixinEntityAgeable;
 import org.spongepowered.common.registry.SpongeVillagerRegistry;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -231,7 +232,7 @@ public abstract class MixinEntityVillager extends MixinEntityAgeable implements 
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getCareerData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityWolf.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityWolf.java
@@ -44,6 +44,7 @@ import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeAggressiveData;
 import org.spongepowered.common.interfaces.entity.IMixinAggressive;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 
@@ -86,7 +87,7 @@ public abstract class MixinEntityWolf extends MixinEntityAnimal implements Wolf 
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(get(SittingData.class).get());
         manipulators.add(new SpongeAggressiveData(this.isAngry()));

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -1084,7 +1084,7 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getJoinData());
         manipulators.add(getGameModeData());

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityArrow.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityArrow.java
@@ -45,6 +45,7 @@ import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.interfaces.entity.projectile.IMixinEntityArrow;
 import org.spongepowered.common.mixin.core.entity.MixinEntity;
 
+import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -80,7 +81,8 @@ public abstract class MixinEntityArrow extends MixinEntity implements Arrow, IMi
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
+        super.supplyVanillaManipulators(manipulators);
         manipulators.add(getKnockbackData());
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntity.java
@@ -72,7 +72,9 @@ import org.spongepowered.common.util.VecHelper;
 
 import java.lang.ref.WeakReference;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -256,18 +258,17 @@ public abstract class MixinTileEntity implements TileEntity, IMixinTileEntity {
         CustomDataNbtUtil.writeCustomData(compound, this);
     }
 
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
-
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
     }
 
     @Override
     public Collection<DataManipulator<?, ?>> getContainers() {
-        final List<DataManipulator<?, ?>> list = Lists.newArrayList();
-        this.supplyVanillaManipulators(list);
+        final Set<DataManipulator<?, ?>> manipulators = new HashSet<>();
+        supplyVanillaManipulators(manipulators);
         if (this instanceof IMixinCustomDataHolder) {
-            list.addAll(((IMixinCustomDataHolder) this).getCustomManipulators());
+            manipulators.addAll(((IMixinCustomDataHolder) this).getCustomManipulators());
         }
-        return list;
+        return manipulators;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityBanner.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityBanner.java
@@ -53,6 +53,7 @@ import org.spongepowered.common.registry.SpongeGameRegistry;
 import org.spongepowered.common.util.NonNullArrayList;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @NonnullByDefault
@@ -82,7 +83,7 @@ public abstract class MixinTileEntityBanner extends MixinTileEntity implements B
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getBannerData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityBeacon.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityBeacon.java
@@ -49,6 +49,7 @@ import org.spongepowered.common.item.inventory.lens.impl.collections.SlotLensCol
 import org.spongepowered.common.item.inventory.lens.impl.slots.InputSlotLensImpl;
 import org.spongepowered.common.item.inventory.lens.slots.InputSlotLens;
 
+import java.util.Collection;
 import java.util.List;
 
 @NonnullByDefault
@@ -115,7 +116,7 @@ public abstract class MixinTileEntityBeacon extends MixinTileEntityLockable impl
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getBeaconData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityChest.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityChest.java
@@ -48,6 +48,7 @@ import org.spongepowered.common.item.inventory.lens.impl.collections.SlotLensCol
 import org.spongepowered.common.item.inventory.lens.impl.comp.GridInventoryLensImpl;
 import org.spongepowered.common.item.inventory.util.InventoryUtil;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -164,12 +165,9 @@ public abstract class MixinTileEntityChest extends MixinTileEntityLockableLoot i
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
-        Optional<ConnectedDirectionData> connectedChestData = get(ConnectedDirectionData.class);
-        if (connectedChestData.isPresent()) {
-            manipulators.add(connectedChestData.get());
-        }
+        get(ConnectedDirectionData.class).ifPresent(manipulators::add);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityCommandBlock.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityCommandBlock.java
@@ -37,6 +37,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.interfaces.IMixinCommandSource;
 
+import java.util.Collection;
 import java.util.List;
 
 @NonnullByDefault
@@ -46,7 +47,7 @@ public abstract class MixinTileEntityCommandBlock extends MixinTileEntity implem
     @Shadow public abstract CommandBlockBaseLogic getCommandBlockLogic();
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getCommandData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityEnchantmentTable.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityEnchantmentTable.java
@@ -36,6 +36,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.interfaces.data.IMixinCustomNameable;
 
+import java.util.Collection;
 import java.util.List;
 
 @NonnullByDefault
@@ -52,7 +53,7 @@ public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity im
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         if (((TileEntityEnchantmentTable) (Object) this).hasCustomName()) {
             manipulators.add(get(DisplayNameData.class).get());

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityFlowerPot.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityFlowerPot.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.RepresentedItemData;
 import org.spongepowered.asm.mixin.Mixin;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,11 +38,8 @@ import java.util.Optional;
 public abstract class MixinTileEntityFlowerPot extends MixinTileEntity implements FlowerPot {
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
-        Optional<RepresentedItemData> flowerItemData = get(RepresentedItemData.class);
-        if (flowerItemData.isPresent()) {
-            manipulators.add(flowerItemData.get());
-        }
+        get(RepresentedItemData.class).ifPresent(manipulators::add);
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityHopper.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityHopper.java
@@ -65,6 +65,7 @@ import org.spongepowered.common.item.inventory.lens.impl.collections.SlotLensCol
 import org.spongepowered.common.item.inventory.lens.impl.comp.GridInventoryLensImpl;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -131,12 +132,9 @@ public abstract class MixinTileEntityHopper extends MixinTileEntityLockableLoot 
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
-        Optional<CooldownData> cooldownData = get(CooldownData.class);
-        if (cooldownData.isPresent()) {
-            manipulators.add(cooldownData.get());
-        }
+        get(CooldownData.class).ifPresent(manipulators::add);
     }
 
     // Call PreEvents

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityJukebox.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityJukebox.java
@@ -38,6 +38,7 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -86,12 +87,9 @@ public abstract class MixinTileEntityJukebox extends MixinTileEntity implements 
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
-        Optional<RepresentedItemData> recordItemData = get(RepresentedItemData.class);
-        if (recordItemData.isPresent()) {
-            manipulators.add(recordItemData.get());
-        }
+        get(RepresentedItemData.class).ifPresent(manipulators::add);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityLockable.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityLockable.java
@@ -55,6 +55,7 @@ import org.spongepowered.common.item.inventory.lens.impl.DefaultIndexedLens;
 import org.spongepowered.common.item.inventory.lens.impl.ReusableLens;
 import org.spongepowered.common.item.inventory.lens.impl.collections.SlotLensCollection;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -90,16 +91,10 @@ public abstract class MixinTileEntityLockable extends MixinTileEntity implements
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
-        Optional<LockableData> lockData = get(LockableData.class);
-        if (lockData.isPresent()) {
-            manipulators.add(lockData.get());
-        }
-        Optional<InventoryItemData> inventoryData = get(InventoryItemData.class);
-        if (inventoryData.isPresent()) {
-            manipulators.add(inventoryData.get());
-        }
+        get(LockableData.class).ifPresent(manipulators::add);
+        get(InventoryItemData.class).ifPresent(manipulators::add);
         if (((TileEntityLockable) (Object) this).hasCustomName()) {
             manipulators.add(get(DisplayNameData.class).get());
         }

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityMobSpawner.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityMobSpawner.java
@@ -38,6 +38,7 @@ import org.spongepowered.common.data.manipulator.mutable.SpongeMobSpawnerData;
 import org.spongepowered.common.data.processor.common.SpawnerUtils;
 import org.spongepowered.common.interfaces.IMixinMobSpawner;
 
+import java.util.Collection;
 import java.util.List;
 
 @NonnullByDefault
@@ -81,7 +82,7 @@ public abstract class MixinTileEntityMobSpawner extends MixinTileEntity implemen
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getMobSpawnerData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityNote.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityNote.java
@@ -33,6 +33,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.data.util.DataQueries;
 
+import java.util.Collection;
 import java.util.List;
 
 @NonnullByDefault
@@ -49,7 +50,7 @@ public abstract class MixinTileEntityNote extends MixinTileEntity implements Not
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getNoteData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntitySign.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntitySign.java
@@ -39,6 +39,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.interfaces.IMixinSubject;
 
+import java.util.Collection;
 import java.util.List;
 
 @NonnullByDefault
@@ -69,7 +70,7 @@ public abstract class MixinTileEntitySign extends MixinTileEntity implements Sig
     }
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getSignData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntitySkull.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntitySkull.java
@@ -39,6 +39,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.data.processor.common.SkullUtils;
 import org.spongepowered.common.interfaces.block.tile.IMixinTileEntitySkull;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,13 +53,10 @@ public abstract class MixinTileEntitySkull extends MixinTileEntity implements Sk
     @Shadow public abstract com.mojang.authlib.GameProfile shadow$getPlayerProfile();
 
     @Override
-    public void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) {
+    public void supplyVanillaManipulators(Collection<DataManipulator<?, ?>> manipulators) {
         super.supplyVanillaManipulators(manipulators);
         manipulators.add(getSkullData());
-        Optional<RepresentedPlayerData> profileData = get(RepresentedPlayerData.class);
-        if (profileData.isPresent()) {
-            manipulators.add(profileData.get());
-        }
+        get(RepresentedPlayerData.class).ifPresent(manipulators::add);
     }
 
     @Intrinsic


### PR DESCRIPTION
This should fix https://github.com/SpongePowered/SpongeCommon/issues/723 and a couple of other issues.

Step to reproduce:
kill a pig.

Code:

```
    @Listener
    public void onBlockBreak(DestructEntityEvent event) {
        if (event.getTargetEntity().getType() == EntityTypes.PIG) {
            System.out.println("1: " + event.getTargetEntity().get(Keys.HEALTH).orElse(12345678.9));
            System.out.println("2: " + event.getTargetEntity().createSnapshot().get(Keys.HEALTH).orElse(12345678.9));
            EntitySnapshot e = EntitySnapshot.builder().build(event.getTargetEntity().createSnapshot().toContainer()).get();
            System.out.println("3: " + e.get(Keys.HEALTH).orElse(12345678.9));
            EntitySnapshot e1 = EntitySnapshot.builder().build(event.getTargetEntity().toContainer()).get();
            System.out.println("4: " + e1.get(Keys.HEALTH).orElse(12345678.9));
        }
    }
```
This is wip but I was looking for input.

Is it possible for an entity to have null vanillaManipulators ? 

While this was born as a fix for #723 I have noticed the problem is present also on ItemStackSnapshot and BlockSnapshot. There was an old PR for the latter (https://github.com/SpongePowered/SpongeCommon/pull/1905). @gabizou Is the concern about performances still valid ? 

