### PR TITLE
Add pathfinding chunkload optimization

### DIFF
--- a/src/main/java/org/spongepowered/common/config/category/OptimizationCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/OptimizationCategory.java
@@ -119,6 +119,13 @@ public class OptimizationCategory extends ConfigCategory {
             "suppress the exceptions printing out in the log.")
     private boolean disableFailingAdvancementDeserialization = true;
 
+    @Setting(value = "disable-pathfinding-chunk-loads", comment = "In vanilla, pathfinding may result in loading chunks.\n" +
+                    "You can disable that here, which may result in a\n" +
+                    "performance improvement. This may not work well\n" +
+                    "with mods."
+    )
+    private boolean disablePathFindingChunkLoads = false;
+
     public OptimizationCategory() {
         try {
             // Enabled by default on SpongeVanilla, disabled by default on SpongeForge.
@@ -201,6 +208,10 @@ public class OptimizationCategory extends ConfigCategory {
 
     public boolean disableFailingAdvancementDeserialization() {
         return this.disableFailingAdvancementDeserialization;
+    }
+
+    public boolean disablePathFindingChunkLoads() {
+        return this.disablePathFindingChunkLoads;
     }
 
 }

--- a/src/main/java/org/spongepowered/common/mixin/optimization/pathfinding/PathNavigateMixin_ChunkLoadOptimizations.java
+++ b/src/main/java/org/spongepowered/common/mixin/optimization/pathfinding/PathNavigateMixin_ChunkLoadOptimizations.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.optimization.pathfinding;
+
+import net.minecraft.pathfinding.PathNavigate;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = PathNavigate.class, priority = 1500)
+public class PathNavigateMixin_ChunkLoadOptimizations {
+
+    @Shadow protected World world;
+
+    /**
+     * Check if a chunk is loaded before attempting to check the state of the block
+     * return false if the chunk is not loaded
+     */
+    @Inject(method = "canEntityStandOnPos", at = @At(value = "HEAD"), cancellable = true)
+    private void canEntityStandOnPos(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        if (!this.world.isBlockLoaded(pos)) {
+            cir.setReturnValue(false);
+        }
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/plugin/OptimizationPlugin.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/OptimizationPlugin.java
@@ -139,6 +139,8 @@ public class OptimizationPlugin implements IMixinConfigPlugin {
                     OptimizationCategory::isUseActiveChunkForCollisions)
             .put("org.spongepowered.common.mixin.optimization.world.WorldServerMixin_UseActiveChunkForCollisions",
                     OptimizationCategory::isUseActiveChunkForCollisions)
+            .put("org.spongepowered.common.mixin.optimization.pathfinding.PathNavigateMixin_ChunkLoadOptimizations",
+                    OptimizationCategory::disablePathFindingChunkLoads)
             .build();
 
 }

--- a/src/main/resources/mixins.common.optimization.json
+++ b/src/main/resources/mixins.common.optimization.json
@@ -17,6 +17,7 @@
         "entity.item.EntityItemFrameMixin_MapOptimization",
         "item.ItemMapMixin_MapOptimization",
         "network.play.server.SPacketChunkDataMixin_Async_Lighting",
+        "pathfinding.PathNavigateMixin_ChunkLoadOptimizations",
         "server.MinecraftServerMixin_MapOptimization",
         "tileentity.TileEntityHopperMixin_HopperOptimization",
         "tileentity.TileEntityMixin_HopperOptimization",


### PR DESCRIPTION
Noticed pathfinding was causing chunkloading while investigating another issue.
```

Chunks loaded 24   [-945 -1656, -942 -1659, -942 -1656, -946 -1658, -945 -1659, -945 -1656, -944 -1655, -943 -1655, -942 -1655, -942 -1656, -942 -1656, -942 -1655, -942 -1656, -944 -1655, -942 -1656, -942 -1655, -944 -1655, -942 -1656, -943 -1655, -944 -1656, -942 -1656, -942 -1656, -944 -1656, -942 -1656]
	at org.spongepowered.common.util.SpongeHooks.logStack(SpongeHooks.java:107) [SpongeHooks.class:1.12.2-2838-7.2.2-RC4027]
	at org.spongepowered.common.util.SpongeHooks.logChunkLoad(SpongeHooks.java:206) [SpongeHooks.class:1.12.2-2838-7.2.2-RC4027]
	at net.minecraft.world.chunk.Chunk.handler$zmb000$impl$UpdateNeighborsOnLoad(Chunk.java:3551) [axw.class:?]
	at net.minecraft.world.chunk.Chunk.onLoad(Chunk.java:863) [axw.class:?]
	at net.minecraftforge.common.chunkio.ChunkIOProvider.syncCallback(ChunkIOProvider.java:109) [ChunkIOProvider.class:?]
	at net.minecraftforge.common.chunkio.ChunkIOExecutor.syncChunkLoad(ChunkIOExecutor.java:94) [ChunkIOExecutor.class:?]
	at net.minecraft.world.gen.ChunkProviderServer.loadChunk(ChunkProviderServer.java:118) [on.class:?]
	at net.minecraft.world.gen.ChunkProviderServer.loadChunk(ChunkProviderServer.java:89) [on.class:?]
	at net.minecraft.world.gen.ChunkProviderServer.redirect$zme000$impl$ProvideChunkForced(ChunkProviderServer.java:1642) [on.class:?]
	at net.minecraft.world.gen.ChunkProviderServer.provideChunk(ChunkProviderServer.java:135) [on.class:?]
	at net.minecraft.world.World.getChunk(World.java:310) [amu.class:?]
	at net.minecraft.world.World.getChunk(World.java:305) [amu.class:?]
	at net.minecraft.world.WorldServer.getBlockState(WorldServer.java:5062) [oo.class:?]
	at net.minecraft.pathfinding.PathNavigate.canEntityStandOnPos(SourceFile:335) [ze.class:?]
	at net.minecraft.entity.ai.RandomPositionGenerator.generateRandomPos(SourceFile:90) [zl.class:?]
	at net.minecraft.entity.ai.RandomPositionGenerator.findRandomTargetBlock(SourceFile:41) [zl.class:?]
	at net.minecraft.entity.ai.RandomPositionGenerator.findRandomTargetBlockAwayFrom(SourceFile:36) [zl.class:?]
	at forestry.lepidopterology.entities.AIButterflyBase.getRandomDestination(AIButterflyBase.java:37) [AIButterflyBase.class:?]
	at forestry.lepidopterology.entities.AIButterflyWander.shouldExecute(AIButterflyWander.java:26) [AIButterflyWander.class:?]
	at net.minecraft.entity.ai.EntityAITasks.onUpdateTasks(SourceFile:94) [xf.class:?]
	at net.minecraft.entity.EntityLiving.updateEntityActionState(EntityLiving.java:763) [vq.class:?]
	at net.minecraft.entity.EntityLivingBase.onLivingUpdate(EntityLivingBase.java:2359) [vp.class:?]
	at net.minecraft.entity.EntityLiving.onLivingUpdate(EntityLiving.java:577) [vq.class:?]
	at net.minecraft.entity.EntityLivingBase.onUpdate(EntityLivingBase.java:2179) [vp.class:?]
	at net.minecraft.entity.EntityLiving.onUpdate(EntityLiving.java:295) [vq.class:?]
	at forestry.lepidopterology.entities.EntityButterfly.onUpdate(EntityButterfly.java:457) [EntityButterfly.class:?]
	at org.spongepowered.common.event.tracking.TrackingUtil.tickEntity(TrackingUtil.java:167) [!!!!!!!spongeforge-1.12.2-2838-7.2.2-RC4027.jar:1.12.2-2838-7.2.2-RC4027]
	at net.minecraft.world.WorldServer.redirect$zlk000$onCallEntityUpdate(WorldServer.java:4738) [oo.class:?]
	at net.minecraft.world.World.updateEntityWithOptionalForce(World.java:1996) [amu.class:?]
	at net.minecraft.world.WorldServer.updateEntityWithOptionalForce(WorldServer.java:832) [oo.class:?]
	at net.minecraft.world.World.updateEntity(World.java:1958) [amu.class:?]
	at net.minecraft.world.World.updateEntities(World.java:1762) [amu.class:?]
	at net.minecraft.world.WorldServer.updateEntities(WorldServer.java:3928) [oo.class:?]
	at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:767) [MinecraftServer.class:?]
	at net.minecraft.server.dedicated.DedicatedServer.updateTimeLightAndEntities(DedicatedServer.java:397) [nz.class:?]
	at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:668) [MinecraftServer.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526) [MinecraftServer.class:?]
	at java.lang.Thread.run(Thread.java:813) [?:1.8.0_212]
```