### PR TITLE
Fix duplicate spawn chunks

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/WorldEntitySpawnerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/WorldEntitySpawnerMixin.java
@@ -208,7 +208,7 @@ public abstract class WorldEntitySpawnerMixin {
                         final int k1 = blockpos.getX();
                         final int l1 = blockpos.getY();
                         final int i2 = blockpos.getZ();
-                        final IBlockState iblockstate = world.getBlockState(blockpos);
+                        final IBlockState iblockstate = chunk.getBlockState(blockpos);
 
                         if (!iblockstate.isNormalCube()) {
                             int spawnCount = 0;

--- a/src/main/java/org/spongepowered/common/mixin/core/world/WorldEntitySpawnerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/WorldEntitySpawnerMixin.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.mixin.core.world;
 
 import com.flowpowered.math.vector.Vector3d;
+import com.google.common.collect.Sets;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntitySpawnPlacementRegistry;
@@ -71,6 +72,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -79,7 +81,7 @@ public abstract class WorldEntitySpawnerMixin {
 
     @Nullable
     private static EntityType impl$spawnerEntityType;
-    private final List<Chunk> impl$eligibleSpawnChunks = new ArrayList<>();
+    private final Set<Chunk> impl$eligibleSpawnChunks = Sets.newIdentityHashSet();
 
     /**
      * @author blood - February 18th, 2017
@@ -136,6 +138,9 @@ public abstract class WorldEntitySpawnerMixin {
                                 .bridge$getLoadedChunkWithoutMarkingActive(i + playerPosX, j + playerPosZ);
                         if (chunk == null || (chunk.unloadQueued && !((ChunkBridge) chunk).bridge$isPersistedChunk())) {
                             // Don't attempt to spawn in an unloaded chunk
+                            continue;
+                        }
+                        if (this.impl$eligibleSpawnChunks.contains(chunk)) {
                             continue;
                         }
 


### PR DESCRIPTION
Vanilla was using a `Set` of `ChunkPos`, thus avoiding the issue. We are ignoring the vanilla `Set` in favor of a `List` of `Chunk`s.

This PR changes the List to a Set and add a condition in the loop. (This is what vanilla was doing).
Additionally when a randomchunkposition is retrieved the chunk itself is used to get the blockstate, avoiding a chunk lookup.

An IdentityHashSet is used because `Chunk`s have no equals/hashcode contract.