### PR TITLE
Re-add sandstone generation (requires non-breaking API change)

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/biome/MixinBiome.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/biome/MixinBiome.java
@@ -26,6 +26,7 @@ package org.spongepowered.common.mixin.core.world.biome;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import net.minecraft.block.BlockSand;
 import net.minecraft.block.BlockStone;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
@@ -34,6 +35,8 @@ import net.minecraft.world.biome.BiomeDecorator;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.ChunkGeneratorSettings;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.data.type.PlantTypes;
 import org.spongepowered.api.data.type.ShrubTypes;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -70,6 +73,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.SpongeImplHooks;
 import org.spongepowered.common.interfaces.world.biome.IMixinBiome;
 import org.spongepowered.common.world.biome.SpongeBiomeGenerationSettings;
+import org.spongepowered.common.world.gen.SandstoneGroundCoverLayer;
 import org.spongepowered.common.world.gen.WorldGenConstants;
 import org.spongepowered.common.world.gen.populators.WrappedBiomeDecorator;
 
@@ -108,6 +112,15 @@ public abstract class MixinBiome implements BiomeType, IMixinBiome {
 
         gensettings.getGroundCoverLayers().add(new GroundCoverLayer((BlockState) this.topBlock, SeededVariableAmount.fixed(1)));
         gensettings.getGroundCoverLayers().add(new GroundCoverLayer((BlockState) this.fillerBlock, WorldGenConstants.GROUND_COVER_DEPTH));
+        if (this.fillerBlock.getBlock() == Blocks.SAND) {
+            BlockType type;
+            if (this.fillerBlock.getValue(BlockSand.VARIANT) == BlockSand.EnumType.RED_SAND) {
+                type = BlockTypes.RED_SANDSTONE;
+            } else {
+                type = BlockTypes.SANDSTONE;
+            }
+            gensettings.getGroundCoverLayers().add(new SandstoneGroundCoverLayer(type.getDefaultState()));
+        }
 
         String s = world.getWorldInfo().getGeneratorOptions();
         ChunkGeneratorSettings settings = ChunkGeneratorSettings.Factory.jsonToFactory(s).build();

--- a/src/main/java/org/spongepowered/common/world/gen/SandstoneGroundCoverLayer.java
+++ b/src/main/java/org/spongepowered/common/world/gen/SandstoneGroundCoverLayer.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.world.gen;
+
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.util.weighted.SeededVariableAmount;
+import org.spongepowered.api.util.weighted.VariableAmount;
+import org.spongepowered.api.world.biome.GroundCoverLayer;
+
+public final class SandstoneGroundCoverLayer extends GroundCoverLayer {
+
+    private static final int MAX_HEIGHT = 4;
+
+    public SandstoneGroundCoverLayer(BlockState state) {
+        super(state, SeededVariableAmount.wrapped(VariableAmount.range(0, MAX_HEIGHT)));
+    }
+
+    @Override
+    public SeededVariableAmount<Double> getDepth(int topYCoordinate) {
+        // Based on the code in Biome.generateBiomeTerrain().
+        // This code uses -62 instead of -63 because the variable in vanilla
+        // points to the block above.
+        return (rand, seed) -> this.getDepth().getFlooredAmount(rand, seed) + Math.max(topYCoordinate - 62, 0);
+    }
+}

--- a/src/main/java/org/spongepowered/common/world/gen/SpongeChunkGenerator.java
+++ b/src/main/java/org/spongepowered/common/world/gen/SpongeChunkGenerator.java
@@ -577,7 +577,7 @@ public class SpongeChunkGenerator implements WorldGenerator, IChunkGenerator {
                     layerDepth = 0;
                     GroundCoverLayer layer = groundcover.get(layerDepth);
                     currentPlacement = (IBlockState) layer.getBlockState().apply(stoneNoise);
-                    layerProgress = layer.getDepth().getFlooredAmount(rand, stoneNoise);
+                    layerProgress = layer.getDepth(currentY).getFlooredAmount(rand, stoneNoise);
                     if (layerProgress <= 0) {
                         continue;
                     }
@@ -587,7 +587,7 @@ public class SpongeChunkGenerator implements WorldGenerator, IChunkGenerator {
                         ++layerDepth;
                         if (layerDepth < groundcover.size()) {
                             layer = groundcover.get(layerDepth);
-                            layerProgress = layer.getDepth().getFlooredAmount(rand, stoneNoise);
+                            layerProgress = layer.getDepth(currentY - 1).getFlooredAmount(rand, stoneNoise);
                             currentPlacement = (IBlockState) layer.getBlockState().apply(stoneNoise);
                         }
                     } else if (currentY < seaLevel - 7 - layerProgress) {
@@ -597,7 +597,7 @@ public class SpongeChunkGenerator implements WorldGenerator, IChunkGenerator {
                         ++layerDepth;
                         if (layerDepth < groundcover.size()) {
                             layer = groundcover.get(layerDepth);
-                            layerProgress = layer.getDepth().getFlooredAmount(rand, stoneNoise);
+                            layerProgress = layer.getDepth(currentY).getFlooredAmount(rand, stoneNoise);
                             currentPlacement = (IBlockState) layer.getBlockState().apply(stoneNoise);
                             chunk.setBlockState(relativeX, currentY, relativeZ, currentPlacement);
                         }
@@ -610,7 +610,7 @@ public class SpongeChunkGenerator implements WorldGenerator, IChunkGenerator {
                         ++layerDepth;
                         if (layerDepth < groundcover.size()) {
                             GroundCoverLayer layer = groundcover.get(layerDepth);
-                            layerProgress = layer.getDepth().getFlooredAmount(rand, stoneNoise);
+                            layerProgress = layer.getDepth(currentY - 1).getFlooredAmount(rand, stoneNoise);
                             currentPlacement = (IBlockState) layer.getBlockState().apply(stoneNoise);
                         }
                     }


### PR DESCRIPTION
This includes a new `GroundCoverLayer` class that emulates vanilla sandstone generation. Because the depth depends on the starting height of the sandstone, this depends on https://github.com/SpongePowered/SpongeAPI/pull/2009.

Fixes #2237.