### PR TITLE
Fix dimension ids duplication

### DIFF
--- a/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
@@ -176,6 +176,8 @@ public final class NbtDataUtil {
     public static final String INVALID_TITLE = "invalid";
     public static final String IS_MOD = "isMod";
     public static final String FORGE_ENTITY_TYPE = "entity_name";
+    public static final String LEGACY_DIMENSION_ARRAY = "DimensionArray";
+    public static final String USED_DIMENSION_IDS = "UsedIDs";
 
     // Legacy migration tags from Bukkit
     public static final String BUKKIT = "bukkit";

--- a/src/main/java/org/spongepowered/common/world/WorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/WorldManager.java
@@ -188,12 +188,7 @@ public final class WorldManager {
         return Optional.empty();
     }
 
-    /**
-     * Return the next free dimension ID. Note: you are not guaranteed a contiguous
-     * block of free ids. Always call for each individual ID you wish to get.
-     * @return the next free dimension ID
-     */
-    public static int getNextFreeDimensionId() {
+    public static Integer getNextFreeDimensionId() {
         int next = lastUsedDimensionId;
         while (usedDimensionIds.contains(next) || !checkAvailable(next)) {
             next++;
@@ -1228,12 +1223,12 @@ public final class WorldManager {
         if (compound == null) {
             dimensionTypeByDimensionId.keySet().stream().filter(dimensionId -> dimensionId >= 0).forEach(usedDimensionIds::add);
         } else {
-            for (int id : compound.getIntArray("UsedIDs")) {
+            for (int id : compound.getIntArray(NbtDataUtil.USED_DIMENSION_IDS)) {
                 usedDimensionIds.add(id);
             }
 
             // legacy data (load but don't save)
-            int[] intArray = compound.getIntArray("DimensionArray");
+            int[] intArray = compound.getIntArray(NbtDataUtil.LEGACY_DIMENSION_ARRAY);
             for (int i = 0; i < intArray.length; i++) {
                 int data = intArray[i];
                 if (data == 0) continue;
@@ -1246,7 +1241,7 @@ public final class WorldManager {
 
     public static NBTTagCompound saveDimensionDataMap() {
         NBTTagCompound dimMap = new NBTTagCompound();
-        dimMap.setIntArray("UsedIDs", usedDimensionIds.toIntArray());
+        dimMap.setIntArray(NbtDataUtil.USED_DIMENSION_IDS, usedDimensionIds.toIntArray());
         return dimMap;
     }
 


### PR DESCRIPTION
Details of main problem defined in issue #2206 and pr #2207, which was not fixed due to mods using negative dimensionIDs.
Since BitSet cannot work with negative dimensionIDs, it is neccessary to use IntSet.

All behavioral changes are taken from [Forge 1.12 DimensionManager.class](https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/main/java/net/minecraftforge/common/DimensionManager.java)
I don't know why forge marks "DimensionArray" compound as legacy data and uses "UsedIDs" compound.