### PR TITLE
Change SchematicUpgradeTest to not use File

### DIFF
--- a/src/test/java/org/spongepowered/common/regression/SchematicUpgradeTest.java
+++ b/src/test/java/org/spongepowered/common/regression/SchematicUpgradeTest.java
@@ -43,7 +43,7 @@ public class SchematicUpgradeTest {
 
     @Test
     public void testUpgradingv1Tov2() throws IOException {
-        ClassLoader classLoader = this.getClass().getClassLoader();
+        final ClassLoader classLoader = this.getClass().getClassLoader();
         try (final InputStream v1InputStream = classLoader.getResource("loadv1.schematic").openStream();
              final InputStream v2InputStream = classLoader.getResource("loadv2.schematic").openStream()) {
                 final DataContainer v1Container = DataFormats.NBT.readFrom(new GZIPInputStream(v1InputStream));

--- a/src/test/java/org/spongepowered/common/regression/SchematicUpgradeTest.java
+++ b/src/test/java/org/spongepowered/common/regression/SchematicUpgradeTest.java
@@ -45,10 +45,12 @@ public class SchematicUpgradeTest {
     public void testUpgradingv1Tov2() throws IOException {
         final ClassLoader classLoader = this.getClass().getClassLoader();
         try (final InputStream v1InputStream = classLoader.getResource("loadv1.schematic").openStream();
-             final InputStream v2InputStream = classLoader.getResource("loadv2.schematic").openStream()) {
-                final DataContainer v1Container = DataFormats.NBT.readFrom(new GZIPInputStream(v1InputStream));
+             final InputStream v2InputStream = classLoader.getResource("loadv2.schematic").openStream();
+             final GZIPInputStream v1GzipInputStream = new GZIPInputStream(v1InputStream);
+             final GZIPInputStream v2GzipInputStream = new GZIPInputStream(v2InputStream)){
+                final DataContainer v1Container = DataFormats.NBT.readFrom(v1GzipInputStream);
                 final Schematic v1Schem = DataTranslators.SCHEMATIC.translate(v1Container);
-                final DataContainer v2Container = DataFormats.NBT.readFrom(new GZIPInputStream(v2InputStream));
+                final DataContainer v2Container = DataFormats.NBT.readFrom(v2GzipInputStream);
                 final Schematic v2Schem = DataTranslators.SCHEMATIC.translate(v2Container);
                 assertEquals(v1Schem, v2Schem);
         }

--- a/src/test/java/org/spongepowered/common/regression/SchematicUpgradeTest.java
+++ b/src/test/java/org/spongepowered/common/regression/SchematicUpgradeTest.java
@@ -43,13 +43,15 @@ public class SchematicUpgradeTest {
 
     @Test
     public void testUpgradingv1Tov2() throws IOException {
-        InputStream inputStream = this.getClass().getClassLoader().getResource("loadv1.schematic").openStream();
-        DataContainer container = DataFormats.NBT.readFrom(new GZIPInputStream(inputStream));
-        final Schematic v1Schem = DataTranslators.SCHEMATIC.translate(container);
-        inputStream = this.getClass().getClassLoader().getResource("loadv2.schematic").openStream();
-        container = DataFormats.NBT.readFrom(new GZIPInputStream(inputStream));
-        final Schematic v2Schem = DataTranslators.SCHEMATIC.translate(container);
-        assertEquals(v1Schem, v2Schem);
+        ClassLoader classLoader = this.getClass().getClassLoader();
+        try (final InputStream v1InputStream = classLoader.getResource("loadv1.schematic").openStream();
+             final InputStream v2InputStream = classLoader.getResource("loadv2.schematic").openStream()) {
+                final DataContainer v1Container = DataFormats.NBT.readFrom(new GZIPInputStream(v1InputStream));
+                final Schematic v1Schem = DataTranslators.SCHEMATIC.translate(v1Container);
+                final DataContainer v2Container = DataFormats.NBT.readFrom(new GZIPInputStream(v2InputStream));
+                final Schematic v2Schem = DataTranslators.SCHEMATIC.translate(v2Container);
+                assertEquals(v1Schem, v2Schem);
+        }
     }
 
 }

--- a/src/test/java/org/spongepowered/common/regression/SchematicUpgradeTest.java
+++ b/src/test/java/org/spongepowered/common/regression/SchematicUpgradeTest.java
@@ -34,9 +34,8 @@ import org.spongepowered.api.data.persistence.DataTranslators;
 import org.spongepowered.api.world.schematic.Schematic;
 import org.spongepowered.lwts.runner.LaunchWrapperTestRunner;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.zip.GZIPInputStream;
 
 @RunWith(LaunchWrapperTestRunner.class)
@@ -44,11 +43,11 @@ public class SchematicUpgradeTest {
 
     @Test
     public void testUpgradingv1Tov2() throws IOException {
-        File inputFile = new File(this.getClass().getClassLoader().getResource("loadv1.schematic").getFile());
-        DataContainer container = DataFormats.NBT.readFrom(new GZIPInputStream(new FileInputStream(inputFile)));
+        InputStream inputStream = this.getClass().getClassLoader().getResource("loadv1.schematic").openStream();
+        DataContainer container = DataFormats.NBT.readFrom(new GZIPInputStream(inputStream));
         final Schematic v1Schem = DataTranslators.SCHEMATIC.translate(container);
-        inputFile = new File(this.getClass().getClassLoader().getResource("loadv2.schematic").getFile());
-        container = DataFormats.NBT.readFrom(new GZIPInputStream(new FileInputStream(inputFile)));
+        inputStream = this.getClass().getClassLoader().getResource("loadv2.schematic").openStream();
+        container = DataFormats.NBT.readFrom(new GZIPInputStream(inputStream));
         final Schematic v2Schem = DataTranslators.SCHEMATIC.translate(container);
         assertEquals(v1Schem, v2Schem);
     }


### PR DESCRIPTION
The current test code breaks on any paths with spaces in the name due to URL encoding,
Changes the test to use a stream directly from the resource, resolving the URL encoding step.

https://i.imgur.com/1DcZfGp.png