### PR TITLE
Expose static methods for plugins to detect whether they're running on Forge or Vanilla

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeImplHooks.java
+++ b/src/main/java/org/spongepowered/common/SpongeImplHooks.java
@@ -110,10 +110,6 @@ import javax.annotation.Nullable;
  */
 public final class SpongeImplHooks {
 
-    public static boolean isVanilla() {
-        return true;
-    }
-
     public static boolean isClientAvailable() {
         return false;
     }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1902) | **SpongeCommon** | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/2417)

Fix https://github.com/SpongePowered/SpongeCommon/issues/804

This was already implemented. It just wasn't exposed to plugins.

See the API PR for discussion.