### PR TITLE
Implement Schematic Format v2

### DIFF
--- a/src/main/java/org/spongepowered/common/block/SpongeTileEntityArchetypeBuilder.java
+++ b/src/main/java/org/spongepowered/common/block/SpongeTileEntityArchetypeBuilder.java
@@ -50,6 +50,7 @@ import org.spongepowered.common.data.persistence.NbtTranslator;
 import org.spongepowered.common.data.util.DataQueries;
 import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.data.util.DataVersions;
+import org.spongepowered.common.data.util.NbtDataUtil;
 
 import java.util.Optional;
 
@@ -117,6 +118,9 @@ public class SpongeTileEntityArchetypeBuilder extends AbstractDataBuilder<TileEn
         nbttagcompound.removeTag("x");
         nbttagcompound.removeTag("y");
         nbttagcompound.removeTag("z");
+        String tileId = nbttagcompound.getString("id");
+        nbttagcompound.removeTag("id");
+        nbttagcompound.setString(NbtDataUtil.Schematic.TILE_ENTITY_ID, tileId);
         this.tileData = NbtTranslator.getInstance().translate(nbttagcompound);
         this.blockState = tileEntity.getBlock();
         this.tileEntityType = tileEntity.getType();

--- a/src/main/java/org/spongepowered/common/data/persistence/SchematicTranslator.java
+++ b/src/main/java/org/spongepowered/common/data/persistence/SchematicTranslator.java
@@ -28,8 +28,10 @@ import com.flowpowered.math.vector.Vector3i;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.ResourceLocation;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.datafix.DataFixer;
+import net.minecraft.util.datafix.FixTypes;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.tileentity.TileEntityArchetype;
@@ -37,33 +39,56 @@ import org.spongepowered.api.block.tileentity.TileEntityType;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataQuery;
 import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.persistence.DataContentUpdater;
 import org.spongepowered.api.data.persistence.DataTranslator;
 import org.spongepowered.api.data.persistence.InvalidDataException;
-import org.spongepowered.api.world.BlockChangeFlags;
+import org.spongepowered.api.entity.EntityArchetype;
+import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.world.biome.BiomeType;
+import org.spongepowered.api.world.extent.MutableBiomeVolume;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
-import org.spongepowered.api.world.schematic.BlockPalette;
-import org.spongepowered.api.world.schematic.BlockPaletteTypes;
+import org.spongepowered.api.world.schematic.Palette;
+import org.spongepowered.api.world.schematic.PaletteTypes;
 import org.spongepowered.api.world.schematic.Schematic;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.block.SpongeTileEntityArchetypeBuilder;
+import org.spongepowered.common.data.persistence.schematic.SchematicUpdater1_to_2;
 import org.spongepowered.common.data.util.DataQueries;
+import org.spongepowered.common.data.util.DataUtil;
+import org.spongepowered.common.entity.SpongeEntityArchetypeBuilder;
+import org.spongepowered.common.mixin.core.server.MixinDedicatedServer;
 import org.spongepowered.common.registry.type.block.TileEntityTypeRegistryModule;
+import org.spongepowered.common.registry.type.entity.EntityTypeRegistryModule;
+import org.spongepowered.common.util.PairStream;
 import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer;
+import org.spongepowered.common.util.gen.ByteArrayMutableBiomeBuffer;
 import org.spongepowered.common.world.schematic.BimapPalette;
+import org.spongepowered.common.world.schematic.BlockPaletteWrapper;
 import org.spongepowered.common.world.schematic.GlobalPalette;
-import org.spongepowered.common.world.schematic.SpongeSchematic;
+import org.spongepowered.common.world.schematic.SpongeSchematicBuilder;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+@SuppressWarnings("deprecation")
 public class SchematicTranslator implements DataTranslator<Schematic> {
 
     private static final SchematicTranslator INSTANCE = new SchematicTranslator();
     private static final TypeToken<Schematic> TYPE_TOKEN = TypeToken.of(Schematic.class);
-    private static final int VERSION = 1;
+    private static final int VERSION = 2;
     private static final int MAX_SIZE = 65535;
+
+    private static final DataContentUpdater V1_TO_2 = new SchematicUpdater1_to_2();
+
+    private static DataFixer VANILLA_FIXER;
 
     public static SchematicTranslator get() {
         return INSTANCE;
@@ -89,13 +114,32 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
     }
 
     @Override
-    public Schematic translate(DataView view) throws InvalidDataException {
-        int version = view.getInt(DataQueries.Schematic.VERSION).get();
-        // TODO version conversions
-        if (version != VERSION) {
-            throw new InvalidDataException(String.format("Unknown schematic version %d (current version is %d)", version, VERSION));
+    public Schematic translate(DataView unprocessed) throws InvalidDataException {
+        if (VANILLA_FIXER == null) {
+            VANILLA_FIXER = SpongeImpl.getDataFixer();
         }
-        DataView metadata = view.getView(DataQueries.Schematic.METADATA).orElse(null);
+        int version = unprocessed.getInt(DataQueries.Schematic.VERSION).get();
+        // TODO version conversions
+
+        if (version > VERSION) {
+            throw new InvalidDataException(String.format("Unknown schematic version %d (current version is %d)", version, VERSION));
+        } else if (version == 1) {
+            unprocessed = V1_TO_2.update(unprocessed);
+        }
+        { // Strictly for loading tile entities when the format wasn't finalized yet.
+            final List<DataView> dataViews = unprocessed.getViewList(DataQueries.Schematic.Versions.V1_TILE_ENTITY_DATA).orElse(null);
+            if (dataViews != null) {
+                unprocessed.remove(DataQueries.Schematic.Versions.V1_TILE_ENTITY_DATA);
+                unprocessed.set(DataQueries.Schematic.BLOCKENTITY_DATA, dataViews);
+            }
+        }
+        int dataVersion = unprocessed.getInt(DataQueries.Schematic.DATA_VERSION).get();
+        // DataFixer will be able to upgrade entity and tile entity data if and only if we're running a valid server and
+        // the data version is outdated.
+        boolean needsFixers = dataVersion < DataUtil.MINECRAFT_DATA_VERSION && VANILLA_FIXER != null;
+        final DataView updatedView = unprocessed;
+
+        DataView metadata = updatedView.getView(DataQueries.Schematic.METADATA).orElse(null);
         if (metadata != null) {
             Optional<DataView> dot_data = metadata.getView(DataQuery.of("."));
             if (dot_data.isPresent()) {
@@ -109,42 +153,60 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
         }
 
         // TODO error handling for these optionals
-        int width = view.getShort(DataQueries.Schematic.WIDTH).get();
-        int height = view.getShort(DataQueries.Schematic.HEIGHT).get();
-        int length = view.getShort(DataQueries.Schematic.LENGTH).get();
+        int width = updatedView.getShort(DataQueries.Schematic.WIDTH).get();
+        int height = updatedView.getShort(DataQueries.Schematic.HEIGHT).get();
+        int length = updatedView.getShort(DataQueries.Schematic.LENGTH).get();
         if (width > MAX_SIZE || height > MAX_SIZE || length > MAX_SIZE) {
             throw new InvalidDataException(String.format("Schematic is larger than maximum allowable size (found: (%d, %d, %d) max: (%d, %<d, %<d)",
                     width, height, length, MAX_SIZE));
         }
 
-        int[] offset = (int[]) view.get(DataQueries.Schematic.OFFSET).orElse(null);
-        if (offset == null) {
-            offset = new int[3];
-        }
+        final int[] offset = (int[]) updatedView.get(DataQueries.Schematic.OFFSET).orElse(new int[3]);
         if (offset.length != 3) {
             throw new InvalidDataException("Schematic offset was not of length 3");
         }
-        BlockPalette palette;
-        Optional<DataView> paletteData = view.getView(DataQueries.Schematic.PALETTE);
-        int palette_max = view.getInt(DataQueries.Schematic.PALETTE_MAX).orElse(0xFFFF);
+        Palette<BlockState> palette;
+        Optional<DataView> paletteData = updatedView.getView(DataQueries.Schematic.PALETTE);
+        int palette_max = updatedView.getInt(DataQueries.Schematic.PALETTE_MAX).orElse(0xFFFF);
         if (paletteData.isPresent()) {
             // If we had a default palette_max we don't want to allocate all
             // that space for nothing so we use a sensible default instead
-            palette = new BimapPalette(palette_max != 0xFFFF ? palette_max : 64);
+            BimapPalette<BlockState> bimap = new BimapPalette<>(PaletteTypes.LOCAL_BLOCKS, palette_max != 0xFFFF ? palette_max : 64);
+            // TODO - 1.13 remove the wrapper.
+            palette = new BlockPaletteWrapper(bimap, org.spongepowered.api.world.schematic.BlockPaletteTypes.LOCAL);
             DataView paletteMap = paletteData.get();
             Set<DataQuery> paletteKeys = paletteMap.getKeys(false);
             for (DataQuery key : paletteKeys) {
                 BlockState state = Sponge.getRegistry().getType(BlockState.class, key.getParts().get(0)).get();
-                ((BimapPalette) palette).assign(state, paletteMap.getInt(key).get());
+                bimap.assign(state, paletteMap.getInt(key).get());
             }
         } else {
-            palette = GlobalPalette.instance;
+            palette = GlobalPalette.getBlockPalette();
         }
+
+        Palette<BiomeType> biomePalette;
+        Optional<DataView> biomePaletteData = updatedView.getView(DataQueries.Schematic.BIOME_PALETTE);
+        int biome_max = updatedView.getInt(DataQueries.Schematic.BIOME_PALETTE_MAX).orElse(0xFFFF);
+        if (biomePaletteData.isPresent()) {
+            BimapPalette<BiomeType> bimap = new BimapPalette<>(PaletteTypes.LOCAL_BIOMES, biome_max != 0xFFF ? palette_max : 64);
+            biomePalette = bimap;
+            DataView biomeMap = biomePaletteData.get();
+            Set<DataQuery> biomeKeys = biomeMap.getKeys(false);
+            for (DataQuery biomeKey : biomeKeys) {
+                BiomeType biome = Sponge.getRegistry().getType(BiomeType.class, biomeKey.getParts().get(0)).get();
+                bimap.assign(biome, biomeMap.getInt(biomeKey).get());
+            }
+        } else {
+            biomePalette = GlobalPalette.getBiomePalette();
+        }
+
+        SpongeSchematicBuilder builder = new SpongeSchematicBuilder();
+        builder.blockPalette(palette);
 
         MutableBlockVolume buffer =
                 new ArrayMutableBlockBuffer(palette, new Vector3i(-offset[0], -offset[1], -offset[2]), new Vector3i(width, height, length));
 
-        byte[] blockdata = (byte[]) view.get(DataQueries.Schematic.BLOCK_DATA).get();
+        byte[] blockdata = (byte[]) updatedView.get(DataQueries.Schematic.BLOCK_DATA).orElseThrow(() -> new InvalidDataException("Missing BlockData for Schematic"));
         int index = 0;
         int i = 0;
         int value = 0;
@@ -173,27 +235,104 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
 
             index++;
         }
-        Map<Vector3i, TileEntityArchetype> tiles = Maps.newHashMap();
-        List<DataView> tiledata = view.getViewList(DataQueries.Schematic.TILEENTITY_DATA).orElse(null);
-        if (tiledata != null) {
-            for (DataView tile : tiledata) {
-                int[] pos = (int[]) tile.get(DataQueries.Schematic.TILEENTITY_POS).get();
-                if (offset.length != 3) {
-                    throw new InvalidDataException("Schematic tileentity pos was not of length 3");
+        builder.blocks(buffer);
+
+        updatedView.get(DataQueries.Schematic.BIOME_DATA).ifPresent(biomesObj -> {
+            MutableBiomeVolume biomeBuffer = new ByteArrayMutableBiomeBuffer(biomePalette, new Vector3i(-offset[0], -offset[1], -offset[2]), new Vector3i(width, height, length));
+            byte[] biomes = (byte[]) biomesObj;
+            int biomeIndex = 0;
+            int biomeJ= 0;
+            int bVal = 0;
+            int varIntLength = 0;
+            while (biomeJ < biomes.length) {
+                bVal = 0;
+                varIntLength = 0;
+
+                while (true) {
+                    bVal |= (biomes[biomeJ] & 127) << (varIntLength++ * 7);
+                    if (varIntLength > 5) {
+                        throw new RuntimeException("VarInt too big (probably corrupted data)");
+                    }
+                    if (((biomes[biomeJ] & 128) != 128)) {
+                        biomeJ++;
+                        break;
+                    }
+                    biomeJ++;
                 }
-                TileEntityType type = TileEntityTypeRegistryModule.getInstance()
-                        .getForClass(TileEntity.REGISTRY.getObject(new ResourceLocation(tile.getString(DataQuery.of("id")).get())));
-                TileEntityArchetype archetype = new SpongeTileEntityArchetypeBuilder()
-                        .state(buffer.getBlock(pos[0] - offset[0], pos[1] - offset[1], pos[2] - offset[2]))
-                        .tileData(tile)
-                        .tile(type)
-                        .build();
-                tiles.put(new Vector3i(pos[0] - offset[0], pos[1] - offset[1], pos[2] - offset[2]), archetype);
+                int z = (biomeIndex % (width * length)) / width;
+                int x = (biomeIndex % (width * length)) % width;
+                BiomeType type = biomePalette.get(bVal).get();
+                biomeBuffer.setBiome(x - offset[0], 0, z - offset[2], type);
+
+                biomeIndex++;
             }
+            builder.biomes(biomeBuffer);
+        });
+
+        Map<Vector3i, TileEntityArchetype> tiles = Maps.newHashMap();
+
+        updatedView.getViewList(DataQueries.Schematic.BLOCKENTITY_DATA)
+            .ifPresent(tileData ->
+                tileData.forEach(tile -> {
+                        int[] pos = (int[]) tile.get(DataQueries.Schematic.BLOCKENTITY_POS).get();
+                        tile.getString(DataQueries.Schematic.BLOCKENTITY_ID)
+                            .flatMap(TileEntityTypeRegistryModule.getInstance()::getById)
+                            .ifPresent(type -> {
+                                final DataView upgraded;
+                                if (needsFixers) {
+                                    NBTTagCompound tileNbt = NbtTranslator.getInstance().translate(tile);
+                                    tileNbt = VANILLA_FIXER.process(FixTypes.BLOCK_ENTITY, tileNbt, version);
+                                    upgraded = NbtTranslator.getInstance().translate(tileNbt);
+                                } else {
+                                    upgraded = tile;
+                                }
+                                final TileEntityArchetype archetype = new SpongeTileEntityArchetypeBuilder()
+                                    .state(buffer.getBlock(pos[0] - offset[0], pos[1] - offset[1], pos[2] - offset[2]))
+                                    .tileData(upgraded)
+                                    .tile(type)
+                                    .build();
+                                final Vector3i position = new Vector3i(pos[0] - offset[0], pos[1] - offset[1], pos[2] - offset[2]);
+                                tiles.put(position, archetype);
+                            });
+                    }
+                )
+            );
+        builder.tiles(tiles);
+        ArrayList<EntityArchetype> entityArchetypes = new ArrayList<>();
+        updatedView.getViewList(DataQueries.Schematic.ENTITIES).map(List::stream)
+            .ifPresent(stream -> {
+                final Stream<DataView>
+                    viewStream =
+                    stream.filter(entity -> entity.contains(DataQueries.Schematic.ENTITIES_POS, DataQueries.Schematic.ENTITIES_ID));
+                PairStream
+                    .from(viewStream,
+                        (entity) -> entity.getString(DataQueries.Schematic.ENTITIES_ID)
+                            .map(EntityTypeRegistryModule.getInstance()::getById))
+                    .filter(((view, entityType) -> entityType.map(Optional::get).isPresent()))
+                    .map((view, type) -> {
+                        final DataView upgraded;
+                        if (needsFixers) {
+                            NBTTagCompound entityNbt = NbtTranslator.getInstance().translate(view);
+                            entityNbt = VANILLA_FIXER.process(FixTypes.ENTITY, entityNbt, version);
+                            upgraded = NbtTranslator.getInstance().translate(entityNbt);
+                        } else {
+                            upgraded = view;
+                        }
+                        return new SpongeEntityArchetypeBuilder()
+                            .type(type.get().get())
+                            .entityData(upgraded)
+                            .build();
+                    })
+                    .forEach(entityArchetypes::add);
+            });
+        if (!entityArchetypes.isEmpty()) {
+            builder.entities(entityArchetypes);
         }
 
-        Schematic schematic = new SpongeSchematic(buffer, tiles, metadata);
-        return schematic;
+        if (metadata != null) {
+            builder.metadata(metadata);
+        }
+        return builder.build();
     }
 
     @Override
@@ -220,6 +359,7 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
         data.set(DataQueries.Schematic.LENGTH, length);
 
         data.set(DataQueries.Schematic.VERSION, VERSION);
+        data.set(DataQueries.Schematic.DATA_VERSION, DataUtil.MINECRAFT_DATA_VERSION);
         for (DataQuery metaKey : schematic.getMetadata().getKeys(false)) {
             data.set(DataQueries.Schematic.METADATA.then(metaKey), schematic.getMetadata().get(metaKey).get());
         }
@@ -227,30 +367,46 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
         int[] offset = new int[] {-xMin, -yMin, -zMin};
         data.set(DataQueries.Schematic.OFFSET, offset);
 
-        BlockPalette palette = schematic.getPalette();
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream(width * height * length);
-
-        for (int y = 0; y < height; y++) {
-            int y0 = yMin + y;
-            for (int z = 0; z < length; z++) {
-                int z0 = zMin + z;
-                for (int x = 0; x < width; x++) {
-                    int x0 = xMin + x;
-                    BlockState state = schematic.getBlock(x0, y0, z0);
-                    int id = palette.getOrAssign(state);
-
-                    while ((id & -128) != 0) {
-                        buffer.write(id & 127 | 128);
-                        id >>>= 7;
+        Palette<BlockState> palette = schematic.getPalette();
+        try (ByteArrayOutputStream buffer = new ByteArrayOutputStream(width * height * length)) {
+            for (int y = 0; y < height; y++) {
+                int y0 = yMin + y;
+                for (int z = 0; z < length; z++) {
+                    int z0 = zMin + z;
+                    for (int x = 0; x < width; x++) {
+                        int x0 = xMin + x;
+                        BlockState state = schematic.getBlock(x0, y0, z0);
+                        writeIdToBuffer(buffer, palette.getOrAssign(state));
                     }
-                    buffer.write(id);
                 }
             }
+
+            data.set(DataQueries.Schematic.BLOCK_DATA, buffer.toByteArray());
+        } catch (IOException e) {
+            // should never reach here
         }
 
-        data.set(DataQueries.Schematic.BLOCK_DATA, buffer.toByteArray());
+        Palette<BiomeType> biomePalette = schematic.getBiomePalette();
+        schematic.getBiomes().ifPresent(biomes -> {
+            try (ByteArrayOutputStream buffer = new ByteArrayOutputStream(width * length)) {
+                for (int z = 0; z < length; z++) {
+                    int z0 = zMin + z;
+                    for (int x = 0; x < width; x++) {
+                        int x0 = xMin + x;
+                        BiomeType state = biomes.getBiome(x0, 0, z0);
+                        writeIdToBuffer(buffer, biomePalette.getOrAssign(state));
+                    }
 
-        if (palette.getType() == BlockPaletteTypes.LOCAL) {
+                }
+
+                data.set(DataQueries.Schematic.BLOCK_DATA, buffer.toByteArray());
+            } catch (IOException e) {
+                // Should never reach here.
+            }
+
+        });
+
+        if (palette.getType() == org.spongepowered.api.world.schematic.BlockPaletteTypes.LOCAL) {
             DataQuery paletteQuery = DataQueries.Schematic.PALETTE;
             for (BlockState state : palette.getEntries()) {
                 // getOrAssign to skip the optional, it will never assign
@@ -258,21 +414,42 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
             }
             data.set(DataQueries.Schematic.PALETTE_MAX, palette.getHighestId());
         }
+        if (biomePalette.getType() == PaletteTypes.LOCAL_BIOMES) {
+            DataQuery paletteQuery = DataQueries.Schematic.BIOME_PALETTE;
+            for (BiomeType biomeType : biomePalette.getEntries()) {
+                data.set(paletteQuery.then(biomeType.getId()), biomePalette.getOrAssign(biomeType));
+            }
+            data.set(DataQueries.Schematic.BIOME_PALETTE_MAX, biomePalette.getHighestId());
+        }
+
         List<DataView> tileEntities = Lists.newArrayList();
         for (Map.Entry<Vector3i, TileEntityArchetype> entry : schematic.getTileEntityArchetypes().entrySet()) {
             Vector3i pos = entry.getKey();
             DataContainer tiledata = entry.getValue().getTileData();
             int[] apos = new int[] {pos.getX() - xMin, pos.getY() - yMin, pos.getZ() - zMin};
-            tiledata.set(DataQueries.Schematic.TILEENTITY_POS, apos);
-            if (!tiledata.contains(DataQueries.CONTENT_VERSION)) {
-                // Set a default content version of 1
-                tiledata.set(DataQueries.CONTENT_VERSION, 1);
-            }
+            tiledata.set(DataQueries.Schematic.BLOCKENTITY_POS, apos);
             tileEntities.add(tiledata);
         }
-        data.set(DataQueries.Schematic.TILEENTITY_DATA, tileEntities);
+        data.set(DataQueries.Schematic.BLOCKENTITY_DATA, tileEntities);
+
+        List<DataView> entities = Lists.newArrayList();
+        for (EntityArchetype entityArchetype : schematic.getEntityArchetypes()) {
+            DataContainer entityData = entityArchetype.getEntityData();
+            entities.add(entityData);
+        }
+        data.set(DataQueries.Schematic.ENTITIES, entities);
 
         return data;
+    }
+
+     private void writeIdToBuffer(ByteArrayOutputStream buffer, int orAssign) {
+        int id = orAssign;
+
+        while ((id & -128) != 0) {
+            buffer.write(id & 127 | 128);
+            id >>>= 7;
+        }
+        buffer.write(id);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/util/DataQueries.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataQueries.java
@@ -221,10 +221,32 @@ public final class DataQueries {
     }
     
     public static final class Schematic {
+
+        public static final class Versions {
+            public static final DataQuery V1_TILE_ENTITY_DATA = of("TileEntities");
+        }
+
+        /**
+         * The NBT structure of the legacy Schematic format used by MCEdit and WorldEdit etc.
+         *
+         * It's no longer updated due to the
+         */
+        public static final class Legacy {
+
+            public static final DataQuery LEGACY_MATERIALS = of("Materials");
+            public static final DataQuery LEGACY_OFFSET_X = of("WEOffsetX");
+            public static final DataQuery LEGACY_OFFSET_Y = of("WEOffsetY");
+            public static final DataQuery LEGACY_OFFSET_Z = of("WEOffsetZ");
+            public static final DataQuery LEGACY_BLOCKS = of("Blocks");
+            public static final DataQuery LEGACY_BLOCK_DATA = of("Data");
+            public static final DataQuery LEGACY_ADD_BLOCKS = of("AddBlocks");
+            public static final DataQuery LEGACY_TILEDATA = of("TileEntities");
+        }
         
         public static final DataQuery VERSION = of("Version");
+        public static final DataQuery DATA_VERSION = of("DataVersion");
         public static final DataQuery METADATA = of("Metadata");
-        
+
         public static final DataQuery WIDTH = of("Width");
         public static final DataQuery HEIGHT = of("Height");
         public static final DataQuery LENGTH = of("Length");
@@ -233,22 +255,19 @@ public final class DataQueries {
         public static final DataQuery PALETTE = of("Palette");
         public static final DataQuery PALETTE_MAX = of("PaletteMax");
         public static final DataQuery BLOCK_DATA = of("BlockData");
-        
-        public static final DataQuery TILEENTITY_DATA = of("TileEntities");
-        public static final DataQuery TILEENTITY_POS = of("Pos");
+        public static final DataQuery BIOME_DATA = of("BiomeData");
 
-        public static final DataQuery LEGACY_MATERIALS = of("Materials");
-        
-        public static final DataQuery LEGACY_OFFSET_X = of("WEOffsetX");
-        public static final DataQuery LEGACY_OFFSET_Y = of("WEOffsetY");
-        public static final DataQuery LEGACY_OFFSET_Z = of("WEOffsetZ");
+        public static final DataQuery BLOCKENTITY_DATA = of("BlockEntities");
+        public static final DataQuery BLOCKENTITY_ID = of("Id");
+        public static final DataQuery BLOCKENTITY_POS = of("Pos");
 
-        public static final DataQuery LEGACY_BLOCKS = of("Blocks");
-        public static final DataQuery LEGACY_BLOCK_DATA = of("Data");
-        public static final DataQuery LEGACY_ADD_BLOCKS = of("AddBlocks");
+        public static final DataQuery ENTITIES = of("Entities");
+        public static final DataQuery ENTITIES_ID = of("Id");
+        public static final DataQuery ENTITIES_POS = of("Pos");
 
-        public static final DataQuery LEGACY_TILEDATA = of("TileEntities");
-        
+        public static final DataQuery BIOME_PALETTE = of("BiomePalette");
+        public static final DataQuery BIOME_PALETTE_MAX = of("BiomePaletteMax");
+
         private Schematic() {
         }
     }

--- a/src/main/java/org/spongepowered/common/data/util/DataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataUtil.java
@@ -93,6 +93,7 @@ public final class DataUtil {
     // TODO Bump this when needing to fix sponge added file data
     public static final int DATA_VERSION = 1;
     public static final DataFixer spongeDataFixer = new DataFixer(DATA_VERSION);
+    public static final int MINECRAFT_DATA_VERSION = 1343;
     private static final Supplier<InvalidDataException> INVALID_DATA_EXCEPTION_SUPPLIER = InvalidDataException::new;
 
     static {

--- a/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
@@ -84,6 +84,11 @@ public final class NbtDataUtil {
         public static final String BLOCK_ENTITY_TAG = "BlockEntityTag";
     }
 
+    public static final class Schematic {
+        public static final String TILE_ENTITY_ID = "Id";
+        public static final String ENTITY_ID = "Id";
+    }
+
     // These are the various tag compound id's for getting to various places
     public static final String BLOCK_ENTITY_TAG = "BlockEntityTag";
     public static final String BLOCK_ENTITY_ID = "id";

--- a/src/main/java/org/spongepowered/common/entity/SpongeEntityArchetype.java
+++ b/src/main/java/org/spongepowered/common/entity/SpongeEntityArchetype.java
@@ -28,6 +28,7 @@ import com.flowpowered.math.vector.Vector3d;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldServer;
 import org.spongepowered.api.Sponge;
@@ -57,15 +58,44 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 public class SpongeEntityArchetype extends AbstractArchetype<EntityType, EntitySnapshot, org.spongepowered.api.entity.Entity> implements EntityArchetype {
 
+    @Nullable
+    private Vector3d position;
+
     SpongeEntityArchetype(SpongeEntityArchetypeBuilder builder) {
-        super(builder.entityType, NbtTranslator.getInstance().translateData(builder.entityData));
+        super(builder.entityType, builder.compound != null ? builder.compound : builder.entityData == null ? new NBTTagCompound() : NbtTranslator.getInstance().translateData(builder.entityData));
     }
 
     @Override
     public EntityType getType() {
         return this.type;
+    }
+
+    @Nullable
+    public NBTTagCompound getData() {
+        return this.data;
+    }
+
+    public Optional<Vector3d> getPosition() {
+        if (this.position != null) {
+            return Optional.of(this.position);
+        }
+        if (!this.data.hasKey(NbtDataUtil.ENTITY_POSITION, NbtDataUtil.TAG_LIST)) {
+            return Optional.empty();
+        }
+        try {
+            NBTTagList pos = this.data.getTagList(NbtDataUtil.ENTITY_POSITION, NbtDataUtil.TAG_DOUBLE);
+            double x = pos.getDoubleAt(0);
+            double y = pos.getDoubleAt(1);
+            double z = pos.getDoubleAt(2);
+            this.position = new Vector3d(x, y, z);
+            return Optional.of(this.position);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
     }
 
     @Override
@@ -172,4 +202,5 @@ public class SpongeEntityArchetype extends AbstractArchetype<EntityType, EntityS
         builder.entityData = NbtTranslator.getInstance().translate(this.data);
         return builder.build();
     }
+
 }

--- a/src/main/java/org/spongepowered/common/registry/type/world/PaletteTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/world/PaletteTypeRegistryModule.java
@@ -30,24 +30,24 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import org.spongepowered.api.registry.util.RegisterCatalog;
-import org.spongepowered.api.world.schematic.BlockPaletteType;
-import org.spongepowered.api.world.schematic.BlockPaletteTypes;
+import org.spongepowered.api.world.schematic.PaletteTypes;
 import org.spongepowered.common.registry.SpongeAdditionalCatalogRegistryModule;
 import org.spongepowered.common.world.schematic.BimapPalette;
+import org.spongepowered.common.world.schematic.BlockPaletteWrapper;
 import org.spongepowered.common.world.schematic.GlobalPalette;
-import org.spongepowered.common.world.schematic.SpongePaletteType;
+import org.spongepowered.common.world.schematic.SpongeBlockPaletteType;
 
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
-public class PaletteTypeRegistryModule implements SpongeAdditionalCatalogRegistryModule<BlockPaletteType> {
+public class PaletteTypeRegistryModule implements SpongeAdditionalCatalogRegistryModule<org.spongepowered.api.world.schematic.BlockPaletteType> {
 
-    @RegisterCatalog(BlockPaletteTypes.class) private final Map<String, BlockPaletteType> paletteMappings = Maps.newHashMap();
+    @RegisterCatalog(org.spongepowered.api.world.schematic.BlockPaletteTypes.class) private final Map<String, org.spongepowered.api.world.schematic.BlockPaletteType> paletteMappings = Maps.newHashMap();
 
     @Override
-    public void registerAdditionalCatalog(BlockPaletteType extraCatalog) {
+    public void registerAdditionalCatalog(org.spongepowered.api.world.schematic.BlockPaletteType extraCatalog) {
         checkNotNull(extraCatalog);
         String id = extraCatalog.getId();
         checkArgument(id.indexOf(' ') == -1, "Palette Type ID " + id + " may not contain a space");
@@ -55,19 +55,19 @@ public class PaletteTypeRegistryModule implements SpongeAdditionalCatalogRegistr
     }
 
     @Override
-    public Optional<BlockPaletteType> getById(String id) {
+    public Optional<org.spongepowered.api.world.schematic.BlockPaletteType> getById(String id) {
         return Optional.ofNullable(this.paletteMappings.get(id));
     }
 
     @Override
-    public Collection<BlockPaletteType> getAll() {
+    public Collection<org.spongepowered.api.world.schematic.BlockPaletteType> getAll() {
         return ImmutableList.copyOf(this.paletteMappings.values());
     }
 
     @Override
     public void registerDefaults() {
-        registerAdditionalCatalog(new SpongePaletteType("global", () -> GlobalPalette.instance));
-        registerAdditionalCatalog(new SpongePaletteType("local", BimapPalette::new));
+        registerAdditionalCatalog(new SpongeBlockPaletteType("global", () -> (org.spongepowered.api.world.schematic.BlockPalette) GlobalPalette.getBlockPalette()));
+        registerAdditionalCatalog(new SpongeBlockPaletteType("local", () -> new BlockPaletteWrapper(new BimapPalette<>(PaletteTypes.LOCAL_BLOCKS), org.spongepowered.api.world.schematic.BlockPaletteTypes.LOCAL)));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/util/PairStream.java
+++ b/src/main/java/org/spongepowered/common/util/PairStream.java
@@ -1,0 +1,161 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.util;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+@FunctionalInterface
+public interface PairStream<K,V> {
+    static <K,V> PairStream<K,V> from(Map<K,V> map) {
+        return from(map.entrySet().stream());
+    }
+    static <K,V> PairStream<K,V> from(Stream<Map.Entry<K,V>> s) {
+        return ()->s;
+    }
+    static <K,V> PairStream<K,V> from(Stream<K> s, Function<? super K, ? extends V> f) {
+        return ()->s.map(k->new AbstractMap.SimpleImmutableEntry<>(k, f.apply(k)));
+    }
+
+    default PairStream<K,V> distinct() {
+        return from(entries().distinct());
+    }
+    default PairStream<K,V> peek(BiConsumer<? super K, ? super V> action) {
+        return from(entries().peek(e->action.accept(e.getKey(), e.getValue())));
+    }
+    default PairStream<K,V> skip(long n) {
+        return from(entries().skip(n));
+    }
+    default PairStream<K,V> limit(long maxSize) {
+        return from(entries().limit(maxSize));
+    }
+    default PairStream<K,V> filterKey(Predicate<? super K> mapper) {
+        return from(entries().filter(e->mapper.test(e.getKey())));
+    }
+    default PairStream<K,V> filterValue(Predicate<? super V> mapper) {
+        return from(entries().filter(e->mapper.test(e.getValue())));
+    }
+    default PairStream<K,V> filter(BiPredicate<? super K, ? super V> mapper) {
+        return from(entries().filter(e->mapper.test(e.getKey(), e.getValue())));
+    }
+    default <R> PairStream<R,V> mapKey(Function<? super K,? extends R> mapper) {
+        return from(entries().map(e->new AbstractMap.SimpleImmutableEntry<>(
+            mapper.apply(e.getKey()), e.getValue()
+        )));
+    }
+    default <R> PairStream<K,R> mapValue(Function<? super V,? extends R> mapper) {
+        return from(entries().map(e->new AbstractMap.SimpleImmutableEntry<>(
+            e.getKey(), mapper.apply(e.getValue())
+        )));
+    }
+    default <R> Stream<R> map(BiFunction<? super K, ? super V,? extends R> mapper) {
+        return entries().map(e->mapper.apply(e.getKey(), e.getValue()));
+    }
+    default DoubleStream mapToDouble(ToDoubleBiFunction<? super K, ? super V> mapper) {
+        return entries().mapToDouble(e->mapper.applyAsDouble(e.getKey(), e.getValue()));
+    }
+    default IntStream mapToInt(ToIntBiFunction<? super K, ? super V> mapper) {
+        return entries().mapToInt(e->mapper.applyAsInt(e.getKey(), e.getValue()));
+    }
+    default LongStream mapToLong(ToLongBiFunction<? super K, ? super V> mapper) {
+        return entries().mapToLong(e->mapper.applyAsLong(e.getKey(), e.getValue()));
+    }
+    default <RK,RV> PairStream<RK,RV> flatMap(
+        BiFunction<? super K, ? super V,? extends PairStream<RK,RV>> mapper) {
+        return from(entries().flatMap(
+            e->mapper.apply(e.getKey(), e.getValue()).entries()));
+    }
+    default <R> Stream<R> flatMapToObj(
+        BiFunction<? super K, ? super V,? extends Stream<R>> mapper) {
+        return entries().flatMap(e->mapper.apply(e.getKey(), e.getValue()));
+    }
+    default DoubleStream flatMapToDouble(
+        BiFunction<? super K, ? super V,? extends DoubleStream> mapper) {
+        return entries().flatMapToDouble(e->mapper.apply(e.getKey(), e.getValue()));
+    }
+    default IntStream flatMapToInt(
+        BiFunction<? super K, ? super V,? extends IntStream> mapper) {
+        return entries().flatMapToInt(e->mapper.apply(e.getKey(), e.getValue()));
+    }
+    default LongStream flatMapToLong(
+        BiFunction<? super K, ? super V,? extends LongStream> mapper) {
+        return entries().flatMapToLong(e->mapper.apply(e.getKey(), e.getValue()));
+    }
+    default PairStream<K,V> sortedByKey(Comparator<? super K> comparator) {
+        return from(entries().sorted(Map.Entry.comparingByKey(comparator)));
+    }
+    default PairStream<K,V> sortedByValue(Comparator<? super V> comparator) {
+        return from(entries().sorted(Map.Entry.comparingByValue(comparator)));
+    }
+
+    default boolean allMatch(BiPredicate<? super K,? super V> predicate) {
+        return entries().allMatch(e->predicate.test(e.getKey(), e.getValue()));
+    }
+    default boolean anyMatch(BiPredicate<? super K,? super V> predicate) {
+        return entries().anyMatch(e->predicate.test(e.getKey(), e.getValue()));
+    }
+    default boolean noneMatch(BiPredicate<? super K,? super V> predicate) {
+        return entries().noneMatch(e->predicate.test(e.getKey(), e.getValue()));
+    }
+    default long count() {
+        return entries().count();
+    }
+
+    Stream<Map.Entry<K,V>> entries();
+    default Stream<K> keys() {
+        return entries().map(Map.Entry::getKey);
+    }
+    default Stream<V> values() {
+        return entries().map(Map.Entry::getValue);
+    }
+    default Optional<Map.Entry<K,V>> maxByKey(Comparator<? super K> comparator) {
+        return entries().max(Map.Entry.comparingByKey(comparator));
+    }
+    default Optional<Map.Entry<K,V>> maxByValue(Comparator<? super V> comparator) {
+        return entries().max(Map.Entry.comparingByValue(comparator));
+    }
+    default Optional<Map.Entry<K,V>> minByKey(Comparator<? super K> comparator) {
+        return entries().min(Map.Entry.comparingByKey(comparator));
+    }
+    default Optional<Map.Entry<K,V>> minByValue(Comparator<? super V> comparator) {
+        return entries().min(Map.Entry.comparingByValue(comparator));
+    }
+    default void forEach(BiConsumer<? super K, ? super V> action) {
+        entries().forEach(e->action.accept(e.getKey(), e.getValue()));
+    }
+    default void forEachOrdered(BiConsumer<? super K, ? super V> action) {
+        entries().forEachOrdered(e->action.accept(e.getKey(), e.getValue()));
+    }
+
+    default Map<K,V> toMap() {
+        return entries().collect(
+            Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+    default Map<K,V> toMap(BinaryOperator<V> valAccum) {
+        return entries().collect(
+            Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, valAccum));
+    }
+}

--- a/src/main/java/org/spongepowered/common/util/gen/AbstractBlockBuffer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/AbstractBlockBuffer.java
@@ -26,10 +26,11 @@ package org.spongepowered.common.util.gen;
 
 import com.flowpowered.math.vector.Vector3i;
 import com.google.common.base.MoreObjects;
+import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
 import org.spongepowered.api.world.extent.BlockVolume;
-import org.spongepowered.api.world.schematic.BlockPalette;
+import org.spongepowered.api.world.schematic.Palette;
 import org.spongepowered.common.util.VecHelper;
 
 /**
@@ -62,7 +63,7 @@ public abstract class AbstractBlockBuffer implements BlockVolume {
         return (x - this.start.getX()) * this.yzSlice + (z - this.start.getZ()) * this.yLine + (y - this.start.getY());
     }
     
-    public abstract BlockPalette getPalette();
+    public abstract Palette<BlockState> getPalette();
 
     @Override
     public Vector3i getBlockMax() {

--- a/src/main/java/org/spongepowered/common/util/gen/ArrayImmutableBlockBuffer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/ArrayImmutableBlockBuffer.java
@@ -33,7 +33,7 @@ import org.spongepowered.api.world.extent.MutableBlockVolume;
 import org.spongepowered.api.world.extent.StorageType;
 import org.spongepowered.api.world.extent.UnmodifiableBlockVolume;
 import org.spongepowered.api.world.extent.worker.BlockVolumeWorker;
-import org.spongepowered.api.world.schematic.BlockPalette;
+import org.spongepowered.api.world.schematic.Palette;
 import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer.BackingData;
 import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer.CharBackingData;
 import org.spongepowered.common.world.extent.ImmutableBlockViewDownsize;
@@ -46,32 +46,31 @@ public class ArrayImmutableBlockBuffer extends AbstractBlockBuffer implements Im
     @SuppressWarnings("ConstantConditions")
     private static final BlockState AIR = BlockTypes.AIR.getDefaultState();
 
-    private final BlockPalette palette;
+    private final Palette<BlockState> palette;
     private final BackingData data;
 
     /**
      * Does not clone!
-     * 
-     * @param palette The palette
+     *  @param palette The palette
+     * @param data The backing data
      * @param start The start block position
      * @param size The block size
-     * @param data The backing data
      */
-    ArrayImmutableBlockBuffer(BlockPalette palette, BackingData data, Vector3i start, Vector3i size) {
+    ArrayImmutableBlockBuffer(Palette<BlockState> palette, BackingData data, Vector3i start, Vector3i size) {
         super(start, size);
         this.data = data;
         this.palette = palette;
     }
 
-    public ArrayImmutableBlockBuffer(BlockPalette palette, Vector3i start, Vector3i size, char[] blocks) {
+    public ArrayImmutableBlockBuffer(Palette<BlockState> palette, Vector3i start, Vector3i size, char[] blocks) {
         super(start, size);
         this.data = new CharBackingData(blocks.clone());
         this.palette = palette;
     }
 
     @Override
-    public BlockPalette getPalette() {
-        return GlobalPalette.instance;
+    public Palette<BlockState> getPalette() {
+        return GlobalPalette.getBlockPalette();
     }
 
     @Override
@@ -122,7 +121,7 @@ public class ArrayImmutableBlockBuffer extends AbstractBlockBuffer implements Im
      * @param size The size of the volume
      * @return A new buffer using the same array reference
      */
-    public static ImmutableBlockVolume newWithoutArrayClone(BlockPalette palette, Vector3i start, Vector3i size, char[] blocks) {
+    public static ImmutableBlockVolume newWithoutArrayClone(Palette<BlockState> palette, Vector3i start, Vector3i size, char[] blocks) {
         return new ArrayImmutableBlockBuffer(palette, new CharBackingData(blocks), start, size);
     }
 }

--- a/src/main/java/org/spongepowered/common/util/gen/ByteArrayImmutableBiomeBuffer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/ByteArrayImmutableBiomeBuffer.java
@@ -33,9 +33,11 @@ import org.spongepowered.api.world.extent.ImmutableBiomeVolume;
 import org.spongepowered.api.world.extent.MutableBiomeVolume;
 import org.spongepowered.api.world.extent.StorageType;
 import org.spongepowered.api.world.extent.worker.BiomeVolumeWorker;
+import org.spongepowered.api.world.schematic.Palette;
 import org.spongepowered.common.world.extent.ImmutableBiomeViewDownsize;
 import org.spongepowered.common.world.extent.ImmutableBiomeViewTransform;
 import org.spongepowered.common.world.extent.worker.SpongeBiomeVolumeWorker;
+import org.spongepowered.common.world.schematic.GlobalPalette;
 
 /**
  * Immutable biome volume, backed by a byte array. The array passed to the
@@ -44,15 +46,18 @@ import org.spongepowered.common.world.extent.worker.SpongeBiomeVolumeWorker;
 public final class ByteArrayImmutableBiomeBuffer extends AbstractBiomeBuffer implements ImmutableBiomeVolume {
 
     private final byte[] biomes;
+    private final Palette<BiomeType> palette;
 
-    public ByteArrayImmutableBiomeBuffer(byte[] biomes, Vector3i start, Vector3i size) {
+    public ByteArrayImmutableBiomeBuffer(Palette<BiomeType> palette, byte[] biomes, Vector3i start, Vector3i size) {
         super(start, size);
         this.biomes = biomes.clone();
+        this.palette = palette;
     }
 
-    private ByteArrayImmutableBiomeBuffer(Vector3i start, Vector3i size, byte[] biomes) {
+    private ByteArrayImmutableBiomeBuffer(Palette<BiomeType> palette, Vector3i start, Vector3i size, byte[] biomes) {
         super(start, size);
         this.biomes = biomes;
+        this.palette = palette;
     }
 
     @Override
@@ -83,7 +88,7 @@ public final class ByteArrayImmutableBiomeBuffer extends AbstractBiomeBuffer imp
     public MutableBiomeVolume getBiomeCopy(StorageType type) {
         switch (type) {
             case STANDARD:
-                return new ByteArrayMutableBiomeBuffer(this.biomes.clone(), this.start, this.size);
+                return new ByteArrayMutableBiomeBuffer(this.palette, this.biomes.clone(), this.start, this.size);
             case THREAD_SAFE:
             default:
                 throw new UnsupportedOperationException(type.name());
@@ -100,7 +105,7 @@ public final class ByteArrayImmutableBiomeBuffer extends AbstractBiomeBuffer imp
      * @return A new buffer using the same array reference
      */
     public static ImmutableBiomeVolume newWithoutArrayClone(byte[] biomes, Vector3i start, Vector3i size) {
-        return new ByteArrayImmutableBiomeBuffer(start, size, biomes);
+        return new ByteArrayImmutableBiomeBuffer(GlobalPalette.getBiomePalette(), start, size, biomes);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/util/gen/ChunkPrimerBuffer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/ChunkPrimerBuffer.java
@@ -36,15 +36,13 @@ import org.spongepowered.api.world.extent.MutableBlockVolume;
 import org.spongepowered.api.world.extent.StorageType;
 import org.spongepowered.api.world.extent.UnmodifiableBlockVolume;
 import org.spongepowered.api.world.extent.worker.MutableBlockVolumeWorker;
-import org.spongepowered.api.world.schematic.BlockPalette;
+import org.spongepowered.api.world.schematic.Palette;
 import org.spongepowered.common.world.extent.MutableBlockViewDownsize;
 import org.spongepowered.common.world.extent.MutableBlockViewTransform;
 import org.spongepowered.common.world.extent.UnmodifiableBlockVolumeWrapper;
 import org.spongepowered.common.world.extent.worker.SpongeMutableBlockVolumeWorker;
 import org.spongepowered.common.world.schematic.GlobalPalette;
 import org.spongepowered.common.world.storage.SpongeChunkLayout;
-
-import java.util.Optional;
 
 /**
  * Makes a {@link ChunkPrimer} usable as a {@link MutableBlockVolume}.
@@ -63,8 +61,8 @@ public final class ChunkPrimerBuffer extends AbstractBlockBuffer implements Muta
     }
 
     @Override
-    public BlockPalette getPalette() {
-        return GlobalPalette.instance;
+    public Palette<BlockState> getPalette() {
+        return GlobalPalette.getBlockPalette();
     }
 
     @Override
@@ -106,7 +104,7 @@ public final class ChunkPrimerBuffer extends AbstractBlockBuffer implements Muta
     public MutableBlockVolume getBlockCopy(StorageType type) {
         switch (type) {
             case STANDARD:
-                return new ArrayMutableBlockBuffer(GlobalPalette.instance, this.start, this.size, this.chunkPrimer.data.clone());
+                return new ArrayMutableBlockBuffer(GlobalPalette.getBlockPalette(), this.start, this.size, this.chunkPrimer.data.clone());
             case THREAD_SAFE:
             default:
                 throw new UnsupportedOperationException(type.name());
@@ -115,7 +113,7 @@ public final class ChunkPrimerBuffer extends AbstractBlockBuffer implements Muta
 
     @Override
     public ImmutableBlockVolume getImmutableBlockCopy() {
-        return new ArrayImmutableBlockBuffer(GlobalPalette.instance, this.start, this.size, this.chunkPrimer.data);
+        return new ArrayImmutableBlockBuffer(GlobalPalette.getBlockPalette(), this.start, this.size, this.chunkPrimer.data);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/extent/AbstractBiomeViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/AbstractBiomeViewDownsize.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.world.extent.MutableBiomeVolume;
 import org.spongepowered.api.world.extent.StorageType;
 import org.spongepowered.common.util.VecHelper;
 import org.spongepowered.common.util.gen.ByteArrayMutableBiomeBuffer;
+import org.spongepowered.common.world.schematic.GlobalPalette;
 
 public abstract class AbstractBiomeViewDownsize<V extends BiomeVolume> implements BiomeVolume {
 
@@ -87,7 +88,7 @@ public abstract class AbstractBiomeViewDownsize<V extends BiomeVolume> implement
     public MutableBiomeVolume getBiomeCopy(StorageType type) {
         switch (type) {
             case STANDARD:
-                return new ByteArrayMutableBiomeBuffer(ExtentBufferUtil.copyToArray(this, this.min, this.max, this.size), this.min, this.size);
+                return new ByteArrayMutableBiomeBuffer(GlobalPalette.getBiomePalette(), ExtentBufferUtil.copyToArray(this, this.min, this.max, this.size), this.min, this.size);
             case THREAD_SAFE:
             default:
                 throw new UnsupportedOperationException(type.name());

--- a/src/main/java/org/spongepowered/common/world/extent/AbstractBiomeViewTransform.java
+++ b/src/main/java/org/spongepowered/common/world/extent/AbstractBiomeViewTransform.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.world.extent.BiomeVolume;
 import org.spongepowered.api.world.extent.MutableBiomeVolume;
 import org.spongepowered.api.world.extent.StorageType;
 import org.spongepowered.common.util.gen.ByteArrayMutableBiomeBuffer;
+import org.spongepowered.common.world.schematic.GlobalPalette;
 
 public abstract class AbstractBiomeViewTransform<V extends BiomeVolume> implements BiomeVolume {
 
@@ -85,7 +86,7 @@ public abstract class AbstractBiomeViewTransform<V extends BiomeVolume> implemen
     public MutableBiomeVolume getBiomeCopy(StorageType type) {
         switch (type) {
             case STANDARD:
-                return new ByteArrayMutableBiomeBuffer(ExtentBufferUtil.copyToArray(this, this.min, this.max, this.size), this.min, this.size);
+                return new ByteArrayMutableBiomeBuffer(GlobalPalette.getBiomePalette(), ExtentBufferUtil.copyToArray(this, this.min, this.max, this.size), this.min, this.size);
             case THREAD_SAFE:
             default:
                 throw new UnsupportedOperationException(type.name());

--- a/src/main/java/org/spongepowered/common/world/extent/AbstractBlockViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/AbstractBlockViewDownsize.java
@@ -92,7 +92,7 @@ public abstract class AbstractBlockViewDownsize<V extends BlockVolume> implement
             case STANDARD:
                 // TODO: Optimize and use a local palette
                 char[] data = ExtentBufferUtil.copyToArray(this, this.min, this.max, this.size);
-                return new ArrayMutableBlockBuffer(GlobalPalette.instance, this.min, this.size, data);
+                return new ArrayMutableBlockBuffer(GlobalPalette.getBlockPalette(), this.min, this.size, data);
             case THREAD_SAFE:
             default:
                 throw new UnsupportedOperationException(type.name());

--- a/src/main/java/org/spongepowered/common/world/extent/AbstractBlockViewTransform.java
+++ b/src/main/java/org/spongepowered/common/world/extent/AbstractBlockViewTransform.java
@@ -94,7 +94,7 @@ public abstract class AbstractBlockViewTransform<V extends BlockVolume> implemen
             case STANDARD:
                 // TODO: Optimize and use a local palette
                 char[] data = ExtentBufferUtil.copyToArray(this, this.min, this.max, this.size);
-                return new ArrayMutableBlockBuffer(GlobalPalette.instance, this.min, this.size, data);
+                return new ArrayMutableBlockBuffer(GlobalPalette.getBlockPalette(), this.min, this.size, data);
             case THREAD_SAFE:
             default:
                 throw new UnsupportedOperationException(type.name());

--- a/src/main/java/org/spongepowered/common/world/extent/DefaultedExtent.java
+++ b/src/main/java/org/spongepowered/common/world/extent/DefaultedExtent.java
@@ -26,9 +26,14 @@ package org.spongepowered.common.world.extent;
 
 import com.flowpowered.math.vector.Vector3i;
 import com.google.common.collect.Maps;
+import net.minecraft.nbt.NBTTagDouble;
+import net.minecraft.nbt.NBTTagList;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.tileentity.TileEntity;
 import org.spongepowered.api.block.tileentity.TileEntityArchetype;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntityArchetype;
+import org.spongepowered.api.util.AABB;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
 import org.spongepowered.api.world.extent.ArchetypeVolume;
@@ -44,18 +49,23 @@ import org.spongepowered.api.world.extent.UnmodifiableBiomeVolume;
 import org.spongepowered.api.world.extent.UnmodifiableBlockVolume;
 import org.spongepowered.api.world.extent.worker.MutableBiomeVolumeWorker;
 import org.spongepowered.api.world.extent.worker.MutableBlockVolumeWorker;
+import org.spongepowered.common.data.util.NbtDataUtil;
+import org.spongepowered.common.entity.EntityUtil;
+import org.spongepowered.common.entity.SpongeEntityArchetype;
 import org.spongepowered.common.util.gen.ArrayImmutableBlockBuffer;
 import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer;
 import org.spongepowered.common.util.gen.ByteArrayImmutableBiomeBuffer;
 import org.spongepowered.common.util.gen.ByteArrayMutableBiomeBuffer;
 import org.spongepowered.common.world.extent.worker.SpongeMutableBiomeVolumeWorker;
 import org.spongepowered.common.world.extent.worker.SpongeMutableBlockVolumeWorker;
-import org.spongepowered.common.world.schematic.BimapPalette;
 import org.spongepowered.common.world.schematic.GlobalPalette;
 import org.spongepowered.common.world.schematic.SpongeArchetypeVolume;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * The Extent interface with extra defaults that are only available in the
@@ -88,7 +98,7 @@ public interface DefaultedExtent extends Extent {
     default MutableBiomeVolume getBiomeCopy(StorageType type) {
         switch (type) {
             case STANDARD:
-                return new ByteArrayMutableBiomeBuffer(ExtentBufferUtil.copyToArray((BiomeVolume) this, getBiomeMin(), getBiomeMax(), getBiomeSize()),
+                return new ByteArrayMutableBiomeBuffer(GlobalPalette.getBiomePalette(), ExtentBufferUtil.copyToArray((BiomeVolume) this, getBiomeMin(), getBiomeMax(), getBiomeSize()),
                         getBiomeMin(), getBiomeSize());
             case THREAD_SAFE:
             default:
@@ -128,7 +138,7 @@ public interface DefaultedExtent extends Extent {
         switch (type) {
             case STANDARD:
                 // TODO: Optimize and use a local palette
-                return new ArrayMutableBlockBuffer(GlobalPalette.instance, getBlockMin(), getBlockSize(),
+                return new ArrayMutableBlockBuffer(GlobalPalette.getBlockPalette(), getBlockMin(), getBlockSize(),
                         ExtentBufferUtil.copyToArray((BlockVolume) this, getBlockMin(), getBlockMax(), getBlockSize()));
             case THREAD_SAFE:
             default:
@@ -139,7 +149,7 @@ public interface DefaultedExtent extends Extent {
     @Override
     default ImmutableBlockVolume getImmutableBlockCopy() {
         char[] data = ExtentBufferUtil.copyToArray((BlockVolume) this, getBlockMin(), getBlockMax(), getBlockSize());
-        return ArrayImmutableBlockBuffer.newWithoutArrayClone(GlobalPalette.instance, getBlockMin(), getBlockSize(), data);
+        return ArrayImmutableBlockBuffer.newWithoutArrayClone(GlobalPalette.getBlockPalette(), getBlockMin(), getBlockSize(), data);
     }
 
     @Override
@@ -159,10 +169,6 @@ public interface DefaultedExtent extends Extent {
         min = tmin;
         max = tmax;
         Extent volume = getExtentView(min, max);
-        BimapPalette palette = new BimapPalette();
-        volume.getBlockWorker().iterate((v, x, y, z) -> {
-            palette.getOrAssign(v.getBlock(x, y, z));
-        });
         int ox = origin.getX();
         int oy = origin.getY();
         int oz = origin.getZ();
@@ -176,7 +182,27 @@ public interface DefaultedExtent extends Extent {
                 tiles.put(new Vector3i(x - ox, y - oy, z - oz), tile.get().createArchetype());
             }
         });
-        return new SpongeArchetypeVolume(backing, tiles);
+        Set<Entity> intersectingEntities = volume.getIntersectingEntities(new AABB(min, max));
+        if (intersectingEntities.isEmpty()) {
+            return new SpongeArchetypeVolume(backing, tiles, Collections.emptyList());
+        }
+        ArrayList<EntityArchetype> entities = new ArrayList<>();
+        for (Entity hit : intersectingEntities) {
+            net.minecraft.entity.Entity nms = EntityUtil.toNative(hit);
+            SpongeEntityArchetype archetype = (SpongeEntityArchetype) hit.createArchetype();
+            NBTTagList tagList = archetype.getData().getTagList(NbtDataUtil.ENTITY_POSITION, NbtDataUtil.TAG_DOUBLE);
+            if (tagList.isEmpty()) {
+                tagList.appendTag(new NBTTagDouble(nms.posX - ox));
+                tagList.appendTag(new NBTTagDouble(nms.posY - oy));
+                tagList.appendTag(new NBTTagDouble(nms.posZ - oz));
+            } else {
+                tagList.set(0, new NBTTagDouble(nms.posX - ox));
+                tagList.set(1, new NBTTagDouble(nms.posY - oy));
+                tagList.set(2, new NBTTagDouble(nms.posZ - oz));
+            }
+            entities.add(archetype);
+        }
+        return new SpongeArchetypeVolume(backing, tiles, entities);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/extent/MutableBlockViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/MutableBlockViewDownsize.java
@@ -72,7 +72,7 @@ public class MutableBlockViewDownsize extends AbstractBlockViewDownsize<MutableB
     @Override
     public ImmutableBlockVolume getImmutableBlockCopy() {
         char[] data = ExtentBufferUtil.copyToArray(this, this.min, this.max, this.size);
-        return ArrayImmutableBlockBuffer.newWithoutArrayClone(GlobalPalette.instance, this.min, this.size, data);
+        return ArrayImmutableBlockBuffer.newWithoutArrayClone(GlobalPalette.getBlockPalette(), this.min, this.size, data);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/extent/MutableBlockViewTransform.java
+++ b/src/main/java/org/spongepowered/common/world/extent/MutableBlockViewTransform.java
@@ -71,7 +71,7 @@ public class MutableBlockViewTransform extends AbstractBlockViewTransform<Mutabl
     @Override
     public ImmutableBlockVolume getImmutableBlockCopy() {
         char[] data = ExtentBufferUtil.copyToArray(this, this.min, this.max, this.size);
-        return ArrayImmutableBlockBuffer.newWithoutArrayClone(GlobalPalette.instance, this.min, this.size, data);
+        return ArrayImmutableBlockBuffer.newWithoutArrayClone(GlobalPalette.getBlockPalette(), this.min, this.size, data);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/extent/SpongeExtentBufferFactory.java
+++ b/src/main/java/org/spongepowered/common/world/extent/SpongeExtentBufferFactory.java
@@ -32,7 +32,10 @@ import org.spongepowered.api.world.extent.MutableBiomeVolume;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
 import org.spongepowered.common.util.gen.ArrayMutableBlockBuffer;
 import org.spongepowered.common.util.gen.ByteArrayMutableBiomeBuffer;
+import org.spongepowered.common.world.schematic.GlobalPalette;
 import org.spongepowered.common.world.schematic.SpongeArchetypeVolume;
+
+import java.util.Collections;
 
 public final class SpongeExtentBufferFactory implements ExtentBufferFactory {
 
@@ -43,7 +46,7 @@ public final class SpongeExtentBufferFactory implements ExtentBufferFactory {
 
     @Override
     public MutableBiomeVolume createBiomeBuffer(Vector3i min, Vector3i size) {
-        return new ByteArrayMutableBiomeBuffer(min, size);
+        return new ByteArrayMutableBiomeBuffer(GlobalPalette.getBiomePalette(), min, size);
     }
 
     @Override
@@ -64,7 +67,7 @@ public final class SpongeExtentBufferFactory implements ExtentBufferFactory {
     @Override
     public ArchetypeVolume createArchetypeVolume(Vector3i size, Vector3i origin) {
         MutableBlockVolume backing = new ArrayMutableBlockBuffer(origin.mul(-1), size);
-        return new SpongeArchetypeVolume(backing, ImmutableMap.of());
+        return new SpongeArchetypeVolume(backing, ImmutableMap.of(), Collections.emptyList());
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/extent/UnmodifiableBlockViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/UnmodifiableBlockViewDownsize.java
@@ -55,7 +55,7 @@ public class UnmodifiableBlockViewDownsize extends AbstractBlockViewDownsize<Blo
     @Override
     public ImmutableBlockVolume getImmutableBlockCopy() {
         char[] data = ExtentBufferUtil.copyToArray(this, this.min, this.max, this.size);
-        return ArrayImmutableBlockBuffer.newWithoutArrayClone(GlobalPalette.instance, this.min, this.size, data);
+        return ArrayImmutableBlockBuffer.newWithoutArrayClone(GlobalPalette.getBlockPalette(), this.min, this.size, data);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/extent/UnmodifiableBlockViewTransform.java
+++ b/src/main/java/org/spongepowered/common/world/extent/UnmodifiableBlockViewTransform.java
@@ -53,7 +53,7 @@ public class UnmodifiableBlockViewTransform extends AbstractBlockViewTransform<U
     @Override
     public ImmutableBlockVolume getImmutableBlockCopy() {
         char[] data = ExtentBufferUtil.copyToArray(this, this.min, this.max, this.size);
-        return ArrayImmutableBlockBuffer.newWithoutArrayClone(GlobalPalette.instance, this.min, this.size, data);
+        return ArrayImmutableBlockBuffer.newWithoutArrayClone(GlobalPalette.getBlockPalette(), this.min, this.size, data);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/schematic/BimapPalette.java
+++ b/src/main/java/org/spongepowered/common/world/schematic/BimapPalette.java
@@ -26,37 +26,39 @@ package org.spongepowered.common.world.schematic;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.world.schematic.BlockPalette;
-import org.spongepowered.api.world.schematic.BlockPaletteType;
-import org.spongepowered.api.world.schematic.BlockPaletteTypes;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.world.schematic.Palette;
+import org.spongepowered.api.world.schematic.PaletteType;
 
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Optional;
 
-public class BimapPalette implements BlockPalette {
+public class BimapPalette<T extends CatalogType> implements Palette<T> {
 
     private static final int DEFAULT_ALLOCATION_SIZE = 64;
 
-    private final BiMap<Integer, BlockState> ids;
-    private final BiMap<BlockState, Integer> idsr;
+    private final BiMap<Integer, T> ids;
+    private final BiMap<T, Integer> idsr;
     private final BitSet allocation = new BitSet(DEFAULT_ALLOCATION_SIZE);
+    private final PaletteType<T> paletteType;
     private int maxId = 0;
 
-    public BimapPalette() {
+    public BimapPalette(PaletteType<T> paletteType) {
         this.ids = HashBiMap.create();
         this.idsr = this.ids.inverse();
+        this.paletteType = paletteType;
     }
 
-    public BimapPalette(int expectedSize) {
+    public BimapPalette(PaletteType<T> paletteType, int expectedSize) {
         this.ids = HashBiMap.create(expectedSize);
         this.idsr = this.ids.inverse();
+        this.paletteType = paletteType;
     }
 
     @Override
-    public BlockPaletteType getType() {
-        return BlockPaletteTypes.LOCAL;
+    public PaletteType<T> getType() {
+        return this.paletteType;
     }
 
     @Override
@@ -65,12 +67,12 @@ public class BimapPalette implements BlockPalette {
     }
 
     @Override
-    public Optional<Integer> get(BlockState state) {
+    public Optional<Integer> get(T state) {
         return Optional.ofNullable(this.idsr.get(state));
     }
 
     @Override
-    public int getOrAssign(BlockState state) {
+    public int getOrAssign(T state) {
         Integer id = this.idsr.get(state);
         if (id == null) {
             int next = this.allocation.nextClearBit(0);
@@ -85,11 +87,11 @@ public class BimapPalette implements BlockPalette {
     }
 
     @Override
-    public Optional<BlockState> get(int id) {
+    public Optional<T> get(int id) {
         return Optional.ofNullable(this.ids.get(id));
     }
 
-    public void assign(BlockState state, int id) {
+    public void assign(T state, int id) {
         if (this.maxId < id) {
             this.maxId = id;
         }
@@ -98,7 +100,7 @@ public class BimapPalette implements BlockPalette {
     }
 
     @Override
-    public boolean remove(BlockState state) {
+    public boolean remove(T state) {
         Integer id = this.idsr.get(state);
         if (id == null) {
             return false;
@@ -112,7 +114,7 @@ public class BimapPalette implements BlockPalette {
     }
 
     @Override
-    public Collection<BlockState> getEntries() {
+    public Collection<T> getEntries() {
         return this.idsr.keySet();
     }
 

--- a/src/main/java/org/spongepowered/common/world/schematic/BlockPaletteWrapper.java
+++ b/src/main/java/org/spongepowered/common/world/schematic/BlockPaletteWrapper.java
@@ -24,27 +24,56 @@
  */
 package org.spongepowered.common.world.schematic;
 
-import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.world.schematic.BlockPalette;
-import org.spongepowered.api.world.schematic.BlockPaletteType;
+import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.world.schematic.Palette;
-import org.spongepowered.api.world.schematic.PaletteType;
-import org.spongepowered.common.SpongeCatalogType;
 
-import java.util.function.Supplier;
+import java.util.Collection;
+import java.util.Optional;
 
-public class SpongePaletteType<T extends CatalogType> extends SpongeCatalogType implements PaletteType<T> {
+@SuppressWarnings("deprecation")
+public class BlockPaletteWrapper implements org.spongepowered.api.world.schematic.BlockPalette {
 
-    private final Supplier<? extends Palette<T>> builder;
+    private final Palette<BlockState> palette;
+    private final org.spongepowered.api.world.schematic.BlockPaletteType type;
 
-    public SpongePaletteType(String id, Supplier<? extends Palette<T>> builder) {
-        super(id);
-        this.builder = builder;
+    public BlockPaletteWrapper(Palette<BlockState> palette, org.spongepowered.api.world.schematic.BlockPaletteType type) {
+        this.palette = palette;
+        this.type = type;
+    }
+
+
+    @Override
+    public org.spongepowered.api.world.schematic.BlockPaletteType getType() {
+        return this.type;
     }
 
     @Override
-    public Palette<T> create() {
-        return this.builder.get();
+    public int getHighestId() {
+        return this.palette.getHighestId();
     }
 
+    @Override
+    public Optional<BlockState> get(int id) {
+        return this.palette.get(id);
+    }
+
+    @Override
+    public Optional<Integer> get(BlockState state) {
+        return this.palette.get(state);
+    }
+
+    @Override
+    public int getOrAssign(BlockState state) {
+        return this.palette.getOrAssign(state);
+    }
+
+    @Override
+    public boolean remove(BlockState state) {
+        return this.palette.remove(state);
+    }
+
+    @Override
+    public Collection<BlockState> getEntries() {
+        return this.palette.getEntries();
+    }
 }

--- a/src/main/java/org/spongepowered/common/world/schematic/GlobalPalette.java
+++ b/src/main/java/org/spongepowered/common/world/schematic/GlobalPalette.java
@@ -24,37 +24,81 @@
  */
 package org.spongepowered.common.world.schematic;
 
+import com.google.common.base.MoreObjects;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.world.biome.Biome;
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.world.schematic.BlockPalette;
-import org.spongepowered.api.world.schematic.BlockPaletteType;
-import org.spongepowered.api.world.schematic.BlockPaletteTypes;
+import org.spongepowered.api.world.biome.BiomeType;
+import org.spongepowered.api.world.biome.VirtualBiomeType;
+import org.spongepowered.api.world.schematic.Palette;
+import org.spongepowered.api.world.schematic.PaletteType;
+import org.spongepowered.api.world.schematic.PaletteTypes;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 
-public class GlobalPalette implements BlockPalette {
+import javax.annotation.Nullable;
 
-    public static GlobalPalette instance = new GlobalPalette();
+public class GlobalPalette<T extends CatalogType> implements Palette<T> {
 
+    @Nullable
+    private static Palette<BlockState> blockPalette;
+    @Nullable
+    private static GlobalPalette<BiomeType> biomePalette;
+
+    private final Function<T, Integer> typeToInt;
+    private final IntFunction<T> intToType;
+    private final PaletteType<T> paletteType;
+    private final Class<T> catalogType;
     private final int length;
 
-    private GlobalPalette() {
+    @SuppressWarnings("unchecked")
+    private GlobalPalette(PaletteType<T> paletteType, Function<T, Integer> map, IntFunction<T> identity, Class<T> catalogType) {
         int highest = 0;
-        for (BlockState state : Sponge.getRegistry().getAllOf(BlockState.class)) {
-            int id = Block.BLOCK_STATE_IDS.get((IBlockState) state);
+        for (T type : Sponge.getRegistry().getAllOf(catalogType)) {
+            int id = map.apply(type);
             if (id > highest) {
                 highest = id;
             }
         }
         this.length = highest;
+        this.typeToInt = map;
+        this.intToType = identity;
+        this.paletteType = paletteType;
+        this.catalogType = catalogType;
+    }
+
+    public static Palette<BlockState> getBlockPalette() {
+        if (blockPalette == null) {
+            blockPalette = new BlockPaletteWrapper(new GlobalPalette<>(PaletteTypes.GLOBAL_BLOCKS,
+                (type) -> Block.BLOCK_STATE_IDS.get((IBlockState) type),
+                (id) -> (BlockState) Block.BLOCK_STATE_IDS.getByValue(id),
+                BlockState.class), org.spongepowered.api.world.schematic.BlockPaletteTypes.GLOBAL);
+        }
+        return blockPalette;
+    }
+
+    public static GlobalPalette<BiomeType> getBiomePalette() {
+        if (biomePalette == null) {
+            biomePalette = new GlobalPalette<>(PaletteTypes.GLOBAL_BIOMES,
+                (type) -> Biome.getIdForBiome((Biome) (type instanceof VirtualBiomeType ? ((VirtualBiomeType) type).getPersistedType() : type)),
+                (id) -> (BiomeType) Biome.getBiomeForId(id),
+                BiomeType.class
+                );
+
+        }
+        return biomePalette;
     }
 
     @Override
-    public BlockPaletteType getType() {
-        return BlockPaletteTypes.GLOBAL;
+    public PaletteType<T> getType() {
+        return this.paletteType;
     }
 
     @Override
@@ -63,28 +107,56 @@ public class GlobalPalette implements BlockPalette {
     }
 
     @Override
-    public Optional<Integer> get(BlockState state) {
-        return Optional.of(Block.BLOCK_STATE_IDS.get((IBlockState) state));
+    public Optional<Integer> get(T type) {
+        return Optional.of(this.typeToInt.apply(type));
     }
 
     @Override
-    public int getOrAssign(BlockState state) {
-        return Block.BLOCK_STATE_IDS.get((IBlockState) state);
+    public int getOrAssign(T state) {
+        return this.typeToInt.apply(state);
     }
 
     @Override
-    public Optional<BlockState> get(int id) {
-        return Optional.ofNullable((BlockState) Block.BLOCK_STATE_IDS.getByValue(id));
+    public Optional<T> get(int id) {
+        return Optional.ofNullable(this.intToType.apply(id));
     }
 
     @Override
-    public boolean remove(BlockState state) {
+    public boolean remove(T state) {
         throw new UnsupportedOperationException("Cannot remove blockstates from the global palette");
     }
 
     @Override
-    public Collection<BlockState> getEntries() {
-        return Sponge.getRegistry().getAllOf(BlockState.class);
+    public Collection<T> getEntries() {
+        return Sponge.getRegistry().getAllOf(this.catalogType);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.paletteType, this.catalogType, this.length);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final GlobalPalette other = (GlobalPalette) obj;
+        return Objects.equals(this.paletteType, other.paletteType)
+               && Objects.equals(this.catalogType, other.catalogType)
+               && Objects.equals(this.length, other.length);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("paletteType", this.paletteType)
+            .add("catalogType", this.catalogType)
+            .add("length", this.length)
+            .toString();
+    }
 }

--- a/src/main/java/org/spongepowered/common/world/schematic/SpongeBlockPaletteType.java
+++ b/src/main/java/org/spongepowered/common/world/schematic/SpongeBlockPaletteType.java
@@ -24,27 +24,19 @@
  */
 package org.spongepowered.common.world.schematic;
 
-import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.world.schematic.BlockPalette;
-import org.spongepowered.api.world.schematic.BlockPaletteType;
-import org.spongepowered.api.world.schematic.Palette;
-import org.spongepowered.api.world.schematic.PaletteType;
-import org.spongepowered.common.SpongeCatalogType;
+import org.spongepowered.api.block.BlockState;
 
 import java.util.function.Supplier;
 
-public class SpongePaletteType<T extends CatalogType> extends SpongeCatalogType implements PaletteType<T> {
+@SuppressWarnings("deprecation")
+public class SpongeBlockPaletteType extends SpongePaletteType<BlockState> implements org.spongepowered.api.world.schematic.BlockPaletteType {
 
-    private final Supplier<? extends Palette<T>> builder;
-
-    public SpongePaletteType(String id, Supplier<? extends Palette<T>> builder) {
-        super(id);
-        this.builder = builder;
+    public SpongeBlockPaletteType(String id, Supplier<org.spongepowered.api.world.schematic.BlockPalette> builder) {
+        super(id, builder);
     }
 
     @Override
-    public Palette<T> create() {
-        return this.builder.get();
+    public org.spongepowered.api.world.schematic.BlockPalette create() {
+        return (org.spongepowered.api.world.schematic.BlockPalette) super.create();
     }
-
 }

--- a/src/main/java/org/spongepowered/common/world/schematic/package-info.java
+++ b/src/main/java/org/spongepowered/common/world/schematic/package-info.java
@@ -22,29 +22,5 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+@org.spongepowered.api.util.annotation.NonnullByDefault
 package org.spongepowered.common.world.schematic;
-
-import org.spongepowered.api.CatalogType;
-import org.spongepowered.api.world.schematic.BlockPalette;
-import org.spongepowered.api.world.schematic.BlockPaletteType;
-import org.spongepowered.api.world.schematic.Palette;
-import org.spongepowered.api.world.schematic.PaletteType;
-import org.spongepowered.common.SpongeCatalogType;
-
-import java.util.function.Supplier;
-
-public class SpongePaletteType<T extends CatalogType> extends SpongeCatalogType implements PaletteType<T> {
-
-    private final Supplier<? extends Palette<T>> builder;
-
-    public SpongePaletteType(String id, Supplier<? extends Palette<T>> builder) {
-        super(id);
-        this.builder = builder;
-    }
-
-    @Override
-    public Palette<T> create() {
-        return this.builder.get();
-    }
-
-}


### PR DESCRIPTION
[Specification](https://github.com/SpongePowered/Schematic-Specification/pull/13) | [SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1987) | **SpongeCommon**

Implements the new Schematic format version 2 as proposed in the linked PR above. 

This implements the new API with some artificial wrapping around the new generic `Palette` to still implement `BlockPalette` and `BlockPaletteType` as required by previous API contracts. This allows for non-binary breakage of the `Schematic` object and has proven to work without making any modifications to the CopyPasta test plugin.

Checklist:
- [x] Implement new Schematic API
- [x] Add EntityArchetype support 
- [x] Add Biome support
- [x] Add DataVersion for the intended Minecraft version
- [x] Add DataContentUpdater for the older `Schematic` format to the new format.