### PR TITLE
Use Accessors in DamageSources

### DIFF
--- a/src/main/java/org/spongepowered/common/event/damage/SpongeCommonDamageSource.java
+++ b/src/main/java/org/spongepowered/common/event/damage/SpongeCommonDamageSource.java
@@ -25,7 +25,6 @@
 package org.spongepowered.common.event.damage;
 
 import net.minecraft.util.DamageSource;
-import org.spongepowered.api.event.cause.entity.damage.source.common.AbstractDamageSource;
 import org.spongepowered.common.mixin.accessor.util.DamageSourceAccessor;
 
 /*
@@ -42,16 +41,6 @@ public abstract class SpongeCommonDamageSource extends DamageSource implements o
 
     protected SpongeCommonDamageSource() {
         super("SpongeDamageSource");
-    }
-
-    /**
-     * Purely for use with {@link AbstractDamageSource} such that
-     * the damage type is set after the super constructor is called.
-     *
-     * @param type The damage type id
-     */
-    public void setDamageType(final String type) {
-        this.damageType = type;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/event/damage/SpongeCommonEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/common/event/damage/SpongeCommonEntityDamageSource.java
@@ -26,7 +26,6 @@ package org.spongepowered.common.event.damage;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.util.EntityDamageSource;
-import org.spongepowered.api.event.cause.entity.damage.source.common.AbstractDamageSource;
 
 /*
 To summarize, the way this works is that DamageSource isn't directly created, but
@@ -42,20 +41,6 @@ public abstract class SpongeCommonEntityDamageSource extends EntityDamageSource 
 
     public SpongeCommonEntityDamageSource() {
         super("SpongeEntityDamageSource", null);
-    }
-
-    /**
-     * Purely for use with {@link AbstractDamageSource} such that
-     * the damage type is set after the super constructor is called.
-     *
-     * @param type The damage type id
-     */
-    public void setDamageType(final String type) {
-        this.damageType = type;
-    }
-
-    public void setEntitySource(final Entity entitySource) {
-        this.damageSourceEntity = entitySource;
     }
 
     public void bridge$setDamageIsAbsolute() {

--- a/src/main/java/org/spongepowered/common/event/damage/SpongeCommonIndirectEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/common/event/damage/SpongeCommonIndirectEntityDamageSource.java
@@ -26,8 +26,6 @@ package org.spongepowered.common.event.damage;
 
 import net.minecraft.entity.Entity;
 import org.spongepowered.api.event.cause.entity.damage.source.IndirectEntityDamageSource;
-import org.spongepowered.api.event.cause.entity.damage.source.common.AbstractDamageSource;
-import org.spongepowered.common.mixin.accessor.util.IndirectEntityDamageSourceAccessor;
 
 /*
 To summarize, the way this works is that DamageSource isn't directly created, but
@@ -44,25 +42,6 @@ public abstract class SpongeCommonIndirectEntityDamageSource extends net.minecra
     public SpongeCommonIndirectEntityDamageSource() {
         super("SpongeEntityDamageSource", null, null);
     }
-
-    /**
-     * Purely for use with {@link AbstractDamageSource} such that
-     * the damage type is set after the super constructor is called.
-     *
-     * @param type The damage type id
-     */
-    public void setDamageType(final String type) {
-        this.damageType = type;
-    }
-
-    public void setEntitySource(final Entity entitySource) {
-        this.damageSourceEntity = entitySource;
-    }
-
-    public void setIndirectSource(final Entity entity) {
-        ((IndirectEntityDamageSourceAccessor) this).accessor$setIndirectEntity(entity);
-    }
-
 
     public void bridge$setDamageIsAbsolute() {
         this.setDamageIsAbsolute();

--- a/src/main/java/org/spongepowered/common/mixin/accessor/util/EntityDamageSourceAccessor.java
+++ b/src/main/java/org/spongepowered/common/mixin/accessor/util/EntityDamageSourceAccessor.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.accessor.util;
+
+import org.spongepowered.api.event.cause.entity.damage.source.EntityDamageSource;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.entity.Entity;
+
+@Mixin(EntityDamageSource.class)
+public interface EntityDamageSourceAccessor {
+	@Accessor("damageSourceEntity") void accessor$setDamageSourceEntity(Entity damageSourceEntity);
+}

--- a/src/main/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractDamageSourceMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractDamageSourceMixin_API.java
@@ -24,11 +24,9 @@
  */
 package org.spongepowered.common.mixin.api.event.cause.entity.damage.source.common;
 
-import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.event.cause.entity.damage.source.common.AbstractDamageSource;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -47,13 +45,11 @@ import org.spongepowered.common.mixin.accessor.util.DamageSourceAccessor;
 @Mixin(AbstractDamageSource.class)
 public abstract class AbstractDamageSourceMixin_API implements DamageSource {
 
-	@Shadow public abstract DamageType getType();
-
-	@SuppressWarnings("ConstantConditions")
+    @SuppressWarnings("ConstantConditions")
     @Inject(method = "<init>", at = @At("RETURN"))
     private void api$setUpBridges(final CallbackInfo callbackInfo) {
         final SpongeCommonDamageSource commonSource = (SpongeCommonDamageSource) (Object) this;
-	    ((DamageSourceAccessor) commonSource).accessor$setDamageType(this.getType().getKey().getFormatted());
+        ((DamageSourceAccessor) commonSource).accessor$setDamageType(this.getType().getKey().getFormatted());
 
         if (this.isAbsolute()) {
             commonSource.bridge$setDamageIsAbsolute();

--- a/src/main/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractDamageSourceMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractDamageSourceMixin_API.java
@@ -24,13 +24,16 @@
  */
 package org.spongepowered.common.mixin.api.event.cause.entity.damage.source.common;
 
+import org.spongepowered.api.event.cause.entity.damage.DamageType;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.event.cause.entity.damage.source.common.AbstractDamageSource;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.event.damage.SpongeCommonDamageSource;
+import org.spongepowered.common.mixin.accessor.util.DamageSourceAccessor;
 
 /*
  * @author gabizou
@@ -44,11 +47,14 @@ import org.spongepowered.common.event.damage.SpongeCommonDamageSource;
 @Mixin(AbstractDamageSource.class)
 public abstract class AbstractDamageSourceMixin_API implements DamageSource {
 
-    @SuppressWarnings("ConstantConditions")
+	@Shadow public abstract DamageType getType();
+
+	@SuppressWarnings("ConstantConditions")
     @Inject(method = "<init>", at = @At("RETURN"))
     private void api$setUpBridges(final CallbackInfo callbackInfo) {
         final SpongeCommonDamageSource commonSource = (SpongeCommonDamageSource) (Object) this;
-        commonSource.setDamageType(this.getType().getId());
+	    ((DamageSourceAccessor) commonSource).accessor$setDamageType(this.getType().getKey().getFormatted());
+
         if (this.isAbsolute()) {
             commonSource.bridge$setDamageIsAbsolute();
         }

--- a/src/main/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractEntityDamageSourceMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractEntityDamageSourceMixin_API.java
@@ -32,6 +32,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.event.damage.SpongeCommonEntityDamageSource;
+import org.spongepowered.common.mixin.accessor.util.DamageSourceAccessor;
+import org.spongepowered.common.mixin.accessor.util.EntityDamageSourceAccessor;
 
 /*
  * @author gabizou
@@ -49,8 +51,9 @@ public abstract class AbstractEntityDamageSourceMixin_API implements EntityDamag
     @Inject(method = "<init>", at = @At("RETURN"))
     private void impl$bridgeApiToImplConstruction(final CallbackInfo callbackInfo) {
         final SpongeCommonEntityDamageSource commonSource = (SpongeCommonEntityDamageSource) (Object) this;
-        commonSource.setDamageType(this.getType().getId());
-        commonSource.setEntitySource((Entity) this.getSource());
+	    ((DamageSourceAccessor) commonSource).accessor$setDamageType(this.getType().getKey().getFormatted());
+        ((EntityDamageSourceAccessor) commonSource).accessor$setDamageSourceEntity((Entity) this.getSource());
+
         if (this.isAbsolute()) {
             commonSource.bridge$setDamageIsAbsolute();
         }

--- a/src/main/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractEntityDamageSourceMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractEntityDamageSourceMixin_API.java
@@ -51,7 +51,7 @@ public abstract class AbstractEntityDamageSourceMixin_API implements EntityDamag
     @Inject(method = "<init>", at = @At("RETURN"))
     private void impl$bridgeApiToImplConstruction(final CallbackInfo callbackInfo) {
         final SpongeCommonEntityDamageSource commonSource = (SpongeCommonEntityDamageSource) (Object) this;
-	    ((DamageSourceAccessor) commonSource).accessor$setDamageType(this.getType().getKey().getFormatted());
+        ((DamageSourceAccessor) commonSource).accessor$setDamageType(this.getType().getKey().getFormatted());
         ((EntityDamageSourceAccessor) commonSource).accessor$setDamageSourceEntity((Entity) this.getSource());
 
         if (this.isAbsolute()) {

--- a/src/main/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSourceMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSourceMixin_API.java
@@ -29,7 +29,6 @@ import org.spongepowered.api.event.cause.entity.damage.source.IndirectEntityDama
 import org.spongepowered.api.event.cause.entity.damage.source.common.AbstractDamageSource;
 import org.spongepowered.api.event.cause.entity.damage.source.common.AbstractIndirectEntityDamageSource;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -51,15 +50,13 @@ import org.spongepowered.common.mixin.accessor.util.IndirectEntityDamageSourceAc
 @Mixin(AbstractIndirectEntityDamageSource.class)
 public abstract class AbstractIndirectEntityDamageSourceMixin_API implements IndirectEntityDamageSource {
 
-	@Shadow public abstract org.spongepowered.api.entity.Entity getIndirectSource();
-
-	@SuppressWarnings("ConstantConditions")
+    @SuppressWarnings("ConstantConditions")
     @Inject(method = "<init>", at = @At("RETURN"))
     private void api$setUpBridges(final CallbackInfo callbackInfo) {
         final SpongeCommonIndirectEntityDamageSource commonIndirect = (SpongeCommonIndirectEntityDamageSource) (Object) this;
-	    ((DamageSourceAccessor) commonIndirect).accessor$setDamageType(this.getType().getKey().getFormatted());
-	    ((EntityDamageSourceAccessor) commonIndirect).accessor$setDamageSourceEntity((Entity) this.getSource());
-	    ((IndirectEntityDamageSourceAccessor) commonIndirect).accessor$setIndirectEntity((Entity) this.getIndirectSource());
+        ((DamageSourceAccessor) commonIndirect).accessor$setDamageType(this.getType().getKey().getFormatted());
+        ((EntityDamageSourceAccessor) commonIndirect).accessor$setDamageSourceEntity((Entity) this.getSource());
+        ((IndirectEntityDamageSourceAccessor) commonIndirect).accessor$setIndirectEntity((Entity) this.getIndirectSource());
 
         if (this.isAbsolute()) {
             commonIndirect.bridge$setDamageIsAbsolute();

--- a/src/main/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSourceMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSourceMixin_API.java
@@ -26,14 +26,20 @@ package org.spongepowered.common.mixin.api.event.cause.entity.damage.source.comm
 
 import net.minecraft.entity.Entity;
 import org.spongepowered.api.event.cause.entity.damage.source.IndirectEntityDamageSource;
+import org.spongepowered.api.event.cause.entity.damage.source.common.AbstractDamageSource;
 import org.spongepowered.api.event.cause.entity.damage.source.common.AbstractIndirectEntityDamageSource;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.event.damage.SpongeCommonDamageSource;
 import org.spongepowered.common.event.damage.SpongeCommonIndirectEntityDamageSource;
+import org.spongepowered.common.mixin.accessor.util.DamageSourceAccessor;
+import org.spongepowered.common.mixin.accessor.util.EntityDamageSourceAccessor;
+import org.spongepowered.common.mixin.accessor.util.IndirectEntityDamageSourceAccessor;
 
-/*
+/**
  * @author gabizou
  *
  * This is absolutely required for the abstract damage sources to have the correct
@@ -45,13 +51,16 @@ import org.spongepowered.common.event.damage.SpongeCommonIndirectEntityDamageSou
 @Mixin(AbstractIndirectEntityDamageSource.class)
 public abstract class AbstractIndirectEntityDamageSourceMixin_API implements IndirectEntityDamageSource {
 
-    @SuppressWarnings("ConstantConditions")
+	@Shadow public abstract org.spongepowered.api.entity.Entity getIndirectSource();
+
+	@SuppressWarnings("ConstantConditions")
     @Inject(method = "<init>", at = @At("RETURN"))
     private void api$setUpBridges(final CallbackInfo callbackInfo) {
         final SpongeCommonIndirectEntityDamageSource commonIndirect = (SpongeCommonIndirectEntityDamageSource) (Object) this;
-        commonIndirect.setDamageType(this.getType().getId());
-        commonIndirect.setEntitySource((Entity) this.getSource());
-        commonIndirect.setIndirectSource((Entity) this.getIndirectSource());
+	    ((DamageSourceAccessor) commonIndirect).accessor$setDamageType(this.getType().getKey().getFormatted());
+	    ((EntityDamageSourceAccessor) commonIndirect).accessor$setDamageSourceEntity((Entity) this.getSource());
+	    ((IndirectEntityDamageSourceAccessor) commonIndirect).accessor$setIndirectEntity((Entity) this.getIndirectSource());
+
         if (this.isAbsolute()) {
             commonIndirect.bridge$setDamageIsAbsolute();
         }

--- a/src/main/resources/mixins.common.accessor.json
+++ b/src/main/resources/mixins.common.accessor.json
@@ -101,6 +101,7 @@
         "util.CombatTrackerAccessor",
         "util.CooldownTracker_CooldownAccessor",
         "util.DamageSourceAccessor",
+        "util.EntityDamageSourceAccessor",
         "util.FoodStatsAccessor",
         "util.IndirectEntityDamageSourceAccessor",
         "util.WeightedRandom_ItemAccessor",


### PR DESCRIPTION
This PR also fixes a compile error involving the DamageType changing from
just an ID holder to a CatalogType.