### PR TITLE
Update JoinData only after the player has joined

### DIFF
--- a/src/main/java/org/spongepowered/common/util/NetworkUtil.java
+++ b/src/main/java/org/spongepowered/common/util/NetworkUtil.java
@@ -165,14 +165,11 @@ public final class NetworkUtil {
         WorldServer worldServer = ((PlayerListAccessor) playerList).accessor$getPlayerListServer().getWorld(playerIn.dimension);
         final int actualDimensionId = ((WorldServerBridge) worldServer).bridge$getDimensionId();
         final BlockPos spawnPos;
-        // Join data
-        final Optional<Instant> firstJoined = SpongePlayerDataHandler.getFirstJoined(playerIn.getUniqueID());
-        final Instant lastJoined = Instant.now();
-        SpongePlayerDataHandler.setPlayerInfo(playerIn.getUniqueID(), firstJoined.orElse(lastJoined), lastJoined);
 
         if (actualDimensionId != playerIn.dimension) {
             SpongeImpl.getLogger().warn("Player [{}] has attempted to login to unloaded world [{}]. This is not safe so we have moved them to "
                                         + "the default world's spawn point.", playerIn.getName(), playerIn.dimension);
+            final Optional<Instant> firstJoined = SpongePlayerDataHandler.getFirstJoined(playerIn.getUniqueID());
             if (!firstJoined.isPresent()) {
                 spawnPos = SpongeImplHooks.getRandomizedSpawnPoint(worldServer);
             } else {
@@ -226,6 +223,11 @@ public final class NetworkUtil {
                 return;
             }
         }
+
+        // Join data
+        final Optional<Instant> firstJoined = SpongePlayerDataHandler.getFirstJoined(playerIn.getUniqueID());
+        final Instant lastJoined = Instant.now();
+        SpongePlayerDataHandler.setPlayerInfo(playerIn.getUniqueID(), firstJoined.orElse(lastJoined), lastJoined);
 
         // Sponge end
 


### PR DESCRIPTION
`JoinData` was updated before firing `ClientConnectionEvent.Login`. 
The event can be canceled because of the whitelist, a ban or by a plugin listening to said event.

This PR moves the code after the event to update `JoinData` only after the player has joined the server