### PR TITLE
Remove Queries.WORLD_NAME costrain from location builder

### DIFF
--- a/src/main/java/org/spongepowered/common/data/builder/world/LocationBuilder.java
+++ b/src/main/java/org/spongepowered/common/data/builder/world/LocationBuilder.java
@@ -44,7 +44,7 @@ public class LocationBuilder extends AbstractDataBuilder<Location<World>> {
 
     @Override
     protected Optional<Location<World>> buildContent(DataView container) throws InvalidDataException {
-        if (!container.contains(Queries.WORLD_NAME, Queries.WORLD_ID, Queries.POSITION_X, Queries.POSITION_Y, Queries.POSITION_Z)) {
+        if (!container.contains(Queries.WORLD_ID, Queries.POSITION_X, Queries.POSITION_Y, Queries.POSITION_Z)) {
             return Optional.empty();
         }
         if (container.contains(Queries.CHUNK_X, Queries.CHUNK_Y, Queries.CHUNK_Z)) {


### PR DESCRIPTION
`Queries.WORLD_NAME` is not used when building a location so it doesn't make sense to return an optional empty when it's not there.

This is required for https://github.com/SpongePowered/SpongeAPI/pull/2067 but can be merged without the API PR