### PR TITLE
Prevent having to use "minecraft:" when getting particle types

### DIFF
--- a/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
@@ -212,7 +212,7 @@ import org.spongepowered.common.registry.type.data.InstrumentTypeRegistryModule;
 import org.spongepowered.common.registry.type.data.KeyRegistryModule;
 import org.spongepowered.common.registry.type.economy.TransactionTypeRegistryModule;
 import org.spongepowered.common.registry.type.effect.ParticleOptionRegistryModule;
-import org.spongepowered.common.registry.type.effect.ParticleRegistryModule;
+import org.spongepowered.common.registry.type.effect.ParticleTypeRegistryModule;
 import org.spongepowered.common.registry.type.effect.PotionEffectTypeRegistryModule;
 import org.spongepowered.common.registry.type.effect.RecordTypeRegistryModule;
 import org.spongepowered.common.registry.type.effect.SoundCategoryRegistryModule;
@@ -439,7 +439,7 @@ public final class CommonModuleRegistry {
                 .registerModule(ObjectiveDisplayMode.class, new ObjectiveDisplayModeRegistryModule())
                 .registerModule(OcelotType.class, new OcelotTypeRegistryModule())
                 .registerModule(ParrotVariant.class, new ParrotVariantRegistryModule())
-                .registerModule(ParticleType.class, ParticleRegistryModule.getInstance())
+                .registerModule(ParticleType.class, ParticleTypeRegistryModule.getInstance())
                 .registerModule((Class<ParticleOption<?>>) (Class<?>) ParticleOption.class, new ParticleOptionRegistryModule())
                 .registerModule(PistonType.class, new PistonTypeRegistryModule())
                 .registerModule(PlantType.class, new PlantTypeModuleRegistry())

--- a/src/main/java/org/spongepowered/common/registry/type/effect/ParticleTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/effect/ParticleTypeRegistryModule.java
@@ -48,6 +48,7 @@ import org.spongepowered.api.util.Direction;
 import org.spongepowered.common.effect.particle.SpongeParticleType;
 import org.spongepowered.common.item.inventory.SpongeItemStackSnapshot;
 import org.spongepowered.common.registry.type.AbstractPrefixAlternateCatalogTypeRegistryModule;
+import org.spongepowered.common.registry.type.AbstractPrefixCheckCatalogRegistryModule;
 import org.spongepowered.common.registry.type.BlockTypeRegistryModule;
 import org.spongepowered.common.registry.type.ItemTypeRegistryModule;
 import org.spongepowered.common.registry.type.NotePitchRegistryModule;
@@ -63,17 +64,14 @@ import javax.annotation.Nullable;
 
 @RegistrationDependency({ ParticleOptionRegistryModule.class, NotePitchRegistryModule.class, BlockTypeRegistryModule.class,
         ItemTypeRegistryModule.class, PotionEffectTypeRegistryModule.class, FireworkShapeRegistryModule.class })
-public final class ParticleTypeRegistryModule extends
-    AbstractPrefixAlternateCatalogTypeRegistryModule<ParticleType> {
+public final class ParticleTypeRegistryModule extends AbstractPrefixCheckCatalogRegistryModule<ParticleType> {
 
     public static ParticleTypeRegistryModule getInstance() {
         return Holder.INSTANCE;
     }
 
     @RegisterCatalog(ParticleTypes.class)
-    private final Map<String, SpongeParticleType> particleMappings = Maps.newHashMap();
     private final Map<String, ParticleType> particleByName = Maps.newHashMap();
-    private final Map<EnumParticleTypes, SpongeParticleType> particleTypeMapping = Maps.newHashMap();
 
     @Override
     public Optional<ParticleType> getById(String id) {
@@ -190,7 +188,6 @@ public final class ParticleTypeRegistryModule extends
 
     private void addEffectType(String id, @Nullable EnumParticleTypes internalType, Map<ParticleOption<?>, Object> options) {
         SpongeParticleType particleType = new SpongeParticleType("minecraft:" + id, id, internalType, options);
-        this.particleMappings.put(id, particleType);
         this.particleByName.put(particleType.getId().toLowerCase(Locale.ENGLISH), particleType);
     }
 

--- a/src/main/java/org/spongepowered/common/registry/type/effect/ParticleTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/effect/ParticleTypeRegistryModule.java
@@ -77,7 +77,11 @@ public final class ParticleTypeRegistryModule extends
 
     @Override
     public Optional<ParticleType> getById(String id) {
-        return Optional.ofNullable(this.particleByName.get(defaultModIdToPrepend + ":" + checkNotNull(id).toLowerCase(Locale.ENGLISH)));
+        String key = checkNotNull(id).toLowerCase(Locale.ENGLISH);
+        if (!key.contains(":")) {
+            key = this.defaultModIdToPrepend + ":" + key;
+        }
+        return Optional.ofNullable(this.particleByName.get(key));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/registry/type/effect/ParticleTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/effect/ParticleTypeRegistryModule.java
@@ -41,13 +41,13 @@ import org.spongepowered.api.effect.potion.PotionEffectTypes;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.FireworkShapes;
 import org.spongepowered.api.item.inventory.ItemStack;
-import org.spongepowered.api.registry.CatalogRegistryModule;
 import org.spongepowered.api.registry.util.RegisterCatalog;
 import org.spongepowered.api.registry.util.RegistrationDependency;
 import org.spongepowered.api.util.Color;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.common.effect.particle.SpongeParticleType;
 import org.spongepowered.common.item.inventory.SpongeItemStackSnapshot;
+import org.spongepowered.common.registry.type.AbstractPrefixAlternateCatalogTypeRegistryModule;
 import org.spongepowered.common.registry.type.BlockTypeRegistryModule;
 import org.spongepowered.common.registry.type.ItemTypeRegistryModule;
 import org.spongepowered.common.registry.type.NotePitchRegistryModule;
@@ -63,9 +63,10 @@ import javax.annotation.Nullable;
 
 @RegistrationDependency({ ParticleOptionRegistryModule.class, NotePitchRegistryModule.class, BlockTypeRegistryModule.class,
         ItemTypeRegistryModule.class, PotionEffectTypeRegistryModule.class, FireworkShapeRegistryModule.class })
-public final class ParticleRegistryModule implements CatalogRegistryModule<ParticleType> {
+public final class ParticleTypeRegistryModule extends
+    AbstractPrefixAlternateCatalogTypeRegistryModule<ParticleType> {
 
-    public static ParticleRegistryModule getInstance() {
+    public static ParticleTypeRegistryModule getInstance() {
         return Holder.INSTANCE;
     }
 
@@ -76,7 +77,7 @@ public final class ParticleRegistryModule implements CatalogRegistryModule<Parti
 
     @Override
     public Optional<ParticleType> getById(String id) {
-        return Optional.ofNullable(this.particleByName.get(checkNotNull(id).toLowerCase(Locale.ENGLISH)));
+        return Optional.ofNullable(this.particleByName.get(defaultModIdToPrepend + ":" + checkNotNull(id).toLowerCase(Locale.ENGLISH)));
     }
 
     @Override
@@ -189,10 +190,11 @@ public final class ParticleRegistryModule implements CatalogRegistryModule<Parti
         this.particleByName.put(particleType.getId().toLowerCase(Locale.ENGLISH), particleType);
     }
 
-    private ParticleRegistryModule() {
+    private ParticleTypeRegistryModule() {
+        super("minecraft");
     }
 
     private static class Holder {
-        static final ParticleRegistryModule INSTANCE = new ParticleRegistryModule();
+        static final ParticleTypeRegistryModule INSTANCE = new ParticleTypeRegistryModule();
     }
 }


### PR DESCRIPTION
#1286 
As stated in the referenced issue the desire was to be able to get the particle type without needing to use "minecraft:" prepended for example "minecraft:heart".

`Optional<ParticleType> heart = Sponge.getRegistry().getType(ParticleType.class, "heart");`

When calling getType and passing only "heart" you would get an empty optional. Looking for other classes that allow you to pass in just the name I saw that they were extending AbstractPrefixAlternateCatalogTypeRegistryModule instead of implementing CatalogRegistryModule. This requires you to set the default string to prepend to the id's. Now in the getById method we're referencing the default string that was set in the constructor and prepending it for the caller when we attempt to find the ParticleType in the map.

`Optional.ofNullable(this.particleByName.get(defaultModIdToPrepend + ":" + checkNotNull(id).toLowerCase(Locale.ENGLISH)));`

I tested this by creating a plugin, calling getType and passing only "heart" and confirmed that you will get the appropriate Optional for the heart particle type.

I have also renamed ParticleRegistryModule to ParticleTypeRegistryModule in keeping with perceived naming conventions.