### PR TITLE
Add minor async lighting improvements

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/world/chunk/ChunkBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/world/chunk/ChunkBridge.java
@@ -118,7 +118,7 @@ public interface ChunkBridge {
 
     boolean isQueuedForUnload();
 
-    CopyOnWriteArrayList<Short> getQueuedLightingUpdates(EnumSkyBlock type);
+    Set<Short> getQueuedLightingUpdates(EnumSkyBlock type);
 
     void markChunkDirty();
 

--- a/src/main/java/org/spongepowered/common/mixin/optimization/world/MixinChunk_Async_Lighting.java
+++ b/src/main/java/org/spongepowered/common/mixin/optimization/world/MixinChunk_Async_Lighting.java
@@ -47,9 +47,11 @@ import org.spongepowered.common.bridge.world.ServerWorldBridge;
 import org.spongepowered.common.bridge.world.ServerChunkProviderBridge;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -58,13 +60,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class MixinChunk_Async_Lighting implements ChunkBridge {
 
     // Keeps track of block positions in this chunk currently queued for sky light update
-    private CopyOnWriteArrayList<Short> queuedSkyLightingUpdates = new CopyOnWriteArrayList<>();
+    private Set<Short> queuedSkyLightingUpdates = ConcurrentHashMap.newKeySet();
     // Keeps track of block positions in this chunk currently queued for block light update
-    private CopyOnWriteArrayList<Short> queuedBlockLightingUpdates = new CopyOnWriteArrayList<>();
+    private Set<Short> queuedBlockLightingUpdates = ConcurrentHashMap.newKeySet();
     private AtomicInteger pendingLightUpdates = new AtomicInteger();
     private long lightUpdateTime;
     private ExecutorService lightExecutorService;
-    private static final List<Chunk> EMPTY_LIST = new ArrayList<>();
+    private static final List<Chunk> EMPTY_LIST = Collections.emptyList();
     private static final BlockPos DUMMY_POS = new BlockPos(0, 0, 0);
     private boolean isServerChunk;
 
@@ -705,7 +707,7 @@ public abstract class MixinChunk_Async_Lighting implements ChunkBridge {
      * @return The list of queued block positions, empty if none
      */
     @Override
-    public CopyOnWriteArrayList<Short> getQueuedLightingUpdates(EnumSkyBlock type) {
+    public Set<Short> getQueuedLightingUpdates(EnumSkyBlock type) {
         if (type == EnumSkyBlock.SKY) {
             return this.queuedSkyLightingUpdates;
         }

--- a/src/main/java/org/spongepowered/common/mixin/optimization/world/MixinWorldServer_Async_Lighting.java
+++ b/src/main/java/org/spongepowered/common/mixin/optimization/world/MixinWorldServer_Async_Lighting.java
@@ -335,20 +335,26 @@ public abstract class MixinWorldServer_Async_Lighting extends MixinWorld impleme
             } else if (i >= 14) {
                 return i;
             } else {
-                for (EnumFacing enumfacing : EnumFacing.values()) {
-                    BlockPos blockpos = pos.offset(enumfacing);
-                    int k = this.getLightForAsync(lightType, blockpos, currentChunk, neighbors) - j;
+                BlockPos.PooledMutableBlockPos pooledBlockPos = BlockPos.PooledMutableBlockPos.retain();
 
-                    if (k > i) {
-                        i = k;
+                try {
+                    for (EnumFacing enumfacing : EnumFacing.values()) {
+                        pooledBlockPos.setPos(pos).move(enumfacing);
+                        int k = this.getLightForAsync(lightType, pooledBlockPos, currentChunk, neighbors) - j;
+
+                        if (k > i) {
+                            i = k;
+                        }
+
+                        if (i >= 14) {
+                            return i;
+                        }
                     }
 
-                    if (i >= 14) {
-                        return i;
-                    }
+                    return i;
+                } finally {
+                    pooledBlockPos.release();
                 }
-
-                return i;
             }
         }
     }


### PR DESCRIPTION
This aims to make some minor improvements to async lighting.

Use Collections.emptyList() for EMPTY_LIST to ensure safe immutability.

Replace CopyOnWriteArrayList with ConcurrentHashMap backed set as the
queued lighting updates collections are written to frequently.

Use a pooled block position for block offset on loop in
getRawBlockLightAsync.

Credits to @astei as well. 