### PR TITLE
New Explosion Event for BlockExplosionResistance

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/world/ExplosionBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/world/ExplosionBridge.java
@@ -24,10 +24,7 @@
  */
 package org.spongepowered.common.bridge.world;
 
-import net.minecraft.entity.Entity;
-import net.minecraft.world.World;
-
-import javax.annotation.Nullable;
+import org.spongepowered.api.world.explosion.ResistanceCalculator;
 
 public interface ExplosionBridge {
 
@@ -50,5 +47,9 @@ public interface ExplosionBridge {
     void bridge$setKnockback(double knockback);
 
     double bridge$getKnockback();
+
+    void bridge$setResistanceCalculator(ResistanceCalculator resistanceCalculator);
+
+    ResistanceCalculator bridge$getResistanceCalculator();
 
 }

--- a/src/main/java/org/spongepowered/common/event/ShouldFire.java
+++ b/src/main/java/org/spongepowered/common/event/ShouldFire.java
@@ -102,7 +102,6 @@ public class ShouldFire {
     public static boolean IGNITE_ENTITY_EVENT = false;
     public static boolean NOTIFY_NEIGHBOR_BLOCK_EVENT = false;
     public static boolean EXPLOSION_EVENT_PRE = false;
-    public static boolean EXPLOSION_EVENT_BLOCK_RESISTANCE = false;
     public static boolean EXPLOSION_EVENT_DETONATE = false;
     public static boolean GAME_REGISTRY_EVENT_REGISTER = false;
     public static boolean LOAD_CHUNK_EVENT = false;

--- a/src/main/java/org/spongepowered/common/event/ShouldFire.java
+++ b/src/main/java/org/spongepowered/common/event/ShouldFire.java
@@ -102,6 +102,7 @@ public class ShouldFire {
     public static boolean IGNITE_ENTITY_EVENT = false;
     public static boolean NOTIFY_NEIGHBOR_BLOCK_EVENT = false;
     public static boolean EXPLOSION_EVENT_PRE = false;
+    public static boolean EXPLOSION_EVENT_FETCH_BLOCK_EXPLOSION_RESISTANCE = false;
     public static boolean EXPLOSION_EVENT_DETONATE = false;
     public static boolean GAME_REGISTRY_EVENT_REGISTER = false;
     public static boolean LOAD_CHUNK_EVENT = false;

--- a/src/main/java/org/spongepowered/common/event/ShouldFire.java
+++ b/src/main/java/org/spongepowered/common/event/ShouldFire.java
@@ -102,7 +102,7 @@ public class ShouldFire {
     public static boolean IGNITE_ENTITY_EVENT = false;
     public static boolean NOTIFY_NEIGHBOR_BLOCK_EVENT = false;
     public static boolean EXPLOSION_EVENT_PRE = false;
-    public static boolean EXPLOSION_EVENT_FETCH_BLOCK_EXPLOSION_RESISTANCE = false;
+    public static boolean EXPLOSION_EVENT_BLOCK_RESISTANCE = false;
     public static boolean EXPLOSION_EVENT_DETONATE = false;
     public static boolean GAME_REGISTRY_EVENT_REGISTER = false;
     public static boolean LOAD_CHUNK_EVENT = false;

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/world/ExplosionMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/world/ExplosionMixin_API.java
@@ -30,15 +30,14 @@ import org.spongepowered.api.entity.explosive.Explosive;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.explosion.Explosion;
+import org.spongepowered.api.world.explosion.ResistanceCalculator;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.bridge.world.ExplosionBridge;
-import org.spongepowered.api.world.explosion.ResistanceCalculator;
-
-import java.util.Optional;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 @Mixin(net.minecraft.world.Explosion.class)
 public abstract class ExplosionMixin_API implements Explosion {
@@ -98,17 +97,17 @@ public abstract class ExplosionMixin_API implements Explosion {
 
     @Override
     public int getResolution() {
-        return  ((ExplosionBridge) this).bridge$getResolution();
+        return ((ExplosionBridge) this).bridge$getResolution();
     }
 
     @Override
     public float getRandomness() {
-        return  ((ExplosionBridge) this).bridge$getRandomness();
+        return ((ExplosionBridge) this).bridge$getRandomness();
     }
 
     @Override
     public double getKnockback() {
-        return  ((ExplosionBridge) this).bridge$getKnockback();
+        return ((ExplosionBridge) this).bridge$getKnockback();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/world/ExplosionMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/world/ExplosionMixin_API.java
@@ -36,8 +36,9 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.bridge.world.ExplosionBridge;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
+
+import javax.annotation.Nullable;
 
 @Mixin(net.minecraft.world.Explosion.class)
 public abstract class ExplosionMixin_API implements Explosion {

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/world/ExplosionMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/world/ExplosionMixin_API.java
@@ -113,7 +113,7 @@ public abstract class ExplosionMixin_API implements Explosion {
 
     @Override
     public Optional<ResistanceCalculator> getResistanceCalculator() {
-        return Optional.of(((ExplosionBridge) this).bridge$getResistanceCalculator());
+        return Optional.ofNullable(((ExplosionBridge) this).bridge$getResistanceCalculator());
     }
 
 }

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/world/ExplosionMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/world/ExplosionMixin_API.java
@@ -34,6 +34,7 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.bridge.world.ExplosionBridge;
+import org.spongepowered.api.world.explosion.ResistanceCalculator;
 
 import java.util.Optional;
 
@@ -108,6 +109,11 @@ public abstract class ExplosionMixin_API implements Explosion {
     @Override
     public double getKnockback() {
         return  ((ExplosionBridge) this).bridge$getKnockback();
+    }
+
+    @Override
+    public Optional<ResistanceCalculator> getResistanceCalculator() {
+        return Optional.of(((ExplosionBridge) this).bridge$getResistanceCalculator());
     }
 
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
@@ -103,8 +103,8 @@ public abstract class ExplosionMixin implements ExplosionBridge {
 
     @Inject(method = "<init>*", at = @At("RETURN"))
     private void onConstructed(final net.minecraft.world.World world, final Entity entity, final double originX, final double originY,
-                               final double originZ, final float radius, final boolean isFlaming, final boolean isSmoking,
-                               final CallbackInfo ci) {
+            final double originZ, final float radius, final boolean isFlaming, final boolean isSmoking,
+            final CallbackInfo ci) {
         // In Vanilla and Forge, 'damagesTerrain' controls both smoke particles and block damage
         // Sponge-created explosions will explicitly set 'impl$shouldBreakBlocks' to its proper value
         this.impl$shouldBreakBlocks = this.damagesTerrain;
@@ -120,10 +120,12 @@ public abstract class ExplosionMixin implements ExplosionBridge {
      * and allows for maximal capability.
      *
      * @author BernardisGood - September 9th, 2019
-     * @reason Additional variables that allow increased control over the explosion's level of detail and entity knockback.
+     * @reason Additional variables that allow increased control over
+     * the explosion's level of detail and entity knockback.
      *
      * @author BernardisGood - June 29th, 2020
-     * @reason Ability for plugins to insert custom logic when calculating the explosion resistance of blocks that are affected by the explosion.
+     * @reason Ability for plugins to insert custom logic when calculating
+     * the explosion resistance of blocks that are affected by the explosion.
      */
     @Final
     @Overwrite
@@ -157,7 +159,8 @@ public abstract class ExplosionMixin implements ExplosionBridge {
                                 if (iblockstate.getMaterial() != Material.AIR) {
                                     // Sponge Start - Allows the insertion of custom block resistance calculations
                                     float f2 = this.exploder != null
-                                            ? this.exploder.getExplosionResistance((net.minecraft.world.Explosion) (Object) this, this.world, blockpos, iblockstate)
+                                            ? this.exploder
+                                            .getExplosionResistance((net.minecraft.world.Explosion) (Object) this, this.world, blockpos, iblockstate)
                                             : iblockstate.getBlock().getExplosionResistance((Entity) null);
 
                                     if (this.impl$resistanceCalculator != null) {
@@ -173,7 +176,8 @@ public abstract class ExplosionMixin implements ExplosionBridge {
                                 }
 
                                 if (f > 0.0F && (this.exploder == null || this.exploder
-                                        .canExplosionDestroyBlock((net.minecraft.world.Explosion) (Object) this, this.world, blockpos, iblockstate, f))) {
+                                        .canExplosionDestroyBlock((net.minecraft.world.Explosion) (Object) this, this.world, blockpos, iblockstate,
+                                                f))) {
                                     set.add(blockpos);
                                 }
 
@@ -198,7 +202,8 @@ public abstract class ExplosionMixin implements ExplosionBridge {
 
         // Sponge Start - Check if this explosion should damage entities
         final List<Entity> list = this.impl$shouldDamageEntities
-                ? this.world.getEntitiesWithinAABBExcludingEntity(this.exploder, new AxisAlignedBB((double) k1, (double) i2, (double) j2, (double) l1, (double) i1, (double) j1))
+                ? this.world.getEntitiesWithinAABBExcludingEntity(this.exploder,
+                new AxisAlignedBB((double) k1, (double) i2, (double) j2, (double) l1, (double) i1, (double) j1))
                 : Collections.emptyList();
         // Now we can throw our Detonate Event
         if (ShouldFire.EXPLOSION_EVENT_DETONATE) {
@@ -262,7 +267,8 @@ public abstract class ExplosionMixin implements ExplosionBridge {
                         final double d14 = (double) this.world.getBlockDensity(vec3d, entity.getEntityBoundingBox());
                         final double d10 = (1.0D - d12) * d14;
                         entity.attackEntityFrom(
-                                DamageSource.causeExplosionDamage((net.minecraft.world.Explosion) (Object) this), (float) ((int) ((d10 * d10 + d10) / 2.0D * 7.0D * (double) f3 + 1.0D)));
+                                DamageSource.causeExplosionDamage((net.minecraft.world.Explosion) (Object) this),
+                                (float) ((int) ((d10 * d10 + d10) / 2.0D * 7.0D * (double) f3 + 1.0D)));
                         double d11 = 1.0D;
 
                         if (entity instanceof EntityLivingBase) {
@@ -278,7 +284,8 @@ public abstract class ExplosionMixin implements ExplosionBridge {
                             final EntityPlayer entityplayer = (EntityPlayer) entity;
 
                             if (!entityplayer.isSpectator() && (!entityplayer.isCreative() || !entityplayer.capabilities.isFlying)) {
-                                this.playerKnockbackMap.put(entityplayer, new Vec3d(d5 * d10 * impl$knockback, d7 * d10 * impl$knockback, d9 * d10 * impl$knockback));
+                                this.playerKnockbackMap.put(entityplayer,
+                                        new Vec3d(d5 * d10 * impl$knockback, d7 * d10 * impl$knockback, d9 * d10 * impl$knockback));
                                 //Sponge End
                             }
                         }
@@ -347,7 +354,8 @@ public abstract class ExplosionMixin implements ExplosionBridge {
                     d3 = d3 * d7;
                     d4 = d4 * d7;
                     d5 = d5 * d7;
-                    this.world.spawnParticle(EnumParticleTypes.EXPLOSION_NORMAL, (d0 + this.x) / 2.0D, (d1 + this.y) / 2.0D, (d2 + this.z) / 2.0D, d3, d4, d5, new int[0]);
+                    this.world.spawnParticle(EnumParticleTypes.EXPLOSION_NORMAL, (d0 + this.x) / 2.0D, (d1 + this.y) / 2.0D, (d2 + this.z) / 2.0D, d3,
+                            d4, d5, new int[0]);
                     this.world.spawnParticle(EnumParticleTypes.SMOKE_NORMAL, d0, d1, d2, d3, d4, d5, new int[0]);
                 }
 
@@ -383,7 +391,8 @@ public abstract class ExplosionMixin implements ExplosionBridge {
 
         if (this.causesFire) {
             for (final BlockPos blockpos1 : this.affectedBlockPositions) {
-                if (this.world.getBlockState(blockpos1).getMaterial() == Material.AIR && this.world.getBlockState(blockpos1.down()).isFullBlock() && this.random.nextInt(3) == 0) {
+                if (this.world.getBlockState(blockpos1).getMaterial() == Material.AIR && this.world.getBlockState(blockpos1.down()).isFullBlock()
+                        && this.random.nextInt(3) == 0) {
                     // Sponge Start - Track the block position being destroyed
                     try (final CaptureBlockPos pos = hasCapturePos ? context.getCaptureBlockPos() : null) {
                         if (pos != null) {

--- a/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
@@ -44,6 +44,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.WorldServer;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.world.ExplosionEvent;
@@ -146,10 +147,23 @@ public abstract class ExplosionMixin implements ExplosionBridge {
                                 final IBlockState iblockstate = this.world.getBlockState(blockpos);
 
                                 if (iblockstate.getMaterial() != Material.AIR) {
-                                    final float f2 = this.exploder != null
-                                               ? this.exploder.getExplosionResistance((net.minecraft.world.Explosion) (Object) this
+                                    float f2 = this.exploder != null
+                                            ? this.exploder.getExplosionResistance((net.minecraft.world.Explosion) (Object) this
                                             , this.world, blockpos, iblockstate)
-                                               : iblockstate.getBlock().getExplosionResistance((Entity) null);
+                                            : iblockstate.getBlock().getExplosionResistance((Entity) null);
+
+                                    //Sponge Start
+                                    if (ShouldFire.EXPLOSION_EVENT_FETCH_BLOCK_EXPLOSION_RESISTANCE) {
+                                        final Cause cause = Sponge.getCauseStackManager().getCurrentCause();
+                                        ExplosionEvent.FetchBlockExplosionResistance event =
+                                                SpongeEventFactory.createExplosionEventFetchBlockExplosionResistance(cause, (BlockState) iblockstate, (Explosion) this, new Location<>((World) this.world, d4, d6, d8), (World) this.world, f2);
+
+                                        Sponge.getEventManager().post(event);
+
+                                        f2 = event.getResistance();
+                                    }
+                                    //Sponge End
+
                                     f -= (f2 + 0.3F) * 0.3F;
                                 }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
@@ -44,12 +44,12 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.WorldServer;
-import org.apache.commons.lang3.tuple.Pair;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.world.ExplosionEvent;
+import org.spongepowered.api.util.Tuple;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.explosion.Explosion;
@@ -120,7 +120,7 @@ public abstract class ExplosionMixin implements ExplosionBridge {
         // Sponge Start - If the explosion should not break blocks, don't bother calculating it
         if (this.impl$shouldBreakBlocks) {
             HashSet<BlockPos> blockPositions = getBlocksInRadius();
-            HashMap<Vector3i, org.apache.commons.lang3.tuple.Pair<BlockState, Float>> blocks = new HashMap<>();
+            HashMap<Vector3i, Tuple<BlockState, Float>> blocks = new HashMap<>();
 
             for (BlockPos blockPos : blockPositions) {
                 final IBlockState iblockstate = this.world.getBlockState(blockPos);
@@ -133,9 +133,9 @@ public abstract class ExplosionMixin implements ExplosionBridge {
                             : iblockstate.getBlock().getExplosionResistance((Entity) null);
                 }
 
-                org.apache.commons.lang3.tuple.Pair<BlockState, Float> pair = Pair.of((BlockState) iblockstate, resistance);
+                Tuple<BlockState, Float> tuple = Tuple.of((BlockState) iblockstate, resistance);
 
-                blocks.put(new Vector3i(blockPos.getX(), blockPos.getY(), blockPos.getZ()), pair);
+                blocks.put(new Vector3i(blockPos.getX(), blockPos.getY(), blockPos.getZ()), tuple);
             }
 
             if (ShouldFire.EXPLOSION_EVENT_BLOCK_RESISTANCE) {
@@ -174,10 +174,10 @@ public abstract class ExplosionMixin implements ExplosionBridge {
 
                                 if (blocks.containsKey(vectorPos)) {
 
-                                    final IBlockState iblockstate = (IBlockState) blocks.get(vectorPos).getKey();
+                                    final IBlockState iblockstate = (IBlockState) blocks.get(vectorPos).getFirst();
 
                                     if (iblockstate.getMaterial() != Material.AIR) {
-                                        final float f2 = blocks.get(vectorPos).getValue();
+                                        final float f2 = blocks.get(vectorPos).getSecond();
                                         f -= (f2 + 0.3F) * 0.3F;
                                     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
@@ -112,6 +112,12 @@ public abstract class ExplosionMixin implements ExplosionBridge {
      * @author gabizou - September 8th, 2016
      * @reason Rewrites to use our own hooks that will patch with forge perfectly well,
      * and allows for maximal capability.
+     *
+     * @author BernardisGood - September 9th, 2019
+     * @reason Additional variables that allow increased control over the explosion's level of detail and entity knockback.
+     *
+     * @author BernardisGood - June 29th, 2020
+     * @reason Ability for plugins to insert custom logic when calculating the explosion resistance of blocks that are affected by the explosion.
      */
     @Final
     @Overwrite
@@ -143,10 +149,13 @@ public abstract class ExplosionMixin implements ExplosionBridge {
                                 final IBlockState iblockstate = this.world.getBlockState(blockpos);
 
                                 if (iblockstate.getMaterial() != Material.AIR) {
-                                    final float f2 = impl$resistanceCalculator.calculateResistance(
-                                            (BlockState) iblockstate,
-                                            VecHelper.toVector3i(blockpos),
-                                            (Explosion) this);
+                                    // Sponge Start - Allows the insertion of custom block resistance calculations
+                                    final float f2 = impl$resistanceCalculator
+                                            .calculateResistance(
+                                                    (BlockState) iblockstate,
+                                                    VecHelper.toVector3i(blockpos),
+                                                    (Explosion) this);
+                                    // Sponge End
 
                                     f -= (f2 + 0.3F) * 0.3F;
                                 }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
@@ -69,8 +69,14 @@ import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.context.CaptureBlockPos;
 import org.spongepowered.common.util.VecHelper;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
 import javax.annotation.Nullable;
-import java.util.*;
 
 @Mixin(net.minecraft.world.Explosion.class)
 public abstract class ExplosionMixin implements ExplosionBridge {
@@ -150,11 +156,17 @@ public abstract class ExplosionMixin implements ExplosionBridge {
 
                                 if (iblockstate.getMaterial() != Material.AIR) {
                                     // Sponge Start - Allows the insertion of custom block resistance calculations
-                                    final float f2 = impl$resistanceCalculator
-                                            .calculateResistance(
-                                                    (BlockState) iblockstate,
-                                                    VecHelper.toVector3i(blockpos),
-                                                    (Explosion) this);
+                                    float f2 = this.exploder != null
+                                            ? this.exploder.getExplosionResistance((net.minecraft.world.Explosion) (Object) this, this.world, blockpos, iblockstate)
+                                            : iblockstate.getBlock().getExplosionResistance((Entity) null);
+
+                                    if (this.impl$resistanceCalculator != null) {
+                                        f2 = this.impl$resistanceCalculator.calculateResistance(
+                                                (BlockState) iblockstate,
+                                                VecHelper.toVector3i(blockpos),
+                                                f2,
+                                                (Explosion) this);
+                                    }
                                     // Sponge End
 
                                     f -= (f2 + 0.3F) * 0.3F;

--- a/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/ExplosionMixin.java
@@ -27,7 +27,6 @@ package org.spongepowered.common.mixin.core.world;
 import com.flowpowered.math.vector.Vector3i;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Sets;
-import javafx.util.Pair;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -45,6 +44,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.WorldServer;
+import org.apache.commons.lang3.tuple.Pair;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.event.SpongeEventFactory;
@@ -120,7 +120,7 @@ public abstract class ExplosionMixin implements ExplosionBridge {
         // Sponge Start - If the explosion should not break blocks, don't bother calculating it
         if (this.impl$shouldBreakBlocks) {
             HashSet<BlockPos> blockPositions = getBlocksInRadius();
-            HashMap<Vector3i, Pair<BlockState, Float>> blocks = new HashMap<>();
+            HashMap<Vector3i, org.apache.commons.lang3.tuple.Pair<BlockState, Float>> blocks = new HashMap<>();
 
             for (BlockPos blockPos : blockPositions) {
                 final IBlockState iblockstate = this.world.getBlockState(blockPos);
@@ -133,7 +133,7 @@ public abstract class ExplosionMixin implements ExplosionBridge {
                             : iblockstate.getBlock().getExplosionResistance((Entity) null);
                 }
 
-                Pair<BlockState, Float> pair = new Pair<>((BlockState) iblockstate, resistance);
+                org.apache.commons.lang3.tuple.Pair<BlockState, Float> pair = Pair.of((BlockState) iblockstate, resistance);
 
                 blocks.put(new Vector3i(blockPos.getX(), blockPos.getY(), blockPos.getZ()), pair);
             }

--- a/src/main/java/org/spongepowered/common/world/SpongeExplosionBuilder.java
+++ b/src/main/java/org/spongepowered/common/world/SpongeExplosionBuilder.java
@@ -24,8 +24,10 @@
  */
 package org.spongepowered.common.world;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 import com.flowpowered.math.vector.Vector3d;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import org.spongepowered.api.entity.explosive.Explosive;
 import org.spongepowered.api.world.Location;
@@ -33,9 +35,6 @@ import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.explosion.Explosion;
 import org.spongepowered.api.world.explosion.ResistanceCalculator;
 import org.spongepowered.common.bridge.world.ExplosionBridge;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 
 public class SpongeExplosionBuilder implements Explosion.Builder {
 

--- a/src/main/java/org/spongepowered/common/world/SpongeExplosionBuilder.java
+++ b/src/main/java/org/spongepowered/common/world/SpongeExplosionBuilder.java
@@ -33,23 +33,11 @@ import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.explosion.Explosion;
 import org.spongepowered.api.world.explosion.ResistanceCalculator;
 import org.spongepowered.common.bridge.world.ExplosionBridge;
-import org.spongepowered.common.util.VecHelper;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 public class SpongeExplosionBuilder implements Explosion.Builder {
-
-    private static final ResistanceCalculator DEFAULT_RESISTANCE_CALCULATOR = ((blockState, blockPosition, explosion) ->
-            explosion.getSourceExplosive().isPresent()
-                    ? ((Entity) explosion.getSourceExplosive().get())
-                    .getExplosionResistance(
-                            (net.minecraft.world.Explosion) explosion,
-                            (net.minecraft.world.World) explosion.getWorld(),
-                            VecHelper.toBlockPos(blockPosition),
-                            (IBlockState) blockState)
-
-                    : ((IBlockState) blockState).getBlock().getExplosionResistance((Entity) null));
 
     private Location<World> location;
     private Explosive sourceExplosive;
@@ -61,7 +49,7 @@ public class SpongeExplosionBuilder implements Explosion.Builder {
     private int resolution = 16;
     private float randomness = 1.0F;
     private double knockback = 1;
-    private ResistanceCalculator resistanceCalculator = DEFAULT_RESISTANCE_CALCULATOR;
+    private ResistanceCalculator resistanceCalculator;
 
     public SpongeExplosionBuilder() {
         reset();
@@ -146,7 +134,7 @@ public class SpongeExplosionBuilder implements Explosion.Builder {
         this.resolution = value.getResolution();
         this.randomness = value.getRandomness();
         this.knockback = value.getKnockback();
-        this.resistanceCalculator = value.getResistanceCalculator().orElse(DEFAULT_RESISTANCE_CALCULATOR);
+        this.resistanceCalculator = value.getResistanceCalculator().orElse(null);
         return this;
     }
 
@@ -162,7 +150,7 @@ public class SpongeExplosionBuilder implements Explosion.Builder {
         this.resolution = 16;
         this.randomness = 1.0F;
         this.knockback = 1;
-        this.resistanceCalculator = DEFAULT_RESISTANCE_CALCULATOR;
+        this.resistanceCalculator = null;
         return this;
     }
 

--- a/src/main/java/org/spongepowered/common/world/SpongeExplosionBuilder.java
+++ b/src/main/java/org/spongepowered/common/world/SpongeExplosionBuilder.java
@@ -36,8 +36,6 @@ import org.spongepowered.api.world.explosion.Explosion;
 import org.spongepowered.api.world.explosion.ResistanceCalculator;
 import org.spongepowered.common.bridge.world.ExplosionBridge;
 
-import java.util.Optional;
-
 public class SpongeExplosionBuilder implements Explosion.Builder {
 
     private Location<World> location;
@@ -50,7 +48,7 @@ public class SpongeExplosionBuilder implements Explosion.Builder {
     private int resolution = 16;
     private float randomness = 1.0F;
     private double knockback = 1;
-    private Optional<ResistanceCalculator> resistanceCalculator = Optional.empty();
+    private ResistanceCalculator resistanceCalculator;
 
     public SpongeExplosionBuilder() {
         reset();
@@ -119,7 +117,7 @@ public class SpongeExplosionBuilder implements Explosion.Builder {
 
     @Override
     public Explosion.Builder resistanceCalculator(ResistanceCalculator resistanceCalculator) {
-        this.resistanceCalculator = Optional.ofNullable(resistanceCalculator);
+        this.resistanceCalculator = resistanceCalculator;
         return this;
     }
 
@@ -135,7 +133,7 @@ public class SpongeExplosionBuilder implements Explosion.Builder {
         this.resolution = value.getResolution();
         this.randomness = value.getRandomness();
         this.knockback = value.getKnockback();
-        this.resistanceCalculator = value.getResistanceCalculator();
+        this.resistanceCalculator = value.getResistanceCalculator().orElse(null);
         return this;
     }
 
@@ -170,7 +168,7 @@ public class SpongeExplosionBuilder implements Explosion.Builder {
         ((ExplosionBridge) explosion).bridge$setResolution(this.resolution);
         ((ExplosionBridge) explosion).bridge$setRandomness(this.randomness);
         ((ExplosionBridge) explosion).bridge$setKnockback(this.knockback);
-        this.resistanceCalculator.ifPresent(((ExplosionBridge) explosion)::bridge$setResistanceCalculator);
+        ((ExplosionBridge) explosion).bridge$setResistanceCalculator(this.resistanceCalculator);
         return (Explosion) explosion;
     }
 }

--- a/src/main/java/org/spongepowered/common/world/SpongeExplosionBuilder.java
+++ b/src/main/java/org/spongepowered/common/world/SpongeExplosionBuilder.java
@@ -170,7 +170,7 @@ public class SpongeExplosionBuilder implements Explosion.Builder {
         ((ExplosionBridge) explosion).bridge$setResolution(this.resolution);
         ((ExplosionBridge) explosion).bridge$setRandomness(this.randomness);
         ((ExplosionBridge) explosion).bridge$setKnockback(this.knockback);
-        ((ExplosionBridge) explosion).bridge$setResistanceCalculator(this.resistanceCalculator.orElse(null));
+        this.resistanceCalculator.ifPresent(((ExplosionBridge) explosion)::bridge$setResistanceCalculator);
         return (Explosion) explosion;
     }
 }

--- a/src/main/java/org/spongepowered/common/world/SpongeExplosionBuilder.java
+++ b/src/main/java/org/spongepowered/common/world/SpongeExplosionBuilder.java
@@ -24,9 +24,6 @@
  */
 package org.spongepowered.common.world;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-
 import com.flowpowered.math.vector.Vector3d;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
@@ -34,13 +31,16 @@ import org.spongepowered.api.entity.explosive.Explosive;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.explosion.Explosion;
+import org.spongepowered.api.world.explosion.ResistanceCalculator;
 import org.spongepowered.common.bridge.world.ExplosionBridge;
 import org.spongepowered.common.util.VecHelper;
-import org.spongepowered.api.world.explosion.ResistanceCalculator;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 public class SpongeExplosionBuilder implements Explosion.Builder {
 
-    private static final ResistanceCalculator DEFAULT_RESISTANCE_CALCULATOR =  ((blockState, blockPosition, explosion) ->
+    private static final ResistanceCalculator DEFAULT_RESISTANCE_CALCULATOR = ((blockState, blockPosition, explosion) ->
             explosion.getSourceExplosive().isPresent()
                     ? ((Entity) explosion.getSourceExplosive().get())
                     .getExplosionResistance(

--- a/src/main/java/org/spongepowered/common/world/SpongeExplosionBuilder.java
+++ b/src/main/java/org/spongepowered/common/world/SpongeExplosionBuilder.java
@@ -36,6 +36,8 @@ import org.spongepowered.api.world.explosion.Explosion;
 import org.spongepowered.api.world.explosion.ResistanceCalculator;
 import org.spongepowered.common.bridge.world.ExplosionBridge;
 
+import java.util.Optional;
+
 public class SpongeExplosionBuilder implements Explosion.Builder {
 
     private Location<World> location;
@@ -48,7 +50,7 @@ public class SpongeExplosionBuilder implements Explosion.Builder {
     private int resolution = 16;
     private float randomness = 1.0F;
     private double knockback = 1;
-    private ResistanceCalculator resistanceCalculator;
+    private Optional<ResistanceCalculator> resistanceCalculator = Optional.empty();
 
     public SpongeExplosionBuilder() {
         reset();
@@ -117,7 +119,7 @@ public class SpongeExplosionBuilder implements Explosion.Builder {
 
     @Override
     public Explosion.Builder resistanceCalculator(ResistanceCalculator resistanceCalculator) {
-        this.resistanceCalculator = resistanceCalculator;
+        this.resistanceCalculator = Optional.ofNullable(resistanceCalculator);
         return this;
     }
 
@@ -133,7 +135,7 @@ public class SpongeExplosionBuilder implements Explosion.Builder {
         this.resolution = value.getResolution();
         this.randomness = value.getRandomness();
         this.knockback = value.getKnockback();
-        this.resistanceCalculator = value.getResistanceCalculator().orElse(null);
+        this.resistanceCalculator = value.getResistanceCalculator();
         return this;
     }
 
@@ -168,7 +170,7 @@ public class SpongeExplosionBuilder implements Explosion.Builder {
         ((ExplosionBridge) explosion).bridge$setResolution(this.resolution);
         ((ExplosionBridge) explosion).bridge$setRandomness(this.randomness);
         ((ExplosionBridge) explosion).bridge$setKnockback(this.knockback);
-        ((ExplosionBridge) explosion).bridge$setResistanceCalculator(this.resistanceCalculator);
+        ((ExplosionBridge) explosion).bridge$setResistanceCalculator(this.resistanceCalculator.orElse(null));
         return (Explosion) explosion;
     }
 }


### PR DESCRIPTION
[ [SpongeAPI ](https://github.com/SpongePowered/SpongeAPI/pull/2130)| **SpongeCommon** ]

Resolves https://github.com/SpongePowered/SpongeAPI/issues/2093

The intention of this PR is to allow plugins to intercept the fetching of a block's explosion resistance and adjust the value dynamically based on the block's location and type.

Example Usage:
```
    public void changeBlockResistance(ExplosionEvent.FetchBlockExplosionResistance event) {

// Check if plugin has a hard number in config for BlockType
        if (Settings.DurabilityOverride != null && Settings.DurabilityOverride.containsKey(event.getBlockState().getType())) {
            event.setResistance(Settings.DurabilityOverride.get(event.getBlockState().getType()));
        }

// Check if location is within plugin managed structure
        float newResistance = event.getResistance();
        for (Craft craft : CraftManager.getInstance().getCraftsFromLocation(event.getLocation())) {
            float testNum = event.getResistance() * (1F + ((float) craft.getSize() / 50000F));

            if (testNum > newResistance) {
                newResistance = testNum;
            }
        }

// Set new block explosion resistance
        event.setResistance(newResistance);
    }
```