### PR TITLE
Fix three issues affecting the Schematic Builder

### DIFF
--- a/src/main/java/org/spongepowered/common/world/extent/DefaultedExtent.java
+++ b/src/main/java/org/spongepowered/common/world/extent/DefaultedExtent.java
@@ -189,11 +189,11 @@ public interface DefaultedExtent extends Extent {
                 tiles.put(new Vector3i(x - ox, y - oy, z - oz), archetype);
             }
         });
-        if (backing.getBlockSize().equals(Vector3i.ONE)) {
-            // We can't get entities within a 1x1x1 block area because of AABB...
-            return new SpongeArchetypeVolume(backing, tiles, Collections.emptyList());
-        }
-        final Set<Entity> intersectingEntities = volume.getIntersectingEntities(new AABB(min, max), entity -> !(entity instanceof Player));
+        // Note that AABB is in real co-ordinate space, but the passed Vector3is are in block co-ordinate space.
+        // This means that in order to capture all of the blocks in the volume, you must go to the maximum
+        // real co-ordinate of the block located at the max Vector3i position, which is +1 in all axes
+        final Set<Entity> intersectingEntities = volume.getIntersectingEntities(
+                new AABB(min, max.add(Vector3i.ONE)), entity -> !(entity instanceof Player));
         if (intersectingEntities.isEmpty()) {
             return new SpongeArchetypeVolume(backing, tiles, Collections.emptyList());
         }

--- a/src/main/java/org/spongepowered/common/world/schematic/SpongeSchematicBuilder.java
+++ b/src/main/java/org/spongepowered/common/world/schematic/SpongeSchematicBuilder.java
@@ -288,7 +288,10 @@ public class SpongeSchematicBuilder implements Schematic.Builder {
                     // We have to set the size to 1 for the y limit due to the
                     // format having that restriction (up until 1.15's supposed
                     // changes.
-                    final MutableBiomeVolume biomes = new ByteArrayMutableBiomeBuffer(this.biomePalette, min, new Vector3i(size.getX(), 1, size.getZ()));
+                    // We also have to set the start y co-ordinate to zero for the
+                    // same reason
+                    final MutableBiomeVolume biomes = new ByteArrayMutableBiomeBuffer(
+                            this.biomePalette, min.mul(1, 0, 1), new Vector3i(size.getX(), 1, size.getZ()));
                     this.view.getBiomeWorker().iterate((v, x, y, z) -> biomes.setBiome(x, y, z, v.getBiome(x, y, z)));
                     this.biomeVolume = biomes;
                 }
@@ -298,7 +301,10 @@ public class SpongeSchematicBuilder implements Schematic.Builder {
             if (this.volume != null) {
                 this.entities = this.volume.getEntityArchetypes();
             } else if (this.view != null && this.backingVolume != null) {
-                this.entities = this.view.getIntersectingEntities(this.backingVolume.getBlockMin().toDouble(), this.backingVolume.getBlockMax().toDouble()).stream()
+                this.entities = this.view.getIntersectingEntities(
+                        this.backingVolume.getBlockMin().toDouble(),
+                        this.backingVolume.getBlockMax().add(1, 1,1).toDouble())
+                    .stream()
                     .map(EntityUniverse.EntityHit::getEntity)
                     .filter(Objects::nonNull)
                     .filter(entity -> !(entity instanceof Player) || !SpongeImplHooks.isFakePlayer((net.minecraft.entity.Entity) entity))

--- a/testplugins/src/main/java/org/spongepowered/test/SchematicBoundsTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/SchematicBoundsTest.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test;
+
+import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandMapping;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.world.extent.ArchetypeVolume;
+import org.spongepowered.api.world.extent.Extent;
+import org.spongepowered.api.world.extent.worker.procedure.BlockVolumeVisitor;
+import org.spongepowered.api.world.schematic.PaletteTypes;
+import org.spongepowered.api.world.schematic.Schematic;
+import org.spongepowered.api.world.storage.WorldProperties;
+
+import java.util.logging.Logger;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+@Plugin(id = SchematicBoundsTest.ID, name = SchematicBoundsTest.NAME, description = SchematicBoundsTest.DESCRIPTION, version = SchematicBoundsTest.VERSION)
+public class SchematicBoundsTest implements LoadableModule {
+
+    public static final String ID = "schematicboundstest";
+    public static final String NAME = "Schematic Bounds Test";
+    public static final String DESCRIPTION = "Testing schematic bounds.";
+    public static final String VERSION = "0.0.0";
+
+    private final Logger logger;
+
+    @Nullable private CommandMapping mapping;
+
+    @Inject
+    public SchematicBoundsTest(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void disable(final CommandSource src) {
+        if (this.mapping != null) {
+            Sponge.getCommandManager().removeMapping(this.mapping);
+            src.sendMessage(Text.of("Removed /schbuild command"));
+        }
+    }
+
+    @Override
+    public void enable(final CommandSource src) {
+        if (this.mapping == null) {
+            this.mapping = Sponge.getCommandManager()
+                    .register(this,
+                            CommandSpec.builder().arguments(
+                                    GenericArguments.world(Text.of("world")),
+                                    GenericArguments.integer(Text.of("x1")),
+                                    GenericArguments.integer(Text.of("y1")),
+                                    GenericArguments.integer(Text.of("z1")),
+                                    GenericArguments.integer(Text.of("x2")),
+                                    GenericArguments.integer(Text.of("y2")),
+                                    GenericArguments.integer(Text.of("z2"))
+                            ).executor((source, context) -> {
+                                Vector3i first = new Vector3i(
+                                        context.requireOne("x1"),
+                                        context.requireOne("y1"),
+                                        context.requireOne("z1")
+                                );
+
+                                Vector3i second = new Vector3i(
+                                        context.requireOne("x2"),
+                                        context.requireOne("y2"),
+                                        context.requireOne("z2")
+                                );
+
+                                Vector3i min = first.min(second);
+                                Vector3i max = first.max(second);
+
+                                WorldProperties properties = context.requireOne("world");
+                                // Extent extent = Sponge.getServer().getWorld(properties.getUniqueId()).get().getExtentView(min, max);
+                                ArchetypeVolume extent = Sponge.getServer().getWorld(properties.getUniqueId()).get()
+                                        .createArchetypeVolume(min, max, min);
+
+                                Schematic sch = Schematic.builder()
+                                        .volume(extent)
+                                        .blockPaletteType(PaletteTypes.LOCAL_BLOCKS)
+                                        .biomePaletteType(PaletteTypes.LOCAL_BIOMES)
+                                        .build();
+                                Vector3i size = sch.getBlockSize();
+                                source.sendMessage(Text.of("Block size: " + size.getX() * size.getY() * size.getZ()));
+                                source.sendMessage(Text.of("Block dimensions: " + size));
+
+                                CountingIterator it = new CountingIterator();
+                                sch.getBlockWorker().iterate(it);
+                                source.sendMessage(Text.of("Iterated size: " + it.count));
+                                return CommandResult.success();
+                            })
+                            .build(),
+                        "schbuild").orElse(null);
+            if (this.mapping == null) {
+                src.sendMessage(Text.of("Could not register schbuild"));
+            } else {
+                src.sendMessage(Text.of("Registered schbuild"));
+            }
+        }
+    }
+
+    private static class CountingIterator implements BlockVolumeVisitor<Schematic> {
+
+        public int count = 0;
+
+        @Override
+        public void visit(Schematic volume, int x, int y, int z) {
+            ++count;
+        }
+    }
+
+}


### PR DESCRIPTION
* When using the ExtentView, ensure that the biome worker only uses valid y values (0).
* When checking for intersecting entities, check over the entire volume (which goes to blockMax+1, not blockMax)
* Ensure that the AABB created when creating an Archetype Volume encompasses the entire volume (also fixing degeneracy issues)
* Add test plugin for schematic bounds testing

---

I PR this mostly for the third point - the change in DefaultedExtent. The changed lines meant that you couldn't create a copy that had a length of 1 block in either one or two dimensions - this happens when the `min` and `max` vectors have the same x or y co-ordinate (the case for min==max was already catered for).

In my understanding, the AABB works on the real co-ordinate space, but is a `Vector3i` to limit the boxes to being along the edges of the blocks. The vectors are passed in "block position" space - which really represent a voxel in the real co-ordinate space from (x->x+1, y->y+1, z->z+1). This means that, in real co-ordinate space, the maximum co-ordinate must be the maximum block pos +1 in all directions - this wasn't accounted for here. The "edge" case<sup>[1](#myfootnote1)</sup> would be that entities in blocks that are along one of the "maximum" edges would not be captured.

I wanted to make sure that this analysis was right before I pulled this in, hence the PR. It's actually a similar issue for point 2, but I'm more confident about that.

Test plugin: `/schbuild <world> <x1> <y1> <z1> <x2> <y2> <z2>` should report the number of blocks in the area. Using all the same number or making xs, ys or zs the same would report an error before this commit. Note that I'm using the `ArchetypeVolume` here, but this also has a fix for actually creating `ExtentView`s (which is why it's commented out, as I tested that first).

So, sanity check please!

---
<a name="myfootnote1">1</a>: Yes, pun intended.