### PR TITLE
Fix Server#copyWorld

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/storage/WorldInfoMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/storage/WorldInfoMixin.java
@@ -360,7 +360,7 @@ public abstract class WorldInfoMixin implements WorldInfoBridge {
     @Override
     public void bridge$readSpongeNbt(final NBTTagCompound nbt) {
         final UUID nbtUniqueId = nbt.getUniqueId(Constants.UUID);
-        if (UUID.fromString("00000000-0000-0000-0000-000000000000").equals(nbtUniqueId)) {
+        if (Constants.World.INVALID_WORLD_UUID.equals(nbtUniqueId)) {
             return;
         }
         this.impl$uuid = nbtUniqueId;


### PR DESCRIPTION
Continuing discussion from https://discordapp.com/channels/142425412096491520/142425521391665153/714447271789461646.

To summarize, I found while writing a personal world manager plugin that the result of `Server#copyWorld` is a non registered `WorldProperties` with dimension id = `Integer.MIN_VALUE` and uuid = `0-0-0-0-0`. This PR fixes this.
I also replaced every remaining `UUID.fromString("00000000-0000-0000-0000-000000000000")` occurrences with `Constants.World.INVALID_WORLD_UUID`, which is the same but not parsed everytime.