### PR TITLE
Fix world unloading not correctly flushing data

### DIFF
--- a/src/main/java/org/spongepowered/common/world/WorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/WorldManager.java
@@ -67,14 +67,13 @@ import org.spongepowered.api.world.SerializationBehaviors;
 import org.spongepowered.api.world.WorldArchetype;
 import org.spongepowered.api.world.storage.WorldProperties;
 import org.spongepowered.common.SpongeImpl;
-import org.spongepowered.common.bridge.entity.player.EntityPlayerMPBridge;
 import org.spongepowered.common.bridge.server.MinecraftServerBridge;
 import org.spongepowered.common.bridge.server.integrated.IntegratedServerBridge;
 import org.spongepowered.common.bridge.world.DimensionTypeBridge;
-import org.spongepowered.common.bridge.world.WorldServerBridge;
-import org.spongepowered.common.bridge.world.WorldServerBridge_AsyncLighting;
 import org.spongepowered.common.bridge.world.WorldBridge;
 import org.spongepowered.common.bridge.world.WorldInfoBridge;
+import org.spongepowered.common.bridge.world.WorldServerBridge;
+import org.spongepowered.common.bridge.world.WorldServerBridge_AsyncLighting;
 import org.spongepowered.common.bridge.world.WorldSettingsBridge;
 import org.spongepowered.common.bridge.world.chunk.ChunkProviderServerBridge;
 import org.spongepowered.common.config.SpongeConfig;
@@ -540,37 +539,35 @@ public final class WorldManager {
             final WorldServerBridge mixinWorldServer = (WorldServerBridge) worldServer;
             final int dimensionId = mixinWorldServer.bridge$getDimensionId();
 
-            try {
-                // Don't save if server is stopping to avoid duplicate saving.
-                if (!isShuttingDown) {
-                    saveWorld(worldServer, true);
-                }
-
-                ((WorldInfoBridge) worldServer.getWorldInfo()).bridge$getConfigAdapter().save();
-            } catch (MinecraftException e) {
-                e.printStackTrace();
-            } finally {
-                SpongeImpl.getLogger().info("Unloading world [{}] ({}/{})", worldServer.getWorldInfo().getWorldName(),
+            SpongeImpl.getLogger().info("Unloading world [{}] ({}/{})", worldServer.getWorldInfo().getWorldName(),
                     ((org.spongepowered.api.world.World) worldServer).getDimension().getType().getId(), dimensionId);
 
-                // Stop the lighting executor only when the world is going to unload - there's no point in running any more lighting tasks.
-                if (globalConfigAdapter.getConfig().getModules().useOptimizations() && globalConfigAdapter.getConfig().getOptimizations().useAsyncLighting()) {
-                    ((WorldServerBridge_AsyncLighting) worldServer).asyncLightingBridge$getLightingExecutor().shutdownNow();
-                }
-
-                worldByDimensionId.remove(dimensionId);
-                weakWorldByWorld.remove(worldServer);
-                ((MinecraftServerBridge) server).bridge$removeWorldTickTimes(dimensionId);
-                reorderWorldsVanillaFirst();
+            // Stop the lighting executor only when the world is going to unload - there's no point in running any more lighting tasks.
+            if (globalConfigAdapter.getConfig().getModules().useOptimizations() && globalConfigAdapter.getConfig().getOptimizations().useAsyncLighting()) {
+                ((WorldServerBridge_AsyncLighting) worldServer).asyncLightingBridge$getLightingExecutor().shutdownNow();
             }
+
+            // Don't save if server is stopping to avoid duplicate saving.
+            if (!isShuttingDown) {
+                try {
+                    saveWorld(worldServer, true);
+                } catch (MinecraftException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            ((WorldInfoBridge) worldServer.getWorldInfo()).bridge$getConfigAdapter().save();
+
+            worldByDimensionId.remove(dimensionId);
+            weakWorldByWorld.remove(worldServer);
+            ((MinecraftServerBridge) server).bridge$removeWorldTickTimes(dimensionId);
+            reorderWorldsVanillaFirst();
         }
         return true;
     }
 
     public static void saveWorld(final WorldServer worldServer, final boolean flush) throws MinecraftException {
-        if (((WorldProperties) worldServer.getWorldInfo()).getSerializationBehavior() == SerializationBehaviors.NONE) {
-            return;
-        } else {
+        if (((WorldProperties) worldServer.getWorldInfo()).getSerializationBehavior() != SerializationBehaviors.NONE) {
             worldServer.saveAllChunks(true, null);
         }
         if (flush) {
@@ -811,7 +808,7 @@ public final class WorldManager {
 
             // Step 7 - Finally, we can create the world and tell it to load
             final WorldServer worldServer = createWorldFromProperties(dimensionId, saveHandler, worldInfo, worldSettings);
-            ;
+
             SpongeImpl.getLogger().info("Loading world [{}] ({}/{})", ((org.spongepowered.api.world.World) worldServer).getName(),
                 apiDimensionType.getId(), dimensionId);
         }
@@ -1108,6 +1105,7 @@ public final class WorldManager {
         try {
             Files.move(oldWorldFolder, newWorldFolder);
         } catch (IOException e) {
+            SpongeImpl.getLogger().error("Failed to move world folder " + worldProperties.getWorldName(), e);
             return Optional.empty();
         }
 


### PR DESCRIPTION
While I was developing a plugin that needs to delete temporary worlds I found that the .mca files where still opened after calling `Server#unloadWorld`. This causes issues when trying to delete or to move the files. Even when doing it via API methods `renameWorld` or `deleteWorld`. This PR intends to fix this.

How to reproduce the issue (before this PR):
Create a world. Load it. Send a player in the world and generate few chunks. Remove the player. Unload the world. Try to delete or rename the world using the API.

Issues fixed by this PR:
- The world rename test plugin was never loading and then unloading the world before renaming it.
- `Server#renameWorld` was silently failing without telling why.
- `Server#unloadWorld` was flushing the world's data before stopping the async light executor.
- `Server#unloadWorld` wasn't flushing the world's data if the world had its serialization behavior set to `NONE`. (Files were still opened if the serialization behavior recently changed from `AUTOMATIC` or `MANUAL` to `NONE`)

Issue not fixed by this PR (should it be ?):
- Worlds are not flushed before the `GameStoppedServerEvent` and thus, in the same way, it's not possible for a plugin to delete or move worlds files.