### PR TITLE
Init collision state lazily

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/entitycollisions/ChunkMixin_Collisions.java
+++ b/src/main/java/org/spongepowered/common/mixin/entitycollisions/ChunkMixin_Collisions.java
@@ -95,6 +95,10 @@ public abstract class ChunkMixin_Collisions {
                 return true;
             }
 
+            if (listToFill.size() < this.world.getGameRules().getInt("maxEntityCramming")) {
+                return true;
+            }
+
             final CollisionsCapability capability = (CollisionsCapability) source;
             if (capability.collision$requiresCollisionsCacheRefresh()) {
                 capability.collision$initializeCollisionState(this.world);
@@ -102,8 +106,7 @@ public abstract class ChunkMixin_Collisions {
             }
 
             return capability.collision$getMaxCollisions() < 0
-                    || listToFill.size() < capability.collision$getMaxCollisions()
-                    || listToFill.size() < this.world.getGameRules().getInt("maxEntityCramming");
+                    || listToFill.size() < capability.collision$getMaxCollisions();
         }
 
         return true;

--- a/src/main/java/org/spongepowered/common/mixin/entitycollisions/EntityMixin_Collisions.java
+++ b/src/main/java/org/spongepowered/common/mixin/entitycollisions/EntityMixin_Collisions.java
@@ -77,7 +77,7 @@ public class EntityMixin_Collisions implements CollisionsCapability {
 
             this.collision$entityModId = ((SpongeEntityType) ((Entity) this).getType()).getModId();
             if (!this.world.isRemote) {
-                collision$initializeCollisionState(this.world);
+                collision$requiresCollisionsCacheRefresh(true);
             }
         }
     }


### PR DESCRIPTION
Don't init collision state during entity construction but do it lazily during entity collisions.

`maxEntityCramming` is checked first since `listToFill.size() < capability.collision$getMaxCollisions()` is enough to make it happen (regardless of the collision state).