### PR TITLE
Update Versioning Strings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,23 @@ ext.common = project
 apply from: 'gradle/minecraft.gradle'
 
 // Inherit SpongeCommon version from SpongeAPI
-version = api.version
-ext.apiVersion = version
+ext {
+    isSnapshot = api.version.contains('-SNAPSHOT')
+    isImplRC = common.recommendedVersion.contains('-SNAPSHOT')
+    trimmedApiVersion = api.version.toString().replace("-SNAPSHOT", "")
+    apiSplitVersion = trimmedApiVersion.split("\\.")
+    // This is to determine if the split api version has at the least a minimum version.
+    apiMinor = apiSplitVersion.length > 1 ? apiSplitVersion[1] : (apiSplitVersion.length > 0 ? apiSplitVersion.last : '0')
+    correctedMinorVersion = Math.max(Integer.parseInt(apiMinor) - 1, 0)
+    // And then here, we determine if the api version still has a patch version, to just ignore it.
+    apiReleaseVersion = apiSplitVersion.length > 2 ? apiSplitVersion[0] + '.' + apiSplitVersion[1] : trimmedApiVersion
+    apiSuffix = isSnapshot ? ext.apiSplitVersion[0] + '.' + correctedMinorVersion : apiReleaseVersion
+    fixedApiVersionWithDecreasedMinor = apiSplitVersion.length > 2 ? apiSplitVersion[0] + '.' + correctedMinorVersion + '.' + apiSplitVersion[2] : apiSplitVersion[0] + '.' + correctedMinorVersion
+}
+version = minecraftVersion + '-' + ext.apiSuffix + '.' + common.recommendedVersion
+
+ext.apiVersion = isSnapshot ? ext.fixedApiVersionWithDecreasedMinor : ext.apiReleaseVersion
+
 
 dependencies {
     compile(api) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ url=https://www.spongepowered.org
 organization=SpongePowered
 
 minecraftVersion=1.12.2
+recommendedVersion=1-SNAPSHOT
 mcpMappings=snapshot_20180808
 
 # We use VanillaGradle instead of an official ForgeGradle plugin.

--- a/gradle/implementation.gradle
+++ b/gradle/implementation.gradle
@@ -37,15 +37,23 @@ apply plugin: 'org.spongepowered.meta'
 generateMetadata {
     dependsOn common.resolveApiRevision
 }
-
+ext {
+    implementationVersion = (common.isImplRC ? common.apiSuffix + '.' + common.recommendedVersion - '-SNAPSHOT' + "-RC$buildNumber" : common.apiSuffix + '.' + common.recommendedVersion)
+}
 sponge {
     plugin {
-        id = 'sponge'
+        id = project.ext.implementationId
+        version = project.version
+        meta {
+            inherit project
+        }
         meta.dependencies {
             spongeapi {
                 forceVersion {common.apiVersion}
             }
-
+            sponge {
+                forceVersion {common.version}
+            }
             minecraft {
                 forceVersion project.minecraft.version
             }
@@ -57,6 +65,21 @@ sponge {
             meta {
                 inherit api
                 version = {common.apiVersion}
+            }
+        }
+        sponge {
+            meta {
+                inherit common
+                name = "Sponge"
+                version = common.version
+                dependencies {
+                    spongeapi {
+                        forceVersion {common.apiVersion}
+                    }
+                    minecraft {
+                        forceVersion project.minecraft.version
+                    }
+                }
             }
         }
     }

--- a/src/main/java/org/spongepowered/common/SpongeImpl.java
+++ b/src/main/java/org/spongepowered/common/SpongeImpl.java
@@ -117,11 +117,6 @@ public final class SpongeImpl {
                 internalPlugins.add(((SpongePlatform) platform).getCommon());
             }
         }
-
-        final PrettyPrinter printer = new PrettyPrinter(60).add("InternalPlugins").centre().hr()
-            .add("Listing plugins:");
-        internalPlugins.forEach(plugin -> printer.add(" - " + plugin.getId() + " : " + plugin.getVersion().orElse("")));
-        printer.trace();
     }
 
     private static <T> T check(@Nullable T instance) {

--- a/src/main/java/org/spongepowered/common/SpongeImpl.java
+++ b/src/main/java/org/spongepowered/common/SpongeImpl.java
@@ -43,6 +43,7 @@ import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.game.state.GameStateEvent;
 import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.asm.util.PrettyPrinter;
 import org.spongepowered.common.config.SpongeConfig;
 import org.spongepowered.common.config.SpongeConfigSaveManager;
 import org.spongepowered.common.config.type.CustomDataConfig;
@@ -73,7 +74,7 @@ public final class SpongeImpl {
 
     public static final String API_NAME = "SpongeAPI";
 
-    public static final String ECOSYSTEM_ID = "sponge";
+    public static final String ECOSYSTEM_ID = "sponge"; // This is different from the id used by the actual implementation
     public static final String ECOSYSTEM_NAME = "Sponge";
 
     // TODO: Keep up to date
@@ -88,6 +89,7 @@ public final class SpongeImpl {
     @Nullable private static SpongeConfig<CustomDataConfig> customDataConfig;
     @Nullable private static SpongeConfigSaveManager configSaveManager;
     @Nullable private static PluginContainer minecraftPlugin;
+    @Nullable private static PluginContainer spongecommon;
 
     @Inject @Nullable private static SpongeGame game;
     @Inject @Nullable private static SpongeGameRegistry registry;
@@ -107,9 +109,19 @@ public final class SpongeImpl {
             minecraftPlugin = platform.getContainer(Platform.Component.GAME);
         }
 
+
         for (Platform.Component component : Platform.Component.values()) {
             internalPlugins.add(platform.getContainer(component));
+            if (component == Platform.Component.API && platform instanceof SpongePlatform) {
+                // We want to set up the common version after the api.
+                internalPlugins.add(((SpongePlatform) platform).getCommon());
+            }
         }
+
+        final PrettyPrinter printer = new PrettyPrinter(60).add("InternalPlugins").centre().hr()
+            .add("Listing plugins:");
+        internalPlugins.forEach(plugin -> printer.add(" - " + plugin.getId() + " : " + plugin.getVersion().orElse("")));
+        printer.trace();
     }
 
     private static <T> T check(@Nullable T instance) {
@@ -169,6 +181,16 @@ public final class SpongeImpl {
     public static void setMinecraftPlugin(PluginContainer minecraft) {
         checkState(minecraftPlugin == null, "Minecraft plugin container is already initialized");
         minecraftPlugin = minecraft;
+    }
+
+    public static void setSpongePlugin(PluginContainer common) {
+        checkState(spongecommon == null);
+        spongecommon = common;
+    }
+
+    public static PluginContainer getSpongePlugin() {
+        checkState(spongecommon != null, "SpongeCommon plugin container is not initialized");
+        return spongecommon;
     }
 
     public static Path getGameDir() {

--- a/src/main/java/org/spongepowered/common/SpongeImplHooks.java
+++ b/src/main/java/org/spongepowered/common/SpongeImplHooks.java
@@ -500,4 +500,8 @@ public final class SpongeImplHooks {
     public static boolean creativeExploitCheck(Packet<?> packetIn, EntityPlayerMP playerMP) {
         return false;
     }
+
+    public static String getImplementationId() {
+        throw new UnsupportedOperationException("SpongeCommon does not have it's own ecosystem, this needs to be mixed into for implementations depending on SpongeCommon");
+    }
 }

--- a/src/main/java/org/spongepowered/common/SpongePlatform.java
+++ b/src/main/java/org/spongepowered/common/SpongePlatform.java
@@ -42,6 +42,7 @@ import java.util.Map;
 public class SpongePlatform implements Platform {
 
     private final PluginContainer api;
+    private final PluginContainer common;
     private final PluginContainer impl;
     private final PluginContainer minecraft;
     private final MinecraftVersion minecraftVersion;
@@ -59,12 +60,13 @@ public class SpongePlatform implements Platform {
 
     @Inject
     public SpongePlatform(PluginManager manager, MinecraftVersion minecraftVersion) {
-        this(manager, manager.getPlugin(SpongeImpl.ECOSYSTEM_ID).get(), minecraftVersion);
+        this(manager, manager.getPlugin(SpongeImplHooks.getImplementationId()).get(), minecraftVersion);
     }
 
     // For SpongeForge (implementation container isn't registered when SpongePlatform is initialized)
-    protected SpongePlatform(PluginManager manager, PluginContainer impl, MinecraftVersion minecraftVersion) {
+    protected SpongePlatform(PluginManager manager,  PluginContainer impl, MinecraftVersion minecraftVersion) {
         this.api = manager.getPlugin(Platform.API_ID).get();
+        this.common = manager.getPlugin(SpongeImpl.ECOSYSTEM_ID).get();
         this.impl = checkNotNull(impl, "impl");
         this.minecraft = manager.getPlugin(SpongeImpl.GAME_ID).get();
         this.minecraftVersion = checkNotNull(minecraftVersion, "minecraftVersion");
@@ -72,6 +74,8 @@ public class SpongePlatform implements Platform {
         this.platformMap.put("Type", this.getType());
         this.platformMap.put("ApiName", this.api.getName());
         this.platformMap.put("ApiVersion", this.api.getVersion());
+        this.platformMap.put("CommonName", this.common.getName());
+        this.platformMap.put("CommonVersion", this.common.getVersion());
         this.platformMap.put("ImplementationName", this.impl.getName());
         this.platformMap.put("ImplementationVersion", this.impl.getVersion());
         this.platformMap.put("MinecraftVersion", this.getMinecraftVersion());
@@ -79,6 +83,10 @@ public class SpongePlatform implements Platform {
 
     // For SpongeCommon we assume that we are always on the server
     // SpongeForge overrides this to return CLIENT when running in a client environment
+
+    public PluginContainer getCommon() {
+        return this.common;
+    }
 
     @Override
     public Type getType() {

--- a/src/test/java/org/spongepowered/common/test/inject/TestImplementationModule.java
+++ b/src/test/java/org/spongepowered/common/test/inject/TestImplementationModule.java
@@ -36,6 +36,7 @@ import org.spongepowered.api.network.ChannelRegistrar;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.plugin.PluginManager;
 import org.spongepowered.common.SpongeGame;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.SpongePlatform;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.inject.SpongeImplementationModule;
@@ -63,8 +64,8 @@ public class TestImplementationModule extends SpongeImplementationModule {
         when(manager.getPlugin(anyString())).thenReturn(Optional.of(mock));
         when(manager.fromInstance(any())).thenReturn(Optional.of(mock));
         this.bind(PluginManager.class).toInstance(manager);
-
-
+        PluginContainer common = mock(PluginContainer.class);
+        SpongeImpl.setSpongePlugin(common);
         this.bind(EventManager.class).toInstance(mock(EventManager.class));
         this.bind(ChannelRegistrar.class).toInstance(mock(ChannelRegistrar.class));
     }


### PR DESCRIPTION
**SpongeCommon** | [SpongeVanilla](https://github.com/SpongePowered/SpongeVanilla/pull/391) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/2472)
To sumarize https://github.com/SpongePowered/SpongeForge/issues/2367:

We are changing our versioning string format for SpongeForge, SpongeVanilla, SpongeCommon, and SpongeAPI.

Because SpongeAPI 7.1.0 has already been released, we will not be making the change to drop the `patchVersion` of the API until API 8.

As of right now however, SpongeCommon has a full blown PluginContainer provided by both implementations (implemented slightly differently due to one having complete control over plugin containers and the other, well, not so much).

Looking for feedback from @Minecrell and others to maybe improve these changes so they're not so ~~janky~~ cluttered.