### PR TITLE
Fix Forge SOUND_EVENTS registry callback using a phantom reference

### DIFF
--- a/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
@@ -421,7 +421,7 @@ public final class CommonModuleRegistry {
                 .registerModule(ShrubType.class, new ShrubTypeRegistryModule())
                 .registerModule(SkullType.class, new SkullTypeRegistryModule())
                 .registerModule(SlabType.class, new SlabTypeRegistryModule())
-                .registerModule(SoundType.class, new SoundRegistryModule())
+                .registerModule(SoundType.class, SoundRegistryModule.inst())
                 .registerModule(SpawnType.class, new SpawnTypeRegistryModule())
                 .registerModule(SoundCategory.class, new SoundCategoryRegistryModule())
                 .registerModule(StairShape.class, new StairShapeRegistryModule())


### PR DESCRIPTION
A new instance of SoundRegistryModule is created in common and used in the SpongeGameRegistry.

However the registry callback for the Forge registry is using another instance (the one from the singleton method) https://github.com/SpongePowered/SpongeForge/blob/c3a1ca670b23a47292a93a60a659e44dd13d56fc/src/main/java/org/spongepowered/mod/SpongeMod.java#L292

This means the catalogs from the registry callback are lost.

