### PR TITLE
Implement TeleporterMixin.bridge$placeEntity for SpongeVanilla.

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/IPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/IPhaseState.java
@@ -906,4 +906,13 @@ public interface IPhaseState<C extends PhaseContext<C>> {
     default boolean allowsGettingQueuedRemovedTiles() {
         return false;
     }
+
+    /**
+     * Allows phases to be notified when an entity successfully teleports
+     * between dimensions.
+     * 
+     * @param phaseContext The appropriate phase context
+     */
+    default void markTeleported(final C phaseContext) {
+    }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/entity/InvokingTeleporterState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/entity/InvokingTeleporterState.java
@@ -72,4 +72,8 @@ public final class InvokingTeleporterState extends EntityPhaseState<InvokingTele
         return false;
     }
 
+    @Override
+    public void markTeleported(InvokingTeleporterContext phaseContext) {
+        phaseContext.setDidPort(true);
+    }
 }

--- a/src/main/java/org/spongepowered/common/util/Constants.java
+++ b/src/main/java/org/spongepowered/common/util/Constants.java
@@ -387,6 +387,7 @@ public final class Constants {
         public static final int MAX_CHUNK_UNLOADS = 100;
         public static final String GENERATE_BONUS_CHEST = "GenerateBonusChest";
         public static final int CHUNK_UNLOAD_DELAY = 30000;
+        public static final int END_DIMENSION_ID = 1;
 
         public static final class Teleporter {
 


### PR DESCRIPTION
Got an AbstractMethodError for this while doing some testing. I just copied over the code from the Forge mixin and removed all the code for "isVanilla == false". Not sure whether this is supposed to be implemented on vanilla (the method was designed for Forge) or whether I just hit a bug.

Optional companion PR: https://github.com/SpongePowered/SpongeForge/pull/3017