### PR TITLE
Fix/move event

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
@@ -423,7 +423,7 @@ public abstract class NetHandlerPlayServerMixin implements NetHandlerPlayServerB
                 final Transform<World> fromTransform = player.getTransform().setPosition(fromPosition).setRotation(fromRotation);
                 Transform<World> toTransform = player.getTransform().setPosition(toPosition).setRotation(toRotation);
                 final Transform<World> originalToTransform = toTransform;
-                if (rotating && ShouldFire.ROTATE_ENTITY_EVENT && !packetIn.moving) {
+                if (rotating && ShouldFire.ROTATE_ENTITY_EVENT && !moving) {
                     final RotateEntityEvent event = SpongeEventFactory.createRotateEntityEvent(Sponge.getCauseStackManager().getCurrentCause(), fromTransform, toTransform, player);
                     if (SpongeImpl.postEvent(event)) {
                         toTransform.setRotation(fromTransform.getRotation());

--- a/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
@@ -423,7 +423,7 @@ public abstract class NetHandlerPlayServerMixin implements NetHandlerPlayServerB
                 final Transform<World> fromTransform = player.getTransform().setPosition(fromPosition).setRotation(fromRotation);
                 Transform<World> toTransform = player.getTransform().setPosition(toPosition).setRotation(toRotation);
                 final Transform<World> originalToTransform = toTransform;
-                if (rotating && ShouldFire.ROTATE_ENTITY_EVENT) {
+                if (rotating && ShouldFire.ROTATE_ENTITY_EVENT && !packetIn.moving) {
                     final RotateEntityEvent event = SpongeEventFactory.createRotateEntityEvent(Sponge.getCauseStackManager().getCurrentCause(), fromTransform, toTransform, player);
                     if (SpongeImpl.postEvent(event)) {
                         toTransform.setRotation(fromTransform.getRotation());


### PR DESCRIPTION
MoveEntityEvent could be bypassed if `CPacketPlayer.PositionRotation` was sent since it has both `moving` and `rotating` field set to true and sponge was using 

`boolean positionOnly = packetIn.moving && !packetIn.rotating;`
`boolean rotationOnly = !packetIn.moving && packetIn.rotating;`

and it would fire an event only `if (rotationOnly || positionOnly)`