### PR TITLE
Don't bypass attackEntityFrom if LivingHurtEvent is cancelled

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
@@ -464,9 +464,7 @@ public abstract class EntityLivingBaseMixin extends EntityMixin implements Livin
                     if (this.entityType.isModdedDamageEntityMethod) {
                         this.damageEntity(source, amount - this.lastDamage);
                     } else {
-                        if (!this.bridge$damageEntityHook(source, amount - this.lastDamage)) {
-                            return false;
-                        }
+                        this.bridge$damageEntityHook(source, amount - this.lastDamage);
                     }
 
                     // this.damageEntity(source, amount - this.lastDamage); // handled above
@@ -478,9 +476,7 @@ public abstract class EntityLivingBaseMixin extends EntityMixin implements Livin
                     if (this.entityType.isModdedDamageEntityMethod) {
                         this.damageEntity(source, amount);
                     } else {
-                        if (!this.bridge$damageEntityHook(source, amount)) {
-                            return false;
-                        }
+                        this.bridge$damageEntityHook(source, amount);
                     }
                     this.lastDamage = amount;
                     this.hurtResistantTime = this.maxHurtResistantTime;


### PR DESCRIPTION
Don't bypass the rest of the attackEntityFrom method if damageEntityHook returns `false`

This brings our method much closer to what Forge does and should fix SpongePowered/SpongeForge#3178