### PR TITLE
Partially revert #1958 for world limit fix

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/util/math/MixinMutableBlockPos.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/util/math/MixinMutableBlockPos.java
@@ -46,12 +46,12 @@ public abstract class MixinMutableBlockPos extends BlockPos implements IMixinBlo
 
     @Override
     public boolean isValidPosition() {
-        return this.x >= -30000000 && this.z >= -30000000 && this.x <= 30000000 && this.z <= 30000000 && this.y >= 0 && this.y < 256;
+        return this.x >= -30000000 && this.z >= -30000000 && this.x < 30000000 && this.z < 30000000 && this.y >= 0 && this.y < 256;
     }
 
     @Override
     public boolean isValidXZPosition() {
-        return this.x >= -30000000 && this.z >= -30000000 && this.x <= 30000000 && this.z <= 30000000;
+        return this.x >= -30000000 && this.z >= -30000000 && this.x < 30000000 && this.z < 30000000;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/util/math/MixinVec3i.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/util/math/MixinVec3i.java
@@ -43,12 +43,12 @@ public abstract class MixinVec3i implements IMixinBlockPos {
 
     @Override
     public boolean isValidPosition() {
-        return this.x >= -30000000 && this.z >= -30000000 && this.x <= 30000000 && this.z <= 30000000 && this.y >= 0 && this.y < 256;
+        return this.x >= -30000000 && this.z >= -30000000 && this.x < 30000000 && this.z < 30000000 && this.y >= 0 && this.y < 256;
     }
 
     @Override
     public boolean isValidXZPosition() {
-        return this.x >= -30000000 && this.z >= -30000000 && this.x <= 30000000 && this.z <= 30000000;
+        return this.x >= -30000000 && this.z >= -30000000 && this.x < 30000000 && this.z < 30000000;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -170,7 +170,7 @@ import javax.annotation.Nullable;
 public abstract class MixinWorld implements World, IMixinWorld {
 
     private static final Vector3i BLOCK_MIN = new Vector3i(-30000000, 0, -30000000);
-    private static final Vector3i BLOCK_MAX = new Vector3i(30000000, 256, 30000000);
+    private static final Vector3i BLOCK_MAX = new Vector3i(30000000, 256, 30000000).sub(Vector3i.ONE);
     private static final Vector3i BLOCK_SIZE = BLOCK_MAX.sub(BLOCK_MIN).add(Vector3i.ONE);
     private static final Vector3i BIOME_MIN = new Vector3i(BLOCK_MIN.getX(), 0, BLOCK_MIN.getZ());
     private static final Vector3i BIOME_MAX = new Vector3i(BLOCK_MAX.getX(), 256, BLOCK_MAX.getZ());

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Lists;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockEventData;
 import net.minecraft.block.BlockPistonBase;
-import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.crash.CrashReportCategory;
@@ -170,8 +169,6 @@ import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseData;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.TrackingUtil;
-import org.spongepowered.common.event.tracking.phase.entity.BasicEntityContext;
-import org.spongepowered.common.event.tracking.phase.entity.EntityPhase;
 import org.spongepowered.common.event.tracking.phase.general.ExplosionContext;
 import org.spongepowered.common.event.tracking.phase.general.GeneralPhase;
 import org.spongepowered.common.event.tracking.phase.generation.GenerationPhase;
@@ -200,7 +197,6 @@ import org.spongepowered.common.registry.type.world.BlockChangeFlagRegistryModul
 import org.spongepowered.common.util.NonNullArrayList;
 import org.spongepowered.common.util.SpongeHooks;
 import org.spongepowered.common.util.VecHelper;
-import org.spongepowered.common.world.SpongeLocatableBlock;
 import org.spongepowered.common.world.SpongeLocatableBlockBuilder;
 import org.spongepowered.common.world.WorldManager;
 import org.spongepowered.common.world.WorldUtil;
@@ -237,7 +233,7 @@ public abstract class MixinWorldServer extends MixinWorld implements IMixinWorld
     private static final String PROFILER_ESS = "Lnet/minecraft/profiler/Profiler;endStartSection(Ljava/lang/String;)V";
 
     private static final Vector3i BLOCK_MIN = new Vector3i(-30000000, 0, -30000000);
-    private static final Vector3i BLOCK_MAX = new Vector3i(30000000, 256, 30000000);
+    private static final Vector3i BLOCK_MAX = new Vector3i(30000000, 256, 30000000).sub(Vector3i.ONE);
 
     private static final EnumSet<EnumFacing> NOTIFY_DIRECTIONS = EnumSet.of(EnumFacing.WEST, EnumFacing.EAST, EnumFacing.DOWN, EnumFacing.UP, EnumFacing.NORTH, EnumFacing.SOUTH);
 

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
@@ -232,9 +232,6 @@ public abstract class MixinWorldServer extends MixinWorld implements IMixinWorld
     private static final String PROFILER_SS = "Lnet/minecraft/profiler/Profiler;startSection(Ljava/lang/String;)V";
     private static final String PROFILER_ESS = "Lnet/minecraft/profiler/Profiler;endStartSection(Ljava/lang/String;)V";
 
-    private static final Vector3i BLOCK_MIN = new Vector3i(-30000000, 0, -30000000);
-    private static final Vector3i BLOCK_MAX = new Vector3i(30000000, 256, 30000000).sub(Vector3i.ONE);
-
     private static final EnumSet<EnumFacing> NOTIFY_DIRECTIONS = EnumSet.of(EnumFacing.WEST, EnumFacing.EAST, EnumFacing.DOWN, EnumFacing.UP, EnumFacing.NORTH, EnumFacing.SOUTH);
 
     private final Map<net.minecraft.entity.Entity, Vector3d> rotationUpdates = new HashMap<>();
@@ -1130,7 +1127,7 @@ public abstract class MixinWorldServer extends MixinWorld implements IMixinWorld
 
     private void checkBlockBounds(int x, int y, int z) {
         if (!containsBlock(x, y, z)) {
-            throw new PositionOutOfBoundsException(new Vector3i(x, y, z), BLOCK_MIN, BLOCK_MAX);
+            throw new PositionOutOfBoundsException(new Vector3i(x, y, z), getBlockMin(), getBlockMax());
         }
     }
 


### PR DESCRIPTION
@ImMorpheus - I'm PRing this because I want to check that I've got this right before it lands on stable - I suspect (as others stated in #2120) that there was some confusion between block position and decimal position. Can you confirm whether this was an error, or if there is a reason for the changes that this reverts? Thanks!

---

Commit message:

A common source of confusion is the decimal co-ordinates vs block co-ordinates. It is stated that the minecraft X/Z co-ordinates have a range of +/-30,000,000, which is true, however, the block coordinates range from -30,000,000 to +29,999,999.

This is because the edges of blocks line up with the unit co-ordinates, such that a block spans from n to n+1 (where n is an integer). Thus, a block that we class as being at (29,999,999, 0, 29,999,999) actually spans to (30,000,000, 0, 30,000,000).

The block limit should be within the 30M radius around 0, meaning that the last possible block that can be interacted with is at 30M-1, as the block with block co-ordinate  X=30M actually strays past the Minecraft border to decimal co-ordinate 30M+1 - which is out of bounds.

This commit reverts the max block limit change.

Fixes https://github.com/SpongePowered/SpongeCommon/issues/2120