### PR TITLE
Implement RegainHealthEvent and HealingTypes.

### DIFF
--- a/src/main/java/org/spongepowered/common/block/SpongeBlockSnapshot.java
+++ b/src/main/java/org/spongepowered/common/block/SpongeBlockSnapshot.java
@@ -38,6 +38,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldServer;
+import net.minecraft.world.chunk.Chunk;
 import org.apache.logging.log4j.Level;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.BlockState;
@@ -60,6 +61,8 @@ import org.spongepowered.asm.util.PrettyPrinter;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.bridge.block.BlockBridge;
 import org.spongepowered.common.bridge.world.WorldServerBridge;
+import org.spongepowered.common.bridge.world.chunk.ChunkProviderBridge;
+import org.spongepowered.common.bridge.world.chunk.ChunkProviderServerBridge;
 import org.spongepowered.common.data.persistence.NbtTranslator;
 import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.event.tracking.PhaseContext;
@@ -194,6 +197,10 @@ public class SpongeBlockSnapshot implements BlockSnapshot {
 //            if (current.getBlock().getClass() == BlockShulkerBox.class) {
 //                world.bridge$removeTileEntity(pos);
 //            }
+            final TileEntity existing = world.getChunk(pos).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK);
+            if (existing != null) {
+                existing.invalidate();
+            }
             world.removeTileEntity(pos);
             PhaseTracker.getInstance().setBlockState(mixinWorldServer, pos, replaced, BlockChangeFlagRegistryModule.andNotifyClients(flag));
             if (this.compound != null) {

--- a/src/main/java/org/spongepowered/common/data/processor/multi/entity/HealthDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/entity/HealthDataProcessor.java
@@ -55,14 +55,14 @@ public class HealthDataProcessor extends AbstractEntityDataProcessor<EntityLivin
     }
 
     @Override
-    protected boolean doesDataExist(EntityLivingBase entity) {
+    protected boolean doesDataExist(final EntityLivingBase entity) {
         return true;
     }
 
     @Override
-    protected boolean set(EntityLivingBase entity, Map<Key<?>, Object> keyValues) {
+    protected boolean set(final EntityLivingBase entity, final Map<Key<?>, Object> keyValues) {
         entity.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).setBaseValue(((Double) keyValues.get(Keys.MAX_HEALTH)).floatValue());
-        float health = ((Double) keyValues.get(Keys.HEALTH)).floatValue();
+        final float health = ((Double) keyValues.get(Keys.HEALTH)).floatValue();
         entity.setHealth(health);
         if (health == 0) {
             entity.attackEntityFrom(DamageSourceRegistryModule.IGNORED_DAMAGE_SOURCE, 10000F);
@@ -71,7 +71,7 @@ public class HealthDataProcessor extends AbstractEntityDataProcessor<EntityLivin
     }
 
     @Override
-    protected Map<Key<?>, ?> getValues(EntityLivingBase entity) {
+    protected Map<Key<?>, ?> getValues(final EntityLivingBase entity) {
         final double health = entity.getHealth();
         final double maxHealth = entity.getMaxHealth();
         return ImmutableMap.<Key<?>, Object>of(Keys.HEALTH, health,
@@ -79,7 +79,7 @@ public class HealthDataProcessor extends AbstractEntityDataProcessor<EntityLivin
     }
 
     @Override
-    public Optional<HealthData> fill(DataContainer container, HealthData healthData) {
+    public Optional<HealthData> fill(final DataContainer container, final HealthData healthData) {
         if (!container.contains(Keys.MAX_HEALTH.getQuery()) || !container.contains(Keys.HEALTH.getQuery())) {
             return Optional.empty();
         }
@@ -89,7 +89,7 @@ public class HealthDataProcessor extends AbstractEntityDataProcessor<EntityLivin
     }
 
     @Override
-    public DataTransactionResult remove(DataHolder dataHolder) {
+    public DataTransactionResult remove(final DataHolder dataHolder) {
         return DataTransactionResult.builder().result(DataTransactionResult.Type.FAILURE).build();
     }
 

--- a/src/main/java/org/spongepowered/common/event/ShouldFire.java
+++ b/src/main/java/org/spongepowered/common/event/ShouldFire.java
@@ -26,6 +26,7 @@ package org.spongepowered.common.event;
 
 public class ShouldFire {
 
+    public static boolean REGAIN_HEALTH_EVENT = false;
     public static boolean PLAYER_CHANGE_CLIENT_SETTINGS_EVENT = false;
     public static boolean CONSTRUCT_ENTITY_EVENT_PRE = false;
 

--- a/src/main/java/org/spongepowered/common/event/SpongeHealingType.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeHealingType.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.event;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import org.spongepowered.api.event.cause.entity.damage.DamageType;
+import org.spongepowered.api.event.cause.entity.health.HealingType;
+
+import java.util.Locale;
+
+public class SpongeHealingType implements HealingType {
+
+    private String id; // TODO: figure out how to handle mods
+    private String name;
+
+    public SpongeHealingType(final String id, final String name) {
+        this.name = name;
+        this.id = id.toLowerCase(Locale.ENGLISH);
+    }
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final SpongeHealingType other = (SpongeHealingType) obj;
+        return this.id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.id, this.name);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("id", this.id)
+                .add("name", this.name)
+                .toString();
+    }
+}

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/block/RestoringBlockPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/block/RestoringBlockPhaseState.java
@@ -101,4 +101,48 @@ final class RestoringBlockPhaseState extends BlockPhaseState {
         return false;
     }
 
+    @Override
+    public boolean tracksBlockSpecificDrops(GeneralizedContext context) {
+        return false;
+    }
+
+    @Override
+    public boolean tracksEntitySpecificDrops() {
+        return false;
+    }
+
+    @Override
+    public boolean doesCaptureEntityDrops(GeneralizedContext context) {
+        return false;
+    }
+
+    @Override
+    public boolean doesDropEventTracking(GeneralizedContext context) {
+        return false;
+    }
+
+    @Override
+    public boolean ignoresScheduledUpdates() {
+        return false;
+    }
+
+    @Override
+    public boolean tracksTileEntityChanges(GeneralizedContext currentContext) {
+        return false;
+    }
+
+    @Override
+    public boolean hasSpecificBlockProcess(GeneralizedContext context) {
+        return false;
+    }
+
+    @Override
+    public boolean doesCaptureNeighborNotifications(GeneralizedContext context) {
+        return false;
+    }
+
+    @Override
+    public boolean allowsGettingQueuedRemovedTiles() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/BlockTickContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/BlockTickContext.java
@@ -50,7 +50,6 @@ public class BlockTickContext extends LocationBasedTickContext<BlockTickContext>
             final LocatableBlock locatableBlock = (LocatableBlock) owner;
             final Block block = ((IBlockState) locatableBlock.getBlockState()).getBlock();
             this.tickingBlock = (BlockBridge) block;
-            this.providesModifier = !(block instanceof BlockDynamicLiquid);
             this.world = locatableBlock.getWorld();
             if (block instanceof TrackableBridge) {
                 final TrackableBridge trackable = (TrackableBridge) block;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityAgeableMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityAgeableMixin.java
@@ -40,7 +40,7 @@ import org.spongepowered.common.event.ShouldFire;
 import java.util.Optional;
 
 @Mixin(EntityAgeable.class)
-public abstract class EntityAgeableMixin extends EntityMixin {
+public abstract class EntityAgeableMixin extends EntityLivingMixin {
 
     @Inject(method = "setGrowingAge", at = @At("RETURN"))
     private void callReadyToMateOnAgeUp(final int age, final CallbackInfo ci) {

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMPMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMPMixin.java
@@ -369,7 +369,7 @@ public abstract class EntityPlayerMPMixin extends EntityPlayerMixin implements S
     @Override
     public User bridge$getUserObject() {
         final UserStorageService service = SpongeImpl.getGame().getServiceManager().provideUnchecked(UserStorageService.class);
-        if (this.isFake) { // Fake players are recogizeable through the field set up with bridge$isFake.
+        if (this.impl$isFake) { // Fake players are recogizeable through the field set up with bridge$isFake.
             return service.getOrCreate(SpongeUserStorageService.FAKEPLAYER_PROFILE);
         }
         return service.getOrCreate((GameProfile) this.getGameProfile());
@@ -418,7 +418,7 @@ public abstract class EntityPlayerMPMixin extends EntityPlayerMixin implements S
      */
     @Overwrite
     public void sendMessage(final ITextComponent component) {
-        if (this.isFake) {
+        if (this.impl$isFake) {
             // Don't bother sending messages to fake players
             return;
         }

--- a/src/main/java/org/spongepowered/common/mixin/core/potion/PotionMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/potion/PotionMixin.java
@@ -24,13 +24,20 @@
  */
 package org.spongepowered.common.mixin.core.potion;
 
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.potion.Potion;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.RegistryNamespaced;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.effect.potion.PotionEffectType;
+import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.api.event.cause.EventContextKeys;
+import org.spongepowered.api.event.cause.entity.health.HealingTypes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.SpongeImplHooks;
+import org.spongepowered.common.event.ShouldFire;
 import org.spongepowered.common.registry.type.effect.PotionEffectTypeRegistryModule;
 
 @Mixin(Potion.class)
@@ -44,6 +51,34 @@ public abstract class PotionMixin {
         final Potion mcPotion = (Potion) potion;
         PotionEffectTypeRegistryModule.getInstance().registerFromGameData(resource.toString(), (PotionEffectType) mcPotion);
         registry.register(id, location, potion);
+    }
+
+    @Redirect(method = "performEffect", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;heal(F)V"))
+    private void impl$addHealingContext(final EntityLivingBase entityLivingBase, final float healAmount) {
+        if (!ShouldFire.REGAIN_HEALTH_EVENT || entityLivingBase.world.isRemote || !SpongeImplHooks.isMainThread()) {
+            entityLivingBase.heal(healAmount);
+            return;
+        }
+        try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+            frame.addContext(EventContextKeys.HEALING_TYPE, HealingTypes.POTION);
+            entityLivingBase.heal(healAmount);
+        }
+    }
+
+    @Redirect(method = "affectEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;heal(F)V"))
+    private void impl$addHealingContextForAffects(final EntityLivingBase entityLivingBase, final float healAmount) {
+        if (entityLivingBase.world.isRemote || !ShouldFire.REGAIN_HEALTH_EVENT || !SpongeImplHooks.isMainThread()) {
+            entityLivingBase.heal(healAmount);
+            return;
+        }
+        try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+            if (entityLivingBase.isEntityUndead()) {
+                frame.addContext(EventContextKeys.HEALING_TYPE, HealingTypes.UNDEAD);
+            } else {
+                frame.addContext(EventContextKeys.HEALING_TYPE, HealingTypes.POTION);
+            }
+            entityLivingBase.heal(healAmount);
+        }
     }
 
 }

--- a/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
@@ -74,6 +74,7 @@ import org.spongepowered.api.event.cause.entity.damage.DamageModifierType;
 import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.damage.source.*;
 import org.spongepowered.api.event.cause.entity.dismount.DismountType;
+import org.spongepowered.api.event.cause.entity.health.HealingType;
 import org.spongepowered.api.event.cause.entity.spawn.SpawnType;
 import org.spongepowered.api.event.cause.entity.teleport.TeleportType;
 import org.spongepowered.api.extra.fluid.FluidStack;
@@ -353,6 +354,7 @@ public final class CommonModuleRegistry {
                 .registerModule(DamageModifierType.class, new DamageModifierTypeRegistryModule())
                 .registerModule(new DamageSourceRegistryModule())
                 .registerModule(DamageType.class, new DamageTypeRegistryModule())
+                .registerModule(HealingType.class, new HealingTypeRegistryModule())
                 .registerModule(DataFormat.class, new DataFormatRegistryModule())
                 .registerModule(DataTranslator.class, DataTranslatorRegistryModule.getInstance())
                 .registerModule(Difficulty.class, DifficultyRegistryModule.getInstance())

--- a/src/main/java/org/spongepowered/common/registry/type/event/EventContextKeysModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/event/EventContextKeysModule.java
@@ -38,6 +38,7 @@ import org.spongepowered.api.event.cause.EventContextKeys;
 import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.event.cause.entity.dismount.DismountType;
+import org.spongepowered.api.event.cause.entity.health.HealingType;
 import org.spongepowered.api.event.cause.entity.spawn.SpawnType;
 import org.spongepowered.api.event.cause.entity.teleport.TeleportType;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
@@ -117,6 +118,7 @@ public final class EventContextKeysModule
         this.createKey("sponge:decay_event", "Decay Event", ChangeBlockEvent.Decay.class);
         this.createKey("sponge:grow_event", "Decay Event", ChangeBlockEvent.Grow.class);
         this.createKey("sponge:growth_origin", "Growth Origin", BlockSnapshot.class);
+        this.createKey("sponge:healing_type", "Healing Type", HealingType.class);
     }
 
     private void createKey(String id, String name, Class<?> usedClass) {

--- a/src/main/java/org/spongepowered/common/registry/type/event/HealingTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/event/HealingTypeRegistryModule.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.registry.type.event;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.spongepowered.api.event.cause.entity.health.HealingType;
+import org.spongepowered.api.event.cause.entity.health.HealingTypes;
+import org.spongepowered.api.registry.AdditionalCatalogRegistryModule;
+import org.spongepowered.api.registry.util.RegisterCatalog;
+import org.spongepowered.common.event.SpongeHealingType;
+import org.spongepowered.common.registry.type.AbstractPrefixAlternateCatalogTypeRegistryModule;
+
+import java.util.Locale;
+
+@RegisterCatalog(HealingTypes.class)
+public class HealingTypeRegistryModule extends AbstractPrefixAlternateCatalogTypeRegistryModule<HealingType>
+    implements AdditionalCatalogRegistryModule<HealingType> {
+
+    public HealingTypeRegistryModule() {
+        super("minecraft");
+    }
+
+    @Override
+    public void registerAdditionalCatalog(final HealingType extraCatalog) {
+        final String id = checkNotNull(extraCatalog).getId();
+        final String key = id.toLowerCase(Locale.ENGLISH);
+        checkArgument(!key.contains("sponge:"), "Cannot register spoofed Damage Type!");
+        checkArgument(!key.contains("minecraft:"), "Cannot register spoofed Damage Type!");
+        checkArgument(!this.catalogTypeMap.containsKey(key), "Cannot register an already registered EventContextKey: %s", key);
+        this.catalogTypeMap.put(key, extraCatalog);
+    }
+
+    @Override
+    public void registerDefaults() {
+        register(new SpongeHealingType("minecraft:generic", "generic"));
+        register(new SpongeHealingType("minecraft:boss", "boss"));
+        register(new SpongeHealingType("minecraft:food", "food"));
+        register(new SpongeHealingType("minecraft:plugin", "plugin"));
+        register(new SpongeHealingType("minecraft:potion", "potion"));
+        register(new SpongeHealingType("minecraft:undead", "undead"));
+    }
+}

--- a/src/main/java/org/spongepowered/common/world/schematic/SpongeArchetypeVolume.java
+++ b/src/main/java/org/spongepowered/common/world/schematic/SpongeArchetypeVolume.java
@@ -130,8 +130,12 @@ public class SpongeArchetypeVolume extends AbstractBlockBuffer implements Archet
 
     @Override
     public void apply(Location<World> location, BlockChangeFlag changeFlag) {
+        final World world = location.getExtent();
         this.backing.getBlockWorker().iterate((v, x, y, z) -> {
-            location.getExtent().setBlock(x + location.getBlockX(), y + location.getBlockY(), z + location.getBlockZ(), v.getBlock(x, y, z), changeFlag);
+            final int posX = x + location.getBlockX();
+            final int posY = y + location.getBlockY();
+            final int posZ = z + location.getBlockZ();
+            world.setBlock(posX, posY, posZ, v.getBlock(x, y, z), changeFlag.withPhysics(false));
         });
         for (Vector3i pos : this.tiles.keySet()) {
             TileEntityArchetype archetype = this.tiles.get(pos);


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2035) | **SpongeCommon**

Implementation of the new proposed `RegainHealthEvent`. There's compatibility built in with some foreign mods like AppleCore that expect to replace certain method calls already and directly call `EntityLivingBase.heal(F)`, so some `@Redirect`s are instead `@Inject`s awaiting the feature of trycatch mixin injections.