### PR TITLE
Fix tileentitysign memory leak

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
@@ -271,11 +271,9 @@ public abstract class NetHandlerPlayServerMixin implements NetHandlerPlayServerB
         return ZERO_LENGTH_ARRAY; // will bypass the for loop after this method.
     }
 
-    @Inject(method = "processUpdateSign", locals = LocalCapture.CAPTURE_FAILHARD,
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/WorldServer;notifyBlockUpdate(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;Lnet/minecraft/block/state/IBlockState;I)V"))
-    private void impl$setPlayer(CPacketUpdateSign packetIn, final CallbackInfo ci, WorldServer worldserver,
-                                BlockPos blockpos, IBlockState iblockstate, TileEntity tileentitysign) {
-        ((TileEntitySign) tileentitysign).setPlayer(null);
+    @Redirect(method = "processUpdateSign", at = @At(value = "INVOKE", target = "Lnet/minecraft/tileentity/TileEntitySign;markDirty()V"))
+    private void impl$setPlayer(TileEntitySign tileentitysign) {
+        tileentitysign.setPlayer(null);
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
@@ -273,6 +273,7 @@ public abstract class NetHandlerPlayServerMixin implements NetHandlerPlayServerB
 
     @Redirect(method = "processUpdateSign", at = @At(value = "INVOKE", target = "Lnet/minecraft/tileentity/TileEntitySign;markDirty()V"))
     private void impl$setPlayer(TileEntitySign tileentitysign) {
+        tileentitysign.markDirty();
         tileentitysign.setPlayer(null);
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
@@ -271,18 +271,11 @@ public abstract class NetHandlerPlayServerMixin implements NetHandlerPlayServerB
         return ZERO_LENGTH_ARRAY; // will bypass the for loop after this method.
     }
 
-    @Inject(method = "processUpdateSign", at = @At(value = "RETURN"))
-    private void impl$setPlayer(CPacketUpdateSign packetIn, final CallbackInfo ci) {
-        WorldServer worldserver = this.server.getWorld(this.player.dimension);
-        BlockPos blockpos = packetIn.getPosition();
-        TileEntity tileentity = worldserver.getTileEntity(blockpos);
-
-        if (!(tileentity instanceof TileEntitySign)) {
-            return;
-        }
-
-        TileEntitySign tileentitysign = (TileEntitySign)tileentity;
-        tileentitysign.setPlayer(null);
+    @Inject(method = "processUpdateSign", locals = LocalCapture.CAPTURE_FAILHARD,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/WorldServer;notifyBlockUpdate(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;Lnet/minecraft/block/state/IBlockState;I)V"))
+    private void impl$setPlayer(CPacketUpdateSign packetIn, final CallbackInfo ci, WorldServer worldserver,
+                                BlockPos blockpos, IBlockState iblockstate, TileEntity tileentitysign) {
+        ((TileEntitySign) tileentitysign).setPlayer(null);
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/NetHandlerPlayServerMixin.java
@@ -26,6 +26,7 @@ package org.spongepowered.common.mixin.core.network;
 
 import com.flowpowered.math.vector.Vector3d;
 import io.netty.util.collection.LongObjectHashMap;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.item.EntityXPOrb;
@@ -268,6 +269,20 @@ public abstract class NetHandlerPlayServerMixin implements NetHandlerPlayServerB
         }
         Sponge.getCauseStackManager().popCause();
         return ZERO_LENGTH_ARRAY; // will bypass the for loop after this method.
+    }
+
+    @Inject(method = "processUpdateSign", at = @At(value = "RETURN"))
+    private void impl$setPlayer(CPacketUpdateSign packetIn, final CallbackInfo ci) {
+        WorldServer worldserver = this.server.getWorld(this.player.dimension);
+        BlockPos blockpos = packetIn.getPosition();
+        TileEntity tileentity = worldserver.getTileEntity(blockpos);
+
+        if (!(tileentity instanceof TileEntitySign)) {
+            return;
+        }
+
+        TileEntitySign tileentitysign = (TileEntitySign)tileentity;
+        tileentitysign.setPlayer(null);
     }
 
     /**


### PR DESCRIPTION
`TileEntitySign` has a player field used by `NetHandlerPlayServer#processUpdateSign`
The player field is set in `EntityPlayerMP#openEditSign` but it's never set to null.
```
if (!tileentitysign.getIsEditable() || tileentitysign.getPlayer() != this.player) {
    this.server.logWarning("Player " + this.player.getName() + " just tried to change non-editable sign");
    return;
}
```