### PR TITLE
ShouldFire-ify some inventory events

### DIFF
--- a/src/main/java/org/spongepowered/common/event/ShouldFire.java
+++ b/src/main/java/org/spongepowered/common/event/ShouldFire.java
@@ -41,7 +41,7 @@ public class ShouldFire {
     // You must always check a flag that either corresponds directly
     // to the event you're firing, or to a supertype of the event.
     // For example, when firing DropItemEvent.Dispense, you can check
-    // ShouldFire.DROP_ITEM_EVENT_DISPENSE or ShouldFire.SPAWN_ENTITY_EVENT
+    // ShouldFire.DROP_ITEM_EVENT_DISPENSE or ShouldFire    .SPAWN_ENTITY_EVENT
     // However, you may *not* check ShouldFire.SPAWN_ENTITY_EVENT_CUSTOM,
     // since SpawnEntityEvent.CUSTOM is not in the hierarchy of DropItemEvent.DISPENSE
 
@@ -61,6 +61,9 @@ public class ShouldFire {
     public static boolean CHANGE_BLOCK_EVENT_BREAK = false;
     public static boolean CHANGE_BLOCK_EVENT_PLACE = false;
     public static boolean CHANGE_BLOCK_EVENT_POST = false;
+
+    public static boolean CLICK_INVENTORY_EVENT = false;
+    public static boolean CLICK_INVENTORY_EVENT_DOUBLE = false;
 
     public static boolean DROP_ITEM_EVENT = false;
     public static boolean DROP_ITEM_EVENT_DESTRUCT = false;

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/DoubleClickInventoryState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/DoubleClickInventoryState.java
@@ -35,6 +35,7 @@ import org.spongepowered.api.item.inventory.Container;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
+import org.spongepowered.common.event.ShouldFire;
 import org.spongepowered.common.event.tracking.phase.packet.PacketConstants;
 import org.spongepowered.common.event.tracking.phase.packet.drag.DragInventoryStopState;
 import org.spongepowered.common.interfaces.IMixinContainer;
@@ -48,6 +49,11 @@ public final class DoubleClickInventoryState extends BasicInventoryPacketState {
 
     public DoubleClickInventoryState() {
         super(PacketConstants.MODE_DOUBLE_CLICK | PacketConstants.BUTTON_PRIMARY | PacketConstants.BUTTON_SECONDARY, PacketConstants.MASK_MODE | PacketConstants.MASK_BUTTON);
+    }
+
+    @Override
+    protected boolean shouldFire() {
+        return ShouldFire.CLICK_INVENTORY_EVENT_DOUBLE;
     }
 
     @Override


### PR DESCRIPTION
This PR checks some ShouldFire flags in some inventory packet listeners. This should greatly improve performance in the case where there are little to no plugins listening for inventory events.