### PR TITLE
Avoid Class#getCanonicalName call when creating a builder

### DIFF
--- a/src/main/java/org/spongepowered/common/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeGameRegistry.java
@@ -378,7 +378,9 @@ public class SpongeGameRegistry implements GameRegistry {
     public <T extends ResettableBuilder<?, ? super T>> T createBuilder(Class<T> builderClass) {
         checkNotNull(builderClass, "Builder class was null!");
         final Supplier<?> supplier = BUILDER_SUPPLIERS.get(builderClass);
-        checkArgument(supplier != null, "Could not find a Supplier for the provided builder class: " + builderClass.getCanonicalName());
+        if (supplier == null) {
+            throw new IllegalArgumentException("Could not find a Supplier for the provided builder class: " + builderClass.getCanonicalName());
+        }
         return (T) supplier.get();
     }
 


### PR DESCRIPTION
`checkArgument` does  not lazy load the error message, meaning the string is created and `Class#getCanonicalName()` is called. This is a hot method.


![class](https://user-images.githubusercontent.com/24737505/82161612-8c0ae380-989e-11ea-8071-0a1d3ffe9695.png)
