### PR TITLE
Fix exceptions when using FusedExplosive methods

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/item/EntityTNTPrimedMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/item/EntityTNTPrimedMixin_API.java
@@ -40,6 +40,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.bridge.entity.item.EntityTNTPrimedBridge;
 import org.spongepowered.common.bridge.explosives.FusedExplosiveBridge;
 import org.spongepowered.common.mixin.api.mcp.entity.EntityMixin_API;
+import org.spongepowered.common.util.Constants;
 
 import java.util.Optional;
 
@@ -54,7 +55,6 @@ public abstract class EntityTNTPrimedMixin_API extends EntityMixin_API implement
     @Shadow @Nullable private EntityLivingBase tntPlacedBy;
     @Shadow private void explode() { }
 
-    private int fuseDuration = 80;
     @Override
     public Optional<Living> getDetonator() {
         return Optional.ofNullable((Living) this.tntPlacedBy);
@@ -65,6 +65,7 @@ public abstract class EntityTNTPrimedMixin_API extends EntityMixin_API implement
     @Override
     public void defuse() {
         checkState(isPrimed(), "not primed");
+        checkState(!((EntityTNTPrimedBridge) this).bridge$isExploding(), "tnt about to explode");
         if (((FusedExplosiveBridge) this).bridge$shouldDefuse()) {
             setDead();
             // Place a TNT block at the Entity's position
@@ -78,13 +79,13 @@ public abstract class EntityTNTPrimedMixin_API extends EntityMixin_API implement
     @Override
     public void prime() {
         checkState(!isPrimed(), "already primed");
-        checkState(this.isDead, "tnt about to be primed");
+        checkState(!((EntityTNTPrimedBridge) this).bridge$isExploding(), "tnt about to explode");
         getWorld().spawnEntity(this);
     }
 
     @Override
     public boolean isPrimed() {
-        return this.fuse > 0 && this.fuse < this.fuseDuration && !this.isDead || ((EntityTNTPrimedBridge) this).bridge$isExploding();
+        return this.fuse > 0 && this.fuse < Constants.Entity.PrimedTNT.DEFAULT_FUSE_DURATION && !this.isDead;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/EntityTNTPrimedMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/EntityTNTPrimedMixin.java
@@ -66,6 +66,11 @@ public abstract class EntityTNTPrimedMixin extends EntityMixin implements Entity
     }
 
     @Override
+    public boolean bridge$isExploding() {
+        return this.isDead && this.fuse <= 0;
+    }
+
+    @Override
     public Optional<Integer> bridge$getExplosionRadius() {
         return Optional.of(this.bridge$explosionRadius);
     }

--- a/testplugins/src/main/java/org/spongepowered/test/DefuseExplosiveTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/DefuseExplosiveTest.java
@@ -31,10 +31,14 @@ import org.spongepowered.api.effect.sound.SoundTypes;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.explosive.FusedExplosive;
 import org.spongepowered.api.entity.explosive.PrimedTNT;
+import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.entity.InteractEntityEvent;
+import org.spongepowered.api.event.filter.cause.Root;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
 
 @Plugin(id = "defuseexplosivetest", name = "Defuse Explosive Test", description = "Defuse Explosive", version = "0.0.0")
 public class DefuseExplosiveTest implements LoadableModule {
@@ -49,14 +53,20 @@ public class DefuseExplosiveTest implements LoadableModule {
 
     public static class Listeners {
         @Listener
-        public void onDispense(InteractEntityEvent.Secondary.MainHand event) {
+        public void onInteractExplosive(InteractEntityEvent.Secondary.MainHand event, @Root Player player) {
             final Entity entity = event.getTargetEntity();
 
             if (!(entity instanceof FusedExplosive)) {
                 return;
             }
 
+            if (!((FusedExplosive) entity).isPrimed()) {
+                player.sendMessage(Text.of(TextColors.RED, "fused explosive not primed"));
+                return;
+            }
+
             ((FusedExplosive) entity).defuse();
+            player.sendMessage(Text.of(TextColors.DARK_GREEN, entity.getType().getName(), " defused"));
         }
     }
 }

--- a/testplugins/src/main/java/org/spongepowered/test/DefuseExplosiveTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/DefuseExplosiveTest.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import com.google.inject.Inject;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.effect.sound.SoundTypes;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.explosive.FusedExplosive;
+import org.spongepowered.api.entity.explosive.PrimedTNT;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.entity.InteractEntityEvent;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.plugin.PluginContainer;
+
+@Plugin(id = "defuseexplosivetest", name = "Defuse Explosive Test", description = "Defuse Explosive", version = "0.0.0")
+public class DefuseExplosiveTest implements LoadableModule {
+
+    @Inject private PluginContainer container;
+    private final Listeners listener = new Listeners();
+
+    @Override
+    public void enable(CommandSource src) {
+        Sponge.getEventManager().registerListeners(this.container, this.listener);
+    }
+
+    public static class Listeners {
+        @Listener
+        public void onDispense(InteractEntityEvent.Secondary.MainHand event) {
+            final Entity entity = event.getTargetEntity();
+
+            if (!(entity instanceof FusedExplosive)) {
+                return;
+            }
+
+            ((FusedExplosive) entity).defuse();
+        }
+    }
+}


### PR DESCRIPTION
Fix https://github.com/SpongePowered/SpongeCommon/issues/1701

The issue is outdated: the current situation is that those methods are not working because `EntityTNTPrimedBridge#bridge$isExploding` is not implemented, thus throwing an abstract method error.

This PR implements the method and add a test plugin to ensure everything is working.

`/testplugins on defuseexplosivetest`