### PR TITLE
Wait for the previous occurrence of the task to terminate

### DIFF
--- a/src/main/java/org/spongepowered/common/scheduler/ScheduledTask.java
+++ b/src/main/java/org/spongepowered/common/scheduler/ScheduledTask.java
@@ -70,6 +70,10 @@ public class ScheduledTask implements Task {
          */
         RUNNING(true),
         /**
+         * Is being executed.
+         */
+        EXECUTING(true),
+        /**
          * Task cancelled, scheduled to be removed from the task map.
          */
         CANCELED(false);


### PR DESCRIPTION
Fix https://github.com/SpongePowered/SpongeCommon/issues/2199

See https://github.com/SpongePowered/SpongeAPI/blob/2ad94d346fbdc7ccd64aaf830d8b15d4407ca311/src/main/java/org/spongepowered/api/scheduler/Task.java#L176 for a detailed explanation.

Note: we can't use `RUNNING`, since it just means the task is present in the taskmap (ex. a repeating task is always in the `RUNNING` state after the first execution).
