### PR TITLE
Fix custom data removal for offline players

### DIFF
--- a/src/main/java/org/spongepowered/common/data/util/DataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataUtil.java
@@ -619,6 +619,8 @@ public final class DataUtil {
                     manipulatorTagList.appendTag(NbtTranslator.getInstance().translateData(dataView));
                 }
                 compound.setTag(Constants.Sponge.CUSTOM_MANIPULATOR_TAG_LIST, manipulatorTagList);
+            } else {
+                compound.removeTag(Constants.Sponge.CUSTOM_MANIPULATOR_TAG_LIST);
             }
             final List<DataView> failedData = ((CustomDataHolderBridge) dataHolder).bridge$getFailedData();
             if (!failedData.isEmpty()) {
@@ -627,6 +629,8 @@ public final class DataUtil {
                     failedList.appendTag(NbtTranslator.getInstance().translateData(failedDatum));
                 }
                 compound.setTag(Constants.Sponge.FAILED_CUSTOM_DATA, failedList);
+            } else {
+                compound.removeTag(Constants.Sponge.FAILED_CUSTOM_DATA);
             }
         }
     }

--- a/src/main/java/org/spongepowered/common/entity/player/SpongeUser.java
+++ b/src/main/java/org/spongepowered/common/entity/player/SpongeUser.java
@@ -110,6 +110,7 @@ public class SpongeUser implements ArmorEquipable, Tamer, DataSerializable, Carr
     @Nullable private SpongeUserInventory inventory; // lazy load when accessing inventory
     @Nullable private InventoryEnderChest enderChest; // lazy load when accessing inventory
     @Nullable private NBTTagCompound nbt;
+    private boolean isConstructing;
 
     public SpongeUser(final GameProfile profile) {
         this.profile = profile;
@@ -343,7 +344,9 @@ public class SpongeUser implements ArmorEquipable, Tamer, DataSerializable, Carr
 
 
         final NBTTagCompound spongeCompound = compound.getCompoundTag(Constants.Forge.FORGE_DATA).getCompoundTag(Constants.Sponge.SPONGE_DATA);
+        this.isConstructing = true;
         DataUtil.readCustomData(spongeCompound, (DataHolder) this);
+        this.isConstructing = false;
         //if (this instanceof GrieferBridge && ((GrieferBridge) this).bridge$isGriefer() && compound.hasKey(NbtDataUtil.CAN_GRIEF)) {
         //    ((GrieferBridge) this).bridge$SetCanGrief(compound.getBoolean(NbtDataUtil.CAN_GRIEF));
         //}
@@ -587,6 +590,9 @@ public class SpongeUser implements ArmorEquipable, Tamer, DataSerializable, Carr
     }
 
     public void markDirty() {
+        if (this.isConstructing) {
+            return;
+        }
         dirtyUsers.add(this);
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/data/SpongeUserMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/data/SpongeUserMixin.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.data;
+
+import net.minecraft.nbt.NBTTagCompound;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.bridge.data.DataCompoundHolder;
+import org.spongepowered.common.entity.player.SpongeUser;
+import org.spongepowered.common.util.Constants;
+
+import javax.annotation.Nullable;
+
+@Mixin(value = SpongeUser.class, remap = false)
+public abstract class SpongeUserMixin implements DataCompoundHolder {
+
+    @Shadow public abstract boolean isInitialized();
+    @Shadow @Nullable private NBTTagCompound nbt;
+
+    @Override
+    public boolean data$hasRootCompound() {
+        if (this.nbt == null) {
+            return false;
+        }
+        return this.nbt.hasKey(Constants.Forge.FORGE_DATA);
+    }
+
+    @Override
+    public NBTTagCompound data$getRootCompound() {
+        if (this.nbt == null) {
+            return new NBTTagCompound();
+        }
+        NBTTagCompound forgeCompound = this.nbt.getCompoundTag(Constants.Forge.FORGE_DATA);
+        if (forgeCompound == null) {
+            forgeCompound = new NBTTagCompound();
+            this.nbt.setTag(Constants.Forge.FORGE_DATA, forgeCompound);
+        }
+        return forgeCompound;
+    }
+}

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -175,6 +175,7 @@
         "crash.CrashReportAccessor",
         "crash.CrashReportCategoryAccessor",
         "data.CustomDataHolderMixin",
+        "data.SpongeUserMixin",
         "dispenser.BehaviorProjectileDispenseMixin",
         "enchantment.EnchantmentMixin",
         "entity.EntityAccessor",


### PR DESCRIPTION
Went down the rabbit hole of figuring out why custom data were not removed from offline player (`SpongeUser`s).

Turned out that:
- custom manipulators weren't removed from the user's nbt but only from the custom manipulators list. This means the usual custom data methods (get/remove/etc.) would work consistently but once the User is saved the data would be there.
- We're reading the old nbt (saved to disk, nb1) and then writing the SpongeUser nbt (nbt2) to the old nbt, overwriting old data. However if nbt1 has custom manipulators and nbt2 does not (they were removed) then nbt1's custom manipulators are not replaced and they are saved again.
- We're marking a SpongeUser as dirty when we offer it custom data. This is good but there's a catch: when reading the nbt we're also reading custom data and "offering" them to the User which means every time a SpongeUser is initialized it is also marked as dirty.

More details:

`User#remove` is calling this:

https://github.com/SpongePowered/SpongeCommon/blob/9be33cf2c38e66fe8ac774503ef88f0b33d51faa/src/main/java/org/spongepowered/common/mixin/core/data/CustomDataHolderMixin.java#L92-L104

Here's `CustomDataHolderBridge#bridge$removeCustomFromNbt`:

https://github.com/SpongePowered/SpongeCommon/blob/31d7f4ff89de4995b9a88d71e622c7000aef4a5e/src/main/java/org/spongepowered/common/bridge/data/CustomDataHolderBridge.java#L65-L87

But wait, a `SpongeUser` is not a `DataCompoundHolder`. This is added by https://github.com/SpongePowered/SpongeCommon/commit/6e1f44a98b55dc059983f62c4853a65a69d5da70 
A separate mixin was used because this is what was done for Entity/TileEntity (there's a separate Mixin for SF and SV).

This is what happens when a SpongeUser is saved:

https://github.com/SpongePowered/SpongeCommon/blob/9be33cf2c38e66fe8ac774503ef88f0b33d51faa/src/main/java/org/spongepowered/common/entity/player/SpongeUser.java#L593-L612

The current nbt (saved to disk) is read, the SpongeUser is written to that tag and then it's saved to disk (replacing the old nbt). So far so good, except when the SpongeUser doesn't have any custom manipulators, whatever custom data is on the old nbt it's kept:

https://github.com/SpongePowered/SpongeCommon/blob/9be33cf2c38e66fe8ac774503ef88f0b33d51faa/src/main/java/org/spongepowered/common/data/util/DataUtil.java#L612-L632

Fixed by https://github.com/SpongePowered/SpongeCommon/commit/4969bcb2a1f70c484940a38cd888df6519a5afd6

