### PR TITLE
Change impl$callSignChangeEvent to a Redirect to support SV upgrade to 0.8

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
@@ -108,6 +108,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Surrogate;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import org.spongepowered.common.SpongeImpl;
@@ -246,6 +247,17 @@ public abstract class NetHandlerPlayServerMixin implements NetHandlerPlayServerB
      */
     @Inject(method = "processUpdateSign", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/play/client/CPacketUpdateSign;getLines()[Ljava/lang/String;"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
     private void impl$callSignChangeEvent(final CPacketUpdateSign packetIn, final CallbackInfo ci, final WorldServer worldserver, final BlockPos blockpos, final IBlockState iblockstate, final TileEntity tileentity, final TileEntitySign tileentitysign) {
+        impl$callSignChangeEventInternal(packetIn, ci, worldserver, blockpos, tileentitysign);
+    }
+
+    // This is required for SpongeVanilla
+    @Surrogate
+    private void impl$callSignChangeEvent(final CPacketUpdateSign packetIn, final CallbackInfo ci, final WorldServer worldserver, final BlockPos blockpos, final IBlockState iblockstate, final TileEntitySign tileentitysign) {
+        impl$callSignChangeEventInternal(packetIn, ci, worldserver, blockpos, tileentitysign);
+    }
+
+    private void impl$callSignChangeEventInternal(final CPacketUpdateSign packetIn, final CallbackInfo ci, final WorldServer worldserver,
+            final BlockPos blockpos, final TileEntitySign tileentitysign) {
         ci.cancel();
         final Optional<SignData> existingSignData = ((Sign) tileentitysign).get(SignData.class);
         if (!existingSignData.isPresent()) {


### PR DESCRIPTION
SpongeCommon | [SpongeVanilla](https://github.com/SpongePowered/SpongeVanilla/pull/425)

This is required for SV due to a "Critical injection failure" in the LVT. I've gone for the path of least resistance and used a surrogate on the method in question. I'm not sure why it shows up now when updating mixin, but I'll let others answer that question. I did a build/clean and setupDecW, but if I've somehow missed something, happy to fix that.

This was tested in a production/obfuscated environment, letting SV download the minecraft server. Without this patch, this is the error: https://gist.github.com/dualspiral/f4d2649e7a44922e570b03836057eaa3

@gabizou just want a sanity check to make sure I've done this right.