### PR TITLE
Use Filesystem watchers to cache game profiles/users in the USS

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeInternalListeners.java
+++ b/src/main/java/org/spongepowered/common/SpongeInternalListeners.java
@@ -29,9 +29,12 @@ import com.google.common.collect.Multimap;
 import net.minecraft.server.MinecraftServer;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.game.state.GameStartingServerEvent;
 import org.spongepowered.api.event.service.ChangeServiceProviderEvent;
 import org.spongepowered.api.event.world.SaveWorldEvent;
 import org.spongepowered.common.bridge.server.management.PlayerProfileCacheBridge;
+import org.spongepowered.api.service.user.UserStorageService;
+import org.spongepowered.common.service.user.SpongeUserStorageService;
 import org.spongepowered.common.util.SpongeUsernameCache;
 
 import java.util.Iterator;
@@ -56,6 +59,14 @@ public class SpongeInternalListeners {
             callback.accept(o);
             return true;
         });
+    }
+
+    @Listener
+    public void onServerStarting(GameStartingServerEvent event) {
+        // if we have the SpongeUserService, we start init now async (this is a filesystem scan).
+        Sponge.getServiceManager().provide(UserStorageService.class)
+                .filter(x -> x instanceof SpongeUserStorageService)
+                .ifPresent(x -> ((SpongeUserStorageService) x).init());
     }
 
     @Listener

--- a/src/main/java/org/spongepowered/common/mixin/core/world/storage/SaveHandlerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/storage/SaveHandlerMixin.java
@@ -78,6 +78,7 @@ import javax.annotation.Nullable;
 public abstract class SaveHandlerMixin implements SaveHandlerBridge {
 
     @Shadow @Final private File worldDirectory;
+    @Shadow @Final private File playersDirectory;
 
     @Shadow protected abstract void shadow$setSessionLock();
 
@@ -428,6 +429,11 @@ public abstract class SaveHandlerMixin implements SaveHandlerBridge {
     @Override
     public File bridge$getSpongeWorldDirectory() {
         return this.worldDirectory;
+    }
+
+    @Override
+    public File bridge$getPlayersDirectory() {
+        return this.playersDirectory;
     }
 
     private boolean impl$loadSpongeDatFile(final WorldInfo info, final File file, boolean isCurrent) {

--- a/src/main/java/org/spongepowered/common/service/user/SpongeUserStorageService.java
+++ b/src/main/java/org/spongepowered/common/service/user/SpongeUserStorageService.java
@@ -45,6 +45,10 @@ public class SpongeUserStorageService implements UserStorageService {
     public static final UUID FAKEPLAYER_UUID = UUID.fromString("41C82C87-7AfB-4024-BA57-13D2C99CAE77");
     public static final GameProfile FAKEPLAYER_PROFILE = (GameProfile) new com.mojang.authlib.GameProfile(FAKEPLAYER_UUID, null);
 
+    public void init() {
+        UserDiscoverer.init();
+    }
+
     @Override
     public Optional<User> get(UUID uniqueId) {
         try {

--- a/src/main/java/org/spongepowered/common/service/user/package-info.java
+++ b/src/main/java/org/spongepowered/common/service/user/package-info.java
@@ -22,33 +22,5 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.bridge.world.storage;
-
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.world.storage.SaveHandler;
-import net.minecraft.world.storage.WorldInfo;
-
-import java.io.File;
-import java.io.IOException;
-
-public interface SaveHandlerBridge {
-
-    void bridge$loadSpongeDatData(WorldInfo info) throws IOException;
-
-    File bridge$getSpongeWorldDirectory();
-
-    File bridge$getPlayersDirectory();
-
-    /**
-     * Used by the SaveHandler, and in SaveHandlerMixin_Vanilla
-     * to load sponge specific data. Since Forge has some handling
-     * already for this, we still have to provide this hook for
-     * SpongeVanilla to take advantage.
-     *
-     * @param handler The save handler instance
-     * @param info The world info
-     * @param compound The compound
-     */
-    void bridge$loadDimensionAndOtherData(final SaveHandler handler, final WorldInfo info, final NBTTagCompound compound);
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault
+package org.spongepowered.common.service.user;


### PR DESCRIPTION
This is very WIP - based on some tinkering I've been doing. Not ready to merge yet, may not merge, but is currently at a proof of concept stage to try to improve server performance when thousands of game profiles exist - usually when tab completing a user argument on a command! I wanted to put this out now to get any early feedback on the idea - especially if I've missed something.

Basically, the idea behind this is after the first, initial, user file scan, we cache the stored UUIDs. We then setup a file system watcher to determine which UUIDs have had files added/removed/changed and therefore only perform operations on _those_ UUIDs - before, though we had the user cache, we still operated on every file.

I did consider the fact that I could have just made the line `final GameProfile profile = profileCache.getProfileByUUID(uuid);` only execute if we don't have a user in the cache (at the moment, we basically ignored this cache), that would have saved some performance. This is intended to save time otherwise spend on I/O and UUID parsing too. I also figured that if a user's profile changed, it might be that their username has changed with Mojang and has changed in the profile cache - so the lookup shouldn't require a call to Mojang servers in the vast majority of cases.

The elephant in the room is that for this cache to work, it needs to have run once! This needs thinking about - when do we populate the cache such that the first tab complete doesn't kill a server!

With one player (me) on my machine, getting all profiles was an 11ms operation the first time around, and went down to 1ms after the cache was built. I hope to get a bigger dataset and play about and see what further gains we can get.