### PR TITLE
Fix discrepancy in the result of Game#getGameDirectory between SV and SF

### DIFF
--- a/src/main/java/org/spongepowered/common/launch/SpongeLaunch.java
+++ b/src/main/java/org/spongepowered/common/launch/SpongeLaunch.java
@@ -85,7 +85,7 @@ public class SpongeLaunch {
     }
 
     public static void initPaths(File gameDirIn) {
-        gameDir = gameDirIn.toPath();
+        gameDir = gameDirIn.toPath().normalize();
         pluginsDir = gameDir.resolve("mods");
         configDir = gameDir.resolve("config");
         spongeConfigDir = configDir.resolve(ECOSYSTEM_ID);


### PR DESCRIPTION
### Issue
#### Code

```java
System.out.println("--- calling getGameDirectory ---");
System.out.println(this.game.getGameDirectory().toString());
System.out.println(this.game.getGameDirectory().toAbsolutePath().toString());
```

#### SF

```
[13:27:14] [Server thread/INFO] [STDOUT]: --- calling getGameDirectory ---
[13:27:14] [Server thread/INFO] [STDOUT]: .
[13:27:14] [Server thread/INFO] [STDOUT]: C:\Users\luck\Desktop\SF\.
```

#### SV

```
[13:34:57 INFO] [STDOUT]: --- calling getGameDirectory ---
[13:34:57 INFO] [STDOUT]:
[13:34:57 INFO] [STDOUT]: C:\Users\luck\Desktop\SV
```

The path when loaded on SpongeForge just needs to be normalized. 
https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html#normalize--

Fixes the floating dot in the middle of all paths calculated relative to that directory. e.g.
```
[13:44:22] [Server thread/INFO] [FML]: Searching C:\Users\luck\Desktop\SF\.\mods for mods
```

Fixes https://github.com/lucko/LuckPerms/issues/1028

