### PR TITLE
Fix/invisibility processor

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/multi/entity/InvisibilityDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/entity/InvisibilityDataProcessor.java
@@ -67,13 +67,9 @@ public class InvisibilityDataProcessor
         final boolean untargetable = (Boolean) keyValues.get(Keys.VANISH_PREVENTS_TARGETING);
         final boolean vanish = (Boolean) keyValues.get(Keys.VANISH);
         dataHolder.bridge$setInvisible(invis);
-        if (vanish) {
-            dataHolder.bridge$setVanished(true);
-            dataHolder.bridge$setUncollideable(collision);
-            dataHolder.bridge$setUntargetable(untargetable);
-        } else {
-            dataHolder.bridge$setVanished(false);
-        }
+        dataHolder.bridge$setVanished(vanish);
+        dataHolder.bridge$setUncollideable(collision);
+        dataHolder.bridge$setUntargetable(untargetable);
         return true;
     }
 

--- a/src/main/java/org/spongepowered/common/data/processor/multi/entity/InvisibilityDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/entity/InvisibilityDataProcessor.java
@@ -68,8 +68,8 @@ public class InvisibilityDataProcessor
         final boolean vanish = (Boolean) keyValues.get(Keys.VANISH);
         dataHolder.bridge$setInvisible(invis);
         dataHolder.bridge$setVanished(vanish);
-        dataHolder.bridge$setUncollideable(collision);
-        dataHolder.bridge$setUntargetable(untargetable);
+        dataHolder.bridge$setUncollideable(vanish && collision);
+        dataHolder.bridge$setUntargetable(vanish && untargetable);
         return true;
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMixin.java
@@ -365,7 +365,7 @@ public abstract class EntityPlayerMixin extends EntityLivingBaseMixin implements
 
     @Redirect(method = "onLivingUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getEntitiesWithinAABBExcludingEntity(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/math/AxisAlignedBB;)Ljava/util/List;"))
     private List<Entity> onSpongeGetEntitiesWithinAABBExcludingEntity(final World world, Entity entityIn, AxisAlignedBB bb) {
-        if (this.bridge$isUncollideable()) {
+        if (this.bridge$isVanished() && this.bridge$isUncollideable()) {
             return Collections.emptyList();
         }
         return world.getEntitiesWithinAABBExcludingEntity(entityIn, bb);


### PR DESCRIPTION
https://github.com/SpongePowered/SpongeAPI/blob/f12f8e7743844b8761b890ce3e440911e97c6f38/src/main/java/org/spongepowered/api/data/key/Keys.java#L2266

https://github.com/SpongePowered/SpongeAPI/blob/f12f8e7743844b8761b890ce3e440911e97c6f38/src/main/java/org/spongepowered/api/data/key/Keys.java#L2252

when turning of vanish with something like this:

```
id.set(Keys.VANISH, false);
id.set(Keys.VANISH_IGNORES_COLLISION, false);
id.set(Keys.VANISH_PREVENTS_TARGETING, false);
```

the invisibilitydataprocessor would just ignore `collision` and `untargetable` (keeping the old values) and set `vanish` to false. 

The redirect was also breaking the api contract (uncollideable is ignored if you're not in vanish).