### PR TITLE
Fix capturedCraftPreviewTransactions leaking when shift-crafting

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/inventory/ContainerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/inventory/ContainerMixin.java
@@ -49,7 +49,6 @@ import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.InventoryArchetype;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.crafting.CraftingInventory;
-import org.spongepowered.api.item.inventory.crafting.CraftingOutput;
 import org.spongepowered.api.item.inventory.query.QueryOperationTypes;
 import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
 import org.spongepowered.api.item.inventory.type.CarriedInventory;
@@ -513,17 +512,6 @@ public abstract class ContainerMixin implements ContainerBridge, InventoryAdapte
                 result = ItemStack.EMPTY; // Return empty to stop shift-crafting
             }
         }
-
-        final Inventory craftInv = ((Inventory) thisContainer).query(QueryOperationTypes.INVENTORY_TYPE.of(CraftingInventory.class));
-        if (craftInv instanceof CraftingInventory) {
-            List<SlotTransaction> previewTransactions = ((ContainerBridge) thisContainer).bridge$getPreviewTransactions();
-            if (previewTransactions.isEmpty()) {
-                final CraftingOutput outSlot = ((CraftingInventory) craftInv).getResult();
-                final SlotTransaction st = new SlotTransaction(outSlot, ItemStackSnapshot.NONE, ItemStackUtil.snapshotOf(outSlot.peek().orElse(org.spongepowered.api.item.inventory.ItemStack.empty())));
-                previewTransactions.add(st);
-            }
-        }
-
         this.impl$shiftCraft = false;
 
         return result;

--- a/src/main/java/org/spongepowered/common/mixin/core/inventory/SlotCraftingMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/inventory/SlotCraftingMixin.java
@@ -179,9 +179,13 @@ public abstract class SlotCraftingMixin extends Slot {
             return; // CraftMatrix is empty and/or no transaction present. Do not fire Preview.
         }
 
-        final SlotTransaction last = previewTransactions.isEmpty()
-                ? new SlotTransaction(craftingInventory.getResult(), ItemStackSnapshot.NONE, ItemStackUtil.snapshotOf(this.getStack()))
-                : previewTransactions.get(0);
+        final SlotTransaction last;
+        if (previewTransactions.isEmpty()) {
+            last = new SlotTransaction(craftingInventory.getResult(), ItemStackSnapshot.NONE, ItemStackUtil.snapshotOf(this.getStack()));
+            previewTransactions.add(last);
+        } else {
+            last = previewTransactions.get(0);
+        }
 
         final CraftingRecipe newRecipe = (CraftingRecipe) CraftingManager.findMatchingRecipe(this.craftMatrix, thePlayer.world);
 


### PR DESCRIPTION
An incorrect event will be fired by dragging items after shift-crafting.
And with codes like below, shift-crafting will not stop until [the crafting matrix is empty](            https://github.com/SpongePowered/SpongeCommon/blob/f7bde6a121d20b0f043b0d96ffd5edca711e103a/src/main/java/org/spongepowered/common/mixin/core/inventory/SlotCraftingMixin.java#L179).
Code
```java
    @Listener(order = Order.FIRST, beforeModifications = true)
    public void onCraft(CraftItemEvent.Preview event) {
        SlotTransaction craftTransaction = event.getPreview();
        craftTransaction.setCustom(craftTransaction.getFinal());
    }
```
Video
https://drive.google.com/file/d/1TWLuJrTkLygO1JWmqo4NdX4TcwDVFSgx/view?usp=sharing