### PR TITLE
Add RegistryModule test plugin

### DIFF
--- a/testplugins/src/main/java/org/spongepowered/test/myranks/MyRanks.java
+++ b/testplugins/src/main/java/org/spongepowered/test/myranks/MyRanks.java
@@ -1,0 +1,53 @@
+package org.spongepowered.test.myranks;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.game.GameRegistryEvent;
+import org.spongepowered.api.event.game.state.GameInitializationEvent;
+import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.test.myranks.api.Keys;
+import org.spongepowered.test.myranks.api.Rank;
+import org.spongepowered.test.myranks.api.Ranks;
+
+import java.util.Collection;
+
+@Plugin(id = "myranks", name = "MyRanks", version = "0.0.0", description = "A simple ranks plugin")
+public class MyRanks {
+
+    @Inject
+    private Logger logger;
+
+    @Listener
+    public void onPreInit(GamePreInitializationEvent event) {
+        Sponge.getRegistry().registerModule(Rank.class, new RankRegistryModule());
+    }
+
+    @Listener
+    public void onInit(GameInitializationEvent event) {
+        CommandSpec myCommandSpec = CommandSpec.builder()
+                .description(Text.of("Rank Command"))
+                .executor((src, args) -> {
+                    Collection<Rank> ranks = Sponge.getRegistry().getAllOf(Rank.class);
+                    Text text = Text.builder("Ranks: ").append(Text.of(ranks)).build();
+                    Sponge.getServer().getBroadcastChannel().send(text);
+
+                    Sponge.getServer().getBroadcastChannel().send(Text.of(Ranks.STAFF.getId()));
+                    return CommandResult.success();
+                })
+                .build();
+
+        Sponge.getCommandManager().register(this, myCommandSpec, "ranks");
+    }
+
+    @Listener
+    public void onKeyRegistration(GameRegistryEvent.Register<Key<?>> event) {
+        event.register(Keys.RANK);
+    }
+}

--- a/testplugins/src/main/java/org/spongepowered/test/myranks/MyRanks.java
+++ b/testplugins/src/main/java/org/spongepowered/test/myranks/MyRanks.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.test.myranks;
 
 import com.google.inject.Inject;

--- a/testplugins/src/main/java/org/spongepowered/test/myranks/RankImpl.java
+++ b/testplugins/src/main/java/org/spongepowered/test/myranks/RankImpl.java
@@ -1,0 +1,34 @@
+package org.spongepowered.test.myranks;
+
+import org.spongepowered.test.myranks.api.Rank;
+
+public class RankImpl implements Rank {
+
+    private final String id;
+    private final String name;
+
+    public RankImpl(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj || (obj instanceof Rank && this.id.equals(((Rank) obj).getId()));
+    }
+
+    @Override
+    public int hashCode() {
+        return this.id.hashCode();
+    }
+}

--- a/testplugins/src/main/java/org/spongepowered/test/myranks/RankImpl.java
+++ b/testplugins/src/main/java/org/spongepowered/test/myranks/RankImpl.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.test.myranks;
 
 import org.spongepowered.test.myranks.api.Rank;

--- a/testplugins/src/main/java/org/spongepowered/test/myranks/RankRegistryModule.java
+++ b/testplugins/src/main/java/org/spongepowered/test/myranks/RankRegistryModule.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.test.myranks;
 
 import org.spongepowered.api.registry.AdditionalCatalogRegistryModule;

--- a/testplugins/src/main/java/org/spongepowered/test/myranks/RankRegistryModule.java
+++ b/testplugins/src/main/java/org/spongepowered/test/myranks/RankRegistryModule.java
@@ -1,0 +1,45 @@
+package org.spongepowered.test.myranks;
+
+import org.spongepowered.api.registry.AdditionalCatalogRegistryModule;
+import org.spongepowered.api.registry.util.RegisterCatalog;
+import org.spongepowered.test.myranks.api.Rank;
+import org.spongepowered.test.myranks.api.Ranks;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class RankRegistryModule implements AdditionalCatalogRegistryModule<Rank> {
+
+    @RegisterCatalog(Ranks.class)
+    private final Map<String, Rank> rankMap = new HashMap<>();
+
+    @Override
+    public void registerDefaults() {
+        register(new RankImpl("user", "User"));
+        register(new RankImpl("staff", "Staff"));
+    }
+
+    private void register(Rank rank) {
+        this.rankMap.put(rank.getId(), rank);
+    }
+
+    @Override
+    public void registerAdditionalCatalog(Rank extraCatalog) {
+        if (!this.rankMap.containsKey(extraCatalog.getId())) {
+            register(extraCatalog);
+        }
+    }
+
+    @Override
+    public Optional<Rank> getById(String id) {
+        return Optional.ofNullable(this.rankMap.get(id));
+    }
+
+    @Override
+    public Collection<Rank> getAll() {
+        return Collections.unmodifiableCollection(this.rankMap.values());
+    }
+}

--- a/testplugins/src/main/java/org/spongepowered/test/myranks/api/Keys.java
+++ b/testplugins/src/main/java/org/spongepowered/test/myranks/api/Keys.java
@@ -1,0 +1,16 @@
+package org.spongepowered.test.myranks.api;
+
+import com.google.common.reflect.TypeToken;
+import org.spongepowered.api.data.DataQuery;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.value.mutable.Value;
+
+public class Keys {
+
+    public static final Key<Value<Rank>> RANK =
+            Key.builder().id("rank")
+                    .name("Rank")
+                    .query(DataQuery.of("Rank"))
+                    .type(new TypeToken<Value<Rank>>() {})
+                    .build();
+}

--- a/testplugins/src/main/java/org/spongepowered/test/myranks/api/Keys.java
+++ b/testplugins/src/main/java/org/spongepowered/test/myranks/api/Keys.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.test.myranks.api;
 
 import com.google.common.reflect.TypeToken;

--- a/testplugins/src/main/java/org/spongepowered/test/myranks/api/Rank.java
+++ b/testplugins/src/main/java/org/spongepowered/test/myranks/api/Rank.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.test.myranks.api;
 
 import org.spongepowered.api.CatalogType;

--- a/testplugins/src/main/java/org/spongepowered/test/myranks/api/Rank.java
+++ b/testplugins/src/main/java/org/spongepowered/test/myranks/api/Rank.java
@@ -1,0 +1,8 @@
+package org.spongepowered.test.myranks.api;
+
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.util.annotation.CatalogedBy;
+
+@CatalogedBy(Ranks.class)
+public interface Rank extends CatalogType {
+}

--- a/testplugins/src/main/java/org/spongepowered/test/myranks/api/Ranks.java
+++ b/testplugins/src/main/java/org/spongepowered/test/myranks/api/Ranks.java
@@ -1,0 +1,13 @@
+package org.spongepowered.test.myranks.api;
+
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+public class Ranks {
+
+    public static final Rank USER = DummyObjectProvider.createFor(Rank.class, "USER");
+    public static final Rank STAFF = DummyObjectProvider.createFor(Rank.class, "STAFF");
+
+
+    private Ranks() {
+    }
+}

--- a/testplugins/src/main/java/org/spongepowered/test/myranks/api/Ranks.java
+++ b/testplugins/src/main/java/org/spongepowered/test/myranks/api/Ranks.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.test.myranks.api;
 
 import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;


### PR DESCRIPTION
I was investigating an issue with custom catalog types (which lead to a refactor of registry loading). 
Thought a test plugin would be a good idea.
 
Current output:

`Ranks: [] ` (registerDefaults() not called ?)

```
[Server thread/ERROR] [Sponge]: Error occurred while executing command 'ranks' for source DedicatedServer: A method was invoked on a dummy class, due to the static field STAFF not being initialized (most likely in a CatalogType-related class).
Method: public abstract java.lang.String org.spongepowered.api.CatalogType.getId()
java.lang.UnsupportedOperationException: A method was invoked on a dummy class, due to the static field STAFF not being initialized (most likely in a CatalogType-related class)
```
( because `@RegisterCatalog` is not working)