### PR TITLE
Implement StatsConfigManager and statistics-collection config

### DIFF
--- a/src/main/java/org/spongepowered/common/command/SpongeCommandFactory.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommandFactory.java
@@ -88,7 +88,7 @@ import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.SpongeImplHooks;
 import org.spongepowered.common.block.BlockUtil;
 import org.spongepowered.common.config.SpongeConfig;
-import org.spongepowered.common.config.category.StatisticsCategory;
+import org.spongepowered.common.config.category.MetricsCategory;
 import org.spongepowered.common.config.type.ConfigBase;
 import org.spongepowered.common.config.type.DimensionConfig;
 import org.spongepowered.common.config.type.GlobalConfig;
@@ -915,7 +915,7 @@ public class SpongeCommandFactory {
                 .description(Text.of("Gets or sets permission for statistics plugins to operate."))
                 .executor((source, context) -> {
                     SpongeConfig<GlobalConfig> config = SpongeImpl.getGlobalConfig();
-                    StatisticsCategory category = config.getConfig().getStatisticsCategory();
+                    MetricsCategory category = config.getConfig().getMetricsCategory();
                     if (!context.hasAny(PLUGIN_KEY)) {
                         // No plugins means that we deal with global state
                         if (category.isGloballyEnabled()) {
@@ -988,13 +988,13 @@ public class SpongeCommandFactory {
     }
 
     private static CompletableFuture<CommentedConfigurationNode> setPermissions(
-            StatisticsCategory category,
+            MetricsCategory category,
             PluginContainer container,
             boolean enabled) {
 
         Map<String, Boolean> permissions = category.getPluginPermissions();
         permissions.put(container.getId(), enabled);
-        return SpongeHooks.savePluginsInStatsConfig(permissions);
+        return SpongeHooks.savePluginsInMetricsConfig(permissions);
     }
 
     private static void createMessageTask(final CommandSource source, final Text message) {

--- a/src/main/java/org/spongepowered/common/command/SpongeCommandFactory.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommandFactory.java
@@ -41,6 +41,7 @@ import static org.spongepowered.common.util.SpongeCommonTranslationHelper.t;
 import co.aikar.timings.SpongeTimingsFactory;
 import co.aikar.timings.Timings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
@@ -48,6 +49,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.chunk.Chunk;
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.command.CommandCallable;
@@ -68,6 +70,7 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.scheduler.Task;
 import org.spongepowered.api.service.pagination.PaginationList;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.action.ClickAction;
@@ -76,6 +79,7 @@ import org.spongepowered.api.text.format.TextColors;
 import org.spongepowered.api.text.format.TextStyles;
 import org.spongepowered.api.util.SpongeApiTranslationHelper;
 import org.spongepowered.api.util.StartsWithPredicate;
+import org.spongepowered.api.util.Tristate;
 import org.spongepowered.api.world.DimensionType;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.storage.WorldProperties;
@@ -84,6 +88,7 @@ import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.SpongeImplHooks;
 import org.spongepowered.common.block.BlockUtil;
 import org.spongepowered.common.config.SpongeConfig;
+import org.spongepowered.common.config.category.StatisticsCategory;
 import org.spongepowered.common.config.type.ConfigBase;
 import org.spongepowered.common.config.type.DimensionConfig;
 import org.spongepowered.common.config.type.GlobalConfig;
@@ -112,8 +117,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -130,6 +137,9 @@ public class SpongeCommandFactory {
     static final Text NEWLINE_TEXT = Text.NEW_LINE;
     static final Text LIST_ITEM_TEXT = Text.of(TextColors.GRAY, "- ");
     static final Text UNKNOWN = Text.of("UNKNOWN");
+    private static final Text ENABLED_TEXT = Text.of(TextColors.GREEN, "enabled");
+    private static final Text DISABLED_TEXT = Text.of(TextColors.RED, "disabled");
+    private static final Text FAILED_TEXT = Text.of(TextColors.RED, "Failed to set config entry.");
 
     private static final CommandElement DUMMY_ELEMENT = new CommandElement(Text.EMPTY) {
         @Nullable @Override protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
@@ -144,6 +154,8 @@ public class SpongeCommandFactory {
     private static final Comparator<CommandMapping> COMMAND_COMPARATOR = Comparator.comparing(CommandMapping::getPrimaryAlias);
     private static final Text PAGE_KEY = Text.of("page");
     private static final Text COMMAND_KEY = Text.of("command");
+    private static final Text PLUGIN_KEY = Text.of("plugin");
+    private static final Text ENABLED_KEY = Text.of("enabled");
     private static final CommandElement COMMAND_ARGUMENT = new CommandElement(COMMAND_KEY) {
 
         @Nullable
@@ -167,6 +179,14 @@ public class SpongeCommandFactory {
     };
     private static final Text NOT_FOUND = Text.of("notFound");
 
+    private static final Map<String, Tristate> ENABLED_CHOICES = ImmutableMap.<String, Tristate>builder()
+            .put("enable", Tristate.TRUE)
+            .put("enabled", Tristate.TRUE)
+            .put("disabled", Tristate.FALSE)
+            .put("disable", Tristate.FALSE)
+            .put("default", Tristate.UNDEFINED)
+            .build();
+
     /**
      * Create a new instance of the Sponge command structure.
      *
@@ -185,6 +205,7 @@ public class SpongeCommandFactory {
         nonFlagChildren.register(createSpongePluginsCommand(), "plugins");
         nonFlagChildren.register(createSpongeTimingsCommand(), "timings");
         nonFlagChildren.register(createSpongeWhichCommand(), "which");
+        nonFlagChildren.register(createSpongeStatsCommand(), "stats");
         flagChildren.register(createSpongeChunksCommand(), "chunks");
         flagChildren.register(createSpongeTpsCommand(), "tps");
         trackerFlagChildren.register(createSpongeConfigCommand(), "config");
@@ -206,6 +227,7 @@ public class SpongeCommandFactory {
                         INDENT, title("plugins"), LONG_INDENT, "List currently installed plugins\n",
                         INDENT, title("which"), LONG_INDENT, "List plugins that own a specific command\n",
                         INDENT, title("tps"), LONG_INDENT, "Provides TPS (ticks per second) data for loaded worlds\n",
+                        INDENT, title("stats"), LONG_INDENT, "Gets or sets permission for statistics plugins to operate\n",
                         SpongeImplHooks.getAdditionalCommandDescriptions()))
                 .arguments(firstParsing(nonFlagChildren,
                         flags().flag("-global", "g")
@@ -882,6 +904,101 @@ public class SpongeCommandFactory {
 
                     return CommandResult.success();
                 }).build();
+    }
+
+    private static CommandCallable createSpongeStatsCommand() {
+        return CommandSpec.builder()
+                .arguments(
+                        GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.plugin(Text.of(PLUGIN_KEY)))),
+                        GenericArguments.optional(GenericArguments.onlyOne(
+                                GenericArguments.choicesInsensitive(Text.of(ENABLED_KEY), ENABLED_CHOICES))))
+                .description(Text.of("Gets or sets permission for statistics plugins to operate."))
+                .executor((source, context) -> {
+                    SpongeConfig<GlobalConfig> config = SpongeImpl.getGlobalConfig();
+                    StatisticsCategory category = config.getConfig().getStatisticsCategory();
+                    if (!context.hasAny(PLUGIN_KEY)) {
+                        // No plugins means that we deal with global state
+                        if (category.isGloballyEnabled()) {
+                            source.sendMessage(Text.of("Stats collection default permission is currently ", ENABLED_TEXT));
+                        } else {
+                            source.sendMessage(Text.of("Stats collection default permission is currently ", DISABLED_TEXT));
+                        }
+                    } else {
+                        PluginContainer container = context.requireOne(PLUGIN_KEY);
+                        if (context.hasAny(ENABLED_KEY)) {
+                            Tristate stateToSet = context.requireOne(ENABLED_KEY);
+                            if (stateToSet == Tristate.UNDEFINED) {
+                                // set to default
+                                setPermissions(category, container, category.isGloballyEnabled())
+                                        .handle((node, exception) -> {
+                                            if (exception == null) {
+                                                createMessageTask(
+                                                        source,
+                                                        Text.of("Stats collection for ", container.getName(),
+                                                                " is now set to the default value (",
+                                                                category.isGloballyEnabled() ? ENABLED_TEXT : DISABLED_TEXT, ")"));
+                                            } else {
+                                                createMessageTask(source, FAILED_TEXT);
+                                            }
+
+                                            return node;
+                                        });
+
+                            } else if (stateToSet == Tristate.TRUE) {
+                                setPermissions(category, container, true)
+                                        .handle((node, exception) -> {
+                                            if (exception == null) {
+                                                createMessageTask(
+                                                        source,
+                                                        Text.of("Set stats collection for ", container.getName(), " to ", ENABLED_TEXT));
+                                            } else {
+                                                createMessageTask(source, FAILED_TEXT);
+                                            }
+
+                                            return node;
+                                        });
+                            } else { // it's false
+                                setPermissions(category, container, false)
+                                        .handle((node, exception) -> {
+                                            if (exception == null) {
+                                                createMessageTask(
+                                                        source,
+                                                        Text.of("Set stats collection for ", container.getName(), " to ", DISABLED_TEXT));
+                                            } else {
+                                                createMessageTask(source, FAILED_TEXT);
+                                            }
+
+                                            return node;
+                                        });
+                            }
+                            config.save();
+                        } else {
+                            boolean state = category.getPluginPermission(container).orElseGet(category::isGloballyEnabled);
+                            if (state) {
+                                source.sendMessage(Text.of("Stats collection for ", container.getName(), " is currently ", ENABLED_TEXT));
+                            } else {
+                                source.sendMessage(Text.of("Stats collection for ", container.getName(), " is currently ", DISABLED_TEXT));
+                            }
+                        }
+                    }
+
+                    return CommandResult.success();
+                })
+                .build();
+    }
+
+    private static CompletableFuture<CommentedConfigurationNode> setPermissions(
+            StatisticsCategory category,
+            PluginContainer container,
+            boolean enabled) {
+
+        Map<String, Boolean> permissions = category.getPluginPermissions();
+        permissions.put(container.getId(), enabled);
+        return SpongeHooks.savePluginsInStatsConfig(permissions);
+    }
+
+    private static void createMessageTask(final CommandSource source, final Text message) {
+        Task.builder().execute(() -> source.sendMessage(message)).submit(SpongeImpl.getPlugin());
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/config/SpongeConfig.java
+++ b/src/main/java/org/spongepowered/common/config/SpongeConfig.java
@@ -34,7 +34,6 @@ import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMapper;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializers;
-import ninja.leaping.configurate.transformation.ConfigurationTransformation;
 import ninja.leaping.configurate.util.ConfigurationNodeWalker;
 import org.spongepowered.api.util.Functional;
 import org.spongepowered.common.SpongeImpl;
@@ -341,6 +340,16 @@ public class SpongeConfig<T extends ConfigBase> {
             upd.setValue(value);
             populateInstance();
             saveNow();
+            return upd;
+        }, ForkJoinPool.commonPool());
+    }
+
+    public <V> CompletableFuture<CommentedConfigurationNode> updateSetting(String key, V value, TypeToken<V> token) {
+        return Functional.asyncFailableFuture(() -> {
+            CommentedConfigurationNode upd = getSetting(key);
+            upd.setValue(token, value);
+            populateInstance();
+            save();
             return upd;
         }, ForkJoinPool.commonPool());
     }

--- a/src/main/java/org/spongepowered/common/config/category/MetricsCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/MetricsCategory.java
@@ -33,15 +33,15 @@ import java.util.Map;
 import java.util.Optional;
 
 @ConfigSerializable
-public class StatisticsCategory {
+public class MetricsCategory {
 
     @Setting(value = "default-permission", comment = "Determines whether plugins that are newly added are allowed to perform\n"
-                                        + "data/statistics collection by default. Plugins detected by Sponge will be added "
+                                        + "data/metric collection by default. Plugins detected by Sponge will be added "
                                         + "to the \"plugin-permissions\" section with this value.\n\n"
-                                        + "Set to true to enable stats gathering by default, false otherwise.")
+                                        + "Set to true to enable metric gathering by default, false otherwise.")
     private boolean defaultPermission = false;
 
-    @Setting(value = "plugin-permissions", comment = "Provides (or revokes) permission for stat gathering on a per plugin basis.\n"
+    @Setting(value = "plugin-permissions", comment = "Provides (or revokes) permission for metric gathering on a per plugin basis.\n"
                                                    + "Entries should be in the format \"plugin-id=<true|false>\".\n\n"
                                                    + "Deleting an entry from this list will reset it to the default specified in\n"
                                                    + "\"default-permission\"")

--- a/src/main/java/org/spongepowered/common/config/category/StatisticsCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/StatisticsCategory.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.config.category;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+import org.spongepowered.api.plugin.PluginContainer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@ConfigSerializable
+public class StatisticsCategory {
+
+    @Setting(value = "default-permission", comment = "Determines whether plugins that are newly added are allowed to perform\n"
+                                        + "data/statistics collection by default. Plugins detected by Sponge will be added "
+                                        + "to the \"plugin-permissions\" section with this value.\n\n"
+                                        + "Set to true to enable stats gathering by default, false otherwise.")
+    private boolean defaultPermission = false;
+
+    @Setting(value = "plugin-permissions", comment = "Provides (or revokes) permission for stat gathering on a per plugin basis.\n"
+                                                   + "Entries should be in the format \"plugin-id=<true|false>\".\n\n"
+                                                   + "Deleting an entry from this list will reset it to the default specified in\n"
+                                                   + "\"default-permission\"")
+    private Map<String, Boolean> perPluginPermissions = new HashMap<>();
+
+    public boolean isGloballyEnabled() {
+        return this.defaultPermission;
+    }
+
+    public Optional<Boolean> getPluginPermission(PluginContainer container) {
+        return Optional.ofNullable(this.perPluginPermissions.get(container.getId()));
+    }
+
+    public Map<String, Boolean> getPluginPermissions() {
+        return new HashMap<>(this.perPluginPermissions);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/config/type/GlobalConfig.java
+++ b/src/main/java/org/spongepowered/common/config/type/GlobalConfig.java
@@ -41,6 +41,7 @@ import org.spongepowered.common.config.category.ModuleCategory;
 import org.spongepowered.common.config.category.MovementChecksCategory;
 import org.spongepowered.common.config.category.OptimizationCategory;
 import org.spongepowered.common.config.category.SqlCategory;
+import org.spongepowered.common.config.category.StatisticsCategory;
 import org.spongepowered.common.config.category.TeleportHelperCategory;
 import org.spongepowered.common.util.IpSet;
 
@@ -91,6 +92,9 @@ public class GlobalConfig extends GeneralConfigBase {
 
     @Setting(value = "broken-mods", comment = "Stopgap measures for dealing with broken mods")
     private BrokenModCategory brokenMods = new BrokenModCategory();
+
+    @Setting(value = "statistics-collection")
+    private StatisticsCategory statisticsCategory = new StatisticsCategory();
 
     public GlobalConfig() {
         super();
@@ -161,4 +165,7 @@ public class GlobalConfig extends GeneralConfigBase {
         return this.movementChecks;
     }
 
+    public StatisticsCategory getStatisticsCategory() {
+        return this.statisticsCategory;
+    }
 }

--- a/src/main/java/org/spongepowered/common/config/type/GlobalConfig.java
+++ b/src/main/java/org/spongepowered/common/config/type/GlobalConfig.java
@@ -41,7 +41,7 @@ import org.spongepowered.common.config.category.ModuleCategory;
 import org.spongepowered.common.config.category.MovementChecksCategory;
 import org.spongepowered.common.config.category.OptimizationCategory;
 import org.spongepowered.common.config.category.SqlCategory;
-import org.spongepowered.common.config.category.StatisticsCategory;
+import org.spongepowered.common.config.category.MetricsCategory;
 import org.spongepowered.common.config.category.TeleportHelperCategory;
 import org.spongepowered.common.util.IpSet;
 
@@ -93,8 +93,8 @@ public class GlobalConfig extends GeneralConfigBase {
     @Setting(value = "broken-mods", comment = "Stopgap measures for dealing with broken mods")
     private BrokenModCategory brokenMods = new BrokenModCategory();
 
-    @Setting(value = "statistics-collection")
-    private StatisticsCategory statisticsCategory = new StatisticsCategory();
+    @Setting(value = "metrics")
+    private MetricsCategory metricsCategory = new MetricsCategory();
 
     public GlobalConfig() {
         super();
@@ -165,7 +165,7 @@ public class GlobalConfig extends GeneralConfigBase {
         return this.movementChecks;
     }
 
-    public StatisticsCategory getStatisticsCategory() {
-        return this.statisticsCategory;
+    public MetricsCategory getMetricsCategory() {
+        return this.metricsCategory;
     }
 }

--- a/src/main/java/org/spongepowered/common/inject/SpongeImplementationModule.java
+++ b/src/main/java/org/spongepowered/common/inject/SpongeImplementationModule.java
@@ -47,6 +47,7 @@ import org.spongepowered.api.plugin.PluginManager;
 import org.spongepowered.api.scheduler.Scheduler;
 import org.spongepowered.api.service.ServiceManager;
 import org.spongepowered.api.service.SimpleServiceManager;
+import org.spongepowered.api.service.stat.StatsConfigManager;
 import org.spongepowered.api.world.TeleportHelper;
 import org.spongepowered.common.SpongeBootstrap;
 import org.spongepowered.common.SpongeGame;
@@ -60,6 +61,7 @@ import org.spongepowered.common.data.property.SpongePropertyRegistry;
 import org.spongepowered.common.event.SpongeCauseStackManager;
 import org.spongepowered.common.registry.SpongeGameRegistry;
 import org.spongepowered.common.scheduler.SpongeScheduler;
+import org.spongepowered.common.service.stat.SpongeStatsConfigManager;
 import org.spongepowered.common.world.teleport.SpongeTeleportHelper;
 
 import javax.annotation.OverridingMethodsMustInvokeSuper;
@@ -82,6 +84,7 @@ public class SpongeImplementationModule extends PrivateModule {
         this.bindAndExpose(ConfigManager.class).to(SpongeConfigManager.class);
         this.bindAndExpose(PropertyRegistry.class).to(SpongePropertyRegistry.class);
         this.bindAndExpose(CauseStackManager.class).to(SpongeCauseStackManager.class);
+        this.bindAndExpose(StatsConfigManager.class).to(SpongeStatsConfigManager.class);
 
         // These are bound in implementation-specific modules
         this.expose(Platform.class);

--- a/src/main/java/org/spongepowered/common/inject/SpongeImplementationModule.java
+++ b/src/main/java/org/spongepowered/common/inject/SpongeImplementationModule.java
@@ -47,7 +47,7 @@ import org.spongepowered.api.plugin.PluginManager;
 import org.spongepowered.api.scheduler.Scheduler;
 import org.spongepowered.api.service.ServiceManager;
 import org.spongepowered.api.service.SimpleServiceManager;
-import org.spongepowered.api.service.stat.StatsConfigManager;
+import org.spongepowered.api.service.metric.MetricsConfigManager;
 import org.spongepowered.api.world.TeleportHelper;
 import org.spongepowered.common.SpongeBootstrap;
 import org.spongepowered.common.SpongeGame;
@@ -61,7 +61,7 @@ import org.spongepowered.common.data.property.SpongePropertyRegistry;
 import org.spongepowered.common.event.SpongeCauseStackManager;
 import org.spongepowered.common.registry.SpongeGameRegistry;
 import org.spongepowered.common.scheduler.SpongeScheduler;
-import org.spongepowered.common.service.stat.SpongeStatsConfigManager;
+import org.spongepowered.common.service.stat.SpongeMetricsConfigManager;
 import org.spongepowered.common.world.teleport.SpongeTeleportHelper;
 
 import javax.annotation.OverridingMethodsMustInvokeSuper;
@@ -84,7 +84,7 @@ public class SpongeImplementationModule extends PrivateModule {
         this.bindAndExpose(ConfigManager.class).to(SpongeConfigManager.class);
         this.bindAndExpose(PropertyRegistry.class).to(SpongePropertyRegistry.class);
         this.bindAndExpose(CauseStackManager.class).to(SpongeCauseStackManager.class);
-        this.bindAndExpose(StatsConfigManager.class).to(SpongeStatsConfigManager.class);
+        this.bindAndExpose(MetricsConfigManager.class).to(SpongeMetricsConfigManager.class);
 
         // These are bound in implementation-specific modules
         this.expose(Platform.class);

--- a/src/main/java/org/spongepowered/common/service/stat/SpongeMetricsConfigManager.java
+++ b/src/main/java/org/spongepowered/common/service/stat/SpongeMetricsConfigManager.java
@@ -25,21 +25,19 @@
 package org.spongepowered.common.service.stat;
 
 import org.spongepowered.api.plugin.PluginContainer;
-import org.spongepowered.api.service.stat.StatsConfigManager;
+import org.spongepowered.api.service.metric.MetricsConfigManager;
 import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.common.config.category.MetricsCategory;
 
 import javax.inject.Singleton;
 
 @Singleton
-public class SpongeStatsConfigManager implements StatsConfigManager {
+public class SpongeMetricsConfigManager implements MetricsConfigManager {
 
     @Override
-    public boolean areStatsEnabled(PluginContainer container) {
-        return SpongeImpl.getGlobalConfig().getConfig().getStatisticsCategory().getPluginPermission(container).orElseGet(this::areStatsEnabled);
-    }
-
-    private boolean areStatsEnabled() {
-        return SpongeImpl.getGlobalConfig().getConfig().getStatisticsCategory().isGloballyEnabled();
+    public boolean areMetricsEnabled(final PluginContainer container) {
+        final MetricsCategory metrics = SpongeImpl.getGlobalConfig().getConfig().getMetricsCategory();
+        return metrics.getPluginPermission(container).orElseGet(metrics::isGloballyEnabled);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/service/stat/SpongeStatsConfigManager.java
+++ b/src/main/java/org/spongepowered/common/service/stat/SpongeStatsConfigManager.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.service.stat;
+
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.service.stat.StatsConfigManager;
+import org.spongepowered.common.SpongeImpl;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class SpongeStatsConfigManager implements StatsConfigManager {
+
+    @Override
+    public boolean areStatsEnabled(PluginContainer container) {
+        return SpongeImpl.getGlobalConfig().getConfig().getStatisticsCategory().getPluginPermission(container).orElseGet(this::areStatsEnabled);
+    }
+
+    private boolean areStatsEnabled() {
+        return SpongeImpl.getGlobalConfig().getConfig().getStatisticsCategory().isGloballyEnabled();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/service/stat/package-info.java
+++ b/src/main/java/org/spongepowered/common/service/stat/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.common.service.stat;

--- a/src/main/java/org/spongepowered/common/util/SpongeHooks.java
+++ b/src/main/java/org/spongepowered/common/util/SpongeHooks.java
@@ -531,22 +531,22 @@ public class SpongeHooks {
         ConfigTeleportHelperFilter.invalidateCache();
     }
 
-    public static void populatePluginsInStatsConfig() {
-        final boolean globalState = SpongeImpl.getGlobalConfig().getConfig().getStatisticsCategory().isGloballyEnabled();
-        final Map<String, Boolean> entries = SpongeImpl.getGlobalConfig().getConfig().getStatisticsCategory().getPluginPermissions();
+    public static void populatePluginsInMetricsConfig() {
+        final boolean globalState = SpongeImpl.getGlobalConfig().getConfig().getMetricsCategory().isGloballyEnabled();
+        final Map<String, Boolean> entries = SpongeImpl.getGlobalConfig().getConfig().getMetricsCategory().getPluginPermissions();
         Sponge.getPluginManager().getPlugins().stream()
                 .filter(SpongeImplHooks.getPluginFilterPredicate()).forEach(plugin -> entries.putIfAbsent(plugin.getId(), globalState));
 
         try {
-            savePluginsInStatsConfig(entries).get();
+            savePluginsInMetricsConfig(entries).get();
         } catch (InterruptedException | ExecutionException e) {
             SpongeImpl.getLogger().warn("Could not populate the plugin list for stats collection", e);
         }
     }
 
-    public static CompletableFuture<CommentedConfigurationNode> savePluginsInStatsConfig(Map<String, Boolean> entries) {
+    public static CompletableFuture<CommentedConfigurationNode> savePluginsInMetricsConfig(Map<String, Boolean> entries) {
         return SpongeImpl.getGlobalConfig()
-                .updateSetting("statistics-collection.plugin-permissions", entries, new TypeToken<Map<String, Boolean>>() {});
+                .updateSetting("metrics.plugin-permissions", entries, new TypeToken<Map<String, Boolean>>() {});
     }
 
     public static String getFriendlyCauseName(Cause cause) {

--- a/testplugins/src/main/java/org/spongepowered/test/StatCheckTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/StatCheckTest.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.game.state.GameInitializationEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+
+/*
+ * Simply checks to see if Sponge indicates that the plugin is entitled to stat checking.
+ */
+@Plugin(id = "statcheck", name = "Stat Check")
+public class StatCheckTest {
+
+    @Listener
+    public void onInit(GameInitializationEvent event) {
+        Sponge.getCommandManager()
+                .register(this,
+                        CommandSpec.builder().executor((source, context) -> {
+                            source.sendMessage(Text.of("Stats checking for \"stat-check\" is set to: ",
+                                    Sponge.getStatsConfigManager().areStatsEnabled(this)));
+                            return CommandResult.success();
+                        }).build(),
+                        "statcheck");
+    }
+
+}


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1895) | **SpongeCommon** | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/2382) | [SpongeVanilla](https://github.com/SpongePowered/SpongeVanilla/pull/385) | [Original Issue](https://github.com/SpongePowered/SpongeAPI/issues/1862)

This implements the stat collection API. Also added `/sponge stats <plugin-id> <enabled|disabled>` and added a test plugin to check whether the stats collection are enabled for a plugin.

**This PR is not for discussion of whether stats are bad or not, Sponge's policies, or any general gripe. This is simply the proposed implementation of the API. Please leave drama out of this PR, thanks.**