### PR TITLE
Fix ProjectileSource being UNKNOWN when launching with a dispenser

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityFireball.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityFireball.java
@@ -38,24 +38,28 @@ import org.spongepowered.common.entity.projectile.ProjectileSourceSerializer;
 import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.mixin.core.entity.MixinEntity;
 
+import javax.annotation.Nullable;
+
 @Mixin(EntityFireball.class)
 public abstract class MixinEntityFireball extends MixinEntity implements Fireball {
 
     @Shadow public EntityLivingBase shootingEntity;
     @Shadow protected abstract void onImpact(RayTraceResult movingObjectPosition);
 
+    @Nullable
     private ProjectileSource projectileSource = null;
 
     @Override
     public ProjectileSource getShooter() {
-        if (this.projectileSource == null || this.projectileSource != this.shootingEntity) {
-            if (this.shootingEntity != null && this.shootingEntity instanceof ProjectileSource) {
-                this.projectileSource = (ProjectileSource) this.shootingEntity;
-            } else {
-                this.projectileSource = ProjectileSource.UNKNOWN;
-            }
+        if (this.shootingEntity instanceof ProjectileSource) {
+            return (ProjectileSource) this.shootingEntity;
         }
-        return this.projectileSource;
+
+        if (this.projectileSource != null) {
+            return this.projectileSource;
+        }
+
+        return ProjectileSource.UNKNOWN;
     }
 
     @Override


### PR DESCRIPTION
Tested with a dispenser throwing fire charges and a ghast.
All of those cases work as intended.

I hope the method is cleaner too now.
