### PR TITLE
Return true when Forge short circuits a damage entity calculation

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityLivingBaseMixin.java
@@ -464,7 +464,9 @@ public abstract class EntityLivingBaseMixin extends EntityMixin implements Livin
                     if (this.entityType.isModdedDamageEntityMethod) {
                         this.damageEntity(source, amount - this.lastDamage);
                     } else {
-                        this.bridge$damageEntityHook(source, amount - this.lastDamage);
+                        if (!this.bridge$damageEntityHook(source, amount - this.lastDamage)) {
+                            return false;
+                        }
                     }
 
                     // this.damageEntity(source, amount - this.lastDamage); // handled above
@@ -476,7 +478,9 @@ public abstract class EntityLivingBaseMixin extends EntityMixin implements Livin
                     if (this.entityType.isModdedDamageEntityMethod) {
                         this.damageEntity(source, amount);
                     } else {
-                        this.bridge$damageEntityHook(source, amount);
+                        if (!this.bridge$damageEntityHook(source, amount)) {
+                            return false;
+                        }
                     }
                     this.lastDamage = amount;
                     this.hurtResistantTime = this.maxHurtResistantTime;
@@ -606,7 +610,7 @@ public abstract class EntityLivingBaseMixin extends EntityMixin implements Livin
             damage = bridge$applyModDamage((EntityLivingBase) (Object) this, damageSource, damage);
             final float originalDamage = damage; // set after forge hook.
             if (damage <= 0) {
-                return false;
+                return true;
             }
 
             final List<DamageFunction> originalFunctions = new ArrayList<>();


### PR DESCRIPTION
This should provide the right balance between mods cancelling LivingHurtEvent and plugins cancelling the DamageEntityEvent.

Reverts e53011124b96d50b88aec42b9d28dcc9d5e086a3 and 4c3a4d4436178ae61e601611a6829f82d3dee60c

Should fix #3042 