### PR TITLE
Fix duplicate InteractItemEvent.Secondary

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
@@ -817,8 +817,7 @@ public abstract class NetHandlerPlayServerMixin implements NetHandlerPlayServerB
                         SpongeCommonEventFactory.lastSecondaryPacketTick = this.server.getTickCounter();
 
                         // Is interaction allowed with item in hand
-                        if (SpongeCommonEventFactory.callInteractItemEventSecondary(frame, this.player, itemstack, hand, VecHelper.toVector3d(packetIn
-                            .getHitVec()), entity).isCancelled() || SpongeCommonEventFactory.callInteractEntityEventSecondary(this.player, itemstack,
+                        if (SpongeCommonEventFactory.callInteractEntityEventSecondary(this.player, itemstack,
                             entity, hand, VecHelper.toVector3d(entity.getPositionVector().add(packetIn.getHitVec()))).isCancelled()) {
 
                             // Restore held item in hand


### PR DESCRIPTION
I'm still testing this, I'll merge it later tonight.

Fixes https://github.com/SpongePowered/SpongeCommon/issues/2402 

As explained on the issue: It seems the two events are fired because of different packets, namely `CPacketUseEntity` and `CPacketPlayerTryUseItem`.
Both packets are sent when right-clicking an entity with an item in hand, leading to duplicate events.

(doot provided a gist with an overview of the current situation).

It looks like a minor issue, not a big deal, except there is a severe problem here:

There are a few sponge events we mark as "equivalent" to forge events, as a result whenever such event is fired we also fire its counterpart. We can't fire (or not fire) them carelessly, because we may end up breaking forge contract with mods, disrupting the event flow and causing subtle bugs.

`InteractItemEvent.Secondary` is the corresponding sponge event for `PlayerInteractEvent.RightClickItem`, which is not fired when processing `CPacketUseEntity` (in forge).

This PR removes the firing of `InteractItemEvent.Secondary` (and thus the forge event when sponge is present) during `CPacketUseEntity`. Restoring the "vanilla" forge behaviour/event flow