### PR TITLE
Selector updates and improvements

### DIFF
--- a/src/main/java/org/spongepowered/common/registry/type/text/ArgumentRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/text/ArgumentRegistryModule.java
@@ -64,7 +64,7 @@ public final class ArgumentRegistryModule implements RegistryModule {
         this.argumentTypeMap.put("radius", radius);
 
         // GAME_MODE
-        this.argumentTypeMap.put("game_mode", factory.createArgumentType("m", GameMode.class));
+        this.argumentTypeMap.put("game_mode", factory.createInvertibleArgumentType("m", GameMode.class));
 
         // COUNT
         this.argumentTypeMap.put("count", factory.createArgumentType("c", Integer.class));

--- a/src/main/java/org/spongepowered/common/registry/type/text/ArgumentRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/text/ArgumentRegistryModule.java
@@ -76,8 +76,7 @@ public final class ArgumentRegistryModule implements RegistryModule {
         this.argumentTypeMap.put("level", level);
 
         // TEAM
-        this.argumentTypeMap.put("team", factory.createInvertibleArgumentType("team", Integer.class,
-                                                                              org.spongepowered.api.scoreboard.Team.class.getName()));
+        this.argumentTypeMap.put("team", factory.createInvertibleArgumentType("team", String.class));
 
         // NAME
         this.argumentTypeMap.put("name", factory.createInvertibleArgumentType("name", String.class));

--- a/src/main/java/org/spongepowered/common/registry/type/text/SelectorTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/text/SelectorTypeRegistryModule.java
@@ -60,6 +60,7 @@ public final class SelectorTypeRegistryModule implements AlternateCatalogRegistr
         this.selectorMappings.put("minecraft:all_players", new SpongeSelectorType("minecraft:all_players", "a"));
         this.selectorMappings.put("minecraft:all_entities", new SpongeSelectorType("minecraft:all_entities", "e"));
         this.selectorMappings.put("minecraft:nearest_player", new SpongeSelectorType("minecraft:nearest_player", "p"));
+        this.selectorMappings.put("minecraft:source", new SpongeSelectorType("minecraft:source", "s"));
         this.selectorMappings.put("minecraft:random", new SpongeSelectorType("minecraft:random", "r"));
     }
 

--- a/src/main/java/org/spongepowered/common/text/selector/SelectorResolver.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SelectorResolver.java
@@ -28,9 +28,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3i;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
@@ -97,7 +95,8 @@ public class SelectorResolver {
         return null;
     }
 
-    private final CommandSource origin;
+    @Nullable private final CommandSource origin;
+    @Nullable private final Entity entityOrigin;
     private final Collection<Extent> extents;
     private final Vector3d position;
     private final Selector selector;
@@ -115,6 +114,11 @@ public class SelectorResolver {
         this.selector = checkNotNull(selector);
         this.extents = ImmutableSet.copyOf(extents);
         this.origin = origin;
+        if (this.origin instanceof Entity) {
+            this.entityOrigin = (Entity) origin;
+        } else {
+            this.entityOrigin = null;
+        }
         this.position = position == null ? Vector3d.ZERO : position;
         this.selectorFilter = makeFilter();
     }
@@ -147,14 +151,15 @@ public class SelectorResolver {
         Integer y = this.selector.get(ArgumentTypes.DIMENSION.y()).orElse(0);
         Integer z = this.selector.get(ArgumentTypes.DIMENSION.z()).orElse(0);
         AABB axisalignedbb = getAABB(this.position.toInt(), x, y, z);
-        filters.add(input -> {
-            Optional<AABB> entityAABB = ((Entity) this.origin).getBoundingBox();
-            return !entityAABB.isPresent() || axisalignedbb.intersects(axisalignedbb);
-        });
+
+        if (this.entityOrigin != null) {
+            filters.add(input -> this.entityOrigin.getBoundingBox().map(aabb -> aabb.intersects(axisalignedbb)).orElse(false));
+        }
     }
 
     private void addGamemodeFilters(List<Predicate<Entity>> filters) {
-        Optional<Invertible<GameMode>> gamemode = this.selector.getArgument(ArgumentTypes.GAME_MODE);
+        // TODO: For bleeding, update API to make ArgumentTypes.GAME_MODE invertible
+        Optional<Invertible<GameMode>> gamemode = this.selector.getArgument((ArgumentType.Invertible<GameMode>) ArgumentTypes.GAME_MODE);
         if (gamemode.isPresent()) {
             final GameMode actualMode = gamemode.get().getValue();
             // If the gamemode is NOT_SET, that means accept any
@@ -306,13 +311,17 @@ public class SelectorResolver {
         return new Vector3d(x.orElse(pos.getX()), y.orElse(pos.getY()), z.orElse(pos.getZ()));
     }
 
-    public List<Entity> resolve() {
+    // This returns an ImmutableSet as we want a guarantee of order. We're also using a set because API 7
+    // must return a set, so returning a list here will require another object to needlessly be created.
+    //
+    // TODO: For API 8, this can be a list instead.
+    public ImmutableSet<Entity> resolve() {
         SelectorType selectorType = this.selector.getType();
         if (selectorType == SelectorTypes.SOURCE) {
-            if (this.origin != null && this.origin instanceof Entity && this.selectorFilter.test((Entity) this.origin)) {
-                return ImmutableList.of((Entity) this.origin);
+            if (this.entityOrigin != null && this.selectorFilter.test(this.entityOrigin)) {
+                return ImmutableSet.of(this.entityOrigin);
             }
-            return ImmutableList.of();
+            return ImmutableSet.of();
         }
 
         int defaultCount = 1;
@@ -329,20 +338,20 @@ public class SelectorResolver {
 
         if (maxToSelect == 0) {
             return entityStream.sorted(distanceSort(isReversed))
-                    .collect(ImmutableList.toImmutableList());
+                    .collect(ImmutableSet.toImmutableSet());
         }
 
         if (selectorType == SelectorTypes.RANDOM) {
             List<Entity> holder = entityStream.collect(Collectors.toList());
-            if (holder.isEmpty()) return ImmutableList.of();
+            if (holder.isEmpty()) return ImmutableSet.of();
 
             Collections.shuffle(holder);
-            return ImmutableList.copyOf(holder.subList(0, maxToSelect));
+            return ImmutableSet.copyOf(holder.subList(0, maxToSelect));
         }
 
         return entityStream.sorted(distanceSort(isReversed))
                 .limit(maxToSelect)
-                .collect(ImmutableList.toImmutableList());
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     private Comparator<? super Entity> distanceSort(boolean isReversed) {
@@ -357,25 +366,29 @@ public class SelectorResolver {
 
     private Set<? extends Extent> getExtentSet() {
         boolean location = this.selector.getArguments().stream()
-                .filter(arg -> LOCATION_BASED_ARGUMENTS.contains(arg.getType()))
-                .findAny()
-                .isPresent();
-        if (location && this.origin != null && this.origin instanceof Locatable) {
+                .anyMatch(arg -> LOCATION_BASED_ARGUMENTS.contains(arg.getType()));
+        if (location && this.origin instanceof Locatable) {
             return ImmutableSet.of(((Locatable) this.origin).getWorld());
         }
         return ImmutableSet.copyOf(this.extents);
     }
 
     private static AABB getAABB(Vector3i pos, int x, int y, int z) {
-        boolean flag = x < 0;
-        boolean flag1 = y < 0;
-        boolean flag2 = z < 0;
-        int i = pos.getX() + (flag ? x : 0);
-        int j = pos.getY() + (flag1 ? y : 0);
-        int k = pos.getZ() + (flag2 ? z : 0);
-        int l = pos.getX() + (flag ? 0 : x) + 1;
-        int i1 = pos.getY() + (flag1 ? 0 : y) + 1;
-        int j1 = pos.getZ() + (flag2 ? 0 : z) + 1;
-        return new AABB((double)i, (double)j, (double)k, (double)l, (double)i1, (double)j1);
+        boolean isNegativeX = x < 0;
+        boolean isNegativeY = y < 0;
+        boolean isNegativeZ = z < 0;
+
+        // First corner co-ordinates (intended to be the minimum co-ordinates)
+        int xmin = pos.getX() + (isNegativeX ? x : 0);
+        int ymin = pos.getY() + (isNegativeY ? y : 0);
+        int zmin = pos.getZ() + (isNegativeZ ? z : 0);
+
+        // Second corner co-ordinates (intended to be the maximum co-ordinates)
+        int xmax = pos.getX() + (isNegativeX ? 0 : x) + 1;
+        int ymax = pos.getY() + (isNegativeY ? 0 : y) + 1;
+        int zmax = pos.getZ() + (isNegativeZ ? 0 : z) + 1;
+
+        return new AABB((double) xmin, (double) ymin, (double) zmin, (double) xmax, (double) ymax, (double) zmax);
     }
+
 }

--- a/src/main/java/org/spongepowered/common/text/selector/SelectorResolver.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SelectorResolver.java
@@ -25,10 +25,12 @@
 package org.spongepowered.common.text.selector;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.spongepowered.common.util.OptionalUtils.asSet;
 
 import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3i;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
@@ -39,22 +41,25 @@ import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.entity.living.player.gamemode.GameModes;
+import org.spongepowered.api.scoreboard.Score;
+import org.spongepowered.api.scoreboard.Scoreboard;
 import org.spongepowered.api.scoreboard.Team;
 import org.spongepowered.api.scoreboard.TeamMember;
+import org.spongepowered.api.scoreboard.objective.Objective;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.selector.Argument;
 import org.spongepowered.api.text.selector.Argument.Invertible;
 import org.spongepowered.api.text.selector.ArgumentHolder;
+import org.spongepowered.api.text.selector.ArgumentType;
 import org.spongepowered.api.text.selector.ArgumentTypes;
 import org.spongepowered.api.text.selector.Selector;
 import org.spongepowered.api.text.selector.SelectorType;
 import org.spongepowered.api.text.selector.SelectorTypes;
+import org.spongepowered.api.util.AABB;
 import org.spongepowered.api.util.Functional;
-import org.spongepowered.api.util.GuavaCollectors;
 import org.spongepowered.api.world.Locatable;
-import org.spongepowered.api.world.Location;
-import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.Extent;
+import org.spongepowered.common.SpongeImpl;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -75,12 +80,14 @@ import javax.annotation.Nullable;
 public class SelectorResolver {
 
     private static final Collection<SelectorType> INFINITE_TYPES = ImmutableSet.of(SelectorTypes.ALL_ENTITIES, SelectorTypes.ALL_PLAYERS);
+    private static final Set<ArgumentType<?>> LOCATION_BASED_ARGUMENTS;
 
-    private static Extent extentFromSource(CommandSource origin) {
-        if (origin instanceof Locatable) {
-            return ((Locatable) origin).getWorld();
-        }
-        return null;
+    static {
+        ImmutableSet.Builder<ArgumentType<?>> builder = ImmutableSet.builder();
+        builder.addAll(ArgumentTypes.POSITION.getTypes());
+        builder.addAll(ArgumentTypes.DIMENSION.getTypes());
+        builder.addAll(ArgumentTypes.RADIUS.getTypes());
+        LOCATION_BASED_ARGUMENTS = builder.build();
     }
 
     private static Vector3d positionFromSource(CommandSource origin) {
@@ -90,108 +97,80 @@ public class SelectorResolver {
         return null;
     }
 
-    private static <I, R extends I> Predicate<I> requireTypePredicate(Class<I> inputType, final Class<R> requiredType) {
-        return requiredType::isInstance;
-    }
-
+    private final CommandSource origin;
     private final Collection<Extent> extents;
     private final Vector3d position;
     private final Selector selector;
     private final Predicate<Entity> selectorFilter;
 
-    public SelectorResolver(Collection<? extends Extent> extents, Selector selector) {
-        this(extents, null, selector);
+    public SelectorResolver(Selector selector, Collection<? extends Extent> extents) {
+        this(selector, extents, null, null);
     }
 
-    public SelectorResolver(Location<World> location, Selector selector) {
-        this(ImmutableSet.of(location.getExtent()), location.getPosition(), selector);
+    public SelectorResolver(Selector selector, CommandSource origin) {
+        this(selector, SpongeImpl.getGame().getServer().getWorlds(), origin, positionFromSource(origin));
     }
 
-    public SelectorResolver(CommandSource origin, Selector selector) {
-        this(asSet(Optional.ofNullable(extentFromSource(origin))), positionFromSource(origin), selector);
-    }
-
-    private SelectorResolver(Collection<? extends Extent> extents, @Nullable Vector3d position, Selector selector) {
-        this.extents = ImmutableSet.copyOf(extents);
-        this.position = position == null ? Vector3d.ZERO : position;
+    private SelectorResolver(Selector selector, Collection<? extends Extent> extents, @Nullable CommandSource origin, @Nullable Vector3d position) {
         this.selector = checkNotNull(selector);
+        this.extents = ImmutableSet.copyOf(extents);
+        this.origin = origin;
+        this.position = position == null ? Vector3d.ZERO : position;
         this.selectorFilter = makeFilter();
     }
 
     private Predicate<Entity> makeFilter() {
-        final Selector sel = this.selector;
         Vector3d position = getPositionOrDefault(this.position, ArgumentTypes.POSITION);
-        ArrayList<Predicate<Entity>> filters = new ArrayList<>(sel.getArguments().size());
-
-        if (isPlayerOnlySelector()) {
-            filters.add(requireTypePredicate(Entity.class, Player.class));
-        }
+        ArrayList<Predicate<Entity>> filters = new ArrayList<Predicate<Entity>>();
 
         addTypeFilters(filters);
-        addDimensionFilters(position, filters);
-        addRadiusFilters(position, filters);
         addLevelFilters(filters);
         addGamemodeFilters(filters);
-        addNameFilters(filters);
-        addRotationFilters(filters);
         addTeamFilters(filters);
         addScoreFilters(filters);
+        addNameFilters(filters);
+        addRadiusFilters(position, filters);
+        addDimensionFilters(position, filters);
+        addRotationFilters(filters);
 
         // Pack the list before returning it to improve space efficiency
         filters.trimToSize();
         return Functional.predicateAnd(filters);
     }
 
-    private boolean isPlayerOnlySelector() {
-        SelectorType type = this.selector.getType();
-        boolean untypedRandom = type == SelectorTypes.RANDOM && !this.selector.get(ArgumentTypes.ENTITY_TYPE).isPresent();
-        return type == SelectorTypes.ALL_PLAYERS || type == SelectorTypes.NEAREST_PLAYER || untypedRandom;
-    }
-
     private void addDimensionFilters(final Vector3d position, List<Predicate<Entity>> filters) {
-        Selector sel = this.selector;
-        Vector3d boxDimensions = getPositionOrDefault(Vector3d.ZERO, ArgumentTypes.DIMENSION);
-        Vector3d det1 = position;
-        Vector3d det2 = position.add(boxDimensions);
-        final Vector3d boxMin = det1.min(det2);
-        final Vector3d boxMax = det1.max(det2);
-        if (sel.has(ArgumentTypes.DIMENSION.x())) {
-            filters.add(input -> {
-                Vector3d pos = input.getLocation().getPosition();
-                return pos.getX() >= boxMin.getX() && pos.getX() <= boxMax.getX();
-            });
-        }
-        if (sel.has(ArgumentTypes.DIMENSION.y())) {
-            filters.add(input -> {
-                Vector3d pos = input.getLocation().getPosition();
-                return pos.getY() >= boxMin.getY() && pos.getY() <= boxMax.getY();
-            });
-        }
-        if (sel.has(ArgumentTypes.DIMENSION.z())) {
-            filters.add(input -> {
-                Vector3d pos = input.getLocation().getPosition();
-                return pos.getZ() >= boxMin.getZ() && pos.getZ() <= boxMax.getZ();
-            });
-        }
+        if (this.selector.has(ArgumentTypes.DIMENSION.x()) || 
+                this.selector.has(ArgumentTypes.DIMENSION.y()) || 
+                this.selector.has(ArgumentTypes.DIMENSION.z())) return;
+
+        Integer x = this.selector.get(ArgumentTypes.DIMENSION.x()).orElse(0);
+        Integer y = this.selector.get(ArgumentTypes.DIMENSION.y()).orElse(0);
+        Integer z = this.selector.get(ArgumentTypes.DIMENSION.z()).orElse(0);
+        AABB axisalignedbb = getAABB(this.position.toInt(), x, y, z);
+        filters.add(input -> {
+            Optional<AABB> entityAABB = ((Entity) this.origin).getBoundingBox();
+            return !entityAABB.isPresent() || axisalignedbb.intersects(axisalignedbb);
+        });
     }
 
     private void addGamemodeFilters(List<Predicate<Entity>> filters) {
-        Selector sel = this.selector;
-        Optional<GameMode> gamemode = sel.get(ArgumentTypes.GAME_MODE);
-        // If the gamemode is NOT_SET, that means accept any
-        if (gamemode.isPresent() && gamemode.get() != GameModes.NOT_SET) {
-            final GameMode actualMode = gamemode.get();
-            filters.add(input -> {
-                Optional<GameModeData> mode = input.get(GameModeData.class);
-                return mode.isPresent() && mode.get() == actualMode;
-            });
+        Optional<Invertible<GameMode>> gamemode = this.selector.getArgument(ArgumentTypes.GAME_MODE);
+        if (gamemode.isPresent()) {
+            final GameMode actualMode = gamemode.get().getValue();
+            // If the gamemode is NOT_SET, that means accept any
+            if (actualMode != GameModes.NOT_SET) {
+                final boolean inverted = gamemode.get().isInverted();
+                filters.add(input -> {
+                    Optional<GameModeData> mode = input.get(GameModeData.class);
+                    return inverted ^ (mode.isPresent() && mode.get().type().get() == actualMode);
+                });
+            }
         }
     }
 
     private void addLevelFilters(List<Predicate<Entity>> filters) {
-        Selector sel = this.selector;
-        Optional<Integer> levelMin = sel.get(ArgumentTypes.LEVEL.minimum());
-        Optional<Integer> levelMax = sel.get(ArgumentTypes.LEVEL.maximum());
+        Optional<Integer> levelMin = this.selector.get(ArgumentTypes.LEVEL.minimum());
+        Optional<Integer> levelMax = this.selector.get(ArgumentTypes.LEVEL.maximum());
         if (levelMin.isPresent()) {
             final int actualMin = levelMin.get();
             filters.add(input -> {
@@ -209,8 +188,7 @@ public class SelectorResolver {
     }
 
     private void addNameFilters(List<Predicate<Entity>> filters) {
-        Selector sel = this.selector;
-        Optional<Argument.Invertible<String>> nameOpt = sel.getArgument(ArgumentTypes.NAME);
+        Optional<Argument.Invertible<String>> nameOpt = this.selector.getArgument(ArgumentTypes.NAME);
         if (nameOpt.isPresent()) {
             final String name = nameOpt.get().getValue();
             final boolean inverted = nameOpt.get().isInverted();
@@ -222,39 +200,37 @@ public class SelectorResolver {
     }
 
     private void addRadiusFilters(final Vector3d position, List<Predicate<Entity>> filters) {
-        final Selector sel = this.selector;
-        Optional<Integer> radiusMin = sel.get(ArgumentTypes.RADIUS.minimum());
-        Optional<Integer> radiusMax = sel.get(ArgumentTypes.RADIUS.maximum());
+        Optional<Integer> radiusMin = this.selector.get(ArgumentTypes.RADIUS.minimum());
+        Optional<Integer> radiusMax = this.selector.get(ArgumentTypes.RADIUS.maximum());
         if (radiusMin.isPresent()) {
-            int radMin = radiusMin.get();
-            final int radMinSquared = radMin * radMin;
+            double radMin = Math.max(radiusMin.get(), 1.0E-4D);
+            final double radMinSquared = radMin * radMin;
             filters.add(input -> input.getLocation().getPosition().distanceSquared(position) >= radMinSquared);
         }
         if (radiusMax.isPresent()) {
-            int radMax = radiusMax.get();
-            final int radMaxSquared = radMax * radMax;
+            double radMax = Math.max(radiusMax.get(), 1.0E-4D);
+            final double radMaxSquared = radMax * radMax;
             filters.add(input -> input.getLocation().getPosition().distanceSquared(position) <= radMaxSquared);
         }
     }
 
     private void addRotationFilters(List<Predicate<Entity>> filters) {
-        Selector sel = this.selector;
-        Optional<Double> rotMinX = sel.get(ArgumentTypes.ROTATION.minimum().x());
+        Optional<Double> rotMinX = this.selector.get(ArgumentTypes.ROTATION.minimum().x());
         if (rotMinX.isPresent()) {
             final double rmx = rotMinX.get();
             filters.add(input -> input.getRotation().getX() >= rmx);
         }
-        Optional<Double> rotMinY = sel.get(ArgumentTypes.ROTATION.minimum().y());
+        Optional<Double> rotMinY = this.selector.get(ArgumentTypes.ROTATION.minimum().y());
         if (rotMinY.isPresent()) {
             final double rmy = rotMinY.get();
             filters.add(input -> input.getRotation().getY() >= rmy);
         }
-        Optional<Double> rotMaxX = sel.get(ArgumentTypes.ROTATION.maximum().x());
+        Optional<Double> rotMaxX = this.selector.get(ArgumentTypes.ROTATION.maximum().x());
         if (rotMaxX.isPresent()) {
             final double rx = rotMaxX.get();
             filters.add(input -> input.getRotation().getX() <= rx);
         }
-        Optional<Double> rotMaxY = sel.get(ArgumentTypes.ROTATION.maximum().y());
+        Optional<Double> rotMaxY = this.selector.get(ArgumentTypes.ROTATION.maximum().y());
         if (rotMaxY.isPresent()) {
             final double ry = rotMaxY.get();
             filters.add(input -> input.getRotation().getY() <= ry);
@@ -262,43 +238,60 @@ public class SelectorResolver {
     }
 
     private void addScoreFilters(List<Predicate<Entity>> filters) {
-        Selector sel = this.selector;
-        sel.getArguments();
+        for (Argument<?> arg : this.selector.getArguments()) {
+            String key = arg.getType().getKey();
+            if (!key.startsWith("score_")) continue;    
+
+            String objectiveName = key.replaceAll("^score_", "").replaceAll("_min$", "");
+            boolean min = key.endsWith("_min");
+            filters.add(input -> {                
+                Optional<Scoreboard> scoreboard = Sponge.getGame().getServer().getServerScoreboard();
+                if (!scoreboard.isPresent()) return false;
+
+                Optional<Objective> objective = scoreboard.get().getObjective(objectiveName);
+                if (!objective.isPresent()) return false;
+
+                String name = input instanceof Player ? ((Player) input).getName() : input.getUniqueId().toString();
+                Optional<Score> value = objective.get().getScore(Text.of(name));
+                if (!value.isPresent()) return false;
+
+                if (min) {
+                    return ((Integer) arg.getValue()) < value.get().getScore();
+                } else {
+                    return ((Integer) arg.getValue()) > value.get().getScore();
+                }
+            });
+        }
     }
 
     private void addTeamFilters(List<Predicate<Entity>> filters) {
-        Selector sel = this.selector;
-        Optional<Invertible<String>> teamOpt = sel.getArgument(ArgumentTypes.TEAM);
+        Optional<Invertible<String>> teamOpt = this.selector.getArgument(ArgumentTypes.TEAM);
         if (teamOpt.isPresent()) {
             Invertible<String> teamArg = teamOpt.get();
             final boolean inverted = teamArg.isInverted();
-            filters.add(new Predicate<Entity>() {
+            filters.add(input -> {
+                if (!(input instanceof TeamMember)) return teamArg.getValue().isEmpty() && inverted;
 
-                @Override
-                public boolean test(Entity input) {
-                    Collection<Team> teams = Sponge.getGame().getServer().getServerScoreboard().get().getTeams();
-                    if (input instanceof TeamMember) {
-                        return inverted != collectMembers(teams).contains(((TeamMember) input).getTeamRepresentation());
-                    }
-                    return false;
+                Optional<Scoreboard> scoreboard = Sponge.getGame().getServer().getServerScoreboard();
+                if (!scoreboard.isPresent()) return false;
+
+                Optional<Team> team = scoreboard.get().getMemberTeam(((TeamMember) input).getTeamRepresentation());
+                if (teamArg.getValue().isEmpty()) {
+                    return inverted ^ team.isPresent();
+                } else {
+                    return inverted ^ (team.isPresent() && team.get().getName().equals(teamArg.getValue()));
                 }
-
-                private Collection<Text> collectMembers(Collection<Team> teams) {
-                    ImmutableSet.Builder<Text> users = ImmutableSet.builder();
-                    for (Team t : teams) {
-                        users.addAll(t.getMembers());
-                    }
-                    return users.build();
-                }
-
             });
         }
     }
 
     private void addTypeFilters(List<Predicate<Entity>> filters) {
-        Selector sel = this.selector;
-        Optional<Argument.Invertible<EntityType>> typeOpt = sel.getArgument(ArgumentTypes.ENTITY_TYPE);
-        if (typeOpt.isPresent()) {
+        SelectorType selectorType = this.selector.getType();
+        Optional<Argument.Invertible<EntityType>> typeOpt = this.selector.getArgument(ArgumentTypes.ENTITY_TYPE);
+        boolean untypedRandom = selectorType == SelectorTypes.RANDOM && !typeOpt.isPresent();
+        if (selectorType == SelectorTypes.ALL_PLAYERS || selectorType == SelectorTypes.NEAREST_PLAYER || untypedRandom) {
+            filters.add(input -> input instanceof Player);
+        } else if (typeOpt.isPresent()) {
             Argument.Invertible<EntityType> typeArg = typeOpt.get();
             final boolean inverted = typeArg.isInverted();
             final EntityType type = typeArg.getValue();
@@ -315,6 +308,13 @@ public class SelectorResolver {
 
     public List<Entity> resolve() {
         SelectorType selectorType = this.selector.getType();
+        if (selectorType == SelectorTypes.SOURCE) {
+            if (this.origin != null && this.origin instanceof Entity && this.selectorFilter.test((Entity) this.origin)) {
+                return ImmutableList.of((Entity) this.origin);
+            }
+            return ImmutableList.of();
+        }
+
         int defaultCount = 1;
         if (INFINITE_TYPES.contains(selectorType)) {
             defaultCount = 0;
@@ -326,19 +326,23 @@ public class SelectorResolver {
         Stream<Entity> entityStream = extents.stream()
                 .flatMap(ext -> ext.getEntities().stream())
                 .filter(this.selectorFilter);
-        if (maxToSelect != 0) {
-            if (selectorType == SelectorTypes.RANDOM) {
-                List<Entity> holder = entityStream.collect(Collectors.toList());
-                Collections.shuffle(holder);
-                entityStream = holder.stream();
-            } else {
-                entityStream = entityStream.sorted(distanceSort(isReversed));
-            }
-            entityStream = entityStream.limit(maxToSelect);
-        } else {
-            entityStream = entityStream.sorted(distanceSort(isReversed));
+
+        if (maxToSelect == 0) {
+            return entityStream.sorted(distanceSort(isReversed))
+                    .collect(ImmutableList.toImmutableList());
         }
-        return entityStream.collect(GuavaCollectors.toImmutableList());
+
+        if (selectorType == SelectorTypes.RANDOM) {
+            List<Entity> holder = entityStream.collect(Collectors.toList());
+            if (holder.isEmpty()) return ImmutableList.of();
+
+            Collections.shuffle(holder);
+            return ImmutableList.copyOf(holder.subList(0, maxToSelect));
+        }
+
+        return entityStream.sorted(distanceSort(isReversed))
+                .limit(maxToSelect)
+                .collect(ImmutableList.toImmutableList());
     }
 
     private Comparator<? super Entity> distanceSort(boolean isReversed) {
@@ -352,7 +356,26 @@ public class SelectorResolver {
     }
 
     private Set<? extends Extent> getExtentSet() {
+        boolean location = this.selector.getArguments().stream()
+                .filter(arg -> LOCATION_BASED_ARGUMENTS.contains(arg.getType()))
+                .findAny()
+                .isPresent();
+        if (location && this.origin != null && this.origin instanceof Locatable) {
+            return ImmutableSet.of(((Locatable) this.origin).getWorld());
+        }
         return ImmutableSet.copyOf(this.extents);
     }
 
+    private static AABB getAABB(Vector3i pos, int x, int y, int z) {
+        boolean flag = x < 0;
+        boolean flag1 = y < 0;
+        boolean flag2 = z < 0;
+        int i = pos.getX() + (flag ? x : 0);
+        int j = pos.getY() + (flag1 ? y : 0);
+        int k = pos.getZ() + (flag2 ? z : 0);
+        int l = pos.getX() + (flag ? 0 : x) + 1;
+        int i1 = pos.getY() + (flag1 ? 0 : y) + 1;
+        int j1 = pos.getZ() + (flag2 ? 0 : z) + 1;
+        return new AABB((double)i, (double)j, (double)k, (double)l, (double)i1, (double)j1);
+    }
 }

--- a/src/main/java/org/spongepowered/common/text/selector/SpongeArgument.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SpongeArgument.java
@@ -60,7 +60,7 @@ public class SpongeArgument<T> implements Argument<T> {
 
     private static String toSelectorArgument(Object val) {
         if (val instanceof CatalogType) {
-            return ((CatalogType) val).getId();
+            return ((CatalogType) val).getName();
         }
         return String.valueOf(val);
     }

--- a/src/main/java/org/spongepowered/common/text/selector/SpongeArgumentType.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SpongeArgumentType.java
@@ -27,11 +27,10 @@ package org.spongepowered.common.text.selector;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.Maps;
+import net.minecraft.world.GameType;
 import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
-import org.spongepowered.api.entity.living.player.gamemode.GameModes;
 import org.spongepowered.api.text.selector.ArgumentType;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.common.SpongeImpl;
@@ -52,23 +51,11 @@ public class SpongeArgumentType<T> extends SpongeArgumentHolder<ArgumentType<T>>
                        (Function<String, EntityType>) input -> EntityTypeRegistryModule.getInstance().getById(input.toLowerCase()).orElse(null));
         converters.put(GameMode.class.getName(), input -> {
             try {
-                int mode = Integer.parseInt(input);
-                switch (mode) {
-                    case -1:
-                        return GameModes.NOT_SET;
-                    case 0:
-                        return GameModes.SURVIVAL;
-                    case 1:
-                        return GameModes.CREATIVE;
-                    case 2:
-                        return GameModes.ADVENTURE;
-                    case 3:
-                        return GameModes.SPECTATOR;
-                }
+                int i = Integer.parseInt(input);
+                return GameType.parseGameTypeWithDefault(i, GameType.NOT_SET);
             } catch (NumberFormatException e) {
-                // ignore
+                return GameType.parseGameTypeWithDefault(input, GameType.NOT_SET);
             }
-            return Sponge.getRegistry().getType(GameMode.class, input);
         });
     }
 

--- a/src/main/java/org/spongepowered/common/text/selector/SpongeArgumentType.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SpongeArgumentType.java
@@ -28,7 +28,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.Maps;
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.entity.living.player.gamemode.GameMode;
+import org.spongepowered.api.entity.living.player.gamemode.GameModes;
 import org.spongepowered.api.text.selector.ArgumentType;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.common.SpongeImpl;
@@ -47,6 +50,26 @@ public class SpongeArgumentType<T> extends SpongeArgumentHolder<ArgumentType<T>>
         converters.put(String.class.getName(), Function.<String>identity());
         converters.put(EntityType.class.getName(),
                        (Function<String, EntityType>) input -> EntityTypeRegistryModule.getInstance().getById(input.toLowerCase()).orElse(null));
+        converters.put(GameMode.class.getName(), input -> {
+            try {
+                int mode = Integer.parseInt(input);
+                switch (mode) {
+                    case -1:
+                        return GameModes.NOT_SET;
+                    case 0:
+                        return GameModes.SURVIVAL;
+                    case 1:
+                        return GameModes.CREATIVE;
+                    case 2:
+                        return GameModes.ADVENTURE;
+                    case 3:
+                        return GameModes.SPECTATOR;
+                }
+            } catch (NumberFormatException e) {
+                // ignore
+            }
+            return Sponge.getRegistry().getType(GameMode.class, input);
+        });
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/spongepowered/common/text/selector/SpongeSelector.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SpongeSelector.java
@@ -40,10 +40,9 @@ import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.Extent;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
+import java.util.stream.Collectors;
 
 @NonnullByDefault
 public class SpongeSelector implements Selector {
@@ -102,43 +101,23 @@ public class SpongeSelector implements Selector {
     }
 
     @Override
-    public Set<Entity> resolve(CommandSource origin) {
-        return new SelectorResolver(origin, this, false).resolve();
+    public List<Entity> resolve(CommandSource origin) {
+        return new SelectorResolver(origin, this).resolve();
     }
 
     @Override
-    public Set<Entity> resolve(Extent... extents) {
+    public List<Entity> resolve(Extent... extents) {
         return resolve(ImmutableSet.copyOf(extents));
     }
 
     @Override
-    public Set<Entity> resolve(Collection<? extends Extent> extents) {
-        return new SelectorResolver(extents, this, false).resolve();
+    public List<Entity> resolve(Collection<? extends Extent> extents) {
+        return new SelectorResolver(extents, this).resolve();
     }
 
     @Override
-    public Set<Entity> resolve(Location<World> location) {
-        return new SelectorResolver(location, this, false).resolve();
-    }
-
-    @Override
-    public Set<Entity> resolveForce(CommandSource origin) {
-        return new SelectorResolver(origin, this, true).resolve();
-    }
-
-    @Override
-    public Set<Entity> resolveForce(Extent... extents) {
-        return resolveForce(ImmutableSet.copyOf(extents));
-    }
-
-    @Override
-    public Set<Entity> resolveForce(Collection<? extends Extent> extents) {
-        return new SelectorResolver(extents, this, true).resolve();
-    }
-
-    @Override
-    public Set<Entity> resolveForce(Location<World> location) {
-        return new SelectorResolver(location, this, true).resolve();
+    public List<Entity> resolve(Location<World> location) {
+        return new SelectorResolver(location, this).resolve();
     }
 
     @Override
@@ -157,16 +136,8 @@ public class SpongeSelector implements Selector {
         result.append('@').append(this.type.getId());
 
         if (!this.arguments.isEmpty()) {
-            result.append('[');
             Collection<Argument<?>> args = this.arguments.values();
-            for (Iterator<Argument<?>> iter = args.iterator(); iter.hasNext();) {
-                Argument<?> arg = iter.next();
-                result.append(arg.toPlain());
-                if (iter.hasNext()) {
-                    result.append(',');
-                }
-            }
-            result.append(']');
+            result.append(args.stream().map(Argument::toPlain).collect(Collectors.joining(",", "[", "]")));
         }
 
         return result.toString();

--- a/src/main/java/org/spongepowered/common/text/selector/SpongeSelector.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SpongeSelector.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.text.selector.Argument;
 import org.spongepowered.api.text.selector.ArgumentType;
+import org.spongepowered.api.text.selector.ArgumentTypes;
 import org.spongepowered.api.text.selector.Selector;
 import org.spongepowered.api.text.selector.SelectorType;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -102,7 +103,7 @@ public class SpongeSelector implements Selector {
 
     @Override
     public List<Entity> resolve(CommandSource origin) {
-        return new SelectorResolver(origin, this).resolve();
+        return new SelectorResolver(this, origin).resolve();
     }
 
     @Override
@@ -112,12 +113,22 @@ public class SpongeSelector implements Selector {
 
     @Override
     public List<Entity> resolve(Collection<? extends Extent> extents) {
-        return new SelectorResolver(extents, this).resolve();
+        return new SelectorResolver(this, extents).resolve();
     }
 
     @Override
     public List<Entity> resolve(Location<World> location) {
-        return new SelectorResolver(location, this).resolve();
+        Builder selector = Selector.builder().from(this);
+        if (!this.has(ArgumentTypes.POSITION.x())) {
+            selector.add(ArgumentTypes.POSITION.x(), location.getPosition().getFloorX());
+        }
+        if (!this.has(ArgumentTypes.POSITION.y())) {
+            selector.add(ArgumentTypes.POSITION.y(), location.getPosition().getFloorY());
+        }
+        if (!this.has(ArgumentTypes.POSITION.z())) {
+            selector.add(ArgumentTypes.POSITION.z(), location.getPosition().getFloorZ());
+        }
+        return new SelectorResolver(selector.build(), ImmutableSet.of(location.getExtent())).resolve();
     }
 
     @Override
@@ -133,7 +144,7 @@ public class SpongeSelector implements Selector {
     private String buildString() {
         StringBuilder result = new StringBuilder();
 
-        result.append('@').append(this.type.getId());
+        result.append('@').append(this.type.getName());
 
         if (!this.arguments.isEmpty()) {
             Collection<Argument<?>> args = this.arguments.values();

--- a/src/main/java/org/spongepowered/common/text/selector/SpongeSelector.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SpongeSelector.java
@@ -102,22 +102,22 @@ public class SpongeSelector implements Selector {
     }
 
     @Override
-    public List<Entity> resolve(CommandSource origin) {
+    public ImmutableSet<Entity> resolve(CommandSource origin) {
         return new SelectorResolver(this, origin).resolve();
     }
 
     @Override
-    public List<Entity> resolve(Extent... extents) {
+    public ImmutableSet<Entity> resolve(Extent... extents) {
         return resolve(ImmutableSet.copyOf(extents));
     }
 
     @Override
-    public List<Entity> resolve(Collection<? extends Extent> extents) {
+    public ImmutableSet<Entity> resolve(Collection<? extends Extent> extents) {
         return new SelectorResolver(this, extents).resolve();
     }
 
     @Override
-    public List<Entity> resolve(Location<World> location) {
+    public ImmutableSet<Entity> resolve(Location<World> location) {
         Builder selector = Selector.builder().from(this);
         if (!this.has(ArgumentTypes.POSITION.x())) {
             selector.add(ArgumentTypes.POSITION.x(), location.getPosition().getFloorX());

--- a/src/main/java/org/spongepowered/common/text/selector/SpongeSelectorFactory.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SpongeSelectorFactory.java
@@ -178,6 +178,15 @@ public class SpongeSelectorFactory implements SelectorFactory {
 
     @Override
     public Optional<ArgumentType<?>> getArgumentType(String name) {
+        if (name.startsWith("score_")) {
+            String objective = name.replaceAll("^score_", "").replaceAll("_min$", "");
+            Limit<ArgumentType<Integer>> limit = createScoreArgumentType(objective);
+            if (name.endsWith("_min")) {
+                return Optional.of(limit.minimum());
+            } else {
+                return Optional.of(limit.maximum());
+            }
+        }
         return Optional.ofNullable(this.argumentLookupMap.get(name));
     }
 
@@ -201,6 +210,7 @@ public class SpongeSelectorFactory implements SelectorFactory {
     public <T> SpongeArgumentType<T> createArgumentType(String key,
             Class<T> type, String converterKey) {
         if (!this.argumentLookupMap.containsKey(key)) {
+            checkNotNull(converterKey, "converter key cannot be null");
             this.argumentLookupMap.put(key, new SpongeArgumentType<>(key,
                                                                      type, converterKey));
         }
@@ -216,7 +226,6 @@ public class SpongeSelectorFactory implements SelectorFactory {
     public <T> SpongeArgumentType.Invertible<T> createInvertibleArgumentType(
             String key, Class<T> type, String converterKey) {
         if (!this.argumentLookupMap.containsKey(key)) {
-            checkNotNull(converterKey, "converter key cannot be null");
             checkNotNull(converterKey, "converter key cannot be null");
             this.argumentLookupMap.put(key,
                                        new SpongeArgumentType.Invertible<>(key, type,
@@ -303,7 +312,7 @@ public class SpongeSelectorFactory implements SelectorFactory {
     private Argument<?> parseArgumentCreateShared(
             SpongeArgumentType<Object> type, String value) {
         Argument<?> created;
-        if (type instanceof ArgumentType.Invertible && value.charAt(0) == '!') {
+        if (type instanceof ArgumentType.Invertible && !value.isEmpty() && value.charAt(0) == '!') {
             created =
                     createArgument((ArgumentType.Invertible<Object>) type,
                             type.convert(value.substring(1)), true);

--- a/src/main/java/org/spongepowered/common/text/selector/SpongeSelectorFactory.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SpongeSelectorFactory.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.text.selector;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -215,6 +216,8 @@ public class SpongeSelectorFactory implements SelectorFactory {
     public <T> SpongeArgumentType.Invertible<T> createInvertibleArgumentType(
             String key, Class<T> type, String converterKey) {
         if (!this.argumentLookupMap.containsKey(key)) {
+            checkNotNull(converterKey, "converter key cannot be null");
+            checkNotNull(converterKey, "converter key cannot be null");
             this.argumentLookupMap.put(key,
                                        new SpongeArgumentType.Invertible<>(key, type,
                                                                            converterKey));

--- a/src/main/java/org/spongepowered/common/util/OptionalUtils.java
+++ b/src/main/java/org/spongepowered/common/util/OptionalUtils.java
@@ -24,17 +24,15 @@
  */
 package org.spongepowered.common.util;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
 
 public class OptionalUtils {
 
-    public static <E> Collection<E> asSet(Optional<E> opt) {
-        if (opt.isPresent()) {
-            return Collections.singleton(opt.get());
-        }
-        return Collections.emptySet();
+    public static <E> Set<E> asSet(Optional<E> opt) {
+        return opt.map(v -> ImmutableSet.of(v)).orElseGet(() -> ImmutableSet.of());
     }
 
 }

--- a/src/main/java/org/spongepowered/common/util/OptionalUtils.java
+++ b/src/main/java/org/spongepowered/common/util/OptionalUtils.java
@@ -24,15 +24,17 @@
  */
 package org.spongepowered.common.util;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
-import java.util.Set;
-
-import com.google.common.collect.ImmutableSet;
 
 public class OptionalUtils {
 
-    public static <E> Set<E> asSet(Optional<E> opt) {
-        return opt.map(v -> ImmutableSet.of(v)).orElseGet(() -> ImmutableSet.of());
+    public static <E> Collection<E> asSet(Optional<E> opt) {
+        if (opt.isPresent()) {
+            return Collections.singleton(opt.get());
+        }
+        return Collections.emptySet();
     }
 
 }

--- a/testplugins/src/main/java/org/spongepowered/test/SelectorTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/SelectorTest.java
@@ -1,0 +1,174 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import com.flowpowered.math.vector.Vector3d;
+import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.game.state.GameInitializationEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.service.pagination.PaginationList;
+import org.spongepowered.api.service.pagination.PaginationService;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.text.selector.Argument;
+import org.spongepowered.api.text.selector.ArgumentTypes;
+import org.spongepowered.api.text.selector.Selector;
+import org.spongepowered.api.world.Locatable;
+import org.spongepowered.api.world.World;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+/*
+ * The Selector test provides the command `/test-selector` and prints out
+ * the number of entities detected along with their positions and distance
+ * from the selector origin
+ */
+@Plugin(id = "selector-test", name = "Selector Test")
+public class SelectorTest {
+
+    private static final String RAW_KEY = "raw";
+    private static final String ORIGIN_KEY = "origin";
+    private static final String ARG_KEY = "selector";
+    private static final Text NOTHING_SELECTED = Text.of(TextColors.RED, "Nothing was selected");
+
+    // Just a command for this one, no toggling required
+    @Listener
+    public void onInit(GameInitializationEvent event) {
+        Sponge.getCommandManager().register(this,
+                        CommandSpec.builder()
+                            .arguments(new SelectorArgument())
+                            .executor((source, context) -> {
+                                Collection<Entity> selectedEntities = context.getAll(ARG_KEY);
+                                if (selectedEntities.isEmpty()) {
+                                    source.sendMessage(NOTHING_SELECTED);
+                                    return CommandResult.empty();
+                                }
+
+                                long selectedPlayers = selectedEntities.stream()
+                                    .filter(x -> x instanceof Player)
+                                    .count();
+
+                                PaginationList.Builder paginationBuilder = Sponge.getServiceManager().provideUnchecked(PaginationService.class)
+                                        .builder()
+                                        .title(Text.of(selectedEntities.size(), " entities / ", selectedPlayers, " players"));
+                                Vector3d currentPosition = context.requireOne(ORIGIN_KEY);
+                                World world;
+
+                                if (source instanceof Locatable) {
+                                    world = ((Locatable) source).getWorld();
+                                } else {
+                                    world = Sponge.getServer().getWorld(Sponge.getServer().getDefaultWorld().get().getUniqueId()).get();
+                                }
+
+                                List<Text> contents = new ArrayList<>();
+                                for (Entity entity : selectedEntities) {
+                                    String distance;
+                                    if (world.equals(entity.getWorld())) {
+                                        distance = String.format("%.2f", currentPosition.distance(entity.getLocation().getPosition()));
+                                    } else {
+                                        distance = "n/a";
+                                    }
+
+                                    boolean isPlayer = entity instanceof Player;
+                                    contents.add(
+                                            Text.of(
+                                                isPlayer ? TextColors.YELLOW : TextColors.GRAY,
+                                                entity.getWorld().getName(),
+                                                " [", entity.getLocation().getBlockX(), ", ",
+                                                entity.getLocation().getBlockY(), ", ",
+                                                entity.getLocation().getBlockZ(), "] (d: ", distance, ") -> ",
+                                                isPlayer ? ((Player) entity).getName() : entity.getType().getName()));
+                                }
+                                paginationBuilder.contents(contents).sendTo(source);
+                                return CommandResult.success();
+                            })
+                            .build(),
+                        "test-selector"
+                );
+    }
+
+    // Selector arg
+    private static class SelectorArgument extends CommandElement {
+
+        protected SelectorArgument() {
+            super(Text.of(ARG_KEY));
+        }
+
+        @Override
+        public void parse(final CommandSource source, final CommandArgs args, final CommandContext context) throws ArgumentParseException {
+            String arg = args.next();
+            if (arg.startsWith("@")) {
+                context.putArg(RAW_KEY, arg);
+                Selector selector = Selector.parse(arg);
+
+                int x = selector.getArgument(ArgumentTypes.POSITION.x()).map(Argument::getValue)
+                        .orElseGet(() -> source instanceof Locatable ? ((Locatable) source).getLocation().getBlockX() : 0);
+                int y = selector.getArgument(ArgumentTypes.POSITION.y()).map(Argument::getValue)
+                        .orElseGet(() -> source instanceof Locatable ? ((Locatable) source).getLocation().getBlockY() : 0);
+                int z = selector.getArgument(ArgumentTypes.POSITION.z()).map(Argument::getValue)
+                        .orElseGet(() -> source instanceof Locatable ? ((Locatable) source).getLocation().getBlockZ() : 0);
+
+                context.putArg(ORIGIN_KEY, new Vector3d(x, y, z));
+
+                // order is preserved
+                selector.resolve(source).forEach(entity -> context.putArg(ARG_KEY, entity));
+                return;
+            }
+
+            throw args.createError(Text.of("This command must be run with a selector!"));
+        }
+
+        @Nullable
+        @Override
+        protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+            String arg = args.next();
+            if (arg.startsWith("@")) {
+                return Selector.parse(arg).resolve(source);
+            }
+
+            throw args.createError(Text.of("This command must be run with a selector!"));
+        }
+
+        @Override
+        public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+            return ImmutableList.of();
+        }
+    }
+}


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1883) | **SpongeCommon**

Previous PRs: [Original API PR](https://github.com/SpongePowered/SpongeAPI/pull/1270) | [Original Common PR](https://github.com/SpongePowered/SpongeCommon/pull/793) | [Revised API PR](https://github.com/SpongePowered/SpongeAPI/pull/1645) | [Revised Common PR](https://github.com/SpongePowered/SpongeCommon/pull/1519)

With thanks to @kenzierocks and @rexbut for their contributions, however, as both of these PRs went stale (sorry!) and I've had no response on https://github.com/SpongePowered/SpongeCommon/pull/1519, I figured it best to open the PR, get it reviewed and in as there are issues with selectors selecting the wrong (or too many) things as it stands.

This PR does the following from previous PRs:

> * Adds new selector 1.12
> * Improvements and fixes for selectors based on 1.9 and my own review of the code.
> * <s>Selectors now use a List</s>, the resolver returns the elements ordered properly as well as the right number of elements. Removed the force argument as I don't remember what it was really useful for.

I've done a review of the code and written a test plugin with a command (`/test-selector`) to check selectors. I have fixed the following issues:

* API is compatible with API 7, selectors use the fact `ImmutableSet` is ordered. This should be changed to a list or some sort of sorted set for API 8.
* Fixed dimension check from checking that its bounding box intersects itself, rather than checking it intersects the entity's.
* Fixed class cast exception when using `@e` on the console

The test plugin lists the entities selected by the provided selector, along with their location and distance from the origin. Players are highlighted in yellow in the list.