### PR TITLE
Fix spectator not working on respawn

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinPlayerList.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinPlayerList.java
@@ -612,6 +612,7 @@ public abstract class MixinPlayerList implements IMixinPlayerList {
         org.spongepowered.api.entity.Entity spongeEntity = (org.spongepowered.api.entity.Entity) newPlayer;
         ((org.spongepowered.api.world.World) worldServer).spawnEntity(spongeEntity);
         this.playerEntityList.add(newPlayer);
+        newPlayer.connection.sendPacket(new SPacketPlayerListItem(SPacketPlayerListItem.Action.UPDATE_GAME_MODE, newPlayer));
         this.uuidToPlayerMap.put(newPlayer.getUniqueID(), newPlayer);
         newPlayer.addSelfToInternalCraftingInventory();
 

--- a/testplugins/src/main/java/org/spongepowered/test/RespawnSpectatorTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/RespawnSpectatorTest.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.gamemode.GameModes;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.entity.living.humanoid.player.RespawnPlayerEvent;
+import org.spongepowered.api.event.filter.cause.Root;
+import org.spongepowered.api.event.game.state.GameInitializationEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+
+@Plugin(id = "respawnspectatortest", name = "Respawn Spectator Test", version = "0.0.0")
+public class RespawnSpectatorTest {
+
+    private final RespawnSpectatorListener listener = new RespawnSpectatorListener();
+    private boolean registered = false;
+
+    @Listener
+    public void onInit(GameInitializationEvent event) {
+        Sponge.getCommandManager().register(this,
+                CommandSpec.builder().executor((source, context) -> {
+                    this.registered = !this.registered;
+                    source.sendMessage(Text.of("listener set to " + this.registered));
+                    if (this.registered) {
+                        Sponge.getEventManager().unregisterListeners(this.listener);
+                    } else {
+                        Sponge.getEventManager().registerListeners(this, this.listener);
+                    }
+                    return CommandResult.success();
+                }).build(), "togglespectatorrespawn");
+    }
+
+    public static class RespawnSpectatorListener {
+
+        @Listener
+        public void onRespawn(RespawnPlayerEvent event, @Root Player player) {
+            if (event.isDeath()) {
+                player.offer(Keys.GAME_MODE, GameModes.SPECTATOR);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Fix https://github.com/SpongePowered/SpongeCommon/issues/1356

Answering @gabizou and expanding my comment

> What do you mean "this"? The data processor that is performing the game mode change is performing the exact same method call as if you were to run the game mode command, there's no tab list modification that needs to take place to make the player a floating head etc.

The data processor is indeed performing the exact same method call of the gamemode command

https://github.com/SpongePowered/SpongeCommon/blob/296e29c3cb14e0d727a44cd4c04feeba5ba67ccc/src/main/java/org/spongepowered/common/data/processor/data/entity/GameModeDataProcessor.java#L59

but let's try to go deeper:

`EntityPlayerMP#setGameType` is calling `PlayerInteractionManager#setGameType` which is calling `PlayerList#sendPacketToAllPlayers`.

However the new player is added to the player list near the end of the method

https://github.com/SpongePowered/SpongeCommon/blob/296e29c3cb14e0d727a44cd4c04feeba5ba67ccc/src/main/java/org/spongepowered/common/mixin/core/server/MixinPlayerList.java#L615

so the `SPacketPlayerListItem` (action `SPacketPlayerListItem.Action.UPDATE_GAME_MODE`) is never sent to him.

(Test plugin included)