### PR TITLE
Implement HealEntityEvent.

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
@@ -65,6 +65,7 @@ import org.spongepowered.api.event.cause.entity.damage.DamageModifier;
 import org.spongepowered.api.event.cause.entity.damage.source.FallingBlockDamageSource;
 import org.spongepowered.api.event.entity.ChangeEntityEquipmentEvent;
 import org.spongepowered.api.event.entity.DamageEntityEvent;
+import org.spongepowered.api.event.entity.HealEntityEvent;
 import org.spongepowered.api.event.entity.MoveEntityEvent;
 import org.spongepowered.api.event.item.inventory.UseItemStackEvent;
 import org.spongepowered.api.item.inventory.Inventory;
@@ -75,6 +76,7 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.Surrogate;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -112,6 +114,7 @@ import org.spongepowered.common.registry.type.event.DamageSourceRegistryModule;
 import org.spongepowered.common.util.Constants;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Optional;
@@ -1169,5 +1172,16 @@ public abstract class EntityLivingBaseMixin extends EntityMixin implements Livin
     }
 
     // End implementation of UseItemStackEvent
+    
+    @ModifyVariable(method = "heal", index = 1, at = @At("HEAD"))
+    private float sponge$fireHealEntityEvent(float original) {
+        HealEntityEvent event = SpongeEventFactory.createHealEntityEvent(SpongeImpl.getCauseStackManager().getCurrentCause(),
+                Collections.emptyList(), (org.spongepowered.api.entity.Entity) this, original);
+        if (SpongeImpl.postEvent(event)) {
+            return 0;
+        } else {
+            return (float) event.getFinalHealAmount();
+        }
+    }
 
 }


### PR DESCRIPTION
This is a basic implementation of `HealEntityEvent`. The original and final health works, but I'm not sure how to handle the `HealthModifier` list. It looks like it was copied from `DamageModifier`, but Minecraft has no built-in counterpart for healing. For now, I'm just going to leave that empty by default.

Test code (drop this in a plugin):
```java
    @Listener
    public void onHeal(HealEntityEvent e) {
        e.getCause().first(MessageReceiver.class).ifPresent(x -> {
            x.sendMessage(Text.of("Attempted to heal by " + e.getFinalHealAmount()));
        });
        e.setBaseHealAmount(5.0);
        e.getCause().first(MessageReceiver.class).ifPresent(x -> {
            x.sendMessage(Text.of("Will now heal by " + e.getFinalHealAmount()));
        });
    }
```

Fixes #2345.