### PR TITLE
Fix Async tasks stalling

### DIFF
--- a/src/main/java/org/spongepowered/common/scheduler/ScheduledTask.java
+++ b/src/main/java/org/spongepowered/common/scheduler/ScheduledTask.java
@@ -48,7 +48,11 @@ public class ScheduledTask implements Task {
     private final PluginContainer owner;
     private final Consumer<Task> consumer;
     private long timestamp;
-    private ScheduledTaskState state;
+
+    // As this state is going to be read by multiple threads
+    // potentially very quickly, marking this a volatile will
+    // give the JVM a hint to not cache this
+    private volatile ScheduledTaskState state;
     private final UUID id;
     private final String name;
     private final TaskSynchronicity syncType;

--- a/testplugins/src/main/java/org/spongepowered/test/AsyncSchedulerTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/AsyncSchedulerTest.java
@@ -49,16 +49,16 @@ public class AsyncSchedulerTest implements LoadableModule {
     public void enable(CommandSource src) {
         this.task = Task.builder()
                 .async()
-                .delay(5, TimeUnit.SECONDS)
-                .interval(5, TimeUnit.SECONDS)
+                .delay(1, TimeUnit.SECONDS)
+                .interval(1, TimeUnit.SECONDS)
                 .execute(task -> {
                     this.logger.info("Async Logger Test Start");
-                    try {
+                    /*try {
                         // Testing that the next iteration will fire straight after the first.
                         Thread.sleep(6000);
                     } catch (InterruptedException e) {
                         e.printStackTrace();
-                    }
+                    }*/
                     this.logger.info("Async Logger Test End");
                 })
                 .submit(this);


### PR DESCRIPTION
See #2482

* Add lock around post-task method - if the condition is awaiting it doesn't have the lock.
* Add a stateChanged boolean to signal to the loop that something's changed and that it should run the loop again at its earliest convenience if it isn't waiting for signalling, as a safety net.