### PR TITLE
Fix dupe when cancelling InteractInventoryOpen event

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/server/management/PlayerInteractionManagerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/management/PlayerInteractionManagerMixin.java
@@ -343,8 +343,8 @@ public abstract class PlayerInteractionManagerMixin implements PlayerInteraction
                         frame.addContext(EventContextKeys.BLOCK_HIT, currentSnapshot);
                         ((ContainerBridge) player.openContainer).bridge$setOpenLocation(currentSnapshot.getLocation().orElse(null));
                         if (!SpongeCommonEventFactory.callInteractInventoryOpenEvent(this.player)) {
-                            result = EnumActionResult.FAIL;
                             this.impl$interactBlockRightClickEventCancelled = true;
+                            return EnumActionResult.FAIL;
                         }
                     }
                 }


### PR DESCRIPTION
Step to reproduce:

```
@Listener(order = Order.FIRST, beforeModifications = true)
public void onInteractInventory(InteractInventoryEvent.Open event) {
    event.setCancelled(true);
}
```

- try to open a chest with a block in the main hand 
- the event is cancelled and there's no gui
- the block is placed (as if you were sneaking) but it is also in your hand.
