### PR TITLE
Fix interaction events not being called correctly when left clicking in the air.

### DIFF
--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -179,7 +179,6 @@ import org.spongepowered.common.util.Constants;
 import org.spongepowered.common.util.VecHelper;
 import org.spongepowered.common.world.SpongeLocatableBlockBuilder;
 
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -197,14 +196,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 public class SpongeCommonEventFactory {
-
-    // Set if any of the events fired during interaction with a block (open
-
-    public static int lastAnimationPacketTick = 0;
-    // For animation packet
-    public static int lastSecondaryPacketTick = 0;
-    public static int lastPrimaryPacketTick = 0;
-    @Nullable public static WeakReference<EntityPlayerMP> lastAnimationPlayer;
 
     public static void callDropItemDispense(final List<EntityItem> items, final PhaseContext<?> context) {
         try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {

--- a/src/main/java/org/spongepowered/common/mixin/core/server/management/PlayerInteractionManagerAccessor.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/management/PlayerInteractionManagerAccessor.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.server.management;
+
+import net.minecraft.server.management.PlayerInteractionManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(PlayerInteractionManager.class)
+public interface PlayerInteractionManagerAccessor {
+
+    @Accessor("isDestroyingBlock") boolean accessor$isDestroyingBlock();
+}

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -374,6 +374,7 @@
         "server.management.PlayerChunkMapEntryAccessor",
         "server.management.PlayerChunkMapEntryMixin",
         "server.management.PlayerChunkMapMixin",
+        "server.management.PlayerInteractionManagerAccessor",
         "server.management.PlayerInteractionManagerMixin",
         "server.management.PlayerProfileCacheMixin",
         "server.management.PlayerProfileCache_ProfileEntryAccessor",


### PR DESCRIPTION
This PR fixes several issues related to `InteractItemEvent.Primary` and `InteractBlockEvent.Primary` when a player is clicking in the air:
- If multiple players click in the air during the same tick, only the last one fires the events.
- The distance of the ray tracing used to determinate if the player is interacting a non-air block was incorrect. It was 6, now it's 5. It should be 4.5 for non-creative players but I didn't dare to touch `SpongeImplHooks#getBlockReachDistance` because it's used in many places and I don't want to break something.
- Black magic based on static variables and delay between packets.

These 3 things were causing problems like #2526.

