### PR TITLE
Don't handle health data changes on player spawn

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/network/datasync/EntityDataManagerBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/network/datasync/EntityDataManagerBridge.java
@@ -28,5 +28,6 @@ import net.minecraft.network.datasync.DataParameter;
 
 public interface EntityDataManagerBridge {
 
-    <T> void setSilently(DataParameter<T> key, T value);
+    <T> void bridge$setSilently(DataParameter<T> key, T value);
+
 }

--- a/src/main/java/org/spongepowered/common/bridge/network/datasync/EntityDataManagerBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/network/datasync/EntityDataManagerBridge.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.bridge.network.datasync;
+
+import net.minecraft.network.datasync.DataParameter;
+
+public interface EntityDataManagerBridge {
+
+    <T> void setSilently(DataParameter<T> key, T value);
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
@@ -590,12 +590,18 @@ public abstract class EntityLivingBaseMixin extends EntityMixin implements Livin
         }
     }
 
+    /**
+     * This is necessary to avoid firing ChangeDataHolderEvent.ValueChange
+     * associated with changing health when constructing and spawning a player entity.
+     *
+     * @author Lignium - January 27th, 2020
+     */
     @Redirect(method = {"<init>", "readEntityFromNBT"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;setHealth(F)V"))
-    private void onInitHealth(final EntityLivingBase entity, final float health) {
-        DataParameter<Float> healthParameter = EntityLivingBaseAccessor.accessor$getHealthParameter();
-        float clampedValue = MathHelper.clamp(health, 0.0F, this.getMaxHealth());
+    private void impl$initializeHealthSilently(final EntityLivingBase entity, final float health) {
+        final DataParameter<Float> healthParameter = EntityLivingBaseAccessor.accessor$getHealthParameter();
+        final float clampedValue = MathHelper.clamp(health, 0.0F, this.getMaxHealth());
 
-        ((EntityDataManagerBridge) entity.getDataManager()).setSilently(healthParameter, clampedValue);
+        ((EntityDataManagerBridge) entity.getDataManager()).bridge$setSilently(healthParameter, clampedValue);
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
@@ -40,6 +40,7 @@ import net.minecraft.init.MobEffects;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.potion.Potion;
 import net.minecraft.util.CombatTracker;
 import net.minecraft.util.DamageSource;
@@ -86,6 +87,7 @@ import org.spongepowered.common.bridge.OwnershipTrackedBridge;
 import org.spongepowered.common.bridge.data.DataCompoundHolder;
 import org.spongepowered.common.bridge.entity.LivingEntityBaseBridge;
 import org.spongepowered.common.bridge.entity.player.InventoryPlayerBridge;
+import org.spongepowered.common.bridge.network.datasync.EntityDataManagerBridge;
 import org.spongepowered.common.bridge.entity.player.EntityPlayerBridge;
 import org.spongepowered.common.bridge.entity.player.EntityPlayerMPBridge;
 import org.spongepowered.common.bridge.world.WorldBridge;
@@ -586,6 +588,14 @@ public abstract class EntityLivingBaseMixin extends EntityMixin implements Livin
                 return !flag; // Sponge - remove 'amount > 0.0F'
             }
         }
+    }
+
+    @Redirect(method = {"<init>", "readEntityFromNBT"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;setHealth(F)V"))
+    private void onInitHealth(final EntityLivingBase entity, final float health) {
+        DataParameter<Float> healthParameter = EntityLivingBaseAccessor.accessor$getHealthParameter();
+        float clampedValue = MathHelper.clamp(health, 0.0F, this.getMaxHealth());
+
+        ((EntityDataManagerBridge) entity.getDataManager()).setSilently(healthParameter, clampedValue);
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/mixin/core/network/datasync/EntityDataManagerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/datasync/EntityDataManagerMixin.java
@@ -35,13 +35,11 @@ import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.data.ChangeDataHolderEvent;
 import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Intrinsic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.data.datasync.DataParameterConverter;
-import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.bridge.network.datasync.EntityDataManagerBridge;
 import org.spongepowered.common.bridge.packet.DataParameterBridge;
 
@@ -63,8 +61,8 @@ public abstract class EntityDataManagerMixin implements EntityDataManagerBridge 
     @Shadow protected abstract <T> EntityDataManager.DataEntry<T> getEntry(DataParameter<T> key);
 
     @Override
-    public <T> void setSilently(DataParameter<T> key, T value) {
-        EntityDataManager.DataEntry<T> dataentry = this.getEntry(key);
+    public <T> void bridge$setSilently(DataParameter<T> key, T value) {
+        final EntityDataManager.DataEntry<T> dataentry = this.getEntry(key);
 
         if (ObjectUtils.notEqual(value, dataentry.getValue())) {
             dataentry.setValue(value);


### PR DESCRIPTION
Fixes a bug, the essence of which is that when a player logs in, `ChangeDataHolderEvent.ValueChange` is called, which indicates a change of health. However, these calls are made when the player’s entity is constructing and deserializing, and should not be construed as a real data change.

Resolves my issue on the forum: https://forums.spongepowered.org/t/strange-firing-of-changedataholderevent-valuechange-when-player-entry/34701

Fixes: https://github.com/SpongePowered/SpongeCommon/issues/2524