### PR TITLE
Make SignSource great again!

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/api/command/BlockCommandSourceMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/command/BlockCommandSourceMixin_API.java
@@ -27,16 +27,13 @@ package org.spongepowered.common.mixin.api.command;
 import net.minecraft.entity.item.EntityMinecartCommandBlock;
 import net.minecraft.tileentity.TileEntityCommandBlock;
 import org.spongepowered.api.command.source.CommandBlockSource;
-import org.spongepowered.api.service.permission.PermissionService;
-import org.spongepowered.api.util.Tristate;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.common.bridge.command.CommandSenderBridge;
 import org.spongepowered.common.bridge.command.CommandSourceBridge;
-import org.spongepowered.common.bridge.permissions.SubjectBridge;
 
 @NonnullByDefault
-@Mixin(value = {TileEntityCommandBlock.class, EntityMinecartCommandBlock.class}, targets = "net/minecraft/tileentity/TileEntitySign$1")
+@Mixin(value = {TileEntityCommandBlock.class, EntityMinecartCommandBlock.class},
+        targets = {"net/minecraft/tileentity/TileEntitySign$1", "net/minecraft/tileentity/TileEntitySign$2"})
 public abstract class BlockCommandSourceMixin_API implements CommandBlockSource {
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/command/CommandSourceMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/command/CommandSourceMixin_API.java
@@ -35,16 +35,15 @@ import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.channel.MessageChannel;
-import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.common.bridge.command.CommandSenderBridge;
 import org.spongepowered.common.bridge.command.CommandSourceBridge;
 import org.spongepowered.common.text.SpongeTexts;
 
 import java.util.Optional;
 
 @Mixin(value = {EntityPlayerMP.class, TileEntityCommandBlock.class, EntityMinecartCommandBlock.class, MinecraftServer.class, RConConsoleSource.class},
-        targets = "net/minecraft/tileentity/TileEntitySign$1", priority = 899) // Allows for other implementations of CommandSource to override/write
+        targets = {"net/minecraft/tileentity/TileEntitySign$1", "net/minecraft/tileentity/TileEntitySign$2"},
+        priority = 899) // Allows for other implementations of CommandSource to override/write
 public abstract class CommandSourceMixin_API implements CommandSource {
 
     private MessageChannel channel = MessageChannel.TO_ALL;

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/tileentity/TileEntitySignCommandSendersMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/tileentity/TileEntitySignCommandSendersMixin_API.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.api.mcp.tileentity;
+
+import net.minecraft.command.ICommandSender;
+import net.minecraft.tileentity.TileEntitySign;
+import org.spongepowered.api.block.tileentity.Sign;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.source.SignSource;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.command.WrapperCommandSource;
+
+@Mixin(targets = {"net/minecraft/tileentity/TileEntitySign$1", "net/minecraft/tileentity/TileEntitySign$2"})
+public abstract class TileEntitySignCommandSendersMixin_API implements SignSource {
+
+    @Shadow(aliases = {"this$0"}, remap = false)
+    @Final
+    private TileEntitySign tileEntitySign;
+
+    @SuppressWarnings({"ConstantConditions", "RedundantCast"}) // This is an ICommandSender anonymous class
+    @Override
+    public CommandSource getOriginalSource() {
+        return WrapperCommandSource.of(((ICommandSender) (Object) this).getCommandSenderEntity());
+    }
+
+    @Override
+    public Sign getSign() {
+        return (Sign) this.tileEntitySign;
+    }
+
+    @Override
+    public World getWorld() {
+        return (World) this.tileEntitySign.getWorld();
+    }
+
+    @Override
+    public Location<World> getLocation() {
+        return ((Sign) this.tileEntitySign).getLocation();
+    }
+}

--- a/src/main/java/org/spongepowered/common/mixin/api/service/permission/SubjectMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/service/permission/SubjectMixin_API.java
@@ -31,7 +31,6 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntityCommandBlock;
 import org.spongepowered.api.service.context.Context;
 import org.spongepowered.api.service.context.Contextual;
-import org.spongepowered.api.service.permission.PermissionService;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.service.permission.SubjectCollection;
 import org.spongepowered.api.service.permission.SubjectData;
@@ -39,24 +38,13 @@ import org.spongepowered.api.service.permission.SubjectReference;
 import org.spongepowered.api.util.Tristate;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.common.SpongeImpl;
-import org.spongepowered.common.SpongeInternalListeners;
-import org.spongepowered.common.bridge.command.CommandSenderBridge;
-import org.spongepowered.common.bridge.command.CommandSourceBridge;
 import org.spongepowered.common.bridge.permissions.SubjectBridge;
 import org.spongepowered.common.entity.player.SpongeUser;
-import org.spongepowered.common.service.permission.SubjectSettingCallback;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-
-import javax.annotation.Nullable;
 
 /**
  * Mixin to provide a common implementation of subject that refers to the
@@ -64,7 +52,7 @@ import javax.annotation.Nullable;
  */
 @NonnullByDefault
 @Mixin(value = {EntityPlayerMP.class, TileEntityCommandBlock.class, EntityMinecartCommandBlock.class, MinecraftServer.class, RConConsoleSource.class,
-        SpongeUser.class}, targets = "net/minecraft/tileentity/TileEntitySign$1")
+        SpongeUser.class}, targets = {"net/minecraft/tileentity/TileEntitySign$1", "net/minecraft/tileentity/TileEntitySign$2"})
 public abstract class SubjectMixin_API implements Subject {
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/command/BlockBasedCommandSourceMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/BlockBasedCommandSourceMixin.java
@@ -31,12 +31,12 @@ import org.spongepowered.api.service.permission.PermissionService;
 import org.spongepowered.api.util.Tristate;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.common.bridge.command.CommandSenderBridge;
 import org.spongepowered.common.bridge.command.CommandSourceBridge;
 import org.spongepowered.common.bridge.permissions.SubjectBridge;
 
 @NonnullByDefault
-@Mixin(value = {TileEntityCommandBlock.class, EntityMinecartCommandBlock.class}, targets = "net/minecraft/tileentity/TileEntitySign$1", priority = 999)
+@Mixin(value = {TileEntityCommandBlock.class, EntityMinecartCommandBlock.class},
+        targets = {"net/minecraft/tileentity/TileEntitySign$1", "net/minecraft/tileentity/TileEntitySign$2"}, priority = 999)
 public abstract class BlockBasedCommandSourceMixin implements CommandSourceBridge, CommandBlockSource, SubjectBridge {
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/command/ICommandSenderMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/ICommandSenderMixin.java
@@ -37,7 +37,7 @@ import org.spongepowered.common.command.CommandPermissions;
 import org.spongepowered.common.bridge.command.CommandSenderBridge;
 
 @Mixin(value = {EntityPlayerMP.class, MinecraftServer.class, RConConsoleSource.class, CommandBlockBaseLogic.class},
-    targets = "net/minecraft/tileentity/TileEntitySign$1")
+    targets = {"net/minecraft/tileentity/TileEntitySign$1", "net/minecraft/tileentity/TileEntitySign$2"})
 public abstract class ICommandSenderMixin implements ICommandSender {
 
     @Inject(method = "canUseCommand(ILjava/lang/String;)Z", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/org/spongepowered/common/mixin/core/service/permission/SubjectMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/service/permission/SubjectMixin.java
@@ -39,7 +39,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.SpongeInternalListeners;
-import org.spongepowered.common.bridge.command.CommandSenderBridge;
 import org.spongepowered.common.bridge.command.CommandSourceBridge;
 import org.spongepowered.common.bridge.permissions.SubjectBridge;
 import org.spongepowered.common.entity.player.SpongeUser;
@@ -56,7 +55,7 @@ import javax.annotation.Nullable;
  */
 @NonnullByDefault
 @Mixin(value = {EntityPlayerMP.class, TileEntityCommandBlock.class, EntityMinecartCommandBlock.class, MinecraftServer.class, RConConsoleSource.class,
-        SpongeUser.class}, targets = "net/minecraft/tileentity/TileEntitySign$1")
+        SpongeUser.class}, targets = {"net/minecraft/tileentity/TileEntitySign$1", "net/minecraft/tileentity/TileEntitySign$2"})
 public abstract class SubjectMixin implements CommandSourceBridge, SubjectBridge {
 
     @Nullable

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/TileEntitySign_2Mixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/TileEntitySign_2Mixin.java
@@ -22,46 +22,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.mixin.api.mcp.tileentity;
+package org.spongepowered.common.mixin.core.tileentity;
 
 import net.minecraft.command.ICommandSender;
-import net.minecraft.tileentity.TileEntitySign;
-import org.spongepowered.api.block.tileentity.Sign;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.source.SignSource;
-import org.spongepowered.api.world.Location;
-import org.spongepowered.api.world.World;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.bridge.command.CommandSenderBridge;
-import org.spongepowered.common.command.WrapperCommandSource;
+import org.spongepowered.common.bridge.command.CommandSourceBridge;
 
-@Mixin(targets = "net/minecraft/tileentity/TileEntitySign$1")
-public abstract class TileEntitySign_1Mixin_API implements SignSource {
+@Mixin(targets = "net/minecraft/tileentity/TileEntitySign$2")
+public abstract class TileEntitySign_2Mixin implements CommandSenderBridge, CommandSourceBridge {
 
-    @Shadow(aliases = {"this$0", "field_174795_a"})
-    @Final
-    private TileEntitySign field_174795_a;
+    @Shadow public abstract String shadow$getName();
 
-    @SuppressWarnings({"ConstantConditions", "RedundantCast"}) // This is an ICommandSender anonymous class
     @Override
-    public CommandSource getOriginalSource() {
-        return WrapperCommandSource.of(((ICommandSender) (Object) this).getCommandSenderEntity());
+    public ICommandSender bridge$asICommandSender() {
+        return (ICommandSender) (Object) this;
     }
 
     @Override
-    public Sign getSign() {
-        return (Sign) this.field_174795_a;
+    public String bridge$getIdentifier() {
+        return this.shadow$getName();
     }
 
     @Override
-    public World getWorld() {
-        return (World) this.field_174795_a.getWorld();
+    public CommandSource bridge$asCommandSource() {
+        return (SignSource) this;
     }
 
-    @Override
-    public Location<World> getLocation() {
-        return ((Sign) this.field_174795_a).getLocation();
-    }
 }

--- a/src/main/resources/mixins.common.api.json
+++ b/src/main/resources/mixins.common.api.json
@@ -282,7 +282,7 @@
         "mcp.tileentity.TileEntityNoteMixin_API",
         "mcp.tileentity.TileEntityPistonMixin_API",
         "mcp.tileentity.TileEntityShulkerBoxMixin_API",
-        "mcp.tileentity.TileEntitySign_1Mixin_API",
+        "mcp.tileentity.TileEntitySignCommandSendersMixin_API",
         "mcp.tileentity.TileEntitySignMixin_API",
         "mcp.tileentity.TileEntitySkullMixin_API",
         "mcp.tileentity.TileEntityStructure_ModeMixin_API",

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -411,6 +411,7 @@
         "tileentity.TileEntityPistonMixin",
         "tileentity.TileEntityShulkerBoxMixin",
         "tileentity.TileEntitySign_1Mixin",
+        "tileentity.TileEntitySign_2Mixin",
         "tileentity.TileEntitySignMixin",
         "tileentity.TileEntitySkullAccessor",
         "tileentity.TileEntitySkullMixin",

--- a/testplugins/src/main/java/org/spongepowered/test/SignSourceTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/SignSourceTest.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.block.tileentity.TileEntity;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.source.SignSource;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.game.state.GameInitializationEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
+
+import java.util.Collections;
+import java.util.Optional;
+
+@Plugin(id = "signsourcetest", name = "SignSourceTest", description = SignSourceTest.DESCRIPTION, version = "0.0.0")
+public class SignSourceTest {
+
+    public static final String DESCRIPTION = "A plugin to test the item SignSource as a ProxySource.";
+
+    @Listener
+    public void onInit(GameInitializationEvent event) {
+        Sponge.getCommandManager().register(this, CommandSpec.builder().executor((src, args) -> {
+            if (!(src instanceof Player)) {
+                throw new CommandException(Text.of("Only players can use this command"));
+            }
+
+            Player source = (Player) src;
+            source.getLocation().setBlockType(BlockTypes.STANDING_SIGN);
+
+            Text signText = Text.builder()
+                    .append(Text.of("Click Me!"))
+                    .onClick(TextActions.runCommand("/doclicksign"))
+                    .build();
+            Optional<TileEntity> maybeTileEntities = source.getLocation().getTileEntity();
+            maybeTileEntities.ifPresent(tileEntity -> tileEntity.offer(Keys.SIGN_LINES, Collections.singletonList(signText)));
+
+            return CommandResult.success();
+        }).build(), "placeclicksign");
+
+        Sponge.getCommandManager().register(this, CommandSpec.builder().executor((src, args) -> {
+            if (!(src instanceof SignSource)) {
+                src.sendMessage(Text.of("You did not click a sign."));
+                return CommandResult.empty();
+            }
+
+            CommandSource originalSource = ((SignSource) src).getOriginalSource();
+            originalSource.sendMessage(Text.of("You clicked me!"));
+            return CommandResult.success();
+        }).build(), "doclicksign");
+    }
+}


### PR DESCRIPTION
The actual Mixin target was only the first anonymous implementation, and not the most important one, for players clicking signs.
Meaning the CommandSender will never be a SignSource, but a WrapperCommandSource.Located, making it impossible to get the original CommandSource (the Player who clicked the sign).

This commit now makes all references target the two anonymous implementations,
and makes possible to have a SignSource as source of a command.

I found this issue while investigating an issue someone was having in the dev Discord channel.

You can get your own [test plugin here](https://gist.github.com/RedNesto/8d138fd1e62ef90e7d912f847992f376)!