### PR TITLE
SpongeEntityType invalid cast fix

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -1397,7 +1397,7 @@ public abstract class MixinEntity implements org.spongepowered.api.entity.Entity
 
     @Override
     public void refreshCache() {
-        if (this.entityType != null) {
+        if (this.entityType instanceof SpongeEntityType) {
             this.allowsBlockBulkCapture = ((SpongeEntityType) this.entityType).allowsBlockBulkCapture;
             this.allowsEntityBulkCapture = ((SpongeEntityType) this.entityType).allowsEntityBulkCapture;
             this.allowsBlockEventCreation = ((SpongeEntityType) this.entityType).allowsBlockEventCreation;


### PR DESCRIPTION
Changes an always true `!= null` check to use `instanceof`. Unsure if this is a proper fix, but comparisons with existing code show `!= null` definitely did not have the intended behavior.

From LemADEC#4620, when executing `sponge -g reload`.
https://gist.github.com/LemADEC/1799a9e8370a423e34715aeba6f8e40f
>>
    Minecraft: 1.12.2
    SpongeAPI: 7.1.0-SNAPSHOT-51caddf
    SpongeForge: 1.12.2-2705-7.1.0-BETA-3355
    Minecraft Forge: 14.23.4.2739
