### PR TITLE
Fix scaled health

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/entity/player/ServerPlayerEntityBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/entity/player/ServerPlayerEntityBridge.java
@@ -89,8 +89,6 @@ public interface ServerPlayerEntityBridge {
 
     boolean bridge$isHealthScaled();
 
-    void bridge$setHealthScaled(boolean scaled);
-
     void bridge$refreshScaledHealth();
 
     void bridge$injectScaledHealth(Collection<IAttributeInstance> set, boolean b);

--- a/src/main/java/org/spongepowered/common/bridge/entity/player/ServerPlayerEntityBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/entity/player/ServerPlayerEntityBridge.java
@@ -91,7 +91,7 @@ public interface ServerPlayerEntityBridge {
 
     void bridge$refreshScaledHealth();
 
-    void bridge$injectScaledHealth(Collection<IAttributeInstance> set, boolean b);
+    void bridge$injectScaledHealth(Collection<IAttributeInstance> set);
 
     void updateDataManagerForScaledHealth();
 

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/HealthScalingProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/HealthScalingProcessor.java
@@ -36,6 +36,7 @@ import org.spongepowered.common.data.manipulator.mutable.entity.SpongeHealthScal
 import org.spongepowered.common.data.processor.common.AbstractEntitySingleDataProcessor;
 import org.spongepowered.common.data.value.SpongeValueFactory;
 import org.spongepowered.common.bridge.entity.player.ServerPlayerEntityBridge;
+import org.spongepowered.common.util.Constants;
 
 import java.util.Optional;
 
@@ -74,7 +75,7 @@ public class HealthScalingProcessor extends AbstractEntitySingleDataProcessor<En
         return SpongeValueFactory.boundedBuilder(Keys.HEALTH_SCALE)
                 .minimum(1D)
                 .maximum((double) Float.MAX_VALUE)
-                .defaultValue(1D)
+                .defaultValue(Constants.Entity.Player.DEFAULT_HEALTH_SCALE)
                 .actualValue(value)
                 .build()
                 .asImmutable();
@@ -85,7 +86,7 @@ public class HealthScalingProcessor extends AbstractEntitySingleDataProcessor<En
         return SpongeValueFactory.boundedBuilder(Keys.HEALTH_SCALE)
                 .minimum(1D)
                 .maximum((double) Float.MAX_VALUE)
-                .defaultValue(1D)
+                .defaultValue(Constants.Entity.Player.DEFAULT_HEALTH_SCALE)
                 .actualValue(actualValue)
                 .build();
     }
@@ -96,7 +97,7 @@ public class HealthScalingProcessor extends AbstractEntitySingleDataProcessor<En
             return DataTransactionResult.failNoData();
         }
         final ImmutableValue<Double> current = constructImmutableValue(((ServerPlayerEntityBridge) container).bridge$getHealthScale());
-        ((ServerPlayerEntityBridge) container).bridge$setHealthScale(1D);
+        ((ServerPlayerEntityBridge) container).bridge$setHealthScale(Constants.Entity.Player.DEFAULT_HEALTH_SCALE);
         return DataTransactionResult.successRemove(current);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/HealthScalingProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/HealthScalingProcessor.java
@@ -59,11 +59,6 @@ public class HealthScalingProcessor extends AbstractEntitySingleDataProcessor<En
             return false;
         }
         final ServerPlayerEntityBridge mixinPlayer = (ServerPlayerEntityBridge) dataHolder;
-        if (value == 20D) {
-            mixinPlayer.bridge$setHealthScale(20);
-            mixinPlayer.bridge$setHealthScaled(true);
-            return true;
-        }
         mixinPlayer.bridge$setHealthScale(value);
         return true;
     }
@@ -79,7 +74,7 @@ public class HealthScalingProcessor extends AbstractEntitySingleDataProcessor<En
         return SpongeValueFactory.boundedBuilder(Keys.HEALTH_SCALE)
                 .minimum(1D)
                 .maximum((double) Float.MAX_VALUE)
-                .defaultValue(20D)
+                .defaultValue(1D)
                 .actualValue(value)
                 .build()
                 .asImmutable();
@@ -90,7 +85,7 @@ public class HealthScalingProcessor extends AbstractEntitySingleDataProcessor<En
         return SpongeValueFactory.boundedBuilder(Keys.HEALTH_SCALE)
                 .minimum(1D)
                 .maximum((double) Float.MAX_VALUE)
-                .defaultValue(20D)
+                .defaultValue(1D)
                 .actualValue(actualValue)
                 .build();
     }
@@ -101,8 +96,7 @@ public class HealthScalingProcessor extends AbstractEntitySingleDataProcessor<En
             return DataTransactionResult.failNoData();
         }
         final ImmutableValue<Double> current = constructImmutableValue(((ServerPlayerEntityBridge) container).bridge$getHealthScale());
-        ((ServerPlayerEntityBridge) container).bridge$setHealthScale(20D);
-        ((ServerPlayerEntityBridge) container).bridge$setHealthScaled(false);
+        ((ServerPlayerEntityBridge) container).bridge$setHealthScale(1D);
         return DataTransactionResult.successRemove(current);
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityTrackerEntryMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityTrackerEntryMixin.java
@@ -133,7 +133,9 @@ public abstract class EntityTrackerEntryMixin {
     @ModifyArg(method = "sendMetadata", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/play/server/SPacketEntityProperties;<init>(ILjava/util/Collection;)V"))
     private Collection<IAttributeInstance> spongeInjectHealth(Collection<IAttributeInstance> set) {
         if (this.trackedEntity instanceof EntityPlayerMP) {
-            ((ServerPlayerEntityBridge) this.trackedEntity).bridge$injectScaledHealth(set, false);
+            if (((ServerPlayerEntityBridge) this.trackedEntity).bridge$isHealthScaled()) {
+                ((ServerPlayerEntityBridge) this.trackedEntity).bridge$injectScaledHealth(set);
+            }
         }
         return set;
     }
@@ -152,7 +154,9 @@ public abstract class EntityTrackerEntryMixin {
     @ModifyArg(method = "updatePlayerEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/play/server/SPacketEntityProperties;<init>(ILjava/util/Collection;)V"))
     private Collection<IAttributeInstance> spongeInjectHealthForUpdate(Collection<IAttributeInstance> set) {
         if (this.trackedEntity instanceof EntityPlayerMP) {
-            ((ServerPlayerEntityBridge) this.trackedEntity).bridge$injectScaledHealth(set, false);
+            if (((ServerPlayerEntityBridge) this.trackedEntity).bridge$isHealthScaled()) {
+                ((ServerPlayerEntityBridge) this.trackedEntity).bridge$injectScaledHealth(set);
+            }
         }
         return set;
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMPMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMPMixin.java
@@ -769,7 +769,7 @@ public abstract class EntityPlayerMPMixin extends EntityPlayerMixin implements S
         return bridge$getInternalScaledHealth();
     }
 
-    @Inject(method = "onUpdateEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;getTotalArmorValue()I", ordinal = 0))
+    @Inject(method = "onUpdateEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;getTotalArmorValue()I", ordinal = 1))
     private void updateHealthPriorToArmor(final CallbackInfo ci) {
         bridge$refreshScaledHealth();
     }

--- a/src/main/java/org/spongepowered/common/util/Constants.java
+++ b/src/main/java/org/spongepowered/common/util/Constants.java
@@ -772,7 +772,7 @@ public final class Constants {
             public static final double MINIMUM_EXHAUSTION = 0;
             public static final double DEFAULT_SATURATION = 0;
             public static final int DEFAULT_FOOD_LEVEL = 20;
-            public static final int DEFAULT_HEALTH_SCALE = 1;
+            public static final double DEFAULT_HEALTH_SCALE = 20D;
             public static final String IS_FLYING = "flying";
             public static final String INVENTORY = "Inventory";
             public static final String INVULNERABLE = "Invulnerable";

--- a/src/main/java/org/spongepowered/common/util/Constants.java
+++ b/src/main/java/org/spongepowered/common/util/Constants.java
@@ -772,7 +772,7 @@ public final class Constants {
             public static final double MINIMUM_EXHAUSTION = 0;
             public static final double DEFAULT_SATURATION = 0;
             public static final int DEFAULT_FOOD_LEVEL = 20;
-            public static final int DEFAULT_HEALTH_SCALE = 20;
+            public static final int DEFAULT_HEALTH_SCALE = 1;
             public static final String IS_FLYING = "flying";
             public static final String INVENTORY = "Inventory";
             public static final String INVULNERABLE = "Invulnerable";


### PR DESCRIPTION
First off, let's define `HEALTH_SCALE`.

From the API https://github.com/SpongePowered/SpongeAPI/blob/c23f58d2a18b61b2ba457977e7aaf57dfbd749d0/src/main/java/org/spongepowered/api/data/key/Keys.java#L1029
```
     * Represents the {@link Key} for how much health a half-heart on a
     * {@link Player}'s GUI will stand for.
```

In vanilla max health value is 20 (or 10 hearts). Thus a half-heart is 1 health value.

Vanilla:

max health: 20
health scale (remember the definition): 1

In the implementation the default health scale is set to 20. Moreover `getMaxHealth()` and `getHealth()` take the health and apply the modifiers, so there's no need to run that logic twice (see `getInternalScaledHealth()`)

EDIT: the api is wrong, see gabi comment

I've played around with the ScaledHealth testplugin and botania's ring of odin.

This should fix https://github.com/SpongePowered/SpongeForge/issues/2898