### PR TITLE
Improve runaway phase state detection

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/PhaseStack.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/PhaseStack.java
@@ -133,19 +133,18 @@ final class PhaseStack {
             return false;
         }
         final int totalCount = this.phases.size();
-        final PhaseContext<?>[] allContexts = new PhaseContext[totalCount];
-        int i = 0;
+        if (totalCount < 2) {
+            return false;
+        }
         // So first, we want to collect all the states into an array as they are pushed to the stack,
         // which means that we should see the re-entrant phase pretty soon.
-        for (PhaseContext<?> data : this.phases) {
-            allContexts[i++] = data;
-        }
+        final Object[] allContexts = this.phases.toArray();
         // Now we can actually iterate through the array
         for (int index = 0; index < allContexts.length; index++) {
             if (index < allContexts.length - 1) { // We can't go further than the length, cause that's the top of the stack
-                final PhaseContext<?> latestContext = allContexts[index];
+                final PhaseContext<?> latestContext = (PhaseContext<?>) allContexts[index];
                 final IPhaseState<?> latestState = latestContext.state;
-                if (latestState == allContexts[index + 1].state && latestState == state && (phaseContext == null || latestContext.isRunaway(phaseContext))) {
+                if (latestState == state && latestState == ((PhaseContext<?>) allContexts[index + 1]).state && (phaseContext == null || latestContext.isRunaway(phaseContext))) {
                     // Found a consecutive duplicate and can now print out
                     return true;
                 }


### PR DESCRIPTION
This is a microoptimization. The only reason it was worth pushing is because `PhaseStack#checkForRunaways` is a hot method.

It's called by `PhaseTracker#completePhase`

https://github.com/SpongePowered/SpongeCommon/blob/c18043b5480b5cbad6401164d67a92957b32ed8b/src/main/java/org/spongepowered/common/event/tracking/PhaseTracker.java#L298-L304

(yes, I saw `isVerbose` but that's on by default)
https://github.com/SpongePowered/SpongeCommon/blob/c18043b5480b5cbad6401164d67a92957b32ed8b/src/main/java/org/spongepowered/common/config/category/PhaseTrackerCategory.java#L46

This PR adds:

- fail-fast behaviour if there are less than 2 phases (since runaway phase detection doesn't make sense in that case).
- Moving array creation from iteration to `toArray` (this wasn't possible in the past, see git history)

Profiling this was difficult: the if condition is catching almost every case and `toArray` is using `System#arraycopy` which is intrinsic.
https://hg.openjdk.java.net/jdk8/jdk8/hotspot/file/tip/src/share/vm/classfile/vmSymbols.hpp#l708. 

The only place I could observe `checkForRunaways` (probably because it was called more than anywhere else) was here:

https://github.com/SpongePowered/SpongeCommon/blob/c18043b5480b5cbad6401164d67a92957b32ed8b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java#L1179

(try catch is calling `close`)