### PR TITLE
Force auto-populate into global config

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/entitycollisions/MixinBlock_Collisions.java
+++ b/src/main/java/org/spongepowered/common/mixin/entitycollisions/MixinBlock_Collisions.java
@@ -28,6 +28,7 @@ import net.minecraft.block.Block;
 import net.minecraft.world.World;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.config.SpongeConfig;
 import org.spongepowered.common.config.category.CollisionModCategory;
 import org.spongepowered.common.config.category.EntityCollisionCategory;
@@ -82,7 +83,8 @@ public abstract class MixinBlock_Collisions implements IModData_Collisions {
     @Override
     public void initializeCollisionState(World worldIn) {
         SpongeConfig<? extends GeneralConfigBase> activeConfig = ((IMixinWorldServer) worldIn).getActiveConfig();
-        EntityCollisionCategory collisionCat = activeConfig.getConfig().getEntityCollisionCategory();
+        SpongeConfig<? extends GeneralConfigBase> globalConfig = SpongeImpl.getGlobalConfig();
+        EntityCollisionCategory collisionCat = globalConfig.getConfig().getEntityCollisionCategory();
         this.setMaxCollisions(collisionCat.getMaxEntitiesWithinAABB());
         String[] ids = ((BlockType) this).getId().split(":");
         String modId = ids[0];
@@ -93,7 +95,7 @@ public abstract class MixinBlock_Collisions implements IModData_Collisions {
             collisionCat.getModList().put(modId, collisionMod);
             collisionMod.getBlockList().put(name, this.getMaxCollisions());
             if (activeConfig.getConfig().getEntityCollisionCategory().autoPopulateData()) {
-                activeConfig.save();
+                globalConfig.save();
             }
 
             return;
@@ -122,7 +124,7 @@ public abstract class MixinBlock_Collisions implements IModData_Collisions {
         }
 
         if (activeConfig.getConfig().getEntityCollisionCategory().autoPopulateData()) {
-            activeConfig.save();
+            globalConfig.save();
         }
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/entitycollisions/MixinEntity_Collisions.java
+++ b/src/main/java/org/spongepowered/common/mixin/entitycollisions/MixinEntity_Collisions.java
@@ -35,6 +35,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.config.SpongeConfig;
 import org.spongepowered.common.config.category.CollisionModCategory;
 import org.spongepowered.common.config.category.EntityCollisionCategory;
@@ -114,7 +115,8 @@ public class MixinEntity_Collisions implements IModData_Collisions {
     @Override
     public void initializeCollisionState(World worldObj) {
         SpongeConfig<? extends GeneralConfigBase> activeConfig = ((IMixinWorldServer) worldObj).getActiveConfig();
-        EntityCollisionCategory collisionCat = activeConfig.getConfig().getEntityCollisionCategory();
+        SpongeConfig<? extends GeneralConfigBase> globalConfig = SpongeImpl.getGlobalConfig();
+        EntityCollisionCategory collisionCat = globalConfig.getConfig().getEntityCollisionCategory();
         this.maxCollisions = collisionCat.getMaxEntitiesWithinAABB();
         boolean requiresSave = false;
         CollisionModCategory collisionMod = collisionCat.getModList().get(this.entityModId);
@@ -122,7 +124,7 @@ public class MixinEntity_Collisions implements IModData_Collisions {
             collisionMod = new CollisionModCategory(this.entityModId);
             collisionCat.getModList().put(this.entityModId, collisionMod);
             collisionMod.getEntityList().put(this.entityName, this.maxCollisions);
-            activeConfig.save();
+            globalConfig.save();
             return;
         } else if (collisionMod != null) {
             if (!collisionMod.isEnabled()) {
@@ -158,7 +160,7 @@ public class MixinEntity_Collisions implements IModData_Collisions {
         }
 
         if (requiresSave && activeConfig.getConfig().getEntityCollisionCategory().autoPopulateData()) {
-            activeConfig.save();
+            globalConfig.save();
         }
         return;
     }

--- a/src/main/java/org/spongepowered/common/mixin/entitycollisions/MixinEntity_Collisions.java
+++ b/src/main/java/org/spongepowered/common/mixin/entitycollisions/MixinEntity_Collisions.java
@@ -116,53 +116,58 @@ public class MixinEntity_Collisions implements IModData_Collisions {
     public void initializeCollisionState(World worldObj) {
         SpongeConfig<? extends GeneralConfigBase> activeConfig = ((IMixinWorldServer) worldObj).getActiveConfig();
         SpongeConfig<? extends GeneralConfigBase> globalConfig = SpongeImpl.getGlobalConfig();
-        EntityCollisionCategory collisionCat = globalConfig.getConfig().getEntityCollisionCategory();
-        this.maxCollisions = collisionCat.getMaxEntitiesWithinAABB();
+        EntityCollisionCategory activeCollCat = activeConfig.getConfig().getEntityCollisionCategory();
+        EntityCollisionCategory globalCollCat = globalConfig.getConfig().getEntityCollisionCategory();
+
+        this.setMaxCollisions(activeCollCat.getMaxEntitiesWithinAABB());
+
         boolean requiresSave = false;
-        CollisionModCategory collisionMod = collisionCat.getModList().get(this.entityModId);
-        if (collisionMod == null && activeConfig.getConfig().getEntityCollisionCategory().autoPopulateData()) {
-            collisionMod = new CollisionModCategory(this.entityModId);
-            collisionCat.getModList().put(this.entityModId, collisionMod);
-            collisionMod.getEntityList().put(this.entityName, this.maxCollisions);
+        CollisionModCategory activeCollMod = activeCollCat.getModList().get(this.getModDataId());
+        CollisionModCategory globalCollMod = globalCollCat.getModList().get(this.getModDataId());
+        if (activeCollMod == null && activeCollCat.autoPopulateData()) {
+            globalCollMod = new CollisionModCategory(this.getModDataId());
+            globalCollCat.getModList().put(this.getModDataId(), globalCollMod);
+            globalCollMod.getEntityList().put(this.getModDataName(), this.getMaxCollisions());
             globalConfig.save();
             return;
-        } else if (collisionMod != null) {
-            if (!collisionMod.isEnabled()) {
-                this.maxCollisions = -1;
+        } else if (activeCollMod != null) {
+            if (!activeCollMod.isEnabled()) {
+                this.setMaxCollisions(-1);
                 return;
             }
             // check mod overrides
-            Integer modCollisionMax = collisionMod.getDefaultMaxCollisions().get("entities");
+            Integer modCollisionMax = activeCollMod.getDefaultMaxCollisions().get("entities");
             if (modCollisionMax != null) {
-                this.maxCollisions = modCollisionMax;
+                this.setMaxCollisions(modCollisionMax);
             }
 
             Integer entityMaxCollision = null;
             if ((Object) this instanceof EntityItem) {
                 // check if all items are overridden
-                entityMaxCollision = collisionMod.getEntityList().get(this.spongeEntityType.getName());
+                entityMaxCollision = activeCollMod.getEntityList().get(this.getModDataName());
             }
 
             if (entityMaxCollision == null) {
-                entityMaxCollision = collisionMod.getEntityList().get(this.entityName);
+                entityMaxCollision = activeCollMod.getEntityList().get(this.getModDataName());
             }
+
             // entity overrides
-            if (entityMaxCollision == null && activeConfig.getConfig().getEntityCollisionCategory().autoPopulateData()) {
-                collisionMod.getEntityList().put(this.entityName, this.maxCollisions);
+            if (entityMaxCollision == null && activeCollCat.autoPopulateData()) {
+                globalCollMod.getEntityList().put(this.getModDataName(), this.getMaxCollisions());
                 requiresSave = true;
             } else if (entityMaxCollision != null) {
-                this.maxCollisions = entityMaxCollision;
+                this.setMaxCollisions(entityMaxCollision);
             }
         }
 
-        if (this.maxCollisions <= 0) {
+        // don't bother saving for negative values
+        if (this.getMaxCollisions() <= 0) {
             return;
         }
 
-        if (requiresSave && activeConfig.getConfig().getEntityCollisionCategory().autoPopulateData()) {
+        if (requiresSave) {
             globalConfig.save();
         }
-        return;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/plugin/entityactivation/EntityActivationRange.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/entityactivation/EntityActivationRange.java
@@ -433,7 +433,8 @@ public class EntityActivationRange {
         checkNotNull(type, "type");
 
         SpongeConfig<? extends GeneralConfigBase> config = ((IMixinWorldServer) world).getActiveConfig();
-        if (config == null || type == null) {
+        SpongeConfig<? extends GeneralConfigBase> globalConfig = SpongeImpl.getGlobalConfig();
+        if (config == null || globalConfig == null || type == null) {
             return;
         }
 
@@ -443,7 +444,7 @@ public class EntityActivationRange {
         entityType = EntityActivationRange.activationTypeMappings.get(activationType);
         final String entityModId = type.getModId().toLowerCase();
         final String entityId = type.getName().toLowerCase();
-        EntityActivationRangeCategory activationCategory = config.getConfig().getEntityActivationRange();
+        EntityActivationRangeCategory activationCategory = globalConfig.getConfig().getEntityActivationRange();
         EntityActivationModCategory entityMod = activationCategory.getModList().get(entityModId);
         Integer defaultActivationRange = activationCategory.getDefaultRanges().get(entityType);
         if (defaultActivationRange == null) {
@@ -484,7 +485,7 @@ public class EntityActivationRange {
         }
 
         if (autoPopulate && requiresSave) {
-            config.save();
+            globalConfig.save();
         }
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/plugin/tileentityactivation/TileEntityActivation.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/tileentityactivation/TileEntityActivation.java
@@ -227,13 +227,14 @@ public class TileEntityActivation {
 
     public static void addTileEntityToConfig(World world, SpongeTileEntityType type) {
         SpongeConfig<? extends GeneralConfigBase> config = ((IMixinWorldServer) world).getActiveConfig();
-        if (config == null || type == null || !config.getConfig().getTileEntityActivationRange().autoPopulateData()) {
+        SpongeConfig<? extends GeneralConfigBase> globalConfig = SpongeImpl.getGlobalConfig();
+        if (config == null || globalConfig == null || type == null || !config.getConfig().getTileEntityActivationRange().autoPopulateData()) {
             return;
         }
 
         boolean requiresSave = false;
         final String tileModId = type.getModId().toLowerCase();
-        TileEntityActivationCategory activationCategory = config.getConfig().getTileEntityActivationRange();
+        TileEntityActivationCategory activationCategory = globalConfig.getConfig().getTileEntityActivationRange();
         TileEntityActivationModCategory tileEntityMod = activationCategory.getModList().get(tileModId);
         int defaultRange = activationCategory.getDefaultBlockRange();
         int defaultTickRate = activationCategory.getDefaultTickRate();
@@ -269,7 +270,7 @@ public class TileEntityActivation {
         }
 
         if (requiresSave) {
-            config.save();
+            globalConfig.save();
         }
     }
 }


### PR DESCRIPTION
Fixes #2076 

still gonna use the value of auto-populate per world, as you may want to disable things from one dimensions being added to the config for whatever reason

~~still need to figure out how to handle collision configs~~