### PR TITLE
Fix TE capturing with mods

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/WorldMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/WorldMixin.java
@@ -595,10 +595,15 @@ public abstract class WorldMixin implements WorldBridge {
             return;
         }
         if (this.isTileMarkedForRemoval(pos) && !this.bridge$isFake()) {
-            // if (PhaseTracker.getInstance().getCurrentState().allowsGettingQueuedRemovedTiles()) {
             // We must always return the queued TE for mods
             // See https://github.com/SpongePowered/SpongeForge/issues/3001
-            cir.setReturnValue(this.getQueuedRemovedTileFromProxy(pos));
+            if (PhaseTracker.getInstance().getCurrentState().allowsGettingQueuedRemovedTiles()) {
+                cir.setReturnValue(this.getQueuedRemovedTileFromProxy(pos));
+            } else {
+                // If we're not unwinding, then a mod wants what the tile entity
+                // will be
+                cir.setReturnValue(this.getProcessingTileFromProxy(pos));
+            }
         }
 
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/WorldMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/WorldMixin.java
@@ -595,11 +595,10 @@ public abstract class WorldMixin implements WorldBridge {
             return;
         }
         if (this.isTileMarkedForRemoval(pos) && !this.bridge$isFake()) {
-            if (PhaseTracker.getInstance().getCurrentState().allowsGettingQueuedRemovedTiles()) {
-                cir.setReturnValue(this.getQueuedRemovedTileFromProxy(pos));
-                return;
-            }
-            cir.setReturnValue(null);
+            // if (PhaseTracker.getInstance().getCurrentState().allowsGettingQueuedRemovedTiles()) {
+            // We must always return the queued TE for mods
+            // See https://github.com/SpongePowered/SpongeForge/issues/3001
+            cir.setReturnValue(this.getQueuedRemovedTileFromProxy(pos));
         }
 
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/chunk/ChunkMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/chunk/ChunkMixin.java
@@ -551,7 +551,7 @@ public abstract class ChunkMixin implements ChunkBridge, CacheKeyBridge {
             TileEntity tileentity = this.getTileEntity(pos, net.minecraft.world.chunk.Chunk.EnumCreateEntityType.CHECK);
 
             if (tileentity == null) {
-                // Sponge Start - use SpongeImplHooks for forge compatibility
+                // Sponge start - Use SpongeImplHooks for forge compatibility
                 // tileentity = ((ITileEntityProvider)block).createNewTileEntity(this.worldObj, block.getMetaFromState(state)); // Sponge
                 tileentity = SpongeImplHooks.createTileEntity(newBlock, this.world, newState);
 
@@ -563,16 +563,8 @@ public abstract class ChunkMixin implements ChunkBridge, CacheKeyBridge {
                         this.bridge$addTrackedBlockPosition(newBlock, pos, owner, PlayerTracker.Type.OWNER);
                     }
                 }
-                if (transaction != null) {
-                    // Go ahead and log the tile being replaced, the tile being removed will be at least already notified of removal
-                    transaction.queueTileSet = tileentity;
-                    if (tileentity != null) {
-                        ((TileEntityBridge) tileentity).bridge$setCaptured(true);
-                        tileentity.setWorld(this.world);
-                        tileentity.setPos(pos);// Set the position
-                    }
-                    transaction.enqueueChanges(mixinWorld.bridge$getProxyAccess(), peek.getCapturedBlockSupplier());
-                } else {
+
+                if (transaction == null) {
                     // Some mods are relying on the world being set prior to setting the tile
                     // world prior to the position. It's weird, but during block restores, this can
                     // cause an exception.
@@ -584,7 +576,21 @@ public abstract class ChunkMixin implements ChunkBridge, CacheKeyBridge {
                     }
                     this.world.setTileEntity(pos, tileentity);
                 }
+                // Sponge end
             }
+
+            // Sponge start - enqueue any changes to the transaction
+            if (transaction != null) {
+                // Go ahead and log the tile being replaced, the tile being removed will be at least already notified of removal
+                transaction.queueTileSet = tileentity;
+                if (tileentity != null) {
+                    ((TileEntityBridge) tileentity).bridge$setCaptured(true);
+                    tileentity.setWorld(this.world);
+                    tileentity.setPos(pos);
+                }
+                transaction.enqueueChanges(mixinWorld.bridge$getProxyAccess(), peek.getCapturedBlockSupplier());
+            }
+            // Sponge end
 
             if (tileentity != null) {
                 tileentity.updateContainingBlockInfo();


### PR DESCRIPTION
After having to revert this branch for now, I tried to see what was going on with these tile entity issues. It turns out, [mods such as TerraFirmaCraft inspect the TE after setting a block state which may replace another TE](https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/40d0ac3709e8ea0c24a2285060e8bf310b88c164/src/main/java/net/dries007/tfc/objects/te/TEPlacedItem.java#L38-L56).

One of the previous changes returned the outgoing TE when requested at all times if there was an outgoing TE - this actually caused duplication of a lot of TEs on drop. What mods were really looking for was the _incoming_ TE, that is, the pending change. Thankfully, it seems like that works.

I've tested furances, chests and skulls, they seem to work okay. Not tried piston flip flops yet. 

TFC pit kilns work fine to a point - I can fire pots and vessels, but ingot holders disappear. Debugging shows me that the TE is populated with them like other items, so that might be another bug altogether - but it is only apparent with Sponge.

I include a test version here, in case anyone wants to test this for me: [spongeforge-1.12.2-2838-7.1.9-RC0.zip](https://github.com/SpongePowered/SpongeCommon/files/4112574/spongeforge-1.12.2-2838-7.1.9-RC0.zip)

Related issues are:

#2487
https://github.com/SpongePowered/SpongeForge/issues/3058
https://github.com/SpongePowered/SpongeForge/issues/3055
https://github.com/SpongePowered/SpongeForge/issues/3001