### PR TITLE
Do not allow for CatalogType#getId in mixin classes to be overridden 

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/advancements/AdvancementMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/advancements/AdvancementMixin_API.java
@@ -98,7 +98,7 @@ public class AdvancementMixin_API implements org.spongepowered.api.advancement.A
     }
 
     @Override
-    public String getId() {
+    public final String getId() {
         checkState(SpongeImplHooks.isMainThread());
         return ((AdvancementBridge) this).bridge$getId();
     }

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/block/BlockMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/block/BlockMixin_API.java
@@ -67,7 +67,7 @@ public abstract class BlockMixin_API implements BlockType {
     @Shadow public abstract BlockStateContainer getBlockState();
 
     @Override
-    public String getId() {
+    public final String getId() {
         return this.getNameFromRegistry();
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/enchantment/EnchantmentMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/enchantment/EnchantmentMixin_API.java
@@ -63,7 +63,7 @@ public abstract class EnchantmentMixin_API implements EnchantmentType {
     @Nullable private String api$id;
 
     @Override
-    public String getId() {
+    public final String getId() {
         if (this.api$id == null || this.api$id.isEmpty()) {
             final ResourceLocation id = REGISTRY.getNameForObject((Enchantment) (Object) this);
             if (id != null) {

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/item/ItemMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/item/ItemMixin_API.java
@@ -54,7 +54,7 @@ public abstract class ItemMixin_API implements ItemType {
     @Nullable private org.spongepowered.api.item.inventory.ItemStack propertyItemStack;
 
     @Override
-    public String getId() {
+    public final String getId() {
         final ResourceLocation resourceLocation = SpongeImplHooks.getItemResourceLocation((Item) (Object) this);
         checkState(resourceLocation != null, "Attempted to access the id before the Item is registered.");
         return resourceLocation.toString();

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/world/biome/BiomeMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/world/biome/BiomeMixin_API.java
@@ -66,7 +66,7 @@ public abstract class BiomeMixin_API implements BiomeType {
     }
 
     @Override
-    public String getId() {
+    public final String getId() {
         return ((BiomeBridge) this).bridge$getId();
     }
 


### PR DESCRIPTION
Close https://github.com/SpongePowered/SpongeCommon/issues/1845

Talked with Mumfrey about that. It's not an issue with Mixin (or something mixin can fix), however it did cause a bit of trouble.

This PR is finalising CatalogType#getId in mixin classes, making the jvm crash if an attemp to override those methods is made, avoiding subtle bugs like 1845.




