### PR TITLE
Cleanup BlockChangeFlagRegistryModule

### DIFF
--- a/src/main/java/org/spongepowered/common/registry/type/world/BlockChangeFlagRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/world/BlockChangeFlagRegistryModule.java
@@ -45,7 +45,7 @@ public final class BlockChangeFlagRegistryModule implements RegistryModule {
 
     @RegisterCatalog(org.spongepowered.api.world.BlockChangeFlags.class)
     private final Map<String, SpongeBlockChangeFlag> flags = new LinkedHashMap<>();
-    private final Int2ObjectMap<SpongeBlockChangeFlag> maskedFlags = new Int2ObjectLinkedOpenHashMap<>(70);
+    private final SpongeBlockChangeFlag[] maskedFlags = new SpongeBlockChangeFlag[64];
     private static BlockChangeFlagRegistryModule INSTANCE = new BlockChangeFlagRegistryModule();
 
     public static BlockChangeFlagRegistryModule getInstance() {
@@ -59,7 +59,7 @@ public final class BlockChangeFlagRegistryModule implements RegistryModule {
         if (flag == 2) {
             return (SpongeBlockChangeFlag) org.spongepowered.api.world.BlockChangeFlags.PHYSICS_OBSERVER;
         }
-        final SpongeBlockChangeFlag spongeBlockChangeFlag = getInstance().maskedFlags.get(flag);
+        final SpongeBlockChangeFlag spongeBlockChangeFlag = getInstance().maskedFlags[flag];
         if (spongeBlockChangeFlag != null) {
             return spongeBlockChangeFlag;
         }
@@ -147,7 +147,7 @@ public final class BlockChangeFlagRegistryModule implements RegistryModule {
     }
 
     private void register(SpongeBlockChangeFlag flag) {
-        this.maskedFlags.put(flag.getRawFlag(), flag);
+        this.maskedFlags[flag.getRawFlag()] = flag;
         this.flags.put(flag.getName(), flag);
     }
 

--- a/src/main/java/org/spongepowered/common/registry/type/world/BlockChangeFlagRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/world/BlockChangeFlagRegistryModule.java
@@ -143,7 +143,6 @@ public final class BlockChangeFlagRegistryModule implements RegistryModule {
                 register(new SpongeBlockChangeFlag(builder.toString().toLowerCase(Locale.ENGLISH), i));
             }
         }
-        RegistryHelper.mapFields(org.spongepowered.api.world.BlockChangeFlags.class, this.flags);
     }
 
     private void register(SpongeBlockChangeFlag flag) {

--- a/src/main/java/org/spongepowered/common/registry/type/world/BlockChangeFlagRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/world/BlockChangeFlagRegistryModule.java
@@ -99,28 +99,28 @@ public final class BlockChangeFlagRegistryModule implements RegistryModule {
         for (int i = 0; i < 64; i++) { // 64 because we get to the 6th bit of possible combinations
             final StringJoiner builder = new StringJoiner("|");
             if ((i & Constants.BlockChangeFlags.NEIGHBOR_MASK) != 0) {
-                builder.add(Flag.NOTIFY_NEIGHBOR.name);
+                builder.add("NEIGHBOR");
             }
             if ((i & Constants.BlockChangeFlags.NOTIFY_CLIENTS) != 0) {
                 // We don't want to confuse that there are going to be multiple flags
                 // but with slight differences because of the notify flag
-                builder.add(Flag.NOTIFY_CLIENTS.name);
+                builder.add("NOTIFY_CLIENTS");
             }
             if ((i & Constants.BlockChangeFlags.IGNORE_RENDER) != 0) {
                 // We don't want to confuse that there are going to be multiple flags
                 // but with a slight difference because of the ignore render flag
-                builder.add(Flag.IGNORE_RENDER.name);
+                builder.add("IGNORE_RENDER");
             }
             if ((i & Constants.BlockChangeFlags.FORCE_RE_RENDER) != 0) {
                 // We don't want to confuse that there are going to be multiple flags
                 // but with a slight difference due to the client only flag.
-                builder.add(Flag.FORCE_RE_RENDER.name);
+                builder.add("FORCE_RE_RENDER");
             }
             if ((i & Constants.BlockChangeFlags.OBSERVER_MASK) == 0) {
-                builder.add(Flag.IGNORE_OBSERVER.name);
+                builder.add("OBSERVER");
             }
             if ((i & Constants.BlockChangeFlags.PHYSICS_MASK) == 0) {
-                builder.add(Flag.IGNORE_PHYSICS.name);
+                builder.add("PHYSICS");
             }
             if (Constants.BlockChangeFlags.NONE == i) {
                 register(new SpongeBlockChangeFlag("NONE".toLowerCase(Locale.ENGLISH), i));
@@ -153,31 +153,6 @@ public final class BlockChangeFlagRegistryModule implements RegistryModule {
 
     public Collection<SpongeBlockChangeFlag> getValues() {
         return Collections.unmodifiableCollection(this.flags.values());
-    }
-
-    public static final class Flag {
-
-        public static final Flag NOTIFY_NEIGHBOR = new Flag("NEIGHBOR", Constants.BlockChangeFlags.NEIGHBOR_MASK);
-        public static final Flag NOTIFY_CLIENTS = new Flag("NOTIFY_CLIENTS", Constants.BlockChangeFlags.NOTIFY_CLIENTS);
-        public static final Flag IGNORE_RENDER = new Flag("IGNORE_RENDER", Constants.BlockChangeFlags.IGNORE_RENDER);
-        public static final Flag FORCE_RE_RENDER = new Flag("FORCE_RE_RENDER", Constants.BlockChangeFlags.FORCE_RE_RENDER);
-        public static final Flag IGNORE_OBSERVER = new Flag("OBSERVER", Constants.BlockChangeFlags.OBSERVER_MASK);
-        public static final Flag IGNORE_PHYSICS = new Flag("PHYSICS", Constants.BlockChangeFlags.PHYSICS_MASK);
-
-        private static final ImmutableList<Flag> flags = ImmutableList.of(NOTIFY_NEIGHBOR, NOTIFY_CLIENTS, IGNORE_RENDER, FORCE_RE_RENDER, IGNORE_OBSERVER, IGNORE_PHYSICS);
-
-        private final String name;
-        private final int mask;
-
-        public static Collection<Flag> values() {
-            return flags;
-        }
-
-        private Flag(String name, int mask) {
-            this.name = name;
-            this.mask = mask;
-        }
-
     }
 
 }

--- a/src/main/java/org/spongepowered/common/registry/type/world/BlockChangeFlagRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/world/BlockChangeFlagRegistryModule.java
@@ -53,6 +53,9 @@ public final class BlockChangeFlagRegistryModule implements RegistryModule {
     }
 
     public static SpongeBlockChangeFlag fromNativeInt(int flag) {
+        if (flag >= getInstance().maskedFlags.length) {
+            return (SpongeBlockChangeFlag) org.spongepowered.api.world.BlockChangeFlags.ALL;
+        }
         if (flag == 3) {
             return (SpongeBlockChangeFlag) org.spongepowered.api.world.BlockChangeFlags.ALL;
         }
@@ -60,10 +63,7 @@ public final class BlockChangeFlagRegistryModule implements RegistryModule {
             return (SpongeBlockChangeFlag) org.spongepowered.api.world.BlockChangeFlags.PHYSICS_OBSERVER;
         }
         final SpongeBlockChangeFlag spongeBlockChangeFlag = getInstance().maskedFlags[flag];
-        if (spongeBlockChangeFlag != null) {
-            return spongeBlockChangeFlag;
-        }
-        return (SpongeBlockChangeFlag) org.spongepowered.api.world.BlockChangeFlags.ALL;
+        return spongeBlockChangeFlag;
     }
 
     public static BlockChangeFlag andNotifyClients(BlockChangeFlag flag) {


### PR DESCRIPTION
`maskedFlags` was only used inside `fromNativeInt` and no iteration was performed. 
It's a waste to use a linkedhashmap (memory-wise) in this case and since the `int`s are ordered (0-63) a simple array is enough.

The `Flag` class was added by https://github.com/SpongePowered/SpongeCommon/commit/b72f54f00a5daf2d9a9792ce003e920771bf209c

Those constants were used inside `SpongeBlockChangeFlag` https://github.com/SpongePowered/SpongeCommon/commit/b72f54f00a5daf2d9a9792ce003e920771bf209c#diff-47fad911f2d242623dfbe1bba8213fccR60

They were later moved to the `Constants` class by this commit https://github.com/SpongePowered/SpongeCommon/commit/bded27b7a48dda4f4d0e0200f4188a0c1cdf7550 
(See https://github.com/SpongePowered/SpongeCommon/commit/bded27b7a48dda4f4d0e0200f4188a0c1cdf7550#diff-47fad911f2d242623dfbe1bba8213fccR49 ) and the class is now unused (aside for the string constants).
