### PR TITLE
Replace craft preview transaction list with a single entry.

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/inventory/ContainerBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/inventory/ContainerBridge.java
@@ -70,7 +70,9 @@ public interface ContainerBridge {
 
     void bridge$setFirePreview(boolean firePreview);
 
-    List<SlotTransaction> bridge$getPreviewTransactions();
+    @Nullable SlotTransaction bridge$getPreviewTransaction();
+
+    void bridge$setPreviewTransaction(@Nullable SlotTransaction transaction);
 
     List<SlotTransaction> bridge$getCurrentShiftCraftTransactions();
 

--- a/src/main/java/org/spongepowered/common/config/category/LoggingCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/LoggingCategory.java
@@ -69,8 +69,9 @@ public class LoggingCategory extends ConfigCategory {
     private boolean logEntityCollisionChecks = false;
     @Setting(value = "entity-speed-removal", comment = "Whether to log entity removals due to speed")
     private boolean logEntitySpeedRemoval = false;
-    @Setting(value = "transaction-merge-fail", comment = "Log when two conflicting changes are merged into one. (This number specifies the maximum "
-            + "number of messages to log. Set to 0 to show all messages.)")
+    @Setting(value = "transaction-merge-fail",
+            comment = "Log when two conflicting changes are merged into one. (This number specifies the maximum number of"
+                    + "\nmessages to log. Set to 0 to show all messages.)")
     private int logTransactionMergeFailure = 25;
     @Setting(value = "world-auto-save", comment = ""
             + "Log when a world auto-saves its chunk data.\n"

--- a/src/main/java/org/spongepowered/common/config/category/LoggingCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/LoggingCategory.java
@@ -69,8 +69,9 @@ public class LoggingCategory extends ConfigCategory {
     private boolean logEntityCollisionChecks = false;
     @Setting(value = "entity-speed-removal", comment = "Whether to log entity removals due to speed")
     private boolean logEntitySpeedRemoval = false;
-    @Setting(value = "transaction-merge-fail", comment = "Log when two conflicting changes are merged into one")
-    private boolean logTransactionMergeFailure = true;
+    @Setting(value = "transaction-merge-fail", comment = "Log when two conflicting changes are merged into one. (This number specifies the maximum "
+            + "number of messages to log. Set to 0 to show all messages.)")
+    private int logTransactionMergeFailure = 25;
     @Setting(value = "world-auto-save", comment = ""
             + "Log when a world auto-saves its chunk data.\n"
             + "Note: This may be spammy depending on the auto-save-interval configured for world.")
@@ -188,7 +189,7 @@ public class LoggingCategory extends ConfigCategory {
         this.logEntitySpeedRemoval = flag;
     }
 
-    public boolean logTransactionMergeFailure() {
+    public int logTransactionMergeFailure() {
         return this.logTransactionMergeFailure;
     }
 

--- a/src/main/java/org/spongepowered/common/config/category/LoggingCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/LoggingCategory.java
@@ -69,6 +69,8 @@ public class LoggingCategory extends ConfigCategory {
     private boolean logEntityCollisionChecks = false;
     @Setting(value = "entity-speed-removal", comment = "Whether to log entity removals due to speed")
     private boolean logEntitySpeedRemoval = false;
+    @Setting(value = "transaction-merge-fail", comment = "Log when two conflicting changes are merged into one")
+    private boolean logTransactionMergeFailure = true;
     @Setting(value = "world-auto-save", comment = ""
             + "Log when a world auto-saves its chunk data.\n"
             + "Note: This may be spammy depending on the auto-save-interval configured for world.")
@@ -184,6 +186,10 @@ public class LoggingCategory extends ConfigCategory {
 
     public void setLogEntitySpeedRemoval(boolean flag) {
         this.logEntitySpeedRemoval = flag;
+    }
+
+    public boolean logTransactionMergeFailure() {
+        return this.logTransactionMergeFailure;
     }
 
     public boolean logWorldAutomaticSaving() {

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/drag/DragInventoryStopState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/drag/DragInventoryStopState.java
@@ -65,7 +65,7 @@ public abstract class DragInventoryStopState extends NamedInventoryState {
 
         Inventory craftInv = ((Inventory) player.openContainer).query(QueryOperationTypes.INVENTORY_TYPE.of(CraftingInventory.class));
         if (craftInv instanceof CraftingInventory) {
-            SlotTransaction previewTransaction = ((ContainerBridge) player.openContainer).bridge$getPreviewTransaction();
+            final SlotTransaction previewTransaction = ((ContainerBridge) player.openContainer).bridge$getPreviewTransaction();
             if (previewTransaction != null) {
                 CraftingRecipe recipe = SpongeCraftingRecipeRegistry
                         .getInstance().findMatchingRecipe(((CraftingInventory) craftInv).getCraftingGrid(), ((World) player.world)).orElse(null);

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/drag/DragInventoryStopState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/drag/DragInventoryStopState.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.event.tracking.phase.packet.drag;
 
+import com.google.common.collect.ImmutableList;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.Packet;
 import org.spongepowered.api.item.inventory.Inventory;
@@ -64,13 +65,13 @@ public abstract class DragInventoryStopState extends NamedInventoryState {
 
         Inventory craftInv = ((Inventory) player.openContainer).query(QueryOperationTypes.INVENTORY_TYPE.of(CraftingInventory.class));
         if (craftInv instanceof CraftingInventory) {
-            List<SlotTransaction> previewTransactions = ((ContainerBridge) player.openContainer).bridge$getPreviewTransactions();
-            if (!previewTransactions.isEmpty()) {
+            SlotTransaction previewTransaction = ((ContainerBridge) player.openContainer).bridge$getPreviewTransaction();
+            if (previewTransaction != null) {
                 CraftingRecipe recipe = SpongeCraftingRecipeRegistry
                         .getInstance().findMatchingRecipe(((CraftingInventory) craftInv).getCraftingGrid(), ((World) player.world)).orElse(null);
-                SpongeCommonEventFactory.callCraftEventPre(player, ((CraftingInventory) craftInv), previewTransactions.get(0),
-                        recipe, player.openContainer, previewTransactions);
-                previewTransactions.clear();
+                SpongeCommonEventFactory.callCraftEventPre(player, ((CraftingInventory) craftInv), previewTransaction,
+                        recipe, player.openContainer, ImmutableList.of(previewTransaction));
+                ((ContainerBridge) player.openContainer).bridge$setPreviewTransaction(null);
             }
         }
     }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/InventoryPacketContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/InventoryPacketContext.java
@@ -50,7 +50,7 @@ public class InventoryPacketContext extends PacketContext<InventoryPacketContext
 
     @Override
     public boolean hasCaptures() {
-        if (!((ContainerBridge) this.packetPlayer.openContainer).bridge$getPreviewTransactions().isEmpty()) {
+        if (((ContainerBridge) this.packetPlayer.openContainer).bridge$getPreviewTransaction() != null) {
             return true;
         }
         if (!((TrackedInventoryBridge) this.packetPlayer.openContainer).bridge$getCapturedSlotTransactions().isEmpty()) {

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/PlaceRecipePacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/PlaceRecipePacketState.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.event.tracking.phase.packet.inventory;
 
+import com.google.common.collect.ImmutableList;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.network.Packet;
@@ -79,15 +80,14 @@ public final class PlaceRecipePacketState extends BasicInventoryPacketState {
             return;
         }
 
-        final List<SlotTransaction> previewTransactions = ((ContainerBridge) player.openContainer).bridge$getPreviewTransactions();
-        if (previewTransactions.isEmpty()) {
+        SlotTransaction previewTransaction = ((ContainerBridge) player.openContainer).bridge$getPreviewTransaction();
+        if (previewTransaction == null) {
             final CraftingOutput slot = ((CraftingInventory) craftInv).getResult();
-            final SlotTransaction st = new SlotTransaction(slot, ItemStackSnapshot.NONE, ItemStackUtil.snapshotOf(slot.peek().orElse(ItemStack.empty())));
-            previewTransactions.add(st);
+            previewTransaction = new SlotTransaction(slot, ItemStackSnapshot.NONE, ItemStackUtil.snapshotOf(slot.peek().orElse(ItemStack.empty())));
         }
-        SpongeCommonEventFactory.callCraftEventPre(player, ((CraftingInventory) craftInv), previewTransactions.get(0),
-                ((CraftingRecipe) recipe), player.openContainer, previewTransactions);
-        previewTransactions.clear();
+        SpongeCommonEventFactory.callCraftEventPre(player, ((CraftingInventory) craftInv), previewTransaction,
+                ((CraftingRecipe) recipe), player.openContainer, ImmutableList.of(previewTransaction));
+        ((ContainerBridge) player.openContainer).bridge$setPreviewTransaction(null);
 
         final Entity spongePlayer = (Entity) player;
         try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/PlaceRecipePacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/PlaceRecipePacketState.java
@@ -80,7 +80,7 @@ public final class PlaceRecipePacketState extends BasicInventoryPacketState {
             return;
         }
 
-        SlotTransaction previewTransaction = ((ContainerBridge) player.openContainer).bridge$getPreviewTransaction();
+        final SlotTransaction previewTransaction = ((ContainerBridge) player.openContainer).bridge$getPreviewTransaction();
         if (previewTransaction == null) {
             final CraftingOutput slot = ((CraftingInventory) craftInv).getResult();
             previewTransaction = new SlotTransaction(slot, ItemStackSnapshot.NONE, ItemStackUtil.snapshotOf(slot.peek().orElse(ItemStack.empty())));

--- a/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/slots/SlotAdapter.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/adapter/impl/slots/SlotAdapter.java
@@ -39,6 +39,7 @@ import org.spongepowered.common.item.inventory.util.ItemStackUtil;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -253,5 +254,22 @@ public class SlotAdapter extends AbstractInventoryAdapter implements Slot {
                 return SlotAdapter.this;
             }
         };
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || this.getClass() != o.getClass()) {
+            return false;
+        }
+        final SlotAdapter that = (SlotAdapter) o;
+        return this.slotNumber == that.slotNumber
+                && this.bridge$getFabric().equals(that.bridge$getFabric());
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(this.slotNumber, this.bridge$getFabric());
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/inventory/ContainerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/inventory/ContainerMixin.java
@@ -124,7 +124,6 @@ public abstract class ContainerMixin implements ContainerBridge, InventoryAdapte
     private List<SlotTransaction> impl$capturedCurrentCraftShiftTransactions = new ArrayList<>();
     private List<SlotTransaction> impl$capturedCraftShiftTransactions = new ArrayList<>();
     @Nullable private SlotTransaction impl$capturedCraftPreviewTransaction;
-    private static int impl$numTransactionErrorsLogged = 0;
     private boolean impl$isLensInitialized;
     @Nullable private Int2ObjectMap<SlotAdapter> impl$adapters;
     @Nullable private InventoryArchetype impl$archetype;
@@ -132,6 +131,8 @@ public abstract class ContainerMixin implements ContainerBridge, InventoryAdapte
     @Nullable Predicate<EntityPlayer> impl$canInteractWithPredicate;
     @Nullable private LinkedHashMap<IInventory, Set<Slot>> impl$allInventories;
     @Nullable private ItemStack impl$previousCursor;
+
+    private static int impl$numTransactionErrorsLogged = 0;
 
     @Override
     public SlotProvider bridge$generateSlotProvider() {
@@ -434,9 +435,9 @@ public abstract class ContainerMixin implements ContainerBridge, InventoryAdapte
                 && this.impl$capturedCraftPreviewTransaction.getFinal().equals(orig)) {
             this.impl$capturedCraftPreviewTransaction = new SlotTransaction(slot, this.impl$capturedCraftPreviewTransaction.getOriginal(), repl);
         } else {
-            SlotTransaction replace = new SlotTransaction(slot, orig, repl);
+            final SlotTransaction replace = new SlotTransaction(slot, orig, repl);
             ContainerMixin.impl$numTransactionErrorsLogged++;
-            int maxLogs = SpongeImpl.getGlobalConfigAdapter().getConfig().getLogging().logTransactionMergeFailure();
+            final int maxLogs = SpongeImpl.getGlobalConfigAdapter().getConfig().getLogging().logTransactionMergeFailure();
             if (maxLogs <= 0 || ContainerMixin.impl$numTransactionErrorsLogged <= maxLogs) {
                 SpongeImpl.getLogger().warn("Could not merge craft preview transactions - some events may break (original {}, replace {})",
                         this.impl$capturedCraftPreviewTransaction, replace);

--- a/src/main/java/org/spongepowered/common/mixin/core/inventory/ContainerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/inventory/ContainerMixin.java
@@ -124,6 +124,7 @@ public abstract class ContainerMixin implements ContainerBridge, InventoryAdapte
     private List<SlotTransaction> impl$capturedCurrentCraftShiftTransactions = new ArrayList<>();
     private List<SlotTransaction> impl$capturedCraftShiftTransactions = new ArrayList<>();
     @Nullable private SlotTransaction impl$capturedCraftPreviewTransaction;
+    private static int impl$numTransactionErrorsLogged = 0;
     private boolean impl$isLensInitialized;
     @Nullable private Int2ObjectMap<SlotAdapter> impl$adapters;
     @Nullable private InventoryArchetype impl$archetype;
@@ -434,9 +435,15 @@ public abstract class ContainerMixin implements ContainerBridge, InventoryAdapte
             this.impl$capturedCraftPreviewTransaction = new SlotTransaction(slot, this.impl$capturedCraftPreviewTransaction.getOriginal(), repl);
         } else {
             SlotTransaction replace = new SlotTransaction(slot, orig, repl);
-            if (SpongeImpl.getGlobalConfigAdapter().getConfig().getLogging().logTransactionMergeFailure()) {
+            ContainerMixin.impl$numTransactionErrorsLogged++;
+            int maxLogs = SpongeImpl.getGlobalConfigAdapter().getConfig().getLogging().logTransactionMergeFailure();
+            if (maxLogs <= 0 || ContainerMixin.impl$numTransactionErrorsLogged <= maxLogs) {
                 SpongeImpl.getLogger().warn("Could not merge craft preview transactions - some events may break (original {}, replace {})",
                         this.impl$capturedCraftPreviewTransaction, replace);
+                if (ContainerMixin.impl$numTransactionErrorsLogged == maxLogs) {
+                    SpongeImpl.getLogger().warn("Further warnings about this will be suppressed. Change transaction-merge-fail in global.conf to "
+                            + "show more.");
+                }
             }
             this.impl$capturedCraftPreviewTransaction = replace;
         }

--- a/src/main/java/org/spongepowered/common/mixin/core/inventory/ContainerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/inventory/ContainerMixin.java
@@ -434,8 +434,10 @@ public abstract class ContainerMixin implements ContainerBridge, InventoryAdapte
             this.impl$capturedCraftPreviewTransaction = new SlotTransaction(slot, this.impl$capturedCraftPreviewTransaction.getOriginal(), repl);
         } else {
             SlotTransaction replace = new SlotTransaction(slot, orig, repl);
-            SpongeImpl.getLogger().warn("Could not merge craft preview transactions - some events may break (original {}, replace {})",
-                    this.impl$capturedCraftPreviewTransaction, replace);
+            if (SpongeImpl.getGlobalConfigAdapter().getConfig().getLogging().logTransactionMergeFailure()) {
+                SpongeImpl.getLogger().warn("Could not merge craft preview transactions - some events may break (original {}, replace {})",
+                        this.impl$capturedCraftPreviewTransaction, replace);
+            }
             this.impl$capturedCraftPreviewTransaction = replace;
         }
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/inventory/SlotCraftingMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/inventory/SlotCraftingMixin.java
@@ -180,7 +180,7 @@ public abstract class SlotCraftingMixin extends Slot {
         ((ContainerBridge) container).bridge$setFirePreview(true);
         this.impl$craftedStack = null;
 
-        SlotTransaction previewTransaction = ((ContainerBridge) container).bridge$getPreviewTransaction();
+        final SlotTransaction previewTransaction = ((ContainerBridge) container).bridge$getPreviewTransaction();
         if (this.craftMatrix.isEmpty()) {
             return; // CraftMatrix is empty and/or no transaction present. Do not fire Preview.
         }

--- a/src/main/java/org/spongepowered/common/mixin/core/inventory/SlotCraftingMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/inventory/SlotCraftingMixin.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.mixin.core.inventory;
 
+import com.google.common.collect.ImmutableList;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.Container;
@@ -179,23 +180,21 @@ public abstract class SlotCraftingMixin extends Slot {
         ((ContainerBridge) container).bridge$setFirePreview(true);
         this.impl$craftedStack = null;
 
-        final List<SlotTransaction> previewTransactions = ((ContainerBridge) container).bridge$getPreviewTransactions();
+        SlotTransaction previewTransaction = ((ContainerBridge) container).bridge$getPreviewTransaction();
         if (this.craftMatrix.isEmpty()) {
             return; // CraftMatrix is empty and/or no transaction present. Do not fire Preview.
         }
 
-        final SlotTransaction last;
-        if (previewTransactions.isEmpty()) {
-            last = new SlotTransaction(craftingInventory.getResult(), ItemStackSnapshot.NONE, ItemStackUtil.snapshotOf(this.getStack()));
-            previewTransactions.add(last);
-        } else {
-            last = previewTransactions.get(0);
+        if (previewTransaction == null) {
+            previewTransaction = new SlotTransaction(craftingInventory.getResult(), ItemStackSnapshot.NONE,
+                    ItemStackUtil.snapshotOf(this.getStack()));
         }
 
         final CraftingRecipe newRecipe = (CraftingRecipe) CraftingManager.findMatchingRecipe(this.craftMatrix, thePlayer.world);
 
-        SpongeCommonEventFactory.callCraftEventPre(thePlayer, craftingInventory, last, newRecipe, container, previewTransactions);
-        previewTransactions.clear();
+        SpongeCommonEventFactory.callCraftEventPre(thePlayer, craftingInventory, previewTransaction, newRecipe, container,
+                ImmutableList.of(previewTransaction));
+        ((ContainerBridge) container).bridge$setPreviewTransaction(null);
 
     }
 }


### PR DESCRIPTION
Basically everything that uses the crafting transaction list relies on it having only a single entry. However, when the player drags in the crafting table, `slotChangedCraftingGrid` is called multiple times, putting multiple entries into the list. This PR merges these calls into a single transaction to prevent issues like this.

Fixes #2505.