### PR TITLE
Add config entry for ensuring mod command permissions are checked.

### DIFF
--- a/src/main/java/org/spongepowered/common/command/MinecraftCommandWrapper.java
+++ b/src/main/java/org/spongepowered/common/command/MinecraftCommandWrapper.java
@@ -185,8 +185,13 @@ public class MinecraftCommandWrapper implements CommandCallable {
 
     @Override
     public boolean testPermission(CommandSource source) {
-        ICommandSender sender = WrapperICommandSender.of(source);
-        return this.command.checkPermission(sender.getServer(), sender);
+        if (!SpongeImpl.getGlobalConfigAdapter().getConfig().getCommands().isEnforcePermissionChecksOnNonSpongeCommands()
+            || source.hasPermission(getCommandPermission())) {
+            ICommandSender sender = WrapperICommandSender.of(source);
+            return this.command.checkPermission(sender.getServer(), sender);
+        }
+
+        return false;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/config/category/CommandsCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/CommandsCategory.java
@@ -37,10 +37,24 @@ public class CommandsCategory extends ConfigCategory {
                      + "Correct syntax is <unqualified command>=<plugin name> e.g. \"sethome=homeplugin\"")
     private Map<String, String> aliases = new HashMap<>();
 
+    @Setting(value = "enforce-permission-checks-on-non-sponge-commands",
+            comment = "Some mods may not trigger a permission check when running their command. Setting this to\n"
+                    + "true will enforce a check of the Sponge provided permission (\"<modid>.command.<commandname>\").\n"
+                    + "Note that setting this to true may cause some commands that are generally accessible to all to\n"
+                    + "require a permission to run.\n\n"
+                    + "Setting this to true will enable greater control over whether a command will appear in\n"
+                    + "tab completion and Sponge's help command.\n\n"
+                    + "If you are not using a permissions plugin, it is highly recommended that this is set to false\n"
+                    + "(as it is by default).")
+    private boolean enforcePermissionChecksOnNonSpongeCommands = false;
 
     @Setting(value = "multi-world-patches", comment = "Patches the specified commands to respect the world of the sender instead of applying the \n"
                                                     + "changes on the all worlds.")
     private Map<String, Boolean> multiWorldCommandPatches = new HashMap<>();
+
+    public boolean isEnforcePermissionChecksOnNonSpongeCommands() {
+        return this.enforcePermissionChecksOnNonSpongeCommands;
+    }
 
     public Map<String, String> getAliases() {
         return this.aliases;


### PR DESCRIPTION
This is informed by, and supersedes, #2375 - there was a lot of discussion there regarding defaults that might be useful background reading. Also see #2372.

Some mod `ICommand`s, such as WorldEdit, have their `checkPermission` methods always return `true` - usually because they do their own permission handling during their invocation. This causes Sponge to not perform any permission checks before a command invocation (as we hook into `ICommandSender#canUseCommand`), and may not during, depending on what the command execute command contains. As a result, such commands appear in `/help` and tab completion, even though standard players cannot execute the commands themselves (because the permission check occurs later on).

A simple solution would be to **additionally** check for the Sponge permission during invocation before testing if the mod grants permission. However, this would break simple, op/no-op setups, effectively meaning that all non `CommandBase` derived `ICommands` would require op status, even if they wouldn't without Sponge.

I played about with trying to use a dummy `ICommandSender` on the `checkPermission` command to try to determine if a permission check occurs, and if not, defaulting the command permission to `true` using the `PermissionService`, as we do for regular Minecraft commands that provide an op level. However, I figured that the simplest solution would be to just put this behind a default off config. That way, if a user wants the additional Sponge permissions to take effect, this can be toggled on. I think this is a reasonable compromise, but it _does_ mean that users would have to be aware of the setting.

Obligatory screenshots to show it works ([using this test mod](https://gist.github.com/dualspiral/db53abdbbebd5af02c51e977e4934ac6)):

**Before**
![before](https://user-images.githubusercontent.com/1904167/64810488-64d37800-d593-11e9-8252-343e8cd5b6e1.png)

**After (note that the `perms-true-test` command permission is now checked)**
![after](https://user-images.githubusercontent.com/1904167/64810500-6b61ef80-d593-11e9-8d9b-8cd2c0f30c00.png)

[If we want to try to do this detection, this is what I had in mind](https://gist.github.com/dualspiral/7393dc8d7563d4806951f0a0d4630e92). I just don't think it's worth it.