### PR TITLE
Fix client completion when a parameter is not optional but reads nothing

### DIFF
--- a/src/main/java/org/spongepowered/common/command/SpongeParameterizedCommand.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeParameterizedCommand.java
@@ -103,7 +103,8 @@ public final class SpongeParameterizedCommand implements Command.Parameterized {
     @Override
     @NonNull
     public Text getUsage(@NonNull final CommandCause cause) {
-        return Text.of(this.associatedCommandNode.getSourceCommandNode().stream().map(CommandNode::getUsageText).collect(Collectors.joining("|")));
+        return Text.of(this.associatedCommandNode.getSourceCommandNode()
+                .getChildrenForSuggestions().stream().map(CommandNode::getUsageText).collect(Collectors.joining("|")));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/command/brigadier/SpongeStringReader.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/SpongeStringReader.java
@@ -182,6 +182,11 @@ public final class SpongeStringReader extends StringReader implements ArgumentRe
         return new ArgumentParseException(errorMessage, this.getInput(), this.getCursor());
     }
 
+    @NonNull
+    public ArgumentParseException createException(@NonNull final Text errorMessage, @NonNull Throwable inner) {
+        return new ArgumentParseException(errorMessage, inner, this.getInput(), this.getCursor());
+    }
+
     // JSON parsing. Mostly taken from JsonToNBT
     protected String readKey() throws ArgumentParseException {
         this.skipWhitespace();

--- a/src/main/java/org/spongepowered/common/command/brigadier/TranslatedParameter.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/TranslatedParameter.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.command.Command;
 import org.spongepowered.api.command.CommandExecutor;
 import org.spongepowered.common.command.brigadier.tree.SpongeCommandExecutorWrapper;
 import org.spongepowered.common.command.brigadier.tree.SpongeLiteralCommandNode;
+import org.spongepowered.common.command.brigadier.tree.SpongeRootCommandNode;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -46,15 +47,15 @@ import java.util.function.Predicate;
 public final class TranslatedParameter {
 
     private final boolean isTerminal;
-    private final List<CommandNode<CommandSource>> sourceCommandNode;
+    private final SpongeRootCommandNode rootCommandNode;
     private final List<LiteralCommandNode<CommandSource>> subcommands;
 
     public TranslatedParameter(
             final boolean isTerminal,
             final List<LiteralCommandNode<CommandSource>> subcommands,
-            final List<CommandNode<CommandSource>> sourceCommandNode) {
+            final SpongeRootCommandNode rootCommandNode) {
         this.isTerminal = isTerminal;
-        this.sourceCommandNode = sourceCommandNode;
+        this.rootCommandNode = rootCommandNode;
         this.subcommands = subcommands;
     }
 
@@ -62,8 +63,8 @@ public final class TranslatedParameter {
         return this.isTerminal;
     }
 
-    public List<CommandNode<CommandSource>> getSourceCommandNode() {
-        return this.sourceCommandNode;
+    public SpongeRootCommandNode getSourceCommandNode() {
+        return this.rootCommandNode;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -71,9 +72,9 @@ public final class TranslatedParameter {
             final Command.Parameterized commandExecutorIfTerminal,
             final String primaryAlias) {
         final LiteralArgumentBuilder<CommandSource> primary = LiteralArgumentBuilder.literal(primaryAlias);
-        this.sourceCommandNode.forEach(primary::then);
         this.subcommands.forEach(primary::then);
-        if (this.isTerminal) {
+        this.rootCommandNode.getChildren().forEach(primary::then);
+        if (this.isTerminal || primary.getArguments().isEmpty()) {
             primary.executes(new SpongeCommandExecutorWrapper(commandExecutorIfTerminal));
         }
         primary.requires((Predicate) commandExecutorIfTerminal.getExecutionRequirements());

--- a/src/main/java/org/spongepowered/common/command/brigadier/argument/AbstractArgumentParser.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/argument/AbstractArgumentParser.java
@@ -101,12 +101,8 @@ public abstract class AbstractArgumentParser<T> implements ArgumentParser<T>, Su
     }
 
     @Override
-    public boolean isHiddenFromClient() {
+    public boolean doesNotRead() {
         return false;
     }
 
-    @Override
-    public boolean canParseEmpty() {
-        return false;
-    }
 }

--- a/src/main/java/org/spongepowered/common/command/brigadier/argument/ArgumentParser.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/argument/ArgumentParser.java
@@ -55,8 +55,6 @@ public interface ArgumentParser<T> {
         return ImmutableList.of(Constants.Command.STANDARD_STRING_ARGUMENT_TYPE);
     }
 
-    boolean isHiddenFromClient();
-
-    boolean canParseEmpty();
+    boolean doesNotRead();
 
 }

--- a/src/main/java/org/spongepowered/common/command/brigadier/argument/CustomArgumentParser.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/argument/CustomArgumentParser.java
@@ -67,15 +67,15 @@ public final class CustomArgumentParser<T> implements ArgumentParser<T>, Suggest
 
     private final Collection<ValueParser<? extends T>> parsers;
     private final ValueCompleter completer;
-    private final boolean isHidden;
-    private final boolean containsDefault;
+    private final boolean doesNotRead;
 
-    public CustomArgumentParser(final Collection<ValueParser<? extends T>> parsers, final ValueCompleter completer, final boolean containsDefault) {
+    public CustomArgumentParser(final Collection<ValueParser<? extends T>> parsers, final ValueCompleter completer, final boolean doesNotRead) {
         this.parsers = parsers;
         this.completer = completer;
-        this.isHidden = parsers.stream().allMatch(x -> x.getClientCompletionType().contains(CustomArgumentParser.NONE_CLIENT_COMPLETION_TYPE));
-        this.containsDefault = containsDefault || this.isHidden; // indicates that we should try to parse this even if there is nothing else to parse.
-        if (this.containsDefault && this.parsers.size() == 2) {
+        this.doesNotRead =
+                doesNotRead || parsers.stream().allMatch(x -> x.getClientCompletionType().contains(CustomArgumentParser.NONE_CLIENT_COMPLETION_TYPE));
+        // indicates that we should try to parse this even if there is nothing else to parse.
+        if (this.parsers.size() == 1) {
             final ValueParser<? extends T> parser = this.parsers.iterator().next();
             if (parser instanceof StandardArgumentParser) {
                 this.types = ImmutableList.copyOf(((StandardArgumentParser<?, ?>) parser).getClientCompletionArgumentType());
@@ -144,13 +144,8 @@ public final class CustomArgumentParser<T> implements ArgumentParser<T>, Suggest
     }
 
     @Override
-    public boolean isHiddenFromClient() {
-        return this.isHidden;
-    }
-
-    @Override
-    public boolean canParseEmpty() {
-        return this.containsDefault;
+    public boolean doesNotRead() {
+        return this.doesNotRead;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/command/brigadier/argument/StandardArgumentParser.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/argument/StandardArgumentParser.java
@@ -100,12 +100,7 @@ public class StandardArgumentParser<S, T> implements ArgumentParser<T>, ValuePar
     }
 
     @Override
-    public boolean isHiddenFromClient() {
-        return false;
-    }
-
-    @Override
-    public boolean canParseEmpty() {
+    public boolean doesNotRead() {
         return false;
     }
 

--- a/src/main/java/org/spongepowered/common/command/brigadier/context/SpongeCommandContextBuilder.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/context/SpongeCommandContextBuilder.java
@@ -403,7 +403,7 @@ public final class SpongeCommandContextBuilder extends CommandContextBuilder<Com
 
     private static boolean checkNodeCannotBeEmpty(final CommandNode<CommandSource> node, final StringRange range) {
         if (range.getStart() == range.getEnd()) {
-            return !(node instanceof SpongeArgumentCommandNode && ((SpongeArgumentCommandNode<?>) node).getParser().canParseEmpty());
+            return !(node instanceof SpongeArgumentCommandNode && ((SpongeArgumentCommandNode<?>) node).getParser().doesNotRead());
         }
         return true;
     }

--- a/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeArgumentCommandNodeBuilder.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeArgumentCommandNodeBuilder.java
@@ -40,14 +40,24 @@ public final class SpongeArgumentCommandNodeBuilder<T> extends ArgumentBuilder<C
     private final SpongeParameterKey<? super T> key;
     private final ArgumentParser<? extends T> type;
     @Nullable private final ValueCompleter completer;
+    @Nullable private final String suffix;
 
     public SpongeArgumentCommandNodeBuilder(
             final SpongeParameterKey<? super T> key,
             final ArgumentParser<? extends T> type,
             final ValueCompleter completer) {
+        this(key, type, completer, null);
+    }
+
+    public SpongeArgumentCommandNodeBuilder(
+            final SpongeParameterKey<? super T> key,
+            final ArgumentParser<? extends T> type,
+            final ValueCompleter completer,
+            @Nullable final String suffix) {
         this.key = key;
         this.type = type;
         this.completer = type == completer && type instanceof StandardCatalogedArgumentParser ? null : completer;
+        this.suffix = suffix;
     }
 
     @Override
@@ -65,7 +75,8 @@ public final class SpongeArgumentCommandNodeBuilder<T> extends ArgumentBuilder<C
                 this.getRequirement(),
                 this.getRedirect(),
                 this.getRedirectModifier(),
-                this.isFork()
+                this.isFork(),
+                this.suffix == null ? this.key.key() : this.key.key() + "_" + this.suffix
         );
         for (final CommandNode<CommandSource> child : this.getArguments()) {
             node.addChild(child);

--- a/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeLiteralCommandNode.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeLiteralCommandNode.java
@@ -30,11 +30,8 @@ import com.mojang.brigadier.tree.LiteralCommandNode;
 import net.minecraft.command.CommandSource;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
 
-public class SpongeLiteralCommandNode extends LiteralCommandNode<CommandSource> implements UnsortedChildrenNode {
+public class SpongeLiteralCommandNode extends LiteralCommandNode<CommandSource> implements SpongeNode {
 
     // used so we can have insertion order.
     private final UnsortedNodeHolder nodeHolder = new UnsortedNodeHolder();
@@ -56,7 +53,8 @@ public class SpongeLiteralCommandNode extends LiteralCommandNode<CommandSource> 
     }
 
     @Override
-    public Collection<CommandNode<CommandSource>> getUnsortedChildren() {
-        return this.nodeHolder.getChildren();
+    public final Collection<CommandNode<CommandSource>> getChildrenForSuggestions() {
+        return this.nodeHolder.getChildrenForSuggestions();
     }
+
 }

--- a/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeNode.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeNode.java
@@ -29,8 +29,9 @@ import net.minecraft.command.CommandSource;
 
 import java.util.Collection;
 
-public interface UnsortedChildrenNode {
+public interface SpongeNode {
 
-    Collection<CommandNode<CommandSource>> getUnsortedChildren();
+    // Handles hidden nodes
+    Collection<CommandNode<CommandSource>> getChildrenForSuggestions();
 
 }

--- a/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeRootCommandNode.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeRootCommandNode.java
@@ -29,9 +29,8 @@ import com.mojang.brigadier.tree.RootCommandNode;
 import net.minecraft.command.CommandSource;
 
 import java.util.Collection;
-import java.util.LinkedList;
 
-public final class SpongeRootCommandNode extends RootCommandNode<CommandSource> implements UnsortedChildrenNode {
+public final class SpongeRootCommandNode extends RootCommandNode<CommandSource> implements SpongeNode {
 
     // used so we can have insertion order.
     private final UnsortedNodeHolder nodeHolder = new UnsortedNodeHolder();
@@ -42,8 +41,9 @@ public final class SpongeRootCommandNode extends RootCommandNode<CommandSource> 
         this.nodeHolder.add(node);
     }
 
-    public Collection<CommandNode<CommandSource>> getUnsortedChildren() {
-        return this.nodeHolder.getChildren();
+    @Override
+    public Collection<CommandNode<CommandSource>> getChildrenForSuggestions() {
+        return this.nodeHolder.getChildrenForSuggestions();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/command/brigadier/tree/UnsortedNodeHolder.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/tree/UnsortedNodeHolder.java
@@ -61,4 +61,27 @@ public final class UnsortedNodeHolder {
         return this.cachedResult;
     }
 
+    // Handles hidden nodes
+    public Collection<CommandNode<CommandSource>> getChildrenForSuggestions() {
+        final ImmutableList.Builder<CommandNode<CommandSource>> nodes = ImmutableList.builder();
+        for (final CommandNode<CommandSource> childNode : this.getChildren()) {
+            if (childNode instanceof SpongeArgumentCommandNode && ((SpongeArgumentCommandNode<CommandSource>) childNode).getParser().doesNotRead()) {
+                final CommandNode<CommandSource> redirected = childNode.getRedirect();
+                if (redirected != null) {
+                    // get the nodes from the redirect
+                    if (redirected instanceof SpongeArgumentCommandNode) {
+                        nodes.addAll(((SpongeArgumentCommandNode<CommandSource>) redirected).getChildrenForSuggestions());
+                    } else {
+                        nodes.addAll(redirected.getChildren());
+                    }
+                } else {
+                    nodes.addAll(((SpongeArgumentCommandNode<CommandSource>) childNode).getChildrenForSuggestions());
+                }
+            } else {
+                nodes.add(childNode);
+            }
+        }
+        return nodes.build();
+    }
+
 }

--- a/src/main/java/org/spongepowered/common/command/parameter/SpongeDefaultValueParser.java
+++ b/src/main/java/org/spongepowered/common/command/parameter/SpongeDefaultValueParser.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.command.parameter;
+
+import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.command.CommandCause;
+import org.spongepowered.api.command.exception.ArgumentParseException;
+import org.spongepowered.api.command.parameter.ArgumentReader;
+import org.spongepowered.api.command.parameter.CommandContext;
+import org.spongepowered.api.command.parameter.Parameter;
+import org.spongepowered.api.command.parameter.managed.ValueParser;
+import org.spongepowered.api.command.parameter.managed.clientcompletion.ClientCompletionType;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.common.command.brigadier.SpongeStringReader;
+import org.spongepowered.common.command.brigadier.argument.CustomArgumentParser;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class SpongeDefaultValueParser<T> implements ValueParser<T> {
+
+    private static final List<ClientCompletionType> CLIENT_COMPLETION_TYPE = ImmutableList.of(CustomArgumentParser.NONE_CLIENT_COMPLETION_TYPE);
+
+    private final Function<CommandCause, T> defaultFunction;
+
+    public SpongeDefaultValueParser(final Function<CommandCause, T> defaultFunction) {
+        this.defaultFunction = defaultFunction;
+    }
+
+    @Override
+    public Optional<? extends T> getValue(
+            final Parameter.Key<? super T> parameterKey,
+            final ArgumentReader.Mutable reader,
+            final CommandContext.Builder context)
+            throws ArgumentParseException {
+        final T result;
+        try {
+            result = this.defaultFunction.apply(context);
+        } catch (final Exception ex) {
+            throw ((SpongeStringReader) reader)
+                    .createException(Text.of("An exception was thrown obtaining a default value for ", parameterKey.key()), ex);
+        }
+        if (result == null) {
+            throw reader.createException(Text.of("No default value was supplied for ", parameterKey.key()));
+        }
+        return Optional.of(result);
+    }
+
+    @Override
+    public List<ClientCompletionType> getClientCompletionType() {
+        return SpongeDefaultValueParser.CLIENT_COMPLETION_TYPE;
+    }
+}

--- a/src/main/java/org/spongepowered/common/command/parameter/SpongeParameterValueBuilder.java
+++ b/src/main/java/org/spongepowered/common/command/parameter/SpongeParameterValueBuilder.java
@@ -38,7 +38,6 @@ import org.spongepowered.api.command.parameter.managed.ValueUsage;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -100,7 +99,8 @@ public final class SpongeParameterValueBuilder<T> implements Parameter.Value.Bui
         }
     }
 
-    @Override public Parameter.Value.@NonNull Builder<T> setRequirements(@Nullable final Predicate<CommandCause> executionRequirements) {
+    @Override
+    public Parameter.Value.@NonNull Builder<T> setRequirements(@Nullable final Predicate<CommandCause> executionRequirements) {
         this.executionRequirements = executionRequirements;
         return this;
     }
@@ -138,13 +138,9 @@ public final class SpongeParameterValueBuilder<T> implements Parameter.Value.Bui
     @NonNull
     public SpongeParameterValue<T> build() throws IllegalStateException {
         Preconditions.checkState(this.key != null, "The command key may not be null");
-        Preconditions.checkState(!this.parsers.isEmpty(), "There must be parsers");
+        Preconditions.checkState(!this.parsers.isEmpty() || this.defaultValueFunction != null, "There must be parsers or a default");
         final ImmutableList.Builder<ValueParser<? extends T>> parsersBuilder = ImmutableList.builder();
         parsersBuilder.addAll(this.parsers);
-        final boolean containsDefault = this.defaultValueFunction != null;
-        if (containsDefault) {
-            parsersBuilder.add((key, reader, context) -> Optional.of(this.defaultValueFunction.apply(context)));
-        }
 
         final ValueCompleter completer;
         if (this.completer != null) {
@@ -176,14 +172,14 @@ public final class SpongeParameterValueBuilder<T> implements Parameter.Value.Bui
 
         return new SpongeParameterValue<>(
                 parsersBuilder.build(),
+                this.defaultValueFunction,
                 completer,
                 this.usage,
                 this.executionRequirements == null ? commandCause -> true : this.executionRequirements,
                 this.key,
                 this.isOptional,
                 this.consumesAll,
-                this.terminal,
-                containsDefault
+                this.terminal
         );
     }
 

--- a/src/main/java/org/spongepowered/common/command/parameter/managed/standard/SpongeWorldPropertiesValueParameter.java
+++ b/src/main/java/org/spongepowered/common/command/parameter/managed/standard/SpongeWorldPropertiesValueParameter.java
@@ -53,7 +53,8 @@ public final class SpongeWorldPropertiesValueParameter extends CatalogedArgument
     @Override
     @NonNull
     public List<String> complete(@NonNull final CommandContext context) {
-        return SpongeCommon.getGame().getServer().getWorldManager().getAllProperties().stream().map(WorldProperties::getDirectoryName).collect(Collectors.toList());
+        return SpongeCommon.getGame().getServer().getWorldManager().getAllProperties().stream().map(WorldProperties::getDirectoryName)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/util/Constants.java
+++ b/src/main/java/org/spongepowered/common/util/Constants.java
@@ -43,6 +43,7 @@ import net.minecraft.util.registry.Registry;
 import net.minecraft.world.GameRules;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.command.parameter.managed.clientcompletion.ClientCompletionType;
 import org.spongepowered.api.data.persistence.DataContentUpdater;
 import org.spongepowered.api.data.persistence.DataQuery;
 import org.spongepowered.api.data.type.ArtType;


### PR DESCRIPTION
This is to fix #3069. The PR is mostly for the diff so I can see what I've changed.

This works on execution, but I don't yet know if it works on the client - it should but I don't have evidence yet.