### PR TITLE
Fix wrapped command permission checks [#2372]

### DIFF
--- a/src/main/java/org/spongepowered/common/command/MinecraftCommandWrapper.java
+++ b/src/main/java/org/spongepowered/common/command/MinecraftCommandWrapper.java
@@ -185,8 +185,7 @@ public class MinecraftCommandWrapper implements CommandCallable {
 
     @Override
     public boolean testPermission(CommandSource source) {
-        ICommandSender sender = WrapperICommandSender.of(source);
-        return this.command.checkPermission(sender.getServer(), sender);
+        return source.hasPermission(getCommandPermission());
     }
 
     @Override


### PR DESCRIPTION
This is a draft PR awaiting testing and feedback to understand the scope of changes and consequences, as well as discussion towards a final solution.

The `MinecraftWrappedCommand` class contains commands from both Minecraft and Forge, which Sponge provides permissions for as shown on the [Sponge docs](https://docs.spongepowered.org/stable/en/server/spongineer/commands.html#forge). The current implementation uses the permission level system in the `testPermission` method, which effectively bypasses the permission system and includes commands with a permission level of `0`. This is how I believe these commands are being included in help commands and related.

I am concerned with this implementation for a number of reasons, the largest being the fact that these permissions presumably work for these commands, meaning the actual permission string is being checked elsewhere. I will have to examine this further in Vanilla/Forge to see what happens. Additionally, I'm not sure what happens if a permission service is not present and the permission level does come into play - this likely does not maintain the same behavior here.

Assistance with tracking this down would be greatly appreciated.