### PR TITLE
 Fix the bug that you can't read custom data in data class before postInit event

### DIFF
--- a/src/main/java/org/spongepowered/common/data/SpongeManipulatorRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeManipulatorRegistry.java
@@ -326,13 +326,13 @@ public class SpongeManipulatorRegistry implements SpongeAdditionalCatalogRegistr
     @Nullable
     public ValueProcessor<?, ?> getDelegate(Key<?> key) {
         if (this.tempRegistry != null) {
+            // During soft registrations
             List<ValueProcessor<?, ?>> list = this.tempRegistry.valueProcessorMap.get(key);
 
             if (list == null) {
                 return null;
             }
 
-            // During soft registrations
             return new ValueProcessorDelegate(key, ImmutableList.copyOf(list));
         }
         return this.valueDelegates.get(key);

--- a/src/main/java/org/spongepowered/common/data/SpongeManipulatorRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeManipulatorRegistry.java
@@ -326,8 +326,14 @@ public class SpongeManipulatorRegistry implements SpongeAdditionalCatalogRegistr
     @Nullable
     public ValueProcessor<?, ?> getDelegate(Key<?> key) {
         if (this.tempRegistry != null) {
+            List<ValueProcessor<?, ?>> list = this.tempRegistry.valueProcessorMap.get(key);
+
+            if (list == null) {
+                return null;
+            }
+
             // During soft registrations
-            return new ValueProcessorDelegate(key, ImmutableList.copyOf(this.tempRegistry.valueProcessorMap.get(key)));
+            return new ValueProcessorDelegate(key, ImmutableList.copyOf(list));
         }
         return this.valueDelegates.get(key);
     }


### PR DESCRIPTION
`this.tempRegistry.valueProcessorMap.get(key)` is nullable and should be checked.  
Not every custom data class is associated with data processor.  
So, `this.tempRegistry.valueProcessorMap.get(key)` may return null.  
And `ImmutableList.copyOf(null)` will throw `NullPointerException` and panic the plugin.

This PR fix the problem that custom data is unreadable before the `SpongeManipulatorRegistry` being completely initialized.

Fixes #2047 