### PR TITLE
Fix missing EventContextKeys during Interact events

### DIFF
--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -823,7 +823,7 @@ public class SpongeCommonEventFactory {
             Direction targetSide, EnumHand hand) {
         try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
             InteractBlockEvent.Secondary event;
-            Sponge.getCauseStackManager().addContext(EventContextKeys.BLOCK_HIT, targetBlock);
+            frame.addContext(EventContextKeys.BLOCK_HIT, targetBlock);
             if (!heldItem.isEmpty()) {
                 frame.addContext(EventContextKeys.USED_ITEM, ItemStackUtil.snapshotOf(heldItem));
             }

--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -797,6 +797,7 @@ public class SpongeCommonEventFactory {
         } else {
             direction = Direction.NONE;
         }
+        Sponge.getCauseStackManager().addContext(EventContextKeys.BLOCK_HIT, blockSnapshot);
         if (!heldItem.isEmpty()) {
             Sponge.getCauseStackManager().addContext(EventContextKeys.USED_ITEM, ItemStackUtil.snapshotOf(heldItem));
         }
@@ -822,6 +823,7 @@ public class SpongeCommonEventFactory {
             Direction targetSide, EnumHand hand) {
         try (CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
             InteractBlockEvent.Secondary event;
+            Sponge.getCauseStackManager().addContext(EventContextKeys.BLOCK_HIT, targetBlock);
             if (!heldItem.isEmpty()) {
                 frame.addContext(EventContextKeys.USED_ITEM, ItemStackUtil.snapshotOf(heldItem));
             }

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinMinecraftServer.java
@@ -59,7 +59,9 @@ import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.source.ConsoleSource;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.cause.EventContextKeys;
 import org.spongepowered.api.event.command.TabCompleteEvent;
 import org.spongepowered.api.profile.GameProfileManager;
 import org.spongepowered.api.resourcepack.ResourcePack;
@@ -586,6 +588,8 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, IMi
                 }
 
                 Sponge.getCauseStackManager().pushCause(player);
+                Sponge.getCauseStackManager().addContext(EventContextKeys.OWNER, (User) player);
+                Sponge.getCauseStackManager().addContext(EventContextKeys.NOTIFIER, (User) player);
                 if (!player.getHeldItemMainhand().isEmpty() && SpongeCommonEventFactory.callInteractItemEventPrimary(player, player.getHeldItemMainhand(), EnumHand.MAIN_HAND, null, blockSnapshot).isCancelled()) {
                     SpongeCommonEventFactory.lastAnimationPacketTick = 0;
                     Sponge.getCauseStackManager().popCause();


### PR DESCRIPTION
BLOCK_HIT was missing.

Since there's no packet for left-clicking on air, there's no PacketPhase adding OWNER/NOTIFIER