### PR TITLE
Introduce Metrics Collection States

### DIFF
--- a/src/main/java/org/spongepowered/common/config/category/MetricsCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/MetricsCategory.java
@@ -27,7 +27,9 @@ package org.spongepowered.common.config.category;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.util.Tristate;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -35,28 +37,22 @@ import java.util.Optional;
 @ConfigSerializable
 public class MetricsCategory {
 
-    @Setting(value = "default-permission", comment = "Determines whether plugins that are newly added are allowed to perform\n"
-                                        + "data/metric collection by default. Plugins detected by Sponge will be added "
-                                        + "to the \"plugin-permissions\" section with this value.\n\n"
-                                        + "Set to true to enable metric gathering by default, false otherwise.")
-    private boolean defaultPermission = false;
+    @Setting(value = "global-state", comment = "The global collection state that should be respected by all plugins that have no specified "
+      + "collection state. If undefined then it is treated as disabled.")
+    private Tristate globalState = Tristate.UNDEFINED;
 
-    @Setting(value = "plugin-permissions", comment = "Provides (or revokes) permission for metric gathering on a per plugin basis.\n"
-                                                   + "Entries should be in the format \"plugin-id=<true|false>\".\n\n"
-                                                   + "Deleting an entry from this list will reset it to the default specified in\n"
-                                                   + "\"default-permission\"")
-    private Map<String, Boolean> perPluginPermissions = new HashMap<>();
+    @Setting(value = "plugin-states", comment = "Plugin-specific collection states that override the global collection state.")
+    private final Map<String, Tristate> pluginStates = new HashMap<>();
 
-    public boolean isGloballyEnabled() {
-        return this.defaultPermission;
+    public Tristate getGlobalCollectionState() {
+        return this.globalState;
     }
 
-    public Optional<Boolean> getPluginPermission(PluginContainer container) {
-        return Optional.ofNullable(this.perPluginPermissions.get(container.getId()));
+    public Tristate getCollectionState(PluginContainer container) {
+        return Optional.ofNullable(this.pluginStates.get(container.getId())).orElse(Tristate.UNDEFINED);
     }
 
-    public Map<String, Boolean> getPluginPermissions() {
-        return new HashMap<>(this.perPluginPermissions);
+    public Map<String, Tristate> getCollectionStates() {
+        return Collections.unmodifiableMap(this.pluginStates);
     }
-
 }

--- a/src/main/java/org/spongepowered/common/util/SpongeHooks.java
+++ b/src/main/java/org/spongepowered/common/util/SpongeHooks.java
@@ -51,6 +51,7 @@ import org.spongepowered.api.block.tileentity.TileEntityType;
 import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.util.Tristate;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.SpongeImplHooks;
 import org.spongepowered.common.bridge.TrackableBridge;
@@ -510,21 +511,8 @@ public class SpongeHooks {
         ConfigTeleportHelperFilter.invalidateCache();
     }
 
-    public static void populatePluginsInMetricsConfig() {
-        final boolean globalState = SpongeImpl.getGlobalConfigAdapter().getConfig().getMetricsCategory().isGloballyEnabled();
-        final Map<String, Boolean> entries = SpongeImpl.getGlobalConfigAdapter().getConfig().getMetricsCategory().getPluginPermissions();
-        Sponge.getPluginManager().getPlugins().stream()
-                .filter(SpongeImplHooks.getPluginFilterPredicate()).forEach(plugin -> entries.putIfAbsent(plugin.getId(), globalState));
-
-        try {
-            savePluginsInMetricsConfig(entries).get();
-        } catch (InterruptedException | ExecutionException e) {
-            SpongeImpl.getLogger().warn("Could not populate the plugin list for metric collection", e);
-        }
-    }
-
-    public static CompletableFuture<CommentedConfigurationNode> savePluginsInMetricsConfig(final Map<String, Boolean> entries) {
+    public static CompletableFuture<CommentedConfigurationNode> savePluginsInMetricsConfig(final Map<String, Tristate> entries) {
         return SpongeImpl.getGlobalConfigAdapter()
-                .updateSetting("metrics.plugin-permissions", entries, new TypeToken<Map<String, Boolean>>() { private static final long serialVersionUID = -1; });
+            .updateSetting("metrics.plugin-states", entries, new TypeToken<Map<String, Tristate>>() {});
     }
 }

--- a/src/main/java/org/spongepowered/common/util/metric/SpongeMetricsConfigManager.java
+++ b/src/main/java/org/spongepowered/common/util/metric/SpongeMetricsConfigManager.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.util.metric;
 
 import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.util.Tristate;
 import org.spongepowered.api.util.metric.MetricsConfigManager;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.config.category.MetricsCategory;
@@ -36,8 +37,20 @@ public class SpongeMetricsConfigManager implements MetricsConfigManager {
 
     @Override
     public boolean areMetricsEnabled(final PluginContainer container) {
-        final MetricsCategory metricsCategory = SpongeImpl.getGlobalConfigAdapter().getConfig().getMetricsCategory();
-        return metricsCategory.getPluginPermission(container).orElseGet(metricsCategory::isGloballyEnabled);
+        final Tristate pluginState = this.getCollectionState(container);
+        return pluginState == Tristate.TRUE
+          || (this.getGlobalCollectionState() == Tristate.TRUE && pluginState == Tristate.UNDEFINED);
     }
 
+    @Override
+    public Tristate getGlobalCollectionState() {
+        final MetricsCategory metricsCategory = SpongeImpl.getGlobalConfigAdapter().getConfig().getMetricsCategory();
+        return metricsCategory.getGlobalCollectionState();
+    }
+
+    @Override
+    public Tristate getCollectionState(final PluginContainer container) {
+        final MetricsCategory metricsCategory = SpongeImpl.getGlobalConfigAdapter().getConfig().getMetricsCategory();
+        return metricsCategory.getCollectionState(container);
+    }
 }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2018) | **SpongeCommon** | [SpongeVanilla](https://github.com/SpongePowered/SpongeVanilla/pull/411) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/2824)

### Commands
Change `/sponge metrics` command to be...
  - `/sponge metrics` - Shows current collection states
  - `/sponge metrics enabled|disabled|undefined` - Sets the global collection state to the specified state
  - `/sponge metrics pluginId enabled|disabled|undefined` - Sets the plugin's collection state to the specified state
  - `enabled` has the following aliases for command usage: `true, on, enable, enabled`
  - `disabled` has the following aliases for command usage: `false, off, disable, disabled`
  - `undefined` has the following aliases for command usage: `default, undefine, undefined`

### Configuration
global.conf will have a block in it that resembles the following.
```hocon
  metrics {
      # The global collection state that should be respected by all plugins that have no specified collection state. If undefined then it is treated as disabled.
      global-state=UNDEFINED
      # Plugin-specific collection states that override the global collection state.
      plugin-states {
          spongeapi=TRUE
      }
  }
```

### Screenshots
![](https://i.imgur.com/TrULSDC.png)
![](https://i.imgur.com/vmKJ7Fi.png)
![](https://i.imgur.com/SwBKX8e.png)


### Going Forward
This is the initial introduction to metrics collection states. In API8 the intention is to introduce a way for the plugin to signal intention to collect stats so that Sponge may alert the user on their behalf.

Signed-off-by: Steven Downer <grinch@outlook.com>