### PR TITLE
Using URLDecoder to decode the possibly encoded strings

### DIFF
--- a/src/test/java/org/spongepowered/common/service/sql/SqlServiceImplTest.java
+++ b/src/test/java/org/spongepowered/common/service/sql/SqlServiceImplTest.java
@@ -64,4 +64,15 @@ public class SqlServiceImplTest {
         assertEquals(jdbcUrl, subject.getAuthlessUrl());
         assertEquals("org.sqlite.JDBC", subject.getDriverClassName());
     }
+
+    @Test
+    public void testUrlEncodedInfo() throws SQLException {
+        final String jdbcUrl = "jdbc:mysql://test%40%3A%C3%A4%C3%B6%C3%BC%26%3F+%40test:pw%40%3A%C3%A4%C3%B6%C3%BC%26%3F+%40pw@localhost/sponge";
+        final SqlServiceImpl.ConnectionInfo subject = SqlServiceImpl.ConnectionInfo.fromUrl(null, jdbcUrl);
+
+        assertEquals("test@:äöü&? @test", subject.getUser());
+        assertEquals("pw@:äöü&? @pw", subject.getPassword());
+        assertEquals("jdbc:mysql://localhost/sponge", subject.getAuthlessUrl());
+        assertEquals("org.mariadb.jdbc.Driver", subject.getDriverClassName());
+    }
 }


### PR DESCRIPTION
This PR should fix #2308 

It URL decodes the username and password in a JDBC connection URL.  
Also adds a unit test to make sure that functionality doesn't break.

Probably a good idea to add that change to API 8 and any other still maintained API version.