### PR TITLE
Add method to get the temperature at a specific position

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinChunk.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinChunk.java
@@ -401,6 +401,13 @@ public abstract class MixinChunk implements Chunk, IMixinChunk, IMixinCachable {
     }
 
     @Override
+    public double getTemperature(int x, int y, int z) {
+        checkBiomeBounds(x, y, z);
+        return getBiome(new BlockPos(x, y, z), this.world.getBiomeProvider())
+                .getTemperature(new BlockPos(this.biomeMin.getX() + x, this.biomeMin.getY() + y, this.biomeMin.getZ() + z));
+    }
+
+    @Override
     public BlockState getBlock(int x, int y, int z) {
         checkBlockBounds(x, y, z);
         return (BlockState) getBlockState(new BlockPos(x, y, z));

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -419,6 +419,13 @@ public abstract class MixinWorld implements World, IMixinWorld {
         ((Chunk) getChunk(x >> 4, z >> 4)).setBiome(x, y, z, biome);
     }
 
+    @Override
+    public double getTemperature(int x, int y, int z) {
+        checkBiomeBounds(x, y, z);
+        BlockPos pos = new BlockPos(x, y, z);
+        return this.getBiome(pos).getTemperature(pos);
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public Collection<Entity> getEntities() {

--- a/src/main/java/org/spongepowered/common/util/gen/AbstractBiomeBuffer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/AbstractBiomeBuffer.java
@@ -28,7 +28,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.flowpowered.math.vector.Vector3i;
 import com.google.common.base.MoreObjects;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.biome.Biome;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
+import org.spongepowered.api.world.biome.BiomeType;
+import org.spongepowered.api.world.biome.VirtualBiomeType;
 import org.spongepowered.api.world.extent.BiomeVolume;
 import org.spongepowered.common.util.VecHelper;
 
@@ -81,6 +85,15 @@ public abstract class AbstractBiomeBuffer implements BiomeVolume {
     @Override
     public boolean containsBiome(int x, int y, int z) {
         return VecHelper.inBounds(x, y, z, this.start, this.end);
+    }
+
+    @Override
+    public double getTemperature(int x, int y, int z) {
+        BiomeType type = this.getBiome(x, y, z);
+        if (type instanceof VirtualBiomeType) {
+            type = ((VirtualBiomeType) type).getPersistedType(); // TODO this ignores custom temperatures
+        }
+        return ((Biome) type).getTemperature(new BlockPos(x, y, z));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/extent/AbstractBiomeViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/AbstractBiomeViewDownsize.java
@@ -84,6 +84,12 @@ public abstract class AbstractBiomeViewDownsize<V extends BiomeVolume> implement
     }
 
     @Override
+    public double getTemperature(int x, int y, int z) {
+        checkRange(x, y, z);
+        return this.volume.getTemperature(x, y, z);
+    }
+
+    @Override
     public MutableBiomeVolume getBiomeCopy(StorageType type) {
         switch (type) {
             case STANDARD:

--- a/src/main/java/org/spongepowered/common/world/extent/AbstractBiomeViewTransform.java
+++ b/src/main/java/org/spongepowered/common/world/extent/AbstractBiomeViewTransform.java
@@ -82,6 +82,12 @@ public abstract class AbstractBiomeViewTransform<V extends BiomeVolume> implemen
     }
 
     @Override
+    public double getTemperature(int x, int y, int z) {
+        return this.volume.getTemperature(this.inverseTransform.transformX(x, y, z), this.inverseTransform.transformY(x, y, z),
+                this.inverseTransform.transformZ(x, y, z));
+    }
+
+    @Override
     public MutableBiomeVolume getBiomeCopy(StorageType type) {
         switch (type) {
             case STANDARD:


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1942) | **SpongeCommon**

Biomes can have different temperatures at different positions - for example, snow only occurs when the ground is higher up. This PR adds a method to get the temperature.