### PR TITLE
Migrate Canary join data

### DIFF
--- a/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
@@ -177,6 +177,11 @@ public final class NbtDataUtil {
     public static final String BUKKIT_FIRST_PLAYED = "firstPlayed";
     public static final String BUKKIT_LAST_PLAYED = "lastPlayed";
 
+    // Legacy migration tags from CanaryMod
+    public static final String CANARY = "Canary";
+    public static final String CANARY_FIRST_JOINED = "FirstJoin";
+    public static final String CANARY_LAST_JOINED = "LastJoin";
+
     // These are used by Minecraft's internals for entity spawning
     public static final String ENTITY_TYPE_ID = "id";
     public static final String MINECART_TYPE = "Type";

--- a/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinSaveHandler.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinSaveHandler.java
@@ -206,6 +206,12 @@ public abstract class MixinSaveHandler implements IMixinSaveHandler {
             creation = Instant.ofEpochMilli(bukkitCompound.getLong(NbtDataUtil.BUKKIT_FIRST_PLAYED));
             lastPlayed = Instant.ofEpochMilli(bukkitCompound.getLong(NbtDataUtil.BUKKIT_LAST_PLAYED));
         }
+        // migrate canary join data
+        if (compound.hasKey(NbtDataUtil.CANARY, NbtDataUtil.TAG_COMPOUND)) {
+            final NBTTagCompound canaryCompound = compound.getCompoundTag(NbtDataUtil.CANARY);
+            creation = Instant.ofEpochMilli(canaryCompound.getLong(NbtDataUtil.CANARY_FIRST_JOINED));
+            lastPlayed = Instant.ofEpochMilli(canaryCompound.getLong(NbtDataUtil.CANARY_LAST_JOINED));
+        }
         UUID playerId = null;
         if (compound.hasUniqueId(NbtDataUtil.UUID)) {
             playerId = compound.getUniqueId(NbtDataUtil.UUID);


### PR DESCRIPTION
There is a bunch of other things that CanaryMod persisted to file, though I think these are the only ones with equivalents in Sponge.

I don't think I implemented all of the NBT tags in Neptune, though no list exists in CanaryMod - so [NbtConstants.java](https://github.com/NeptunePowered/NeptuneMod/blob/master/src/main/java/org/neptunepowered/vanilla/util/NbtConstants.java#L47-L58) is the best list I know of currently.

There also isn't much of a reason to support importing the Canary world structure (IMO anyhow), given that there exists a command in Canary to revert to a vanilla-style world structure. I'm fairly certain there is a docs page on this.

At some point in the future, I may trawl through CanaryMod again and see if any do match up to Sponge - though for now, it'd be nice to at least keep join data :)