### PR TITLE
Don't fire ChangeDataHolderEvent.ValueChange when the entity is constructing

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/network/datasync/EntityDataManagerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/datasync/EntityDataManagerMixin.java
@@ -39,6 +39,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.bridge.entity.EntityBridge;
 import org.spongepowered.common.data.datasync.DataParameterConverter;
 import org.spongepowered.common.bridge.packet.DataParameterBridge;
 
@@ -81,7 +82,7 @@ public abstract class EntityDataManagerMixin {
             // Client side can have an entity, because reasons.......
             // Really silly reasons......
             // I don't know, ask Grum....
-            if (this.entity != null && this.entity.world != null && !this.entity.world.isRemote) { // We only want to spam the server world ;)
+            if (this.entity != null && this.entity.world != null && !this.entity.world.isRemote && !((EntityBridge) this.entity).bridge$isConstructing()) { // We only want to spam the server world ;)
                 final Optional<DataParameterConverter<T>> converter = ((DataParameterBridge) key).bridge$getDataConverter();
                 // At this point it is changing
                 if (converter.isPresent()) {


### PR DESCRIPTION
When constructing an entity (readFromNBT) the event is fired, but the entity is in a inconsistent state

Fix https://github.com/SpongePowered/SpongeCommon/issues/2524