### PR TITLE
Fix inventory middle click state id

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/MiddleInventoryClickState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/MiddleInventoryClickState.java
@@ -44,8 +44,7 @@ import javax.annotation.Nullable;
 public final class MiddleInventoryClickState extends BasicInventoryPacketState {
 
     public MiddleInventoryClickState() {
-        super(Constants.Networking.MODE_CLICK
-              | Constants.Networking.BUTTON_PRIMARY // The primary is set if the pick block is used as a different button mapping.
+        super(Constants.Networking.BUTTON_PRIMARY // The primary is set if the pick block is used as a different button mapping.
               | Constants.Networking.BUTTON_MIDDLE
               | Constants.Networking.MODE_PICKBLOCK
               | Constants.Networking.CLICK_INSIDE_WINDOW


### PR DESCRIPTION
Mentioned this in the discord and gabizou told that when rebinding the middle click key to any keyboard key the client will send button as primary instead of middle.

After testing this for while, this is true. However, the current state id also includes **mode** for click and this is not sent and stays as it is.

Also rebinding the key makes so that the client does not send packets related to the middle clicking outside of the window. (Unrelated)

Closes #2391