### PR TITLE
Don't process packets sent by dead players

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -166,16 +166,10 @@ public final class PacketPhaseUtil {
     public static void onProcessPacket(final Packet packetIn, final INetHandler netHandler) {
         if (netHandler instanceof NetHandlerPlayServer) {
             EntityPlayerMP packetPlayer = ((NetHandlerPlayServer) netHandler).player;
+            // Don't process packets from a player when they are dead.
             if (!packetPlayer.isEntityAlive()) {
-                // Don't process packets from a player when they are dead.
-                if (!(packetIn instanceof CPacketClientStatus)) {
-                    return;
-                }
-
-                CPacketClientStatus clientStatusPacket = (CPacketClientStatus) packetIn;
-
                 // Allow the player to respawn.
-                if (clientStatusPacket.getStatus() != CPacketClientStatus.State.PERFORM_RESPAWN) {
+                if (!(packetIn instanceof CPacketClientStatus) || ((CPacketClientStatus) packetIn).getStatus() != CPacketClientStatus.State.PERFORM_RESPAWN) {
                     return;
                 }
             }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -46,6 +46,7 @@ import net.minecraft.network.Packet;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.play.client.CPacketClientSettings;
 import net.minecraft.network.play.client.CPacketClientStatus;
+import net.minecraft.network.play.client.CPacketCustomPayload;
 import net.minecraft.network.play.client.CPacketPlayer;
 import net.minecraft.network.play.server.SPacketSetSlot;
 import net.minecraft.util.EnumHand;
@@ -166,10 +167,11 @@ public final class PacketPhaseUtil {
     public static void onProcessPacket(final Packet packetIn, final INetHandler netHandler) {
         if (netHandler instanceof NetHandlerPlayServer) {
             EntityPlayerMP packetPlayer = ((NetHandlerPlayServer) netHandler).player;
-            // Only process the Respawn packet from players if they are dead.
+            // Only process the CustomPayload & Respawn packets from players if they are dead.
             if (!packetPlayer.isEntityAlive()
+                    && (!(packetIn instanceof CPacketCustomPayload)
                     && (!(packetIn instanceof CPacketClientStatus)
-                    || ((CPacketClientStatus) packetIn).getStatus() != CPacketClientStatus.State.PERFORM_RESPAWN)) {
+                    || ((CPacketClientStatus) packetIn).getStatus() != CPacketClientStatus.State.PERFORM_RESPAWN))) {
                 return;
             }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -165,8 +165,22 @@ public final class PacketPhaseUtil {
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static void onProcessPacket(final Packet packetIn, final INetHandler netHandler) {
         if (netHandler instanceof NetHandlerPlayServer) {
+            EntityPlayerMP packetPlayer = ((NetHandlerPlayServer) netHandler).player;
+            if (packetPlayer.isDead) {
+                // Don't process packets from a player when they are dead.
+                if (!(packetIn instanceof CPacketClientStatus)) {
+                    return;
+                }
+
+                CPacketClientStatus clientStatusPacket = (CPacketClientStatus) packetIn;
+
+                // Allow the player to respawn.
+                if (clientStatusPacket.getStatus() != CPacketClientStatus.State.PERFORM_RESPAWN) {
+                    return;
+                }
+            }
+
             try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
-                EntityPlayerMP packetPlayer = ((NetHandlerPlayServer) netHandler).player;
                 frame.pushCause(packetPlayer);
                 if (SpongeImplHooks.creativeExploitCheck(packetIn, packetPlayer)) {
                     return;

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -166,12 +166,11 @@ public final class PacketPhaseUtil {
     public static void onProcessPacket(final Packet packetIn, final INetHandler netHandler) {
         if (netHandler instanceof NetHandlerPlayServer) {
             EntityPlayerMP packetPlayer = ((NetHandlerPlayServer) netHandler).player;
-            // Don't process packets from a player when they are dead.
-            if (!packetPlayer.isEntityAlive()) {
-                // Allow the player to respawn.
-                if (!(packetIn instanceof CPacketClientStatus) || ((CPacketClientStatus) packetIn).getStatus() != CPacketClientStatus.State.PERFORM_RESPAWN) {
-                    return;
-                }
+            // Only process the Respawn packet from players if they are dead.
+            if (!packetPlayer.isEntityAlive()
+                    && (!(packetIn instanceof CPacketClientStatus)
+                    || ((CPacketClientStatus) packetIn).getStatus() != CPacketClientStatus.State.PERFORM_RESPAWN)) {
+                return;
             }
 
             try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -166,7 +166,7 @@ public final class PacketPhaseUtil {
     public static void onProcessPacket(final Packet packetIn, final INetHandler netHandler) {
         if (netHandler instanceof NetHandlerPlayServer) {
             EntityPlayerMP packetPlayer = ((NetHandlerPlayServer) netHandler).player;
-            if (packetPlayer.isDead) {
+            if (!packetPlayer.isEntityAlive()) {
                 // Don't process packets from a player when they are dead.
                 if (!(packetIn instanceof CPacketClientStatus)) {
                     return;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMixin.java
@@ -310,9 +310,14 @@ public abstract class EntityPlayerMixin extends EntityLivingBaseMixin implements
     }
 
     @Inject(method = "readEntityFromNBT", at = @At("RETURN"))
-    private void recalculateXpOnLoad(final NBTTagCompound compound, final CallbackInfo ci) {
+    private void onReadEntityFromNBT(final NBTTagCompound compound, final CallbackInfo ci) {
         // Fix the mistakes of /xp commands past.
         bridge$recalculateTotalExperience();
+
+        // Fix isDead not getting set back to true when a player that hasn't respawned after dying reconnects.
+        if (getHealth() <= 0.0F) {
+            this.isDead = true;
+        }
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMixin.java
@@ -310,7 +310,7 @@ public abstract class EntityPlayerMixin extends EntityLivingBaseMixin implements
     }
 
     @Inject(method = "readEntityFromNBT", at = @At("RETURN"))
-    private void onReadEntityFromNBT(final NBTTagCompound compound, final CallbackInfo ci) {
+    private void impl$fixEntityProperties(final NBTTagCompound compound, final CallbackInfo ci) {
         // Fix the mistakes of /xp commands past.
         bridge$recalculateTotalExperience();
 


### PR DESCRIPTION
This is a potential fix for #2396 

The first fix is for the EntityPlayerMixin to ensure a consistent isDead state, When a player dies the isDead flag is set to true however when the player relogs without respawning this flag isn't updated on login resulting in a player whose health is 0 and isn't marked as dead.

The method has also been renamed from `recalculateXpOnLoad` -> `onReadEntityFromNBT` as it's no longer just recalculating xp.

The second fix is for the PacketPhaseUtil as this is where all packets end up getting processed on the Server Thread, The idea is that when a player dies the only thing they can realistic do is Respawn or Disconnect and as such all packets that aren't a Respawn packet are simply ignored.

The KeepAlive packet is processed on the Netty Thread so it will continue to function.

I have put the logic for this before the try-with-resources I'm not sure if this correct? My reasoning is that there is no point in Sponge attempting to track these packets if they are going to be ignored anyway.