### PR TITLE
Fix and optimize DestructEntityEvent for non-living entities

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/EntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/EntityMixin_API.java
@@ -447,7 +447,7 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
 
     @Override
     public void remove() {
-        this.isDead = true;
+        setDead();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/EntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/EntityMixin_API.java
@@ -447,7 +447,7 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
 
     @Override
     public void remove() {
-        setDead();
+        this.setDead();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java
@@ -61,10 +61,10 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.EventContextKeys;
 import org.spongepowered.api.event.cause.entity.dismount.DismountType;
 import org.spongepowered.api.event.cause.entity.dismount.DismountTypes;
-import org.spongepowered.api.event.entity.DestructEntityEvent;
 import org.spongepowered.api.event.entity.IgniteEntityEvent;
 import org.spongepowered.api.event.message.MessageEvent;
 import org.spongepowered.api.text.Text;
@@ -95,8 +95,8 @@ import org.spongepowered.common.bridge.entity.EntityBridge;
 import org.spongepowered.common.bridge.entity.GrieferBridge;
 import org.spongepowered.common.bridge.network.NetHandlerPlayServerBridge;
 import org.spongepowered.common.bridge.util.DamageSourceBridge;
-import org.spongepowered.common.bridge.world.WorldServerBridge;
 import org.spongepowered.common.bridge.world.WorldBridge;
+import org.spongepowered.common.bridge.world.WorldServerBridge;
 import org.spongepowered.common.bridge.world.chunk.ActiveChunkReferantBridge;
 import org.spongepowered.common.bridge.world.chunk.ChunkBridge;
 import org.spongepowered.common.data.util.DataUtil;
@@ -132,7 +132,7 @@ public abstract class EntityMixin implements EntityBridge, TrackableBridge, Vani
     private boolean vanish$isVanished = false;
     private boolean vanish$pendingVisibilityUpdate = false;
     private int vanish$visibilityTicks = 0;
-    @Nullable private DestructEntityEvent impl$destructEvent;
+    @Nullable private Cause impl$destructCause;
 
     @Shadow @Nullable private Entity ridingEntity;
     @Shadow @Final private List<Entity> riddenByEntities;
@@ -242,11 +242,14 @@ public abstract class EntityMixin implements EntityBridge, TrackableBridge, Vani
         this.trackedInWorld = tracked;
         // Since this is called during removeEntity from world, we can
         // post the removal event here, basically.
-        if (!tracked) {
-            if (this.impl$destructEvent != null) {
-                SpongeImpl.postEvent(this.impl$destructEvent);
-            }
-            this.impl$destructEvent = null;
+        if (!tracked && this.impl$destructCause != null) {
+            final MessageChannel originalChannel = MessageChannel.TO_NONE;
+            SpongeImpl.postEvent(SpongeEventFactory.createDestructEntityEvent(
+                    this.impl$destructCause, originalChannel, Optional.of(originalChannel),
+                    new MessageEvent.MessageFormatter(), (org.spongepowered.api.entity.Entity) this, true
+            ));
+
+            this.impl$destructCause = null;
         }
     }
 
@@ -854,16 +857,8 @@ public abstract class EntityMixin implements EntityBridge, TrackableBridge, Vani
         if (ShouldFire.DESTRUCT_ENTITY_EVENT
             && !((WorldBridge) this.world).bridge$isFake()
             && !((Entity) (Object) this instanceof EntityLiving)) {
-            final MessageChannel originalChannel = MessageChannel.TO_NONE;
-            try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
 
-                final DestructEntityEvent event = SpongeEventFactory.createDestructEntityEvent(
-                    frame.getCurrentCause(), originalChannel, Optional.of(originalChannel),
-                    new MessageEvent.MessageFormatter(), (org.spongepowered.api.entity.Entity) this, true
-                );
-
-                this.impl$destructEvent = event;
-            }
+            this.impl$destructCause = Sponge.getCauseStackManager().getCurrentCause();
         }
     }
 


### PR DESCRIPTION
Fixes an issue where `DestructEntityEvent` was not (always) called for non-living entities removed by API `Entity#remove`. Moreover, this PR only stores the cause of the event instead of the whole event.