### PR TITLE
Ensure default permissions are used with some wrapped subjects

### DIFF
--- a/src/main/java/org/spongepowered/common/command/AndPermissionLevelSubject.java
+++ b/src/main/java/org/spongepowered/common/command/AndPermissionLevelSubject.java
@@ -102,12 +102,8 @@ public final class AndPermissionLevelSubject extends SpongeBaseSubject {
         final Tristate value = getPermissionValue(contexts, permission);
         if (value == Tristate.UNDEFINED) {
             Subject target = this.delegate;
-            while (target instanceof ProxySource) {
-                if (target instanceof SpongeProxySource) {
-                    target = ((SpongeProxySource) target).getSubjectDelegate();
-                } else {
-                    target = ((ProxySource) target).getOriginalSource();
-                }
+            while (target instanceof SpongeProxySource) {
+                target = ((SpongeProxySource) target).getSubjectDelegate();
             }
             if (target instanceof SubjectBridge) {
                 return ((SubjectBridge) target).bridge$permDefault(permission).asBoolean();

--- a/src/main/java/org/spongepowered/common/command/SpongeProxySource.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeProxySource.java
@@ -67,6 +67,10 @@ public class SpongeProxySource implements ProxySource, CommandSourceBridge {
         return this.messageSource;
     }
 
+    public Subject getSubjectDelegate() {
+        return this.subjectDelegate;
+    }
+
     @Override
     public String bridge$getIdentifier() {
         return this.subjectDelegate.getIdentifier();


### PR DESCRIPTION
See #2599

The reason I make this a PR at first is to:

a) make sure I'm not accidently causing a big security hole; and
b) talk about the notion of a default permission in the API.

As you can see in the diff, I have the following:

```
if (target instanceof SubjectBridge) {
    return ((SubjectBridge) target).bridge$permDefault(permission).asBoolean();
}
```

Would it be better to graduate `bridge$permDefault(permission)` to the API `Subject` interface (as `defaultPermission`) so that we don't need to check if the object is of type `SubjectBridge` and allow third-party `Subjects` (e.g. `ProxySource`s) to have their own defaults, and make `hasPermission(...)` check `defaultPermision(...)` if the value is undefined?

Such an API change shouldn't affect permission plugins.

(Note, I'm willing to pull this whenever, even if we decide to put defaults into the API, it's just a thought I had)

@clienthax please test this - it worked for me but I'd like to make sure it works for you too.