### PR TITLE
Fix a few issues with shouldfires and use specific flags

### DIFF
--- a/src/main/java/org/spongepowered/common/event/ShouldFire.java
+++ b/src/main/java/org/spongepowered/common/event/ShouldFire.java
@@ -59,6 +59,7 @@ public class ShouldFire {
 
     public static boolean CHANGE_BLOCK_EVENT = false;
     public static boolean CHANGE_BLOCK_EVENT_PRE = false;
+    public static boolean CHANGE_BLOCK_EVENT_DECAY = false;
     public static boolean CHANGE_BLOCK_EVENT_MODIFY = false;
     public static boolean CHANGE_BLOCK_EVENT_BREAK = false;
     public static boolean CHANGE_BLOCK_EVENT_PLACE = false;

--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -925,7 +925,7 @@ public class SpongeCommonEventFactory {
         final EntityTickContext context) {
 
         // Ignore movement event if entity is dead
-        if (entity.isDead || (!ShouldFire.MOVE_ENTITY_EVENT && !ShouldFire.MOVE_ENTITY_EVENT_POSITION && !ShouldFire.ROTATE_ENTITY_EVENT)) {
+        if (entity.isDead) {
             return null;
         }
 
@@ -957,12 +957,16 @@ public class SpongeCommonEventFactory {
                 final Transform<World> newTransform = new Transform<>(world, currentPositionVector, currentRotationVector, spongeEntity.getScale());
                 Event event  = null;
                 Transform<World> eventToTransform = null;
-                if (!oldPositionVector.equals(currentPositionVector) && ShouldFire.MOVE_ENTITY_EVENT_POSITION) {
-                    event = SpongeEventFactory.createMoveEntityEventPosition(frame.getCurrentCause(), oldTransform, newTransform, spongeEntity);
-                    eventToTransform = ((MoveEntityEvent) event).getToTransform();
-                } else if (ShouldFire.ROTATE_ENTITY_EVENT) {
-                    event = SpongeEventFactory.createRotateEntityEvent(frame.getCurrentCause(), oldTransform, newTransform, spongeEntity);
-                    eventToTransform = ((RotateEntityEvent) event).getToTransform();
+                if (!oldPositionVector.equals(currentPositionVector)) {
+                    if (ShouldFire.MOVE_ENTITY_EVENT_POSITION) {
+                        event = SpongeEventFactory.createMoveEntityEventPosition(frame.getCurrentCause(), oldTransform, newTransform, spongeEntity);
+                        eventToTransform = ((MoveEntityEvent) event).getToTransform();
+                    }
+                } else {
+                    if (ShouldFire.ROTATE_ENTITY_EVENT) {
+                        event = SpongeEventFactory.createRotateEntityEvent(frame.getCurrentCause(), oldTransform, newTransform, spongeEntity);
+                        eventToTransform = ((RotateEntityEvent) event).getToTransform();
+                    }
                 }
 
                 if (event == null) {

--- a/src/main/java/org/spongepowered/common/event/tracking/PhaseTracker.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/PhaseTracker.java
@@ -925,48 +925,47 @@ public final class PhaseTracker {
 
                 final SpongeBlockSnapshot originalBlockSnapshot = context.getSingleSnapshot();
 
-                final Transaction<BlockSnapshot> transaction = TrackingUtil.TRANSACTION_CREATION.apply(originalBlockSnapshot).get();
-                final ImmutableList<Transaction<BlockSnapshot>> transactions = ImmutableList.of(transaction);
-                // Create and throw normal event
-                final Cause currentCause = Sponge.getCauseStackManager().getCurrentCause();
-                final ChangeBlockEvent normalEvent =
-                    originalBlockSnapshot.blockChange.createEvent(currentCause, transactions);
-                try (@SuppressWarnings("try") final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
-                    SpongeImpl.postEvent(normalEvent);
-                    // We put the normal event at the end of the cause, still keeping in line with the
-                    // API contract that the ChangeBlockEvnets are pushed to the cause for Post, but they
-                    // will not replace the root causes. Likewise, this does not leak into the cause stack
-                    // for plugin event listeners performing other operations that could potentially alter
-                    // the cause stack (CauseStack:[Player, ScheduledTask] vs. CauseStack:[ChangeBlockEvent, Player, ScheduledTask])
-                    final Cause normalizedEvent;
-                    if (ShouldFire.CHANGE_BLOCK_EVENT_POST) {
-                        normalizedEvent = currentCause.with(normalEvent);
-                    } else {
-                        normalizedEvent = currentCause;
-                    }
-                    if (normalEvent.isCancelled()) {
-                        // If the normal event is cancelled, mark the transaction as invalid already
-                        transaction.setValid(false);
-                    }
-                    final ChangeBlockEvent.Post post = ((IPhaseState) phaseState).createChangeBlockPostEvent(context, transactions, normalizedEvent);
-                    if (ShouldFire.CHANGE_BLOCK_EVENT_POST) {
-                        SpongeImpl.postEvent(post);
-                    }
-                    if (post.isCancelled()) {
-                        // And finally, if the post event is cancelled, mark the transaction as invalid.
-                        transaction.setValid(false);
-                    }
-                    if (!transaction.isValid()) {
-                        transaction.getOriginal().restore(true, BlockChangeFlags.NONE);
-                        if (((IPhaseState) phaseState).tracksBlockSpecificDrops(context)) {
-                            ((PhaseContext) context).getBlockDropSupplier().removeAllIfNotEmpty(pos);
+                if (ShouldFire.CHANGE_BLOCK_EVENT_POST || originalBlockSnapshot.blockChange.shouldFire()) {
+                    final Transaction<BlockSnapshot> transaction = TrackingUtil.TRANSACTION_CREATION.apply(originalBlockSnapshot).get();
+                    final ImmutableList<Transaction<BlockSnapshot>> transactions = ImmutableList.of(transaction);
+                    // Create and throw normal event
+                    final Cause currentCause = Sponge.getCauseStackManager().getCurrentCause();
+                    final ChangeBlockEvent normalEvent =
+                            originalBlockSnapshot.blockChange.createEvent(currentCause, transactions);
+                    try (@SuppressWarnings("try") final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+                        if (originalBlockSnapshot.blockChange.shouldFire()) {
+                            SpongeImpl.postEvent(normalEvent);
+                            if (normalEvent.isCancelled()) {
+                                // If the normal event is cancelled, mark the transaction as invalid already
+                                transaction.setValid(false);
+                            }
                         }
-                        return false; // Short circuit
+                        if (ShouldFire.CHANGE_BLOCK_EVENT_POST) {
+                            // We put the normal event at the end of the cause, still keeping in line with the
+                            // API contract that the ChangeBlockEvnets are pushed to the cause for Post, but they
+                            // will not replace the root causes. Likewise, this does not leak into the cause stack
+                            // for plugin event listeners performing other operations that could potentially alter
+                            // the cause stack (CauseStack:[Player, ScheduledTask] vs. CauseStack:[ChangeBlockEvent, Player, ScheduledTask])
+                            final Cause normalizedEvent = currentCause.with(normalEvent);
+                            final ChangeBlockEvent.Post post = ((IPhaseState) phaseState).createChangeBlockPostEvent(context, transactions, normalizedEvent);
+                            SpongeImpl.postEvent(post);
+                            if (post.isCancelled()) {
+                                // And finally, if the post event is cancelled, mark the transaction as invalid.
+                                transaction.setValid(false);
+                            }
+                        }
+                        if (!transaction.isValid()) {
+                            transaction.getOriginal().restore(true, BlockChangeFlags.NONE);
+                            if (((IPhaseState) phaseState).tracksBlockSpecificDrops(context)) {
+                                ((PhaseContext) context).getBlockDropSupplier().removeAllIfNotEmpty(pos);
+                            }
+                            return false; // Short circuit
+                        }
+                        // And now, proceed as normal.
+                        // If we've gotten this far, the transaction wasn't cancelled, so pass 'noCancelledTransactions' as 'true'
+                        TrackingUtil.performTransactionProcess(transaction, context, 0);
+                        return true;
                     }
-                    // And now, proceed as normal.
-                    // If we've gotten this far, the transaction wasn't cancelled, so pass 'noCancelledTransactions' as 'true'
-                    TrackingUtil.performTransactionProcess(transaction, context, 0);
-                    return true;
                 }
             } catch (final Exception | NoClassDefFoundError e) {
                 this.printBlockTrackingException(context, phaseState, e);

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java
@@ -255,7 +255,7 @@ public abstract class EntityMixin implements EntityBridge, TrackableBridge, Vani
     @Inject(method = "startRiding(Lnet/minecraft/entity/Entity;Z)Z", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/Entity;ridingEntity:Lnet/minecraft/entity/Entity;", ordinal = 0),
             cancellable = true)
     private void onStartRiding(final Entity vehicle, final boolean force, final CallbackInfoReturnable<Boolean> ci) {
-        if (!this.world.isRemote && (ShouldFire.RIDE_ENTITY_EVENT_MOUNT || ShouldFire.RIDE_ENTITY_EVENT)) {
+        if (!this.world.isRemote && ShouldFire.RIDE_ENTITY_EVENT_MOUNT) {
             Sponge.getCauseStackManager().pushCause(this);
             if (SpongeImpl.postEvent(SpongeEventFactory.createRideEntityEventMount(Sponge.getCauseStackManager().getCurrentCause(), (org.spongepowered.api.entity.Entity) vehicle))) {
                 ci.cancel();
@@ -282,7 +282,7 @@ public abstract class EntityMixin implements EntityBridge, TrackableBridge, Vani
 
     @SuppressWarnings("ConstantConditions")
     private boolean spongeImpl$dismountRidingEntity(final DismountType type) {
-        if (!this.world.isRemote && (ShouldFire.RIDE_ENTITY_EVENT_DISMOUNT || ShouldFire.RIDE_ENTITY_EVENT)) {
+        if (!this.world.isRemote && ShouldFire.RIDE_ENTITY_EVENT_DISMOUNT) {
             try (final CauseStackManager.StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
                 frame.pushCause(this);
                 frame.addContext(EventContextKeys.DISMOUNT_TYPE, type);

--- a/src/main/java/org/spongepowered/common/world/BlockChange.java
+++ b/src/main/java/org/spongepowered/common/world/BlockChange.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.EventContextKey;
 import org.spongepowered.api.event.cause.EventContextKeys;
 import org.spongepowered.common.config.category.LoggingCategory;
+import org.spongepowered.common.event.ShouldFire;
 
 public enum BlockChange {
 
@@ -41,6 +42,11 @@ public enum BlockChange {
         @Override
         public ChangeBlockEvent createEvent(Cause cause, ImmutableList<Transaction<BlockSnapshot>> transactions) {
             return SpongeEventFactory.createChangeBlockEventBreak(cause, transactions);
+        }
+
+        @Override
+        public boolean shouldFire() {
+            return ShouldFire.CHANGE_BLOCK_EVENT_BREAK;
         }
 
         @Override
@@ -60,6 +66,11 @@ public enum BlockChange {
         }
 
         @Override
+        public boolean shouldFire() {
+            return ShouldFire.CHANGE_BLOCK_EVENT_DECAY;
+        }
+
+        @Override
         public EventContextKey<? extends ChangeBlockEvent> getKey() {
             return EventContextKeys.DECAY_EVENT;
         }
@@ -68,6 +79,11 @@ public enum BlockChange {
         @Override
         public ChangeBlockEvent createEvent(Cause cause, ImmutableList<Transaction<BlockSnapshot>> transactions) {
             return SpongeEventFactory.createChangeBlockEventModify(cause, transactions);
+        }
+
+        @Override
+        public boolean shouldFire() {
+            return ShouldFire.CHANGE_BLOCK_EVENT_MODIFY;
         }
 
         @Override
@@ -87,6 +103,11 @@ public enum BlockChange {
         }
 
         @Override
+        public boolean shouldFire() {
+            return ShouldFire.CHANGE_BLOCK_EVENT_PLACE;
+        }
+
+        @Override
         public EventContextKey<? extends ChangeBlockEvent> getKey() {
             return EventContextKeys.PLACE_EVENT;
         }
@@ -103,6 +124,11 @@ public enum BlockChange {
         }
 
         @Override
+        public boolean shouldFire() {
+            return ShouldFire.CHANGE_BLOCK_EVENT_GROW;
+        }
+
+        @Override
         public EventContextKey<? extends ChangeBlockEvent> getKey() {
             return EventContextKeys.GROW_EVENT;
         }
@@ -116,6 +142,8 @@ public enum BlockChange {
     }
 
     public abstract ChangeBlockEvent createEvent(Cause cause, ImmutableList<Transaction<BlockSnapshot>> transactions);
+
+    public abstract boolean shouldFire();
 
     public abstract EventContextKey<? extends ChangeBlockEvent> getKey();
 }


### PR DESCRIPTION
Splitting bugs and enhancements from actually "[missing shouldfires](https://github.com/SpongePowered/SpongeCommon/pull/2567)" 

Namely:
https://github.com/SpongePowered/SpongeCommon/blob/a4f4c117ad89266a57762eaf27cd01d30251a7bb/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java#L960-L966
Listening to `RotateEntityEvent` without listening to `MoveEntityEvent` would fire an event even when `!oldPositionVector.equals(currentPositionVector)`.
This is breaking the API contract (a `RotateEntityEvent` is only fired when the position is unchanged).

`(!ShouldFire.MOVE_ENTITY_EVENT && !ShouldFire.MOVE_ENTITY_EVENT_POSITION && !ShouldFire.ROTATE_ENTITY_EVENT)` is always false since that's handled before calling the factory method.

`ShouldFire.RIDE_ENTITY_EVENT_MOUNT || ShouldFire.RIDE_ENTITY_EVENT` is not good (this also applies to move events). Only the flag for the specific event should be used (when listening to a generic event the flag for the specific event is updated). 

Additionally a `shouldFire()` method is added to block change to enable targeted flag check instead of just `ShouldFire.CHANGE_BLOCK_EVENT`