### PR TITLE
Fix duplicate empty chunk

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/world/WorldBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/world/WorldBridge.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.bridge.world;
 
 import net.minecraft.world.World;
+import org.spongepowered.common.world.SpongeEmptyChunk;
 
 public interface WorldBridge {
 
@@ -46,4 +47,6 @@ public interface WorldBridge {
     void bridge$clearFakeCheck();
 
     boolean bridge$isAreaLoaded(int xStart, int yStart, int zStart, int xEnd, int yEnd, int zEnd, boolean allowEmpty);
+
+    SpongeEmptyChunk getEmptyChunk();
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/WorldMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/WorldMixin.java
@@ -493,6 +493,11 @@ public abstract class WorldMixin implements WorldBridge {
         )
     )
     private Chunk impl$returnEmptyChunk(final World world, final int chunkX, final int chunkZ) {
+        return getEmptyChunk();
+    }
+
+    @Override
+    public SpongeEmptyChunk getEmptyChunk() {
         if (this.impl$emptyChunk == null) {
             this.impl$emptyChunk = new SpongeEmptyChunk((World) (Object) this, 0, 0);
         }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/ChunkProviderServerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/ChunkProviderServerMixin.java
@@ -78,7 +78,6 @@ import javax.annotation.Nullable;
 @Mixin(ChunkProviderServer.class)
 public abstract class ChunkProviderServerMixin implements ChunkProviderServerBridge, ChunkProviderBridge {
 
-    @Nullable private SpongeEmptyChunk impl$EMPTY_CHUNK;
     private boolean impl$denyChunkRequests = true;
     private boolean impl$forceChunkRequests = false;
     private long impl$chunkUnloadDelay = Constants.World.DEFAULT_CHUNK_UNLOAD_DELAY;
@@ -101,7 +100,6 @@ public abstract class ChunkProviderServerMixin implements ChunkProviderServerBri
         if (((WorldBridge) worldObjIn).bridge$isFake()) {
             return;
         }
-        this.impl$EMPTY_CHUNK = new SpongeEmptyChunk(worldObjIn, 0, 0);
         final WorldCategory worldCategory = ((WorldInfoBridge) this.world.getWorldInfo()).bridge$getConfigAdapter().getConfig().getWorld();
 
         ((WorldServerBridge) worldObjIn).bridge$updateConfigCache();
@@ -147,7 +145,7 @@ public abstract class ChunkProviderServerMixin implements ChunkProviderServerBri
 
         Chunk chunk = this.getLoadedChunk(x, z);
         if (chunk == null && this.impl$canDenyChunkRequest()) {
-            return this.impl$EMPTY_CHUNK;
+            return ((WorldBridge) this.world).getEmptyChunk();
         }
 
         if (chunk == null) {

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/ChunkProviderServerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/ChunkProviderServerMixin.java
@@ -145,6 +145,9 @@ public abstract class ChunkProviderServerMixin implements ChunkProviderServerBri
 
         Chunk chunk = this.getLoadedChunk(x, z);
         if (chunk == null && this.impl$canDenyChunkRequest()) {
+            if (((WorldBridge) this.world).bridge$isFake()) {
+                return null;
+            }
             return ((WorldBridge) this.world).getEmptyChunk();
         }
 


### PR DESCRIPTION
There's an empty chunk in the `World` class and one in `ChunkProviderServer`. 
This PR keeps a single instance around for each world.