### PR TITLE
Implement LaunchProjectileEvent, Take 2

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/block/DispenserBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/block/DispenserBridge.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.bridge.block;
+
+import net.minecraft.item.ItemStack;
+
+public interface DispenserBridge {
+
+    void bridge$setDispensedItem(ItemStack dispensed);
+
+    void bridge$restoreDispensedItem(int count);
+}

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -52,23 +52,12 @@ import net.minecraft.network.play.server.SPacketSetSlot;
 import net.minecraft.util.EnumHand;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.entity.living.player.User;
-import org.spongepowered.api.entity.projectile.Projectile;
-import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.event.CauseStackManager;
-import org.spongepowered.api.event.SpongeEventFactory;
-import org.spongepowered.api.event.cause.EventContextKeys;
-import org.spongepowered.api.event.cause.entity.spawn.SpawnTypes;
-import org.spongepowered.api.event.entity.projectile.LaunchProjectileEvent;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
-import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.SpongeImplHooks;
 import org.spongepowered.common.bridge.entity.player.EntityPlayerMPBridge;
 import org.spongepowered.common.bridge.inventory.TrackedInventoryBridge;
-import org.spongepowered.common.entity.EntityUtil;
-import org.spongepowered.common.event.ShouldFire;
-import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.item.inventory.adapter.impl.slots.SlotAdapter;
@@ -81,9 +70,7 @@ import org.spongepowered.common.mixin.core.entity.passive.EntitySheepAccessor;
 import org.spongepowered.common.mixin.core.entity.passive.EntityWolfAccessor;
 import org.spongepowered.common.mixin.core.network.play.client.CPacketPlayerAccessor;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -288,5 +275,4 @@ public final class PacketPhaseUtil {
 
         return null;
     }
-
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -52,12 +52,23 @@ import net.minecraft.network.play.server.SPacketSetSlot;
 import net.minecraft.util.EnumHand;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.entity.projectile.Projectile;
+import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.cause.EventContextKeys;
+import org.spongepowered.api.event.cause.entity.spawn.SpawnTypes;
+import org.spongepowered.api.event.entity.projectile.LaunchProjectileEvent;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.SpongeImplHooks;
 import org.spongepowered.common.bridge.entity.player.EntityPlayerMPBridge;
 import org.spongepowered.common.bridge.inventory.TrackedInventoryBridge;
+import org.spongepowered.common.entity.EntityUtil;
+import org.spongepowered.common.event.ShouldFire;
+import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.item.inventory.adapter.impl.slots.SlotAdapter;
@@ -70,7 +81,9 @@ import org.spongepowered.common.mixin.core.entity.passive.EntitySheepAccessor;
 import org.spongepowered.common.mixin.core.entity.passive.EntityWolfAccessor;
 import org.spongepowered.common.mixin.core.network.play.client.CPacketPlayerAccessor;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -275,4 +288,5 @@ public final class PacketPhaseUtil {
 
         return null;
     }
+
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/InteractionPacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/InteractionPacketState.java
@@ -27,7 +27,6 @@ package org.spongepowered.common.event.tracking.phase.packet.player;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.item.EntityXPOrb;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.client.CPacketPlayerDigging;
 import net.minecraft.util.math.BlockPos;
@@ -260,14 +259,14 @@ public final class InteractionPacketState extends PacketState<InteractionPacketC
 
     private void throwEntitySpawnEvents(final InteractionPacketContext phaseContext, final EntityPlayerMP player, final ItemStackSnapshot usedSnapshot,
         final BlockSnapshot firstBlockChange, final Collection<Entity> entities) {
-        final List<Entity> projectiles = new ArrayList<>(entities.size());
+        final List<Projectile> projectiles = new ArrayList<>(entities.size());
         final List<Entity> spawnEggs = new ArrayList<>(entities.size());
         final List<Entity> xpOrbs = new ArrayList<>(entities.size());
         final List<Entity> normalPlacement = new ArrayList<>(entities.size());
         final List<Entity> items = new ArrayList<>(entities.size());
         for (final Entity entity : entities) {
-            if (entity instanceof Projectile || entity instanceof EntityThrowable) {
-                projectiles.add(entity);
+            if (entity instanceof Projectile) {
+                projectiles.add((Projectile) entity);
             } else if (usedSnapshot.getType() == ItemTypes.SPAWN_EGG) {
                 spawnEggs.add(entity);
             } else if (entity instanceof EntityItem) {
@@ -279,14 +278,8 @@ public final class InteractionPacketState extends PacketState<InteractionPacketC
             }
         }
         if (!projectiles.isEmpty()) {
-            if (ShouldFire.SPAWN_ENTITY_EVENT) {
-                try (final CauseStackManager.StackFrame frame2 = Sponge.getCauseStackManager().pushCauseFrame()) {
-                    for (Entity projectile : projectiles) {
-                        SpongeCommonEventFactory.callProjectileLaunchEvent(frame2, player, (Projectile) projectile, phaseContext);
-                    }
-                }
-            } else {
-                processEntities(player, projectiles);
+            try (final CauseStackManager.StackFrame frame2 = Sponge.getCauseStackManager().pushCauseFrame()) {
+                SpongeCommonEventFactory.callProjectileLaunchEvent(frame2, player, projectiles, phaseContext);
             }
         }
         if (!spawnEggs.isEmpty()) {

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/PlaceBlockPacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/PlaceBlockPacketState.java
@@ -129,8 +129,6 @@ public final class PlaceBlockPacketState extends BasicPacketState {
         final ItemStack itemStack = context.getItemUsed();
         final SpongeItemStackSnapshot snapshot = context.getItemUsedSnapshot();
 
-//        ((ContainerBridge) player.inventoryContainer).bridge$detectAndSendChanges(false);
-
         boolean entityCaptured = !context.getCapturedEntities().isEmpty();
         context.getCapturedEntitySupplier()
             .acceptAndClearIfNotEmpty(entities -> {
@@ -150,8 +148,8 @@ public final class PlaceBlockPacketState extends BasicPacketState {
                         SpongeCommonEventFactory.callSpawnEntity(entities, context);
                     }
 
-                    for (Projectile projectile : projectiles) {
-                        SpongeCommonEventFactory.callProjectileLaunchEvent(frame, player, projectile, context);
+                    if (!projectiles.isEmpty()) {
+                        SpongeCommonEventFactory.callProjectileLaunchEvent(frame, player, projectiles, context);
                     }
                 }
             });

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/UseItemPacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/UseItemPacketState.java
@@ -146,8 +146,8 @@ public final class UseItemPacketState extends BasicPacketState {
                         SpongeCommonEventFactory.callSpawnEntity(entities, context);
                     }
 
-                    for (Projectile projectile : projectiles) {
-                        SpongeCommonEventFactory.callProjectileLaunchEvent(frame, player, projectile, context);
+                    if (!projectiles.isEmpty()) {
+                        SpongeCommonEventFactory.callProjectileLaunchEvent(frame, player, projectiles, context);
                     }
                 });
             if (!context.getCapturedBlockSupplier().isEmpty()) {

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/EntityTickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/EntityTickPhaseState.java
@@ -44,10 +44,14 @@ import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.Ageable;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.projectile.Projectile;
+import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.EventContextKeys;
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.event.cause.entity.spawn.SpawnTypes;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.block.SpongeBlockSnapshot;
 import org.spongepowered.common.bridge.entity.EntityBridge;
 import org.spongepowered.common.entity.EntityUtil;
@@ -148,6 +152,13 @@ class EntityTickPhaseState extends TickPhaseState<EntityTickContext> {
                     }
                     if (!projectile.isEmpty()) {
                         frame.addContext(EventContextKeys.SPAWN_TYPE, SpawnTypes.PROJECTILE);
+                        if (tickingEntity instanceof ProjectileSource) {
+                            frame.addContext(EventContextKeys.PROJECTILE_SOURCE, (ProjectileSource) tickingEntity);
+                            final Cause cause = Sponge.getCauseStackManager().getCurrentCause();
+                            projectile.removeIf(proj ->
+                                    SpongeImpl.postEvent(SpongeEventFactory.createLaunchProjectileEvent(cause, (Projectile) proj)));
+                            frame.removeContext(EventContextKeys.PROJECTILE_SOURCE);
+                        }
                         SpongeCommonEventFactory.callSpawnEntity(projectile, phaseContext);
                         frame.removeContext(EventContextKeys.SPAWN_TYPE);
 

--- a/src/main/java/org/spongepowered/common/mixin/core/block/BlockDispenserMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/BlockDispenserMixin.java
@@ -56,6 +56,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.block.SpongeBlockSnapshot;
+import org.spongepowered.common.bridge.block.DispenserBridge;
 import org.spongepowered.common.bridge.world.WorldServerBridge;
 import org.spongepowered.common.bridge.world.chunk.ChunkBridge;
 import org.spongepowered.common.data.ImmutableDataCachingUtil;
@@ -144,6 +145,7 @@ public abstract class BlockDispenserMixin extends BlockMixin {
     )
     private void impl$InjectToStoreOriginalItem(
         final World worldIn, final BlockPos pos, final CallbackInfo ci, final BlockSourceImpl source, final TileEntityDispenser dispenser, final int slotIndex, final ItemStack dispensedItem, final IBehaviorDispenseItem behavior) {
+        ((DispenserBridge) dispenser).bridge$setDispensedItem(dispensedItem);
         this.originalItem = ItemStackUtil.cloneDefensiveNative(dispensedItem);
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/TileEntityDispenserMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/TileEntityDispenserMixin.java
@@ -24,17 +24,23 @@
  */
 package org.spongepowered.common.mixin.core.tileentity;
 
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntityDispenser;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.common.bridge.block.DispenserBridge;
 import org.spongepowered.common.item.inventory.adapter.InventoryAdapter;
 import org.spongepowered.common.item.inventory.lens.Fabric;
 import org.spongepowered.common.item.inventory.lens.SlotProvider;
 import org.spongepowered.common.item.inventory.lens.impl.ReusableLens;
-import org.spongepowered.common.item.inventory.lens.impl.minecraft.SingleGridLens;
 import org.spongepowered.common.item.inventory.lens.impl.collections.SlotCollection;
+import org.spongepowered.common.item.inventory.lens.impl.minecraft.SingleGridLens;
 
 @Mixin(TileEntityDispenser.class)
-public abstract class TileEntityDispenserMixin extends TileEntityLockableLootMixin {
+public abstract class TileEntityDispenserMixin extends TileEntityLockableLootMixin implements DispenserBridge {
+
+    private @Nullable ItemStack originalStack;
+    private int originalStackSize;
 
     @Override
     public ReusableLens<?> bridge$generateReusableLens(final Fabric fabric, final InventoryAdapter adapter) {
@@ -50,4 +56,16 @@ public abstract class TileEntityDispenserMixin extends TileEntityLockableLootMix
         return new SingleGridLens(0, 3, 3, (Class) TileEntityDispenser.class, slots);
     }
 
+    @Override
+    public void bridge$setDispensedItem(ItemStack dispensed) {
+        this.originalStack = dispensed;
+        this.originalStackSize = dispensed.getCount();
+    }
+
+    @Override
+    public void bridge$restoreDispensedItem(int count) {
+        if (originalStack != null) {
+            this.originalStack.setCount(this.originalStackSize + count);
+        }
+    }
 }


### PR DESCRIPTION
This is an adapted version of #1769 for API 7

One big issue with the current event is that it is limited to one projectile, where mods (and crossbows with the Multishot enchantment) can shoot multiple at once . I'd like to fix that later for API 8 in another PR.

**What works**

- [x] A non-player entity shoots a projectile (skeletons shooting arrows, llamas spitting, ghasts shooting fireballs, snowmans shooting snowballs, blaze shooting small fireballs, withers, ender dragon)
  - [x] Cancelling, at least for vanilla entities, that shoot one projectile and not do not consume stacks from an inventory
- [x] A player shoots arrows
  - [x] Cancelling, if only one projectile is launched
  - [ ] ~Cancelling when several projectiles are shot (possible with mods) and only one is cancelled: this may restore all consumed stacks~ - I guess we'll have to forget this one for API 7, let's consider one cancelled event as the cancellation of all the other events
- [x] A player throws projectiles (snowballs, eggs, potions - splash and lingering -, enderpearls, eyes of ender, using fishing rod, experience bottle)
  - [x] Cancelling (assuming it only launches one at a time)
- [x] A dispenser launches a projectile (arrows, snowballs, eggs, potions - splash and lingering -, experience bottle)
  - [x] Cancelling (assuming it only launches one at a time)
- [x] A plugin shoots a projectile
- [x] A player uses a firework - I had to add a condition operand, otherwise fireworks are always restored to the player's inventory. I need help on this one
  - [x] Cancelling
- [x] A dispenser dispenses a firework
  - [x] Cancelling

There can be issues in cases where multiple projectiles are launched at the same time (but in vanilla it shouldn't be an issue). I think the best way to handle it is to cancel all events if one is cancelled.