### PR TITLE
Avoid double key lookup in DataCompoundHolder#getSpongeCompound

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/data/DataCompoundHolder.java
+++ b/src/main/java/org/spongepowered/common/bridge/data/DataCompoundHolder.java
@@ -39,9 +39,10 @@ public interface DataCompoundHolder {
 
     default NBTTagCompound data$getSpongeCompound() {
         final NBTTagCompound data = this.data$getRootCompound();
-        if (!data.hasKey(Constants.Sponge.SPONGE_DATA, Constants.NBT.TAG_COMPOUND)) {
-            data.setTag(Constants.Sponge.SPONGE_DATA, new NBTTagCompound());
+        final NBTTagCompound sponge = data.getCompoundTag(Constants.Sponge.SPONGE_DATA);
+        if (sponge.isEmpty()) {
+            data.setTag(Constants.Sponge.SPONGE_DATA, sponge);
         }
-        return data.getCompoundTag(Constants.Sponge.SPONGE_DATA);
+        return sponge;
     }
 }


### PR DESCRIPTION
![](https://transfer.sh/lhUAN/compound.png)

`NBTTagCompound#getCompoundTag` returns an empty compound if it doesn't have the key.