### PR TITLE
Make hiding commands that subjects don't have permission for configurable

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeImpl.java
+++ b/src/main/java/org/spongepowered/common/SpongeImpl.java
@@ -44,6 +44,7 @@ import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.game.state.GameStateEvent;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.util.Direction;
+import org.spongepowered.common.command.SpongeCommandManager;
 import org.spongepowered.common.config.SpongeConfig;
 import org.spongepowered.common.config.SpongeConfigSaveManager;
 import org.spongepowered.common.config.type.CustomDataConfig;
@@ -96,6 +97,7 @@ public final class SpongeImpl {
     @Inject @Nullable private static SpongeDataManager dataManager;
     @Inject @Nullable private static SpongePropertyRegistry propertyRegistry;
     @Inject @Nullable private static SpongeScheduler scheduler;
+    @Inject @Nullable private static SpongeCommandManager commandManager;
     @Inject @Nullable private static SpongeCauseStackManager causeStackManager;
 
     private static final List<PluginContainer> internalPlugins = new ArrayList<>();
@@ -154,6 +156,10 @@ public final class SpongeImpl {
 
     public static SpongeScheduler getScheduler() {
         return check(scheduler);
+    }
+
+    public static SpongeCommandManager getCommandManager() {
+        return check(commandManager);
     }
 
     public static SpongeCauseStackManager getCauseStackManager() {

--- a/src/main/java/org/spongepowered/common/command/SpongeCommandDisambiguator.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommandDisambiguator.java
@@ -35,7 +35,6 @@ import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.command.CommandMapping;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.dispatcher.Disambiguator;
-import org.spongepowered.api.command.dispatcher.SimpleDispatcher;
 import org.spongepowered.common.SpongeImpl;
 
 import java.util.List;
@@ -48,7 +47,7 @@ public class SpongeCommandDisambiguator implements Disambiguator {
     private final Game game;
 
     /**
-     * Disambiguator that takes preferences from the global configuration, falling back to {@link SimpleDispatcher#FIRST_DISAMBIGUATOR}.
+     * Disambiguator that takes preferences from the global configuration, falling back to {@link SpongeCommandDispatcher#FIRST_DISAMBIGUATOR}.
      *
      * @param game The game instance to be used
      */
@@ -84,6 +83,6 @@ public class SpongeCommandDisambiguator implements Disambiguator {
                 }
             }
         }
-        return SimpleDispatcher.FIRST_DISAMBIGUATOR.disambiguate(source, aliasUsed, availableOptions);
+        return SpongeCommandDispatcher.FIRST_DISAMBIGUATOR.disambiguate(source, aliasUsed, availableOptions);
     }
 }

--- a/src/main/java/org/spongepowered/common/command/SpongeCommandDispatcher.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommandDispatcher.java
@@ -1,0 +1,471 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.command;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.spongepowered.api.command.CommandMessageFormatting.SPACE_TEXT;
+import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandCallable;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandMapping;
+import org.spongepowered.api.command.CommandMessageFormatting;
+import org.spongepowered.api.command.CommandNotFoundException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.ImmutableCommandMapping;
+import org.spongepowered.api.command.dispatcher.Disambiguator;
+import org.spongepowered.api.command.dispatcher.Dispatcher;
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
+import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.text.format.TextStyles;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+import org.spongepowered.common.SpongeImpl;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+final class SpongeCommandDispatcher implements Dispatcher {
+
+    private static final BiPredicate<CommandSource, CommandMapping> ON_EXECUTE = (source, mapping) -> {
+        if (SpongeImpl.getGlobalConfigAdapter().getConfig().getCommands().getCommandHiding().isHideDuringExecution()) {
+            return mapping.getCallable().testPermission(source);
+        }
+
+        return true;
+    };
+    static final BiPredicate<CommandSource, CommandMapping> ON_DISCOVERY = (source, mapping) -> {
+        if (SpongeImpl.getGlobalConfigAdapter().getConfig().getCommands().getCommandHiding().isHideDuringDiscovery()) {
+            return mapping.getCallable().testPermission(source);
+        }
+
+        return true;
+    };
+
+    /**
+     * This is a disambiguator function that returns the first matching command.
+     */
+    static final Disambiguator FIRST_DISAMBIGUATOR = (source, aliasUsed, availableOptions) -> {
+        for (CommandMapping mapping : availableOptions) {
+            if (mapping.getPrimaryAlias().toLowerCase().equals(aliasUsed.toLowerCase())) {
+                return Optional.of(mapping);
+            }
+        }
+        return Optional.of(availableOptions.get(0));
+    };
+
+    private final Disambiguator disambiguatorFunc;
+    private final ListMultimap<String, CommandMapping> commands = ArrayListMultimap.create();
+
+    /**
+     * Creates a new dispatcher with a specific disambiguator.
+     *
+     * @param disambiguatorFunc Function that returns the preferred command if
+     *     multiple exist for a given alias
+     */
+    public SpongeCommandDispatcher(Disambiguator disambiguatorFunc) {
+        this.disambiguatorFunc = disambiguatorFunc;
+    }
+
+    /**
+     * Register a given command using the given list of aliases.
+     *
+     * <p>If there is a conflict with one of the aliases (i.e. that alias
+     * is already assigned to another command), then the alias will be skipped.
+     * It is possible for there to be no alias to be available out of
+     * the provided list of aliases, which would mean that the command would not
+     * be assigned to any aliases.</p>
+     *
+     * <p>The first non-conflicted alias becomes the "primary alias."</p>
+     *
+     * @param callable The command
+     * @param alias An array of aliases
+     * @return The registered command mapping, unless no aliases could be
+     *     registered
+     */
+    public Optional<CommandMapping> register(CommandCallable callable, String... alias) {
+        checkNotNull(alias, "alias");
+        return register(callable, Arrays.asList(alias));
+    }
+
+    /**
+     * Register a given command using the given list of aliases.
+     *
+     * <p>If there is a conflict with one of the aliases (i.e. that alias
+     * is already assigned to another command), then the alias will be skipped.
+     * It is possible for there to be no alias to be available out of
+     * the provided list of aliases, which would mean that the command would not
+     * be assigned to any aliases.</p>
+     *
+     * <p>The first non-conflicted alias becomes the "primary alias."</p>
+     *
+     * @param callable The command
+     * @param aliases A list of aliases
+     * @return The registered command mapping, unless no aliases could be
+     *     registered
+     */
+    public Optional<CommandMapping> register(CommandCallable callable, List<String> aliases) {
+        return register(callable, aliases, Function.identity());
+    }
+
+    /**
+     * Register a given command using a given list of aliases.
+     *
+     * <p>The provided callback function will be called with a list of aliases
+     * that are not taken (from the list of aliases that were requested) and
+     * it should return a list of aliases to actually register. Aliases may be
+     * removed, and if no aliases remain, then the command will not be
+     * registered. It may be possible that no aliases are available, and thus
+     * the callback would receive an empty list. New aliases should not be added
+     * to the list in the callback as this may cause
+     * {@link IllegalArgumentException} to be thrown.</p>
+     *
+     * <p>The first non-conflicted alias becomes the "primary alias."</p>
+     *
+     * @param callable The command
+     * @param aliases A list of aliases
+     * @param callback The callback
+     * @return The registered command mapping, unless no aliases could
+     *     be registered
+     */
+    public synchronized Optional<CommandMapping> register(CommandCallable callable, List<String> aliases,
+            Function<List<String>, List<String>> callback) {
+        checkNotNull(aliases, "aliases");
+        checkNotNull(callable, "callable");
+        checkNotNull(callback, "callback");
+
+        // Invoke the callback with the commands that /can/ be registered
+        // noinspection ConstantConditions
+        aliases = ImmutableList.copyOf(callback.apply(aliases));
+        if (aliases.isEmpty()) {
+            return Optional.empty();
+        }
+        String primary = aliases.get(0);
+        List<String> secondary = aliases.subList(1, aliases.size());
+        CommandMapping mapping = new ImmutableCommandMapping(callable, primary, secondary);
+
+        for (String alias : aliases) {
+            this.commands.put(alias.toLowerCase(), mapping);
+        }
+
+        return Optional.of(mapping);
+    }
+
+    /**
+     * Remove a mapping identified by the given alias.
+     *
+     * @param alias The alias
+     * @return The previous mapping associated with the alias, if one was found
+     */
+    public synchronized Collection<CommandMapping> remove(String alias) {
+        return this.commands.removeAll(alias.toLowerCase());
+    }
+
+    /**
+     * Remove all mappings identified by the given aliases.
+     *
+     * @param aliases A collection of aliases
+     * @return Whether any were found
+     */
+    public synchronized boolean removeAll(Collection<?> aliases) {
+        checkNotNull(aliases, "aliases");
+
+        boolean found = false;
+
+        for (Object alias : aliases) {
+            if (!this.commands.removeAll(alias.toString().toLowerCase()).isEmpty()) {
+                found = true;
+            }
+        }
+
+        return found;
+    }
+
+    /**
+     * Remove a command identified by the given mapping.
+     *
+     * @param mapping The mapping
+     * @return The previous mapping associated with the alias, if one was found
+     */
+    public synchronized Optional<CommandMapping> removeMapping(CommandMapping mapping) {
+        checkNotNull(mapping, "mapping");
+
+        CommandMapping found = null;
+
+        Iterator<CommandMapping> it = this.commands.values().iterator();
+        while (it.hasNext()) {
+            CommandMapping current = it.next();
+            if (current.equals(mapping)) {
+                it.remove();
+                found = current;
+            }
+        }
+
+        return Optional.ofNullable(found);
+    }
+
+    /**
+     * Remove all mappings contained with the given collection.
+     *
+     * @param mappings The collection
+     * @return Whether the at least one command was removed
+     */
+    public synchronized boolean removeMappings(Collection<?> mappings) {
+        checkNotNull(mappings, "mappings");
+
+        boolean found = false;
+
+        Iterator<CommandMapping> it = this.commands.values().iterator();
+        while (it.hasNext()) {
+            if (mappings.contains(it.next())) {
+                it.remove();
+                found = true;
+            }
+        }
+
+        return found;
+    }
+
+    @Override
+    public synchronized Set<CommandMapping> getCommands() {
+        return ImmutableSet.copyOf(this.commands.values());
+    }
+
+    @Override
+    public synchronized Set<String> getPrimaryAliases() {
+        Set<String> aliases = new HashSet<>();
+
+        for (CommandMapping mapping : this.commands.values()) {
+            aliases.add(mapping.getPrimaryAlias());
+        }
+
+        return Collections.unmodifiableSet(aliases);
+    }
+
+    @Override
+    public synchronized Set<String> getAliases() {
+        Set<String> aliases = new HashSet<>();
+
+        for (CommandMapping mapping : this.commands.values()) {
+            aliases.addAll(mapping.getAllAliases());
+        }
+
+        return Collections.unmodifiableSet(aliases);
+    }
+
+    @Override
+    public Optional<CommandMapping> get(String alias) {
+        return get(alias, null);
+    }
+
+    @Override
+    public synchronized Optional<CommandMapping> get(String alias, @Nullable CommandSource source) {
+        return get(alias, source, (src, mapping) -> mapping.getCallable().testPermission(src));
+    }
+
+    public synchronized Optional<CommandMapping> get(String alias,
+            @Nullable CommandSource source,
+            BiPredicate<CommandSource, CommandMapping> filter) {
+        List<CommandMapping> results = this.commands.get(alias.toLowerCase());
+        Optional<CommandMapping> result = Optional.empty();
+        if (results.size() == 1) {
+            result = Optional.of(results.get(0));
+        } else if (results.size() > 1) {
+            result = this.disambiguatorFunc.disambiguate(source, alias, results);
+        }
+        return result.filter(x -> source == null || filter.test(source, x));
+    }
+
+    @Override
+    public synchronized boolean containsAlias(String alias) {
+        return this.commands.containsKey(alias.toLowerCase());
+    }
+
+    @Override
+    public boolean containsMapping(CommandMapping mapping) {
+        checkNotNull(mapping, "mapping");
+
+        for (CommandMapping test : this.commands.values()) {
+            if (mapping.equals(test)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public CommandResult process(CommandSource source, String commandLine) throws CommandException {
+        final String[] argSplit = commandLine.split(" ", 2);
+        Optional<CommandMapping> cmdOptional = get(argSplit[0], source, ON_EXECUTE);
+        if (!cmdOptional.isPresent()) {
+            throw new CommandNotFoundException(t("commands.generic.notFound"), argSplit[0]); // TODO: Fix properly to use a SpongeTranslation??
+        }
+        final String arguments = argSplit.length > 1 ? argSplit[1] : "";
+        CommandMapping mapping = cmdOptional.get();
+        Optional<PluginContainer> pluginOwner = Sponge.getCommandManager().getOwner(mapping);
+        pluginOwner.ifPresent(pluginContainer -> Sponge.getCauseStackManager().pushCause(pluginContainer));
+        final CommandCallable spec = mapping.getCallable();
+        Sponge.getCauseStackManager().pushCause(spec);
+        try {
+            return spec.process(source, arguments);
+        } catch (CommandNotFoundException e) {
+            throw new CommandException(t("No such child command: %s", e.getCommand()));
+        } finally {
+            if (pluginOwner.isPresent()) {
+                Sponge.getCauseStackManager().popCause();
+            }
+
+            Sponge.getCauseStackManager().popCause();
+        }
+    }
+
+    @Override
+    public List<String> getSuggestions(CommandSource src, final String arguments, @Nullable Location<World> targetPosition) throws CommandException {
+        final String[] argSplit = arguments.split(" ", 2);
+        Optional<CommandMapping> cmdOptional = get(argSplit[0], src, ON_DISCOVERY);
+        if (argSplit.length == 1) {
+            return filterCommands(src, argSplit[0]).stream().collect(ImmutableList.toImmutableList());
+        } else if (!cmdOptional.isPresent()) {
+            return ImmutableList.of();
+        }
+        return cmdOptional.get().getCallable().getSuggestions(src, argSplit[1], targetPosition);
+    }
+
+    @Override
+    public boolean testPermission(CommandSource source) {
+        for (CommandMapping mapping : this.commands.values()) {
+            if (mapping.getCallable().testPermission(source)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Optional<Text> getShortDescription(CommandSource source) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Text> getHelp(CommandSource source) {
+        if (this.commands.isEmpty()) {
+            return Optional.empty();
+        }
+        Text.Builder build = t("Available commands:\n").toBuilder();
+        for (Iterator<String> it = filterCommands(source).iterator(); it.hasNext();) {
+            final Optional<CommandMapping> mappingOpt = get(it.next(), source);
+            if (!mappingOpt.isPresent()) {
+                continue;
+            }
+            CommandMapping mapping = mappingOpt.get();
+            final Optional<Text> description = mapping.getCallable().getShortDescription(source);
+            build.append(Text.builder(mapping.getPrimaryAlias())
+                            .color(TextColors.GREEN)
+                            .style(TextStyles.UNDERLINE)
+                            .onClick(TextActions.suggestCommand("/" + mapping.getPrimaryAlias())).build(),
+                    SPACE_TEXT, description.orElse(mapping.getCallable().getUsage(source)));
+            if (it.hasNext()) {
+                build.append(Text.NEW_LINE);
+            }
+        }
+        return Optional.of(build.build());
+    }
+
+    private Set<String> filterCommands(final CommandSource src) {
+        return Multimaps.filterValues(this.commands, input -> input.getCallable().testPermission(src)).keys().elementSet();
+    }
+
+    // Filter out commands by String first
+    private Set<String> filterCommands(final CommandSource src, String start) {
+        ListMultimap<String, CommandMapping> map = Multimaps.filterKeys(this.commands,
+                input -> input != null && input.toLowerCase().startsWith(start.toLowerCase()));
+        return Multimaps.filterValues(map, input -> input.getCallable().testPermission(src)).keys().elementSet();
+    }
+
+    /**
+     * Gets the number of registered aliases.
+     *
+     * @return The number of aliases
+     */
+    public synchronized int size() {
+        return this.commands.size();
+    }
+
+    @Override
+    public Text getUsage(final CommandSource source) {
+        final Text.Builder build = Text.builder();
+        Iterable<String> filteredCommands = filterCommands(source).stream()
+                .filter(input -> {
+                    if (input == null) {
+                        return false;
+                    }
+                    final Optional<CommandMapping> ret = get(input, source);
+                    return ret.isPresent() && ret.get().getPrimaryAlias().equals(input);
+                })
+                .collect(Collectors.toList());
+
+        for (Iterator<String> it = filteredCommands.iterator(); it.hasNext();) {
+            build.append(Text.of(it.next()));
+            if (it.hasNext()) {
+                build.append(CommandMessageFormatting.PIPE_TEXT);
+            }
+        }
+        return build.build();
+    }
+
+    @Override
+    public synchronized Set<CommandMapping> getAll(String alias) {
+        return ImmutableSet.copyOf(this.commands.get(alias));
+    }
+
+    @Override
+    public Multimap<String, CommandMapping> getAll() {
+        return ImmutableMultimap.copyOf(this.commands);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/command/SpongeCommandManager.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommandManager.java
@@ -58,7 +58,6 @@ import org.spongepowered.api.text.serializer.TextSerializers;
 import org.spongepowered.api.util.TextMessageException;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
-import org.spongepowered.common.bridge.entity.player.InventoryPlayerBridge;
 import org.spongepowered.common.bridge.inventory.TrackedInventoryBridge;
 import org.spongepowered.common.event.ShouldFire;
 import org.spongepowered.common.event.tracking.phase.general.CommandPhaseContext;
@@ -77,6 +76,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -92,7 +92,7 @@ public class SpongeCommandManager implements CommandManager {
 
     private static final Pattern SPACE_PATTERN = Pattern.compile(" ", Pattern.LITERAL);
     private final Logger logger;
-    private final SimpleDispatcher dispatcher;
+    private final SpongeCommandDispatcher dispatcher;
     private final Multimap<PluginContainer, CommandMapping> owners = HashMultimap.create();
     private final Map<CommandMapping, PluginContainer> reverseOwners = new ConcurrentHashMap<>();
     private final Object lock = new Object();
@@ -104,7 +104,7 @@ public class SpongeCommandManager implements CommandManager {
      */
     @Inject
     public SpongeCommandManager(Logger logger) {
-        this(logger, SimpleDispatcher.FIRST_DISAMBIGUATOR);
+        this(logger, SpongeCommandDispatcher.FIRST_DISAMBIGUATOR);
     }
 
     /**
@@ -115,7 +115,7 @@ public class SpongeCommandManager implements CommandManager {
      */
     public SpongeCommandManager(Logger logger, Disambiguator disambiguator) {
         this.logger = logger;
-        this.dispatcher = new SimpleDispatcher(disambiguator);
+        this.dispatcher = new SpongeCommandDispatcher(disambiguator);
     }
 
     @Override
@@ -272,6 +272,10 @@ public class SpongeCommandManager implements CommandManager {
     @Override
     public Optional<? extends CommandMapping> get(String alias, @Nullable CommandSource source) {
         return this.dispatcher.get(alias, source);
+    }
+
+    Optional<? extends CommandMapping> get(String alias, @Nullable CommandSource source, BiPredicate<CommandSource, CommandMapping> filter) {
+        return this.dispatcher.get(alias, source, filter);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/config/category/CommandsCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/CommandsCategory.java
@@ -52,6 +52,11 @@ public class CommandsCategory extends ConfigCategory {
                                                     + "changes on the all worlds.")
     private Map<String, Boolean> multiWorldCommandPatches = new HashMap<>();
 
+    @Setting(value = "command-hiding",
+            comment = "Defines how Sponge should act when a user tries to access a command they do not have\n"
+                    + "permission for")
+    private CommandsHiddenCategory commandHiding = new CommandsHiddenCategory();
+
     public boolean isEnforcePermissionChecksOnNonSpongeCommands() {
         return this.enforcePermissionChecksOnNonSpongeCommands;
     }
@@ -62,6 +67,10 @@ public class CommandsCategory extends ConfigCategory {
 
     public Map<String, Boolean> getMultiWorldCommandPatches() {
         return this.multiWorldCommandPatches;
+    }
+
+    public CommandsHiddenCategory getCommandHiding() {
+        return this.commandHiding;
     }
 
 }

--- a/src/main/java/org/spongepowered/common/config/category/CommandsHiddenCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/CommandsHiddenCategory.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.config.category;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class CommandsHiddenCategory extends ConfigCategory {
+
+    @Setting(value = "hide-on-discovery-attempt",
+             comment = "If this is true, when a user tries to tab complete a command, or use \"/sponge which\" or \n"
+                     + "\"/sponge:help\" this prevents commands a user does not have permission for from being completed.\n\n"
+                     + "Note that some commands may not show up during tab complete if a user does not have permission\n"
+                     + "regardless of this setting.")
+    private boolean hideDuringDiscovery = true;
+
+    @Setting(value = "hide-on-execution-attempt",
+             comment = "If this is true, when a user tries to use a command they don't have permission for, Sponge\n"
+                     + "will act as if the command doesn't exist, rather than showing a no permissions message.")
+    private boolean hideDuringExecution = false;
+
+    public boolean isHideDuringDiscovery() {
+        return this.hideDuringDiscovery;
+    }
+
+    public boolean isHideDuringExecution() {
+        return this.hideDuringExecution;
+    }
+
+}


### PR DESCRIPTION
~~[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2049)~~ | **SpongeCommon** | [Original Issue](https://github.com/SpongePowered/SpongeAPI/pull/2048)

---

See SpongePowered/SpongeAPI#2048.

Basically, after https://github.com/SpongePowered/SpongeAPI/commit/b38390e1751fff802d355155c45b2eb4913f5817, people setting up new servers found that commands that stated they had no permission before now state that they don't exist. The original intention was to remove commands from tab completion when a player doesn't have permission, and prevent players from running `/sponge:help <command>` to discover commands.

However, this has somewhat backfired. What this has done is effectively hide commands from players that don't have permissions for them - so, if you run, say `/tp` and you don't have permission, Sponge will now tell you the command is unknown, rather than you don't have permission.

I should have considered this being the case before pulling, oh well. So, I figured I'd go inbetween, add configuration to enable this command hiding behaviour with ~~four~~ two different options:

* The first is on execute - whether a command that you don't have permission for should either act as if it doesn't exist, or return a no permission message (default, 7.1.6 behaviour)
* The second is a combination of the following three, which I thought was the best idea after thinking on @ryantheleach's comment some more.
  * On Tab Completion - whether you can tab complete a command name that you don't have permissions for (default to no, not 7.1.6 behaviour)
  * On `/sponge which` - whether you can inspect commands you don't have access to (as an admin tool, this might not be important, but defaults to no anyway, not 7.1.6 behaviour)
  * On `/sponge:help <command>` - can you inspect commands you don't have access to (default no, not 7.1.6 behaviour)

Of course, what I thought would be a simple problem to solve actually turned out to be more complex - the API implementation of commands strikes again!

My original intention was to alter https://github.com/SpongePowered/SpongeAPI/commit/b38390e1751fff802d355155c45b2eb4913f5817#diff-89adf4090b06b371ecc8b77db21c4abfR305 and create a new method that accepts a `BiPredicate<CommandSource, CommandMapping>` that you would then do the filtering in. However... `SimpleDispatcher` is a `final` class in the API. So, that means:

* No access to the Sponge config - so we can't set filters based on the task that we need to do.
* Changing the impl to send `null` as the `CommandSource` parameter to this method is also a no-go, as it might have implications for those using the dispatcher with a different `Disambiguator`.
* We have to be mindful of other consumers of the API and I am now of mind, considering that the change is further widespread, to revert the commit involved.

The obvious solution to this, therefore, is to create our own dispatcher in Common. This is what I've suggested below, it's very rough as it's effectively starting with a copy of the `SimpleDispatcher`. The idea is that I basically add filters to the dispatcher where relavent, it becomes an implementation detail and we can play a little more fast and loose with how we deal with selecting commands, while the `SimpleDispatcher` can be left alone.

Of course, right now there is a lot of duplicate code. I thought about using Mixins to alter the API implementation to add our configuration, but again, that could change the fundamentals of the dispatcher if others are using it. So, I'd like to [revert this commit](https://github.com/SpongePowered/SpongeAPI/commit/b38390e1751fff802d355155c45b2eb4913f5817) to pull it into an implementation change, and then remove the `final` modifier from `SimpleDispatcher`. I don't think it's a breaking change to allow the `SimpleDispatcher` to be extended, but once we do it, we can't go back.

@gabizou @Zidane - particularly on that last point, I'd like some opinion of whether removing that modifier is okay. If it is not, then I think we'll just have to do what I'm doing right now, duplicating the class (as in the linked API PR).

---

As a resolution, no, we're just copying the dispatcher into common. That should give us more flexibility to fix things in the future should it be needed. On a further note, I won't revert the API commit, it actually works well for tab completion of child commands - if that was a problem I think we would have seen an issue by now.