### PR TITLE
Stagger saving and invalidating user data.

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/server/PlayerListMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/PlayerListMixin.java
@@ -447,8 +447,12 @@ public abstract class PlayerListMixin implements PlayerListBridge {
 
     @Inject(method = "saveAllPlayerData()V", at = @At("RETURN"))
     private void onSaveAllPlayerData(final CallbackInfo ci) {
-        for (final SpongeUser user : SpongeUser.dirtyUsers) {
-            user.save();
+        for (final SpongeUser user : SpongeUser.initializedUsers) {
+            if (SpongeUser.dirtyUsers.contains(user)) {
+                user.save();
+            } else {
+                user.invalidate();
+            }
         }
     }
 

--- a/src/main/java/org/spongepowered/common/service/user/UserDiscoverer.java
+++ b/src/main/java/org/spongepowered/common/service/user/UserDiscoverer.java
@@ -91,6 +91,7 @@ class UserDiscoverer {
         final SpongeUser user = (SpongeUser) userCache.getIfPresent(profile.getId());
         if (user != null && SpongeUser.dirtyUsers.contains(user)) {
             user.save();
+            user.invalidate(); // we're forcing the recreation so we need to ensure nothing will save to it now.
         }
         return create(profile);
     }

--- a/src/main/java/org/spongepowered/common/util/NetworkUtil.java
+++ b/src/main/java/org/spongepowered/common/util/NetworkUtil.java
@@ -158,9 +158,9 @@ public final class NetworkUtil {
         final SpongeUser user = (SpongeUser) ((EntityPlayerMPBridge) playerIn).bridge$getUserObject();
         if (SpongeUser.dirtyUsers.contains(user)) {
             user.save();
-        } else {
-            user.invalidate();
         }
+
+        user.invalidate();
         // Sponge end
 
         final NBTTagCompound nbttagcompound = playerList.readPlayerDataFromFile(playerIn);


### PR DESCRIPTION
* Don't invalidate a user until a save cycle where the user was not marked dirty.
* Don't allow users to be marked as dirty if they are not initialised.
* Do invalidate in specialised scenarios (none were found in SF or SV)

I wonder, would it be worth overloading save to make it easier if other save locations are introduced: e.g.:

```java
void save() {
    save(true);
}

void save(boolean andInvalidate) {
    // saving code
    if (andInvalidate) {
        invalidate();
    }
}
```

Fixes #2596