### PR TITLE
Rate-limiting InteractBlockEvent

### DIFF
--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -176,8 +176,10 @@ public class SpongeCommonEventFactory {
     // For animation packet
     public static int lastSecondaryPacketTick = 0;
     public static int lastPrimaryPacketTick = 0;
-    public static long lastTryBlockPacketTimeStamp = 0;
-    public static boolean lastInteractItemOnBlockCancelled = false;
+    public static long lastTryItemPacketTimeStamp = 0;
+    public static long lastTryItemOnBlockPacketTimeStamp = 0;
+    public static boolean lastInteractItemCancelled = false;
+    public static boolean lastInteractBlockCancelled = false;
     public static WeakReference<EntityPlayerMP> lastAnimationPlayer;
 
     public static void callDropItemDispense(List<EntityItem> items, PhaseContext<?> context) {

--- a/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
@@ -751,7 +751,7 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection, IMi
         }
     }
 
-    @Inject(method = "processTryUseItemOnBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;getWorld(I)Lnet/minecraft/world/WorldServer;"))
+    @Inject(method = "processTryUseItemOnBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;getWorld(I)Lnet/minecraft/world/WorldServer;"), cancellable = true)
     public void onProcessTryUseItemOnBlock(CPacketPlayerTryUseItemOnBlock packetIn, CallbackInfo ci) {
         SpongeCommonEventFactory.lastSecondaryPacketTick = SpongeImpl.getServer().getTickCounter();
         long packetDiff = System.currentTimeMillis() - SpongeCommonEventFactory.lastTryItemOnBlockPacketTimeStamp;

--- a/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
@@ -740,11 +740,12 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection, IMi
     @Inject(method = "processTryUseItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;getWorld(I)Lnet/minecraft/world/WorldServer;"), cancellable = true)
     public void onProcessTryUseItem(CPacketPlayerTryUseItem packetIn, CallbackInfo ci) {
         SpongeCommonEventFactory.lastSecondaryPacketTick = SpongeImpl.getServer().getTickCounter();
-        long packetDiff = System.currentTimeMillis() - SpongeCommonEventFactory.lastTryBlockPacketTimeStamp;
+        long packetDiff = System.currentTimeMillis() - SpongeCommonEventFactory.lastTryItemPacketTimeStamp;
+        SpongeCommonEventFactory.lastTryItemPacketTimeStamp = System.currentTimeMillis();
         // If the time between packets is small enough, use the last result.
         if (packetDiff < 100) {
             // Use previous result and avoid firing a second event
-            if (SpongeCommonEventFactory.lastInteractItemOnBlockCancelled) {
+            if (SpongeCommonEventFactory.lastInteractItemCancelled) {
                 ci.cancel();
             }
         }
@@ -752,11 +753,16 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection, IMi
 
     @Inject(method = "processTryUseItemOnBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;getWorld(I)Lnet/minecraft/world/WorldServer;"))
     public void onProcessTryUseItemOnBlock(CPacketPlayerTryUseItemOnBlock packetIn, CallbackInfo ci) {
-        // InteractItemEvent on block must be handled in PlayerInteractionManager to support item/block results.
-        // Only track the timestamps to support our block animation events
-        SpongeCommonEventFactory.lastTryBlockPacketTimeStamp = System.currentTimeMillis();
         SpongeCommonEventFactory.lastSecondaryPacketTick = SpongeImpl.getServer().getTickCounter();
-
+        long packetDiff = System.currentTimeMillis() - SpongeCommonEventFactory.lastTryItemOnBlockPacketTimeStamp;
+        SpongeCommonEventFactory.lastTryItemOnBlockPacketTimeStamp = System.currentTimeMillis();
+        // If the time between packets is small enough, use the last result.
+        if (packetDiff < 100) {
+            // Use previous result and avoid firing a second event
+            if (SpongeCommonEventFactory.lastInteractBlockCancelled) {
+                ci.cancel();
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/mixin/core/server/management/MixinPlayerInteractionManager.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/management/MixinPlayerInteractionManager.java
@@ -240,7 +240,7 @@ public abstract class MixinPlayerInteractionManager implements IMixinPlayerInter
             ((PacketContext<?>) peek.context).interactItemChanged(true);
         }
 
-        SpongeCommonEventFactory.lastInteractItemOnBlockCancelled = event.isCancelled() || event.getUseItemResult() == Tristate.FALSE;
+        SpongeCommonEventFactory.lastInteractBlockCancelled = event.isCancelled() || event.getUseItemResult() == Tristate.FALSE;
 
         if (event.isCancelled()) {
             final IBlockState state = (IBlockState) currentSnapshot.getState();
@@ -378,7 +378,7 @@ public abstract class MixinPlayerInteractionManager implements IMixinPlayerInter
             ((PacketContext<?>) peek.context).interactItemChanged(true);
         }
 
-        SpongeCommonEventFactory.lastInteractItemOnBlockCancelled = event.isCancelled(); //|| event.getUseItemResult() == Tristate.FALSE;
+        SpongeCommonEventFactory.lastInteractItemCancelled = event.isCancelled(); //|| event.getUseItemResult() == Tristate.FALSE;
 
         if (event.isCancelled()) {
             SpongeCommonEventFactory.interactBlockRightClickEventCancelled = true;


### PR DESCRIPTION
[SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/2579) | **SpongeCommon**

Introduce the same rate-limiting policy for InteractBlock events.

`// If the time between packets is small enough, use the last result.`

and use the appropriate flag based on the event.

