### PR TITLE
Fix entity death logging and shouldfire flag for DestructEntityEvent

### DIFF
--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -177,6 +177,7 @@ import org.spongepowered.common.item.inventory.util.ItemStackUtil;
 import org.spongepowered.common.registry.provider.DirectionFacingProvider;
 import org.spongepowered.common.text.SpongeTexts;
 import org.spongepowered.common.util.Constants;
+import org.spongepowered.common.util.SpongeHooks;
 import org.spongepowered.common.util.VecHelper;
 import org.spongepowered.common.world.SpongeLocatableBlockBuilder;
 
@@ -1060,6 +1061,9 @@ public class SpongeCommonEventFactory {
             // Check the event isn't cancelled either. If it is, then don't spawn the message.
             if (!event.isCancelled() && !event.isMessageCancelled() && !message.isEmpty()) {
                 event.getChannel().ifPresent(eventChannel -> eventChannel.send(entity, event.getMessage()));
+            }
+            if (!event.isCancelled()) {
+                SpongeHooks.logEntityDeath(entity);
             }
             return Optional.of(event);
         }


### PR DESCRIPTION
**SpongeCommon** | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/3177)

Just like https://github.com/SpongePowered/SpongeCommon/pull/2650 but way more severe.

The listener is only registered in SF. This means entity death logging doesn't work in SV.
Plus the `ShouldFire` flag is always true because of the internal listener.