### PR TITLE
[Discussion] Block Explosion Resistance Event

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
@@ -146,11 +146,16 @@ public abstract class ExplosionMixin implements ExplosionBridge {
                                 final IBlockState iblockstate = this.world.getBlockState(blockpos);
 
                                 if (iblockstate.getMaterial() != Material.AIR) {
+
+                                    // Block Explosion Resistance START
+
                                     final float f2 = this.exploder != null
                                                ? this.exploder.getExplosionResistance((net.minecraft.world.Explosion) (Object) this
                                             , this.world, blockpos, iblockstate)
                                                : iblockstate.getBlock().getExplosionResistance((Entity) null);
                                     f -= (f2 + 0.3F) * 0.3F;
+
+                                    // Block Explosion Resistance END
                                 }
 
                                 if (f > 0.0F && (this.exploder == null || this.exploder


### PR DESCRIPTION
No code changes have yet been made to the fork. I am opening this PR to discuss the best method of implementing this feature.

I planned a feature for my plugin that changes the explosion resistance of a block based on the size of the craft containing it. e.g. a 2000 block craft would increase the blast resistance of it blocks by 4%.

I have been unable to find a better way to do this.