### PR TITLE
Fix/data compound

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
@@ -191,8 +191,13 @@ public abstract class EntityLivingBaseMixin extends EntityMixin implements Livin
     @Override
     public void bridge$setMaxAir(final int air) {
         this.impl$maxAir = air;
-        if (air == Constants.Sponge.Entity.DEFAULT_MAX_AIR && this instanceof DataCompoundHolder && ((DataCompoundHolder) this).data$hasSpongeCompound()) {
-            ((DataCompoundHolder) this).data$getSpongeCompound().removeTag(Constants.Sponge.Entity.MAX_AIR);
+        if (air != Constants.Sponge.Entity.DEFAULT_MAX_AIR) {
+            final NBTTagCompound spongeData = ((DataCompoundHolder) this).data$getSpongeCompound();
+            spongeData.setInteger(Constants.Sponge.Entity.MAX_AIR, air);
+        } else {
+            if (((DataCompoundHolder) this).data$hasSpongeCompound()) {
+                ((DataCompoundHolder) this).data$getSpongeCompound().removeTag(Constants.Sponge.Entity.MAX_AIR);
+            }
         }
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java
@@ -591,8 +591,13 @@ public abstract class EntityMixin implements EntityBridge, TrackableBridge, Vani
     @Override
     public void bridge$setInvisible(final boolean invisible) {
         this.setInvisible(invisible);
-        if (!invisible && this instanceof DataCompoundHolder && ((DataCompoundHolder) this).data$hasSpongeCompound()) {
-            ((DataCompoundHolder) this).data$getSpongeCompound().removeTag(Constants.Sponge.Entity.IS_INVISIBLE);
+        if (invisible) {
+            final NBTTagCompound spongeData = ((DataCompoundHolder) this).data$getSpongeCompound();
+            spongeData.setBoolean(Constants.Sponge.Entity.IS_INVISIBLE, true);
+        } else {
+            if (((DataCompoundHolder) this).data$hasSpongeCompound()) {
+                ((DataCompoundHolder) this).data$getSpongeCompound().removeTag(Constants.Sponge.Entity.IS_INVISIBLE);
+            }
         }
     }
 
@@ -606,11 +611,12 @@ public abstract class EntityMixin implements EntityBridge, TrackableBridge, Vani
         this.vanish$isVanished = vanished;
         this.vanish$pendingVisibilityUpdate = true;
         this.vanish$visibilityTicks = 20;
-        if (this instanceof DataCompoundHolder && ((DataCompoundHolder) this).data$hasSpongeCompound()) {
+        if (vanished) {
             final NBTTagCompound spongeData = ((DataCompoundHolder) this).data$getSpongeCompound();
-            if (vanished) {
-                spongeData.setBoolean(Constants.Sponge.Entity.IS_VANISHED, true);
-            } else {
+            spongeData.setBoolean(Constants.Sponge.Entity.IS_VANISHED, true);
+        } else {
+            if (((DataCompoundHolder) this).data$hasSpongeCompound()) {
+                final NBTTagCompound spongeData = ((DataCompoundHolder) this).data$getSpongeCompound();
                 spongeData.removeTag(Constants.Sponge.Entity.IS_VANISHED);
                 spongeData.removeTag(Constants.Sponge.Entity.VANISH_UNCOLLIDEABLE);
                 spongeData.removeTag(Constants.Sponge.Entity.VANISH_UNTARGETABLE);

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java
@@ -83,6 +83,7 @@ import org.spongepowered.common.SpongeImplHooks;
 import org.spongepowered.common.bridge.TimingBridge;
 import org.spongepowered.common.bridge.TrackableBridge;
 import org.spongepowered.common.bridge.block.BlockBridge;
+import org.spongepowered.common.bridge.data.CustomDataHolderBridge;
 import org.spongepowered.common.bridge.data.DataCompoundHolder;
 import org.spongepowered.common.bridge.data.InvulnerableTrackedBridge;
 import org.spongepowered.common.bridge.data.VanishableBridge;
@@ -446,7 +447,7 @@ public abstract class EntityMixin implements EntityBridge, TrackableBridge, Vani
      */
     @Inject(method = "writeToNBT(Lnet/minecraft/nbt/NBTTagCompound;)Lnet/minecraft/nbt/NBTTagCompound;", at = @At("HEAD"))
     private void onSpongeWriteToNBT(final NBTTagCompound compound, final CallbackInfoReturnable<NBTTagCompound> ci) {
-        if (((DataCompoundHolder) this).data$hasRootCompound()) {
+        if (((CustomDataHolderBridge) this).bridge$hasManipulators()) {
             this.spongeImpl$writeToSpongeCompound(((DataCompoundHolder) this).data$getSpongeCompound());
         }
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/GrieferBridgeMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/GrieferBridgeMixin.java
@@ -28,6 +28,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.projectile.EntityLargeFireball;
 import net.minecraft.entity.projectile.EntitySmallFireball;
 import net.minecraft.entity.projectile.EntityWitherSkull;
+import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.common.bridge.data.DataCompoundHolder;
 import org.spongepowered.common.bridge.entity.GrieferBridge;
@@ -46,8 +47,13 @@ public abstract class GrieferBridgeMixin implements GrieferBridge {
     @Override
     public void bridge$SetCanGrief(final boolean grief) {
         this.griefer$canGrief = grief;
-        if (!grief && this instanceof DataCompoundHolder && ((DataCompoundHolder) this).data$hasSpongeCompound()) {
-            ((DataCompoundHolder) this).data$getSpongeCompound().removeTag(Constants.Sponge.Entity.CAN_GRIEF);
+        if (grief) {
+            final NBTTagCompound spongeData = ((DataCompoundHolder) this).data$getSpongeCompound();
+            spongeData.setBoolean(Constants.Sponge.Entity.CAN_GRIEF, true);
+        } else {
+            if (((DataCompoundHolder) this).data$hasSpongeCompound()) {
+                ((DataCompoundHolder) this).data$getSpongeCompound().removeTag(Constants.Sponge.Entity.CAN_GRIEF);
+            }
         }
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMPMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMPMixin.java
@@ -761,10 +761,13 @@ public abstract class EntityPlayerMPMixin extends EntityPlayerMixin implements S
         this.impl$healthScale = scale;
         this.impl$cachedModifiedHealth = -1;
         this.lastHealth = -1.0F;
-        if (scale == Constants.Entity.Player.DEFAULT_HEALTH_SCALE
-            && this instanceof DataCompoundHolder
-            && ((DataCompoundHolder) this).data$hasSpongeCompound()) {
-            ((DataCompoundHolder) this).data$getSpongeCompound().removeTag(Constants.Sponge.Entity.Player.HEALTH_SCALE);
+        if (scale != Constants.Entity.Player.DEFAULT_HEALTH_SCALE) {
+            final NBTTagCompound spongeData = ((DataCompoundHolder) this).data$getSpongeCompound();
+            spongeData.setDouble(Constants.Sponge.Entity.Player.HEALTH_SCALE, scale);
+        } else {
+            if (((DataCompoundHolder) this).data$hasSpongeCompound()) {
+                ((DataCompoundHolder) this).data$getSpongeCompound().removeTag(Constants.Sponge.Entity.Player.HEALTH_SCALE);
+            }
         }
         bridge$refreshScaledHealth();
     }


### PR DESCRIPTION
Sponge data: they are stored to the compound on setting (if there's no compound, create it), not on write.
Custom data: the entity needs to say "if i have custom manipulators, write it"

This make sure the current system respect that.
It should fix https://github.com/SpongePowered/SpongeCommon/issues/2367