### PR TITLE
Fix bug where parsing invalid block states would throw an exception.

### DIFF
--- a/src/main/java/org/spongepowered/common/registry/type/BlockStateRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/BlockStateRegistryModule.java
@@ -70,6 +70,10 @@ public final class BlockStateRegistryModule implements CatalogRegistryModule<Blo
             final String[] propertyValuePairs = properties.split(",");
             List<Tuple<BlockTrait<?>, ? extends Comparable<?>>> foundPairs = new ArrayList<>(propertyValuePairs.length);
             for (String propertyValuePair : propertyValuePairs) {
+                if (!propertyValuePair.contains("=")) {
+                    continue;
+                }
+
                 final String name = propertyValuePair.split("=")[0];
                 final String value = propertyValuePair.split("=")[1];
                 type.getTrait(name).ifPresent(trait -> {

--- a/src/main/java/org/spongepowered/common/registry/type/BlockStateRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/BlockStateRegistryModule.java
@@ -71,7 +71,7 @@ public final class BlockStateRegistryModule implements CatalogRegistryModule<Blo
             List<Tuple<BlockTrait<?>, ? extends Comparable<?>>> foundPairs = new ArrayList<>(propertyValuePairs.length);
             for (String propertyValuePair : propertyValuePairs) {
                 if (!propertyValuePair.contains("=")) {
-                    continue;
+                    return Optional.empty();
                 }
 
                 final String name = propertyValuePair.split("=")[0];


### PR DESCRIPTION
This pull request fixes a problem where if a string block state had the opening and closing brackets, but either no key value pairs between them or an entry in the list did not include an equal sign an argument out of bounds exception would be thrown.  This change adds a check for an equal sign in the raw key value string.