### PR TITLE
Fix only zombie spawners can be generated in newly-generated dungeons

### DIFF
--- a/src/main/java/org/spongepowered/common/registry/type/world/gen/DungeonMobRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/world/gen/DungeonMobRegistryModule.java
@@ -105,7 +105,10 @@ public class DungeonMobRegistryModule implements RegistryModule {
                 .getEntries()
                 .stream()
                 .map(entry -> (WeightedSerializableObject<EntityArchetype>) entry)
-                .findFirst();
+                .filter(entry -> {
+                    return entry.get().getType().getEntityClass().equals(type.getEntityClass());
+                }).findFirst();
+
     }
 
     public WeightedTable<EntityArchetype> getRaw() {


### PR DESCRIPTION
I'm not a programmer who masters Java. Sorry. 

Now I'm hosting a modded Minecraft server. Players in my server reported that they could not find a  dungeon with a skeleton spawner or the spider one. Only zombie spawners can be found. I set up a server with the same configurations on my own computer and the problem appeared as expected. After removing all mods that the server installed expect SpongeForge, I found out the problem still exists. So this must be SpongeForge's fault.

Then I struggled to manually build SpongeForge with the latest modifications on git. The problem persists. To solve the problem, I had to inspect which part of the code that controls the dungeons' generation. I noticed that the mechanism related to the monster type in dungeons works as normal. However, after the monster type was generated, the monster type was not successfully applied to the mob spawner that was going to be placed in the world. No matter what the monster type is, the mob spawner is always assigned to the zombie one.

Finally, I found the following code might be responsible for this problem. The code locates in the file `SpongeCommon/src/main/java/org/spongepowered/common/mixin/core/world/gen/feature/WorldGenDungeonsMixin.java`.
```
@Mixin(WorldGenDungeons.class)
public abstract class WorldGenDungeonsMixin extends WorldGeneratorMixin {

    @Redirect(method = "generate", at = @At(value = "INVOKE", target = "Lnet/minecraft/tileentity/MobSpawnerBaseLogic;setEntityId(Lnet/minecraft/util/ResourceLocation;)V"))
    private void impl$updateDataAndChoices(final MobSpawnerBaseLogic logic, final ResourceLocation mobName) {
        if (((Dungeon) this).getMobSpawnerData().isPresent()) {
            // Use custom spawner data
            SpawnerUtils.applyData(logic, ((Dungeon) this).getMobSpawnerData().get());
            return;
        }

        if (((Dungeon) this).getChoices().isPresent()) {
            // Use custom choices
            final WeightedTable<EntityArchetype> choices = ((Dungeon) this).getChoices().get();
            final EntityArchetype entity = choices.get(logic.getSpawnerWorld().rand).stream().findFirst().orElse(null);
            if (entity == null) {
                return; // No choices to choose from? Use default instead.
            }
            SpawnerUtils.setNextEntity(logic, new WeightedSerializableObject<>(entity, 1));
            return;
        }

        // Just use the given mobName
        logic.setEntityId(mobName);
    }
```
By commenting the code before `logic.setEntityId(mobName);` in the method, the problem disappears.

It seems these codes relate to the APIs that the Sponge project provided, which means I must find the root cause of the problem. And here is the modification I made that might solve this problem and with no side effects. 
 