### PR TITLE
Increase valid Y position range for entity loading

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/util/math/Vec3iMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/util/math/Vec3iMixin.java
@@ -43,7 +43,7 @@ public abstract class Vec3iMixin implements BlockPosBridge {
 
     @Override
     public boolean bridge$isValidPosition() {
-        return this.x >= -30000000 && this.z >= -30000000 && this.x < 30000000 && this.z < 30000000 && this.y >= 0 && this.y < 256;
+        return this.x >= -30000000 && this.z >= -30000000 && this.x < 30000000 && this.z < 30000000 && this.y >= 0 && this.y < 1024;
     }
 
     @Override
@@ -53,6 +53,6 @@ public abstract class Vec3iMixin implements BlockPosBridge {
 
     @Override
     public boolean bridge$isInvalidYPosition() {
-        return this.y < 0 || this.y >= 256;
+        return this.y < 0 || this.y >= 1024;
     }
 }


### PR DESCRIPTION
Fixes disapearing Flat Transfer Nodes in ExtraUtils2 (Stores a master entity above the chunk at y512)
https://github.com/SpongePowered/SpongeForge/issues/2293