### PR TITLE
Fix Forge LivingHurtEvent cancelling not being respected

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
@@ -610,7 +610,7 @@ public abstract class EntityLivingBaseMixin extends EntityMixin implements Livin
             damage = bridge$applyModDamage((EntityLivingBase) (Object) this, damageSource, damage);
             final float originalDamage = damage; // set after forge hook.
             if (damage <= 0) {
-                damage = 0;
+                return false;
             }
 
             final List<DamageFunction> originalFunctions = new ArrayList<>();


### PR DESCRIPTION
By ignoring the Forge LivingHurtEvent cancelling return value, Sponge is breaking Forge contract.

For comparison see : https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch#L250