### PR TITLE
Casting a very big shadow (API Mixins) (1.14)

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/api/common/event/cause/block/damage/MinecraftFallingBlockDamageSourceMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/common/event/cause/block/damage/MinecraftFallingBlockDamageSourceMixin_API.java
@@ -52,7 +52,7 @@ public abstract class MinecraftFallingBlockDamageSourceMixin_API extends EntityD
     @Override
     public String toString() {
         return MoreObjects.toStringHelper("FallingBlockDamageSource")
-            .add("Name", this.getDamageType())
+            .add("Name", this.shadow$getDamageType())
             .add("Key", this.getType().getKey())
             .add("FallingBlock", this.getSource().toString())
             .add("Data", this.getFallingBlockData())

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/advancements/CriterionProgressMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/advancements/CriterionProgressMixin_API.java
@@ -45,8 +45,7 @@ public abstract class CriterionProgressMixin_API implements org.spongepowered.ap
 
     @Shadow @Final private AdvancementProgress advancementProgress;
     @Shadow @Nullable private Date obtained;
-
-    @Shadow public abstract void reset();
+    @Shadow public abstract void shadow$reset();
 
     @Override
     public AdvancementCriterion getCriterion() {

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/advancements/DisplayInfoMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/advancements/DisplayInfoMixin_API.java
@@ -55,9 +55,7 @@ public abstract class DisplayInfoMixin_API implements TreeLayoutElement, org.spo
     @Shadow @Final private boolean showToast;
     @Shadow private float x;
     @Shadow private float y;
-
     @Shadow public abstract boolean shadow$shouldAnnounceToChat();
-
     @Shadow public abstract boolean shadow$isHidden();
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/enchantment/EnchantmentMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/enchantment/EnchantmentMixin_API.java
@@ -49,13 +49,13 @@ public abstract class EnchantmentMixin_API implements EnchantmentType {
 
     @Shadow protected String name;
     @Shadow @Final private net.minecraft.enchantment.Enchantment.Rarity rarity;
-    @Shadow public abstract int getMinLevel();
-    @Shadow public abstract int getMaxLevel();
-    @Shadow public abstract int getMinEnchantability(int level);
-    @Shadow public abstract int getMaxEnchantability(int level);
-    @Shadow protected abstract boolean canApplyTogether(net.minecraft.enchantment.Enchantment ench);
+    @Shadow public abstract int shadow$getMinLevel();
+    @Shadow public abstract int shadow$getMaxLevel();
+    @Shadow public abstract int shadow$getMinEnchantability(int level);
+    @Shadow public abstract int shadow$getMaxEnchantability(int level);
+    @Shadow protected abstract boolean shadow$canApplyTogether(net.minecraft.enchantment.Enchantment ench);
     @Shadow public abstract String shadow$getName();
-    @Shadow public abstract boolean isTreasureEnchantment();
+    @Shadow public abstract boolean shadow$isTreasureEnchantment();
     @Shadow public abstract boolean shadow$isCurse();
 
     @Shadow @Final public static SimpleRegistry<ResourceLocation, Enchantment> REGISTRY;
@@ -80,22 +80,22 @@ public abstract class EnchantmentMixin_API implements EnchantmentType {
 
     @Override
     public int getMinimumLevel() {
-        return this.getMinLevel();
+        return this.shadow$getMinLevel();
     }
 
     @Override
     public int getMaximumLevel() {
-        return this.getMaxLevel();
+        return this.shadow$getMaxLevel();
     }
 
     @Override
     public int getMinimumEnchantabilityForLevel(int level) {
-        return this.getMinEnchantability(level);
+        return this.shadow$getMinEnchantability(level);
     }
 
     @Override
     public int getMaximumEnchantabilityForLevel(int level) {
-        return this.getMaxEnchantability(level);
+        return this.shadow$getMaxEnchantability(level);
     }
 
     @Override
@@ -110,7 +110,7 @@ public abstract class EnchantmentMixin_API implements EnchantmentType {
 
     @Override
     public boolean isCompatibleWith(EnchantmentType ench) {
-        return this.canApplyTogether((net.minecraft.enchantment.Enchantment) ench);
+        return this.shadow$canApplyTogether((net.minecraft.enchantment.Enchantment) ench);
     }
 
     @Intrinsic
@@ -125,7 +125,7 @@ public abstract class EnchantmentMixin_API implements EnchantmentType {
 
     @Override
     public boolean isTreasure() {
-        return this.isTreasureEnchantment();
+        return this.shadow$isTreasureEnchantment();
     }
 
     @Intrinsic

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/EntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/EntityMixin_API.java
@@ -117,16 +117,16 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
     @Shadow public DimensionType dimension;
     @Shadow protected UUID entityUniqueID;
     @Shadow public boolean removed;
-    @Shadow public abstract void setPosition(double x, double y, double z);
-    @Shadow public abstract void setDead();
-    @Shadow public abstract int getAir();
-    @Shadow public abstract void setAir(int air);
-    @Shadow public abstract UUID getUniqueID();
-    @Shadow public abstract void setFire(int seconds);
-    @Shadow public abstract CompoundNBT writeToNBT(CompoundNBT compound);
-    @Shadow public abstract boolean attackEntityFrom(DamageSource source, float amount);
-    @Shadow public abstract int getEntityId();
-    @Shadow public abstract void playSound(SoundEvent soundIn, float volume, float pitch);
+    @Shadow public abstract void shadow$setPosition(double x, double y, double z);
+    @Shadow public abstract void shadow$setDead();
+    @Shadow public abstract int shadow$getAir();
+    @Shadow public abstract void shadow$setAir(int air);
+    @Shadow public abstract UUID shadow$getUniqueID();
+    @Shadow public abstract void shadow$setFire(int seconds);
+    @Shadow public abstract CompoundNBT shadow$writeToNBT(CompoundNBT compound);
+    @Shadow public abstract boolean shadow$attackEntityFrom(DamageSource source, float amount);
+    @Shadow public abstract int shadow$getEntityId();
+    @Shadow public abstract void shadow$playSound(SoundEvent soundIn, float volume, float pitch);
     @Shadow protected abstract void shadow$setRotation(float yaw, float pitch);
     @Shadow protected abstract AxisAlignedBB shadow$getBoundingBox();
     @Shadow @Nullable public abstract MinecraftServer shadow$getServer();
@@ -248,7 +248,7 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
                             ((Entity) (Object) this).rotationPitch);
                     ((ServerPlayNetHandlerBridge) player.connection).bridge$setLastMoveLocation(null); // Set last move to teleport target
                 } else {
-                    this.setPosition(location.getPosition().getX(), location.getPosition().getY(), location.getPosition().getZ());
+                    this.shadow$setPosition(location.getPosition().getX(), location.getPosition().getY(), location.getPosition().getZ());
                 }
 
                 if (isTeleporting || isChangingDimension) {
@@ -434,7 +434,7 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
             return false;
         }
         // Causes at this point should already be pushed from plugins before this point with the cause system.
-        return this.attackEntityFrom((DamageSource) damageSource, (float) damage);
+        return this.shadow$attackEntityFrom((DamageSource) damageSource, (float) damage);
     }
 
     @Override
@@ -466,7 +466,7 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
     public DataContainer toContainer() {
         final Transform<World> transform = this.getTransform();
         final CompoundNBT compound = new CompoundNBT();
-        this.writeToNBT(compound);
+        this.shadow$writeToNBT(compound);
         Constants.NBT.filterSpongeCustomData(compound); // We must filter the custom data so it isn't stored twice
         final DataContainer unsafeNbt = NbtTranslator.getInstance().translateFrom(compound);
         final DataContainer container = DataContainer.createNew()
@@ -514,7 +514,7 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
         }
         try {
             final CompoundNBT compound = new CompoundNBT();
-            this.writeToNBT(compound);
+            this.shadow$writeToNBT(compound);
             final Entity entity = EntityList.createEntityByIDFromName(new ResourceLocation(this.entityType.getId()), this.world);
             compound.putUniqueId(Constants.UUID, entity.getUniqueID());
             entity.read(compound);

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/LivingEntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/LivingEntityMixin_API.java
@@ -50,7 +50,7 @@ public abstract class LivingEntityMixin_API extends EntityMixin_API implements L
 
     @Override
     public Text getTeamRepresentation() {
-        return Text.of(this.getUniqueID().toString());
+        return Text.of(this.shadow$getUniqueID().toString());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/boss/dragon/phase/PhaseManagerMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/boss/dragon/phase/PhaseManagerMixin_API.java
@@ -36,8 +36,8 @@ import org.spongepowered.asm.mixin.Shadow;
 @Mixin(PhaseManager.class)
 public abstract class PhaseManagerMixin_API implements DragonPhaseManager {
 
-    @Shadow public abstract void setPhase(PhaseType<?> phaseIn);
     @Shadow private IPhase phase;
+    @Shadow public abstract void shadow$setPhase(PhaseType<?> phaseIn);
 
     @Override
     public DragonPhase getPhase() {
@@ -46,7 +46,7 @@ public abstract class PhaseManagerMixin_API implements DragonPhaseManager {
 
     @Override
     public DragonPhase setPhase(DragonPhaseType phase) {
-        this.setPhase((PhaseType<?>) phase);
+        this.shadow$setPhase((PhaseType<?>) phase);
         return (DragonPhase) this.phase;
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/item/EnderCrystalEntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/item/EnderCrystalEntityMixin_API.java
@@ -25,16 +25,12 @@
 package org.spongepowered.common.mixin.api.mcp.entity.item;
 
 import net.minecraft.entity.item.EnderCrystalEntity;
-import net.minecraft.util.math.BlockPos;
-import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.entity.explosive.EnderCrystal;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.bridge.entity.item.EnderCrystalEntityBridge;
 import org.spongepowered.common.mixin.api.mcp.entity.EntityMixin_API;
 
-import javax.annotation.Nullable;
 import java.util.Set;
 
 @Mixin(EnderCrystalEntity.class)
@@ -42,7 +38,7 @@ public abstract class EnderCrystalEntityMixin_API extends EntityMixin_API implem
 
     @Override
     public void detonate() {
-        this.setDead();
+        this.shadow$setDead();
         ((EnderCrystalEntityBridge) this).bridge$ThrowEventWithDetonation(this.world, null, this.posX, this.posY, this.posZ, true, null);
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/item/FireworkRocketEntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/item/FireworkRocketEntityMixin_API.java
@@ -39,12 +39,12 @@ public abstract class FireworkRocketEntityMixin_API extends EntityMixin_API impl
     @Shadow private int fireworkAge;
     @Shadow private int lifetime;
 
-    @Shadow public abstract void onUpdate();
+    @Shadow public abstract void shadow$func_213893_k();
 
     @Override
     public void detonate() {
         this.fireworkAge = this.lifetime + 1;
-        this.onUpdate();
+        this.shadow$func_213893_k();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/item/TNTEntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/item/TNTEntityMixin_API.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.mixin.api.mcp.entity.item;
 
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.item.TNTEntity;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.entity.explosive.fused.PrimedTNT;
@@ -34,18 +33,15 @@ import org.spongepowered.common.mixin.api.mcp.entity.EntityMixin_API;
 
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
 @Mixin(TNTEntity.class)
 public abstract class TNTEntityMixin_API extends EntityMixin_API implements PrimedTNT {
 
-    @Shadow @Nullable private LivingEntity tntPlacedBy;
-    @Shadow private void explode() { }
+    @Shadow private void shadow$explode() { }
 
     @Override
     public void detonate() {
-        this.setDead();
-        this.explode();
+        this.shadow$setDead();
+        this.shadow$explode();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/item/minecart/TNTMinecartEntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/item/minecart/TNTMinecartEntityMixin_API.java
@@ -39,7 +39,7 @@ import java.util.Set;
 public abstract class TNTMinecartEntityMixin_API extends AbstractMinecartEntityMixin_API implements TNTMinecart {
 
     @Shadow private int minecartTNTFuse;
-    @Shadow public abstract void ignite();
+    @Shadow public abstract void shadow$ignite();
 
     @Override
     public void detonate() {

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/merchant/villager/AbstractVillagerEntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/merchant/villager/AbstractVillagerEntityMixin_API.java
@@ -40,7 +40,6 @@ import java.util.Set;
 @Mixin(AbstractVillagerEntity.class)
 public abstract class AbstractVillagerEntityMixin_API extends AgeableEntityMixin_API implements Trader {
 
-    @Shadow public abstract boolean shadow$hasCustomer();
     @Shadow public abstract void shadow$setCustomer(PlayerEntity player);
     @Shadow public abstract PlayerEntity shadow$getCustomer();
 

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/monster/CreeperEntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/monster/CreeperEntityMixin_API.java
@@ -35,11 +35,11 @@ import java.util.Set;
 @Mixin(CreeperEntity.class)
 public abstract class CreeperEntityMixin_API extends MonsterEntityMixin_API implements Creeper {
 
-    @Shadow private void explode() { } // explode
+    @Shadow private void shadow$explode() { } // explode
 
     @Override
     public void detonate() {
-        this.explode();
+        this.shadow$explode();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/passive/ParrotEntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/passive/ParrotEntityMixin_API.java
@@ -28,14 +28,11 @@ import net.minecraft.entity.passive.ParrotEntity;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.entity.living.animal.Parrot;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 
 import java.util.Set;
 
 @Mixin(ParrotEntity.class)
 public abstract class ParrotEntityMixin_API extends TameableEntityMixin_API implements Parrot {
-
-    @Shadow public abstract int getVariant();
 
     @Override
     protected Set<Value.Immutable<?>> api$getVanillaValues() {

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/passive/horse/LlamaEntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/passive/horse/LlamaEntityMixin_API.java
@@ -28,16 +28,11 @@ import net.minecraft.entity.passive.horse.LlamaEntity;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.entity.living.animal.horse.llama.Llama;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 
 import java.util.Set;
 
 @Mixin(LlamaEntity.class)
 public abstract class LlamaEntityMixin_API extends AbstractChestedHorseEntityMixin_API implements Llama {
-
-    @Shadow public abstract int getStrength();
-    @Shadow public abstract int getVariant();
-    @Shadow public abstract void setVariant(int p_190710_1_);
 
     @Override
     protected Set<Value.Immutable<?>> api$getVanillaValues() {

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/player/PlayerEntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/player/PlayerEntityMixin_API.java
@@ -48,11 +48,11 @@ public abstract class PlayerEntityMixin_API extends LivingEntityMixin_API {
 
     @Shadow public Container openContainer;
     @Shadow public float experience;
-    @Shadow public PlayerAbilities capabilities;
+    @Shadow public PlayerAbilities abilities;
     @Shadow public PlayerInventory inventory;
-    @Shadow protected EnderChestInventory enderChest;
+    @Shadow protected EnderChestInventory enterChestInventory;
     @Shadow public abstract String shadow$getName();
-    @Shadow @Nullable public abstract Team getTeam();
+    @Shadow @Nullable public abstract Team shadow$getTeam();
     @Shadow public abstract CooldownTracker shadow$getCooldownTracker();
 
     final boolean impl$isFake = SpongeImplHooks.isFakePlayer((PlayerEntity) (Object) this);

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/projectile/FireballEntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/projectile/FireballEntityMixin_API.java
@@ -41,7 +41,7 @@ public abstract class FireballEntityMixin_API extends AbstractFireballEntityMixi
     @Override
     public void detonate() {
         ((FireballEntityBridge) this).bridge$throwExplosionEventAndExplode(this.world, null, this.posX, this.posY, this.posZ, this.explosionPower, true, true);
-        this.setDead();
+        this.shadow$setDead();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/projectile/WitherSkullEntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/projectile/WitherSkullEntityMixin_API.java
@@ -38,7 +38,7 @@ public abstract class WitherSkullEntityMixin_API extends DamagingProjectileEntit
     @Override
     public void detonate() {
         ((WitherSkullEntityBridge) this).bridge$CreateAndProcessExplosionEvent(this.world, (WitherSkullEntity) (Object) this, this.posX, this.posY, this.posZ, 0, false, true);
-        this.setDead();
+        this.shadow$setDead();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/item/ItemMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/item/ItemMixin_API.java
@@ -47,8 +47,8 @@ import javax.annotation.Nullable;
 @Mixin(Item.class)
 public abstract class ItemMixin_API implements ItemType {
 
-    @Shadow public abstract int getItemStackLimit();
-    @Shadow public abstract String getTranslationKey();
+    @Shadow public abstract int shadow$getMaxStackSize();
+    @Shadow public abstract String shadow$getTranslationKey();
     @Shadow private Item containerItem;
 
     @Nullable protected BlockType blockType = null;
@@ -76,12 +76,12 @@ public abstract class ItemMixin_API implements ItemType {
 
     @Override
     public Translation getTranslation() {
-        return new SpongeTranslation(this.getTranslationKey() + ".name");
+        return new SpongeTranslation(this.shadow$getTranslationKey() + ".name");
     }
 
     @Override
     public int getMaxStackQuantity() {
-        return this.getItemStackLimit();
+        return this.shadow$getMaxStackSize();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/item/ItemStackMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/item/ItemStackMixin_API.java
@@ -29,7 +29,6 @@ import net.minecraft.item.Item;
 import net.minecraft.nbt.CompoundNBT;
 import org.apache.logging.log4j.Level;
 import org.spongepowered.api.data.DataHolder;
-import org.spongepowered.api.data.DataManipulator.Mutable;
 import org.spongepowered.api.data.persistence.DataContainer;
 import org.spongepowered.api.data.persistence.DataView;
 import org.spongepowered.api.data.persistence.InvalidDataException;
@@ -63,20 +62,20 @@ import javax.annotation.Nullable;
 @Implements(@Interface(iface = ItemStack.class, prefix = "apiStack$")) // We need to soft implement this interface due to a synthetic bridge method
 public abstract class ItemStackMixin_API implements DataHolder {       // conflict from overriding ValueContainer#copy() from DataHolder
 
-    @Shadow public abstract int getCount();
-    @Shadow public abstract void setCount(int size); // Do not use field directly as Minecraft tracks the empty state
-    @Shadow public abstract void setItemDamage(int meta);
-    @Shadow public abstract void setTagCompound(@Nullable CompoundNBT compound);
-    @Shadow public abstract int getItemDamage();
-    @Shadow public abstract int getMaxStackSize();
-    @Shadow public abstract boolean hasTagCompound();
+    @Shadow public abstract int shadow$getCount();
+    @Shadow public abstract void shadow$setCount(int size); // Do not use field directly as Minecraft tracks the empty state
+    @Shadow public abstract void shadow$setDamage(int meta);
+    @Shadow public abstract void shadow$setTag(@Nullable CompoundNBT compound);
+    @Shadow public abstract int shadow$getDamage();
+    @Shadow public abstract int shadow$getMaxStackSize();
+    @Shadow public abstract boolean shadow$hasTag();
     @Shadow public abstract boolean shadow$isEmpty();
-    @Shadow public abstract CompoundNBT getTagCompound();
+    @Shadow public abstract CompoundNBT shadow$getTag();
     @Shadow public abstract net.minecraft.item.ItemStack shadow$copy();
     @Shadow public abstract Item shadow$getItem();
 
     public int apiStack$getQuantity() {
-        return this.getCount();
+        return this.shadow$getCount();
     }
 
     public ItemType apiStack$getType() {
@@ -84,11 +83,11 @@ public abstract class ItemStackMixin_API implements DataHolder {       // confli
     }
 
     public void apiStack$setQuantity(int quantity) throws IllegalArgumentException {
-        this.setCount(quantity);
+        this.shadow$setCount(quantity);
     }
 
     public int apiStack$getMaxStackQuantity() {
-        return this.getMaxStackSize();
+        return this.shadow$getMaxStackSize();
     }
 
     @Override
@@ -106,10 +105,10 @@ public abstract class ItemStackMixin_API implements DataHolder {       // confli
         }
         final DataView nbtData = container.getView(Constants.Sponge.UNSAFE_NBT).get();
         try {
-            final int integer = container.getInt(Constants.ItemStack.DAMAGE_VALUE).orElse(this.getItemDamage());
-            this.setItemDamage(integer);
+            final int integer = container.getInt(Constants.ItemStack.DAMAGE_VALUE).orElse(this.shadow$getDamage());
+            this.shadow$setDamage(integer);
             final CompoundNBT stackCompound = NbtTranslator.getInstance().translate(nbtData);
-            this.setTagCompound(stackCompound);
+            this.shadow$setTag(stackCompound);
         } catch (Exception e) {
             throw new InvalidDataException("Unable to set raw data or translate raw data for ItemStack setting", e);
         }
@@ -121,7 +120,7 @@ public abstract class ItemStackMixin_API implements DataHolder {       // confli
     }
 
     public ItemStack apiStack$copy() {
-        return (ItemStack) this.shadow$copy();
+        return (ItemStack) (Object) this.shadow$copy();
     }
 
     @Override
@@ -135,9 +134,9 @@ public abstract class ItemStackMixin_API implements DataHolder {       // confli
             .set(Queries.CONTENT_VERSION, this.getContentVersion())
                 .set(Constants.ItemStack.TYPE, this.apiStack$getType().getId())
                 .set(Constants.ItemStack.COUNT, this.apiStack$getQuantity())
-                .set(Constants.ItemStack.DAMAGE_VALUE, this.getItemDamage());
-        if (this.hasTagCompound()) { // no tag? no data, simple as that.
-            final CompoundNBT compound = this.getTagCompound().copy();
+                .set(Constants.ItemStack.DAMAGE_VALUE, this.shadow$getDamage());
+        if (this.shadow$hasTag()) { // no tag? no data, simple as that.
+            final CompoundNBT compound = this.shadow$getTag().copy();
             if (compound.contains(Constants.Sponge.SPONGE_DATA)) {
                 final CompoundNBT spongeCompound = compound.getCompound(Constants.Sponge.SPONGE_DATA);
                 if (spongeCompound.contains(Constants.Sponge.CUSTOM_MANIPULATOR_TAG_LIST)) {
@@ -174,7 +173,7 @@ public abstract class ItemStackMixin_API implements DataHolder {       // confli
     public boolean apiStack$equalTo(ItemStack that) {
         return net.minecraft.item.ItemStack.areItemStacksEqual(
                 (net.minecraft.item.ItemStack) (Object) this,
-                (net.minecraft.item.ItemStack) that
+                (net.minecraft.item.ItemStack) (Object) that
         );
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/network/PacketBufferMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/network/PacketBufferMixin_API.java
@@ -54,19 +54,19 @@ import javax.annotation.Nullable;
 public abstract class PacketBufferMixin_API extends ByteBuf {
 
     // mojang methods, fluent in target
-    @Shadow public abstract PacketBuffer writeByteArray(byte[] array);
-    @Shadow public abstract PacketBuffer writeVarInt(int input);
-    @Shadow public abstract PacketBuffer writeString(String string);
-    @Shadow public abstract PacketBuffer writeCompoundTag(@Nullable CompoundNBT nbt);
-    @Shadow public abstract PacketBuffer writeUniqueId(UUID uniqueId);
+    @Shadow public abstract PacketBuffer shadow$writeByteArray(byte[] array);
+    @Shadow public abstract PacketBuffer shadow$writeVarInt(int input);
+    @Shadow public abstract PacketBuffer shadow$writeString(String string);
+    @Shadow public abstract PacketBuffer shadow$writeCompoundTag(@Nullable CompoundNBT nbt);
+    @Shadow public abstract PacketBuffer shadow$writeUniqueId(UUID uniqueId);
     
     // mojang methods, non-fluent
-    @Shadow public abstract byte[] readByteArray();
-    @Shadow public abstract byte[] readByteArray(int limit);
-    @Shadow public abstract int readVarInt();
-    @Shadow public abstract String readString(int maxLength);
-    @Shadow public abstract CompoundNBT readCompoundTag() throws IOException;
-    @Shadow public abstract UUID readUniqueId();
+    @Shadow public abstract byte[] shadow$readByteArray();
+    @Shadow public abstract byte[] shadow$readByteArray(int limit);
+    @Shadow public abstract int shadow$readVarInt();
+    @Shadow public abstract String shadow$readString(int maxLength);
+    @Shadow public abstract CompoundNBT shadow$readCompoundTag() throws IOException;
+    @Shadow public abstract UUID shadow$readUniqueId();
 
     public int cbuf$getCapacity() {
         return this.capacity();
@@ -196,7 +196,7 @@ public abstract class PacketBufferMixin_API extends ByteBuf {
     }
 
     public ChannelBuf cbuf$writeByteArray(byte[] data) {
-        return (ChannelBuf) this.writeByteArray(data); // fluent in target
+        return (ChannelBuf) this.shadow$writeByteArray(data); // fluent in target
     }
 
     public ChannelBuf cbuf$writeByteArray(byte[] data, int start, int length) {
@@ -216,12 +216,12 @@ public abstract class PacketBufferMixin_API extends ByteBuf {
 
     @Intrinsic
     public byte[] cbuf$readByteArray() {
-        return this.readByteArray();
+        return this.shadow$readByteArray();
     }
 
     @Intrinsic
     public byte[] cbuf$readByteArray(int index) {
-        return this.readByteArray(index);
+        return this.shadow$readByteArray(index);
     }
 
     public ChannelBuf cbuf$writeBytes(byte[] data) {
@@ -376,51 +376,51 @@ public abstract class PacketBufferMixin_API extends ByteBuf {
     }
 
     public ChannelBuf cbuf$writeVarInt(int value) {
-        return (ChannelBuf) this.writeVarInt(value); // fluent in target
+        return (ChannelBuf) this.shadow$writeVarInt(value); // fluent in target
     }
 
     public ChannelBuf cbuf$setVarInt(int index, int value) {
         final int oldIndex = this.writerIndex();
         this.writerIndex(index);
-        this.writeVarInt(value);
+        this.shadow$writeVarInt(value);
         this.writerIndex(oldIndex);
         return (ChannelBuf) this;
     }
 
     @Intrinsic
     public int cbuf$readVarInt() {
-        return this.readVarInt();
+        return this.shadow$readVarInt();
     }
 
     public int cbuf$getVarInt(int index) {
         final int oldIndex = this.readerIndex();
         this.readerIndex(index);
-        final int value = this.readVarInt();
+        final int value = this.shadow$readVarInt();
         this.readerIndex(oldIndex);
         return value;
     }
 
     public ChannelBuf cbuf$writeString(String data) {
-        return (ChannelBuf) this.writeString(checkNotNull(data)); // fluent in target
+        return (ChannelBuf) this.shadow$writeString(checkNotNull(data)); // fluent in target
     }
 
     public ChannelBuf cbuf$setString(int index, String data) {
         checkNotNull(data);
         final int oldIndex = this.writerIndex();
         this.writerIndex(index);
-        this.writeString(data);
+        this.shadow$writeString(data);
         this.writerIndex(oldIndex);
         return (ChannelBuf) this;
     }
 
     public String cbuf$readString() {
-        return this.readString(Constants.Networking.MAX_STRING_LENGTH);
+        return this.shadow$readString(Constants.Networking.MAX_STRING_LENGTH);
     }
 
     public String cbuf$getString(int index) {
         final int oldIndex = this.readerIndex();
         this.readerIndex(index);
-        final String value = this.readString(Constants.Networking.MAX_STRING_LENGTH);
+        final String value = this.shadow$readString(Constants.Networking.MAX_STRING_LENGTH);
         this.readerIndex(oldIndex);
         return value;
     }
@@ -465,34 +465,34 @@ public abstract class PacketBufferMixin_API extends ByteBuf {
 
     public ChannelBuf cbuf$writeUniqueId(UUID data) {
         checkNotNull(data, "data");
-        return (ChannelBuf) this.writeUniqueId(data); // fluent in target
+        return (ChannelBuf) this.shadow$writeUniqueId(data); // fluent in target
     }
 
     public ChannelBuf cbuf$setUniqueId(int index, UUID data) {
         checkNotNull(data, "data");
         final int oldIndex = this.writerIndex();
         this.writerIndex(index);
-        this.writeUniqueId(data);
+        this.shadow$writeUniqueId(data);
         this.writerIndex(oldIndex);
         return (ChannelBuf) this;
     }
 
     @Intrinsic
     public UUID cbuf$readUniqueId() {
-        return this.readUniqueId();
+        return this.shadow$readUniqueId();
     }
 
     public UUID getUniqueId(int index) {
         final int oldIndex = this.readerIndex();
         this.readerIndex(index);
-        final UUID data = this.readUniqueId();
+        final UUID data = this.shadow$readUniqueId();
         this.readerIndex(oldIndex);
         return data;
     }
 
     public ChannelBuf cbuf$writeDataView(DataView data) {
         final CompoundNBT compound = NbtTranslator.getInstance().translateData(checkNotNull(data, "data"));
-        this.writeCompoundTag(compound);
+        this.shadow$writeCompoundTag(compound);
         return (ChannelBuf) this;
     }
 
@@ -507,7 +507,7 @@ public abstract class PacketBufferMixin_API extends ByteBuf {
 
     public DataView cbuf$readDataView() {
         try {
-            return NbtTranslator.getInstance().translateFrom(this.readCompoundTag());
+            return NbtTranslator.getInstance().translateFrom(this.shadow$readCompoundTag());
         } catch (IOException e) {
             throw new DecoderException(e);
         }

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/network/play/ServerPlayNetHandlerMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/network/play/ServerPlayNetHandlerMixin_API.java
@@ -44,10 +44,9 @@ public abstract class ServerPlayNetHandlerMixin_API implements PlayerConnection 
     @Shadow @Final public NetworkManager netManager;
     @Shadow public ServerPlayerEntity player;
 
-    @Shadow public abstract void sendPacket(final IPacket<?> packetIn);
-    @Shadow public abstract void disconnect(ITextComponent reason);
-
-    @Shadow protected abstract long currentTimeMillis();
+    @Shadow public abstract void shadow$sendPacket(final IPacket<?> packetIn);
+    @Shadow public abstract void shadow$disconnect(ITextComponent reason);
+    @Shadow protected abstract long shadow$currentTimeMillis();
 
     @Override
     public Player getPlayer() {

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/potion/EffectInstanceMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/potion/EffectInstanceMixin_API.java
@@ -44,7 +44,7 @@ public abstract class EffectInstanceMixin_API implements PotionEffect {
     @Shadow @Final private Effect potion;
     @Shadow private int duration;
     @Shadow private int amplifier;
-    @Shadow private boolean isAmbient;
+    @Shadow private boolean ambient;
     @Shadow private boolean showParticles;
 
     @Override
@@ -64,7 +64,7 @@ public abstract class EffectInstanceMixin_API implements PotionEffect {
 
     @Override
     public boolean isAmbient() {
-        return this.isAmbient;
+        return this.ambient;
     }
 
     @Override
@@ -84,7 +84,7 @@ public abstract class EffectInstanceMixin_API implements PotionEffect {
                 .set(Constants.Item.Potions.POTION_TYPE, this.getType().getId())
                 .set(Constants.Item.Potions.POTION_DURATION, this.duration)
                 .set(Constants.Item.Potions.POTION_AMPLIFIER, this.amplifier)
-                .set(Constants.Item.Potions.POTION_AMBIANCE, this.isAmbient)
+                .set(Constants.Item.Potions.POTION_AMBIANCE, this.ambient)
                 .set(Constants.Item.Potions.POTION_SHOWS_PARTICLES, this.showParticles);
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/scoreboard/ScorePlayerTeamMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/scoreboard/ScorePlayerTeamMixin_API.java
@@ -26,6 +26,7 @@ package org.spongepowered.common.mixin.api.mcp.scoreboard;
 
 import net.minecraft.scoreboard.ScorePlayerTeam;
 import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextFormatting;
 import org.spongepowered.api.scoreboard.Team;
 import org.spongepowered.api.scoreboard.Visibility;
@@ -58,17 +59,17 @@ public abstract class ScorePlayerTeamMixin_API implements Team {
     @Shadow @Final private Set<String> membershipSet;
 
     @Shadow public abstract void shadow$setAllowFriendlyFire(boolean friendlyFire);
-    @Shadow public abstract void setSeeFriendlyInvisiblesEnabled(boolean friendlyInvisibles);
+    @Shadow public abstract void shadow$setSeeFriendlyInvisiblesEnabled(boolean friendlyInvisibles);
     @Shadow public abstract void shadow$setNameTagVisibility(net.minecraft.scoreboard.Team.Visible visibility);
     @Shadow public abstract void shadow$setDeathMessageVisibility(net.minecraft.scoreboard.Team.Visible visibility);
     @Shadow public abstract void shadow$setCollisionRule(net.minecraft.scoreboard.Team.CollisionRule rule);
-    @Shadow public abstract void setDisplayName(String name);
+    @Shadow public abstract void shadow$setDisplayName(ITextComponent text);
     @Shadow public abstract boolean shadow$getAllowFriendlyFire();
-    @Shadow public abstract boolean getSeeFriendlyInvisiblesEnabled();
+    @Shadow public abstract boolean shadow$getSeeFriendlyInvisiblesEnabled();
     @Shadow public abstract net.minecraft.scoreboard.Team.Visible shadow$getNameTagVisibility();
     @Shadow public abstract net.minecraft.scoreboard.Team.Visible shadow$getDeathMessageVisibility();
     @Shadow public abstract net.minecraft.scoreboard.Team.CollisionRule shadow$getCollisionRule();
-    @Shadow public abstract Collection<String> getMembershipCollection();
+    @Shadow public abstract Collection<String> shadow$getMembershipCollection();
 
     @Intrinsic
     public String team$getName() {
@@ -129,12 +130,12 @@ public abstract class ScorePlayerTeamMixin_API implements Team {
 
     @Override
     public boolean canSeeFriendlyInvisibles() {
-        return this.getSeeFriendlyInvisiblesEnabled();
+        return this.shadow$getSeeFriendlyInvisiblesEnabled();
     }
 
     @Override
     public void setCanSeeFriendlyInvisibles(final boolean enabled) {
-        this.setSeeFriendlyInvisiblesEnabled(enabled);
+        this.shadow$setSeeFriendlyInvisiblesEnabled(enabled);
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -175,7 +176,7 @@ public abstract class ScorePlayerTeamMixin_API implements Team {
 
     @Override
     public Set<Text> getMembers() {
-        return this.getMembershipCollection().stream().map(SpongeTexts::fromLegacy).collect(Collectors.toSet());
+        return this.shadow$getMembershipCollection().stream().map(SpongeTexts::fromLegacy).collect(Collectors.toSet());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/scoreboard/ServerScoreboardMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/scoreboard/ServerScoreboardMixin_API.java
@@ -66,7 +66,7 @@ import java.util.stream.Collectors;
 @Implements(@Interface(iface = org.spongepowered.api.scoreboard.Scoreboard.class, prefix = "scoreboard$"))
 public abstract class ServerScoreboardMixin_API extends Scoreboard {
 
-    @Shadow protected abstract void markSaveDataDirty();
+    @Shadow protected abstract void shadow$markSaveDataDirty();
 
     // Get Objective
 
@@ -161,7 +161,7 @@ public abstract class ServerScoreboardMixin_API extends Scoreboard {
         }
 
         // We deliberately don't call func_96533_c, because there's no need
-        this.markSaveDataDirty();
+        this.shadow$markSaveDataDirty();
 
         ((SpongeObjective) objective).removeObjectiveFor(this);
     }

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/server/management/PlayerProfileCacheMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/server/management/PlayerProfileCacheMixin_API.java
@@ -61,9 +61,9 @@ public abstract class PlayerProfileCacheMixin_API implements GameProfileCache {
 
     @Shadow @Final private Map<String, PlayerProfileCache_ProfileEntryAccessor> usernameToProfileEntryMap;
     @Shadow @Final private Map<UUID, PlayerProfileCache_ProfileEntryAccessor> uuidToProfileEntryMap;
-    @Nullable @Shadow public abstract com.mojang.authlib.GameProfile getProfileByUUID(UUID uniqueId);
-    @Shadow public abstract void save();
-    @Shadow private void addEntry(com.mojang.authlib.GameProfile profile, @Nullable Date expiry) { }
+    @Nullable @Shadow public abstract com.mojang.authlib.GameProfile shadow$getProfileByUUID(UUID uniqueId);
+    @Shadow public abstract void shadow$save();
+    @Shadow private void shadow$addEntry(com.mojang.authlib.GameProfile profile, @Nullable Date expiry) { }
     // Thread-safe queue
     private Queue<com.mojang.authlib.GameProfile> profiles = new ConcurrentLinkedQueue<>();
 
@@ -76,7 +76,7 @@ public abstract class PlayerProfileCacheMixin_API implements GameProfileCache {
             return false;
         }
 
-        this.addEntry((com.mojang.authlib.GameProfile) profile, expiry == null ? null : new Date(expiry.toEpochMilli()));
+        this.shadow$addEntry((com.mojang.authlib.GameProfile) profile, expiry == null ? null : new Date(expiry.toEpochMilli()));
 
         return true;
     }
@@ -121,12 +121,12 @@ public abstract class PlayerProfileCacheMixin_API implements GameProfileCache {
         this.uuidToProfileEntryMap.clear();
         this.profiles.clear();
         this.usernameToProfileEntryMap.clear();
-        this.save();
+        this.shadow$save();
     }
 
     @Override
     public Optional<GameProfile> getById(UUID uniqueId) {
-        return Optional.ofNullable((GameProfile) this.getProfileByUUID(checkNotNull(uniqueId, "unique id")));
+        return Optional.ofNullable((GameProfile) this.shadow$getProfileByUUID(checkNotNull(uniqueId, "unique id")));
     }
 
     @Override
@@ -136,7 +136,7 @@ public abstract class PlayerProfileCacheMixin_API implements GameProfileCache {
         Map<UUID, Optional<GameProfile>> result = Maps.newHashMap();
 
         for (UUID uniqueId : uniqueIds) {
-            result.put(uniqueId, Optional.ofNullable((GameProfile) this.getProfileByUUID(uniqueId)));
+            result.put(uniqueId, Optional.ofNullable((GameProfile) this.shadow$getProfileByUUID(uniqueId)));
         }
 
         return result.isEmpty() ? ImmutableMap.of() : ImmutableMap.copyOf(result);
@@ -149,7 +149,7 @@ public abstract class PlayerProfileCacheMixin_API implements GameProfileCache {
         com.mojang.authlib.GameProfile profile = SpongeImpl.getServer().getMinecraftSessionService().fillProfileProperties(
                 new com.mojang.authlib.GameProfile(uniqueId, ""), true);
         if (profile != null && profile.getName() != null && !profile.getName().isEmpty()) {
-            this.addEntry(profile, null);
+            this.shadow$addEntry(profile, null);
             return Optional.of((GameProfile) profile);
         }
         return Optional.empty();
@@ -165,12 +165,12 @@ public abstract class PlayerProfileCacheMixin_API implements GameProfileCache {
         for (UUID uniqueId : uniqueIds) {
             com.mojang.authlib.GameProfile profile = service.fillProfileProperties(new com.mojang.authlib.GameProfile(uniqueId, ""), true);
             if (profile != null && profile.getName() != null && !profile.getName().isEmpty()) {
-                this.addEntry(profile, null);
+                this.shadow$addEntry(profile, null);
                 result.put(uniqueId, Optional.of((GameProfile) profile));
             } else {
                 // create a dummy profile to avoid future lookups
                 // if actual user logs in, the profile will be updated during PlayerList#initializeConnectionToPlayer
-                this.addEntry(new com.mojang.authlib.GameProfile(uniqueId, "[sponge]"), null);
+                this.shadow$addEntry(new com.mojang.authlib.GameProfile(uniqueId, "[sponge]"), null);
                 result.put(uniqueId, Optional.empty());
             }
         }
@@ -231,7 +231,7 @@ public abstract class PlayerProfileCacheMixin_API implements GameProfileCache {
 
         Optional<GameProfile> profile = callback.getResult();
         if (profile.isPresent()) {
-            this.addEntry((com.mojang.authlib.GameProfile) profile.get(), null);
+            this.shadow$addEntry((com.mojang.authlib.GameProfile) profile.get(), null);
         }
 
         return profile;
@@ -249,7 +249,7 @@ public abstract class PlayerProfileCacheMixin_API implements GameProfileCache {
         if (!result.isEmpty()) {
             for (Optional<GameProfile> entry : result.values()) {
                 if (entry.isPresent()) {
-                    this.addEntry((com.mojang.authlib.GameProfile) entry.get(), null);
+                    this.shadow$addEntry((com.mojang.authlib.GameProfile) entry.get(), null);
                 }
             }
             return ImmutableMap.copyOf(result);

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/server/management/ProfileBanEntryMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/server/management/ProfileBanEntryMixin_API.java
@@ -41,6 +41,6 @@ public abstract class ProfileBanEntryMixin_API extends BanEntryMixin_API<com.moj
 
     @Override
     public GameProfile getProfile() {
-        return (GameProfile) this.getValue();
+        return (GameProfile) this.shadow$getValue();
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/server/management/UserListEntryMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/server/management/UserListEntryMixin_API.java
@@ -31,6 +31,6 @@ import org.spongepowered.asm.mixin.Shadow;
 @Mixin(UserListEntry.class)
 public abstract class UserListEntryMixin_API<T> {
 
-    @Shadow abstract T getValue(); // Valid for subclass use, it's package
+    @Shadow abstract T shadow$getValue(); // Valid for subclass use, it's package
 
 }

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/util/CooldownTrackerMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/util/CooldownTrackerMixin_API.java
@@ -44,15 +44,14 @@ public abstract class CooldownTrackerMixin_API implements org.spongepowered.api.
 
     @Shadow @Final private Map<Item, ?> cooldowns;
     @Shadow private int ticks;
-
-    @Shadow public abstract boolean hasCooldown(Item itemIn);
-    @Shadow public abstract float getCooldown(Item itemIn, float partialTicks);
-    @Shadow public abstract void setCooldown(final Item item, final int ticks);
+    @Shadow public abstract boolean shadow$hasCooldown(Item itemIn);
+    @Shadow public abstract float shadow$getCooldown(Item itemIn, float partialTicks);
+    @Shadow public abstract void shadow$setCooldown(final Item item, final int ticks);
 
     @Override
     public boolean hasCooldown(final ItemType type) {
         checkNotNull(type, "Item type cannot be null!");
-        return this.hasCooldown((Item) type);
+        return this.shadow$hasCooldown((Item) type);
     }
 
     @Override
@@ -73,7 +72,7 @@ public abstract class CooldownTrackerMixin_API implements org.spongepowered.api.
     @Override
     public boolean setCooldown(final ItemType type, final int ticks) {
         checkNotNull(type, "Item type cannot be null!");
-        this.setCooldown((Item) type, ticks);
+        this.shadow$setCooldown((Item) type, ticks);
         return ((CooldownTrackerBridge) this).bridge$getSetCooldownResult();
     }
 
@@ -86,7 +85,7 @@ public abstract class CooldownTrackerMixin_API implements org.spongepowered.api.
     @Override
     public OptionalDouble getFractionRemaining(final ItemType type) {
         checkNotNull(type, "Item type cannot be null!");
-        final float cooldown = this.getCooldown((Item) type, 0);
+        final float cooldown = this.shadow$getCooldown((Item) type, 0);
 
         if (cooldown > 0.0F) {
             return OptionalDouble.of(cooldown);

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/util/DamageSourceMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/util/DamageSourceMixin_API.java
@@ -33,51 +33,51 @@ import org.spongepowered.common.bridge.util.DamageSourceBridge;
 @Mixin(value = net.minecraft.util.DamageSource.class)
 public abstract class DamageSourceMixin_API implements DamageSource {
 
-    @Shadow public abstract boolean isProjectile();
-    @Shadow public abstract boolean isUnblockable();
-    @Shadow public abstract boolean canHarmInCreative();
-    @Shadow public abstract boolean isDamageAbsolute();
-    @Shadow public abstract boolean isMagicDamage();
-    @Shadow public abstract float getHungerDamage();
-    @Shadow public abstract boolean isDifficultyScaled();
-    @Shadow public abstract boolean isExplosion();
-    @Shadow public abstract String getDamageType();
+    @Shadow public abstract boolean shadow$isProjectile();
+    @Shadow public abstract boolean shadow$isUnblockable();
+    @Shadow public abstract boolean shadow$canHarmInCreative();
+    @Shadow public abstract boolean shadow$isDamageAbsolute();
+    @Shadow public abstract boolean shadow$isMagicDamage();
+    @Shadow public abstract float shadow$getHungerDamage();
+    @Shadow public abstract boolean shadow$isDifficultyScaled();
+    @Shadow public abstract boolean shadow$isExplosion();
+    @Shadow public abstract String shadow$getDamageType();
 
     @Shadow public String damageType;
 
     @Override
     public boolean isExplosive() {
-        return this.isExplosion();
+        return this.shadow$isExplosion();
     }
 
     @Override
     public boolean isMagic() {
-        return this.isMagicDamage();
+        return this.shadow$isMagicDamage();
     }
 
     @Override
     public boolean doesAffectCreative() {
-        return this.canHarmInCreative();
+        return this.shadow$canHarmInCreative();
     }
 
     @Override
     public boolean isAbsolute() {
-        return this.isDamageAbsolute();
+        return this.shadow$isDamageAbsolute();
     }
 
     @Override
     public boolean isBypassingArmor() {
-        return this.isUnblockable();
+        return this.shadow$isUnblockable();
     }
 
     @Override
     public boolean isScaledByDifficulty() {
-        return this.isDifficultyScaled();
+        return this.shadow$isDifficultyScaled();
     }
 
     @Override
     public double getExhaustion() {
-        return this.getHungerDamage();
+        return this.shadow$getHungerDamage();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/util/SoundEventMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/util/SoundEventMixin_API.java
@@ -36,21 +36,21 @@ import javax.annotation.Nullable;
 @Mixin(SoundEvent.class)
 public abstract class SoundEventMixin_API implements SoundType {
 
-    @Shadow @Final private ResourceLocation soundName;
+    @Shadow @Final private ResourceLocation name;
 
     @Nullable private String id;
 
     @Override
     public String getId() {
         if (this.id == null) {
-            this.id = this.soundName.toString();
+            this.id = this.name.toString();
         }
         return this.id;
     }
 
     @Override
     public String getName() {
-        return this.soundName.getPath();
+        return this.name.getPath();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/raid/SpongeWave.java
+++ b/src/main/java/org/spongepowered/common/raid/SpongeWave.java
@@ -88,11 +88,9 @@ public class SpongeWave implements Wave {
     @Override
     public boolean removeRaider(Raider raider) {
         checkNotNull(raider, "Raider cannot be null.");
-        if (raider.getRaid().isPresent()) {
-            if (this.equals(raider.getRaid().get().getWaves().get(this.waveId))) {
-                this.raid.leaveRaid((AbstractRaiderEntity) raider, true);
-                return true;
-            }
+        if (raider.raidWave().isPresent() && this.equals(raider.raidWave().get().get())) {
+            this.raid.leaveRaid((AbstractRaiderEntity) raider, true);
+            return true;
         }
 
         return false;


### PR DESCRIPTION
prepends most of the api package mixins, where methods are shadowed with `shadow$`

Some shadowed fields were renamed to match their new names/alternatives.

BlockEntities and World package were intentionally excluded due to other prs in the works to avoid possible conflicts.