### PR TITLE
Make some Jar in Jar tasks for distribution

### DIFF
--- a/forge/gradle.properties
+++ b/forge/gradle.properties
@@ -1,6 +1,7 @@
 name=SpongeForge
 implementation=Forge
 description=The SpongeAPI implementation for MinecraftForge
+group=org.spongepowered
 
 forgeDep=forge
 forgeOrg=net.minecraftforge

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ name=SpongeCommon
 implementation=Common
 description=Shared code between SpongeForge and SpongeVanilla
 url=https://www.spongepowered.org
+group=org.spongepowered
 organization=SpongePowered
 projectUrl=https://www.spongepowered.org
 projectDescription=Shared code between SpongeForge and SpongeVanilla

--- a/vanilla/gradle.properties
+++ b/vanilla/gradle.properties
@@ -1,3 +1,4 @@
 name=SpongeVanilla
 implementation=Vanilla
 description=The SpongeAPI implementation for Vanilla Minecraft
+group=org.spongepowered


### PR DESCRIPTION
So, there's something that I've been wanting to tackle for a minute, something that is closer to the end-goal of our wonderful 1.14 update: Building artifacts of our implementations with the new setup...

# Goals

We've wanted to be able to support jar-in-jar for a moment, but previous toolchains did not allow for such a thing. Now we're at the start with our newest toolchain that does support jar-in-jars, and with our split up source sets, we're in a prime case of being able to do exactly that: Build SpongeCommon/SpongeVanilla/SpongeForge with jar-in-jars.

# Anti-goals

We aren't setting up an installer ~~yet~~, but this will allow us to carefully manage our dependencies and reduce delegating libraries in a module centric world (Java 9+).

# Output

Currently, we support creating the following:
- [x] `sourcesJar`
- [x] `javadocJar`
- [x] `launchJar`
- [x] `accessorsJar`
- [x] `mixinsJar`
- [x] `fatJar`*

Caveats:
- [ ] Verify whether mixing configs can exist within these jars in the fat jar
- [ ] plugin-spi detection of plugins within jar-in-jars
- [ ] Manifest generation for these different jars?
- [ ] Should sourcesJar build all source sets?
- [ ] modlauncher questions?

<details name="Some Pretty Pictures">
<img width="295" alt="Screen_Shot_2020-07-13_at_10 47 02_PM" src="https://user-images.githubusercontent.com/1203877/87448769-1dea5080-c5b1-11ea-90b3-31a9543c64f3.png">
</details>