### PR TITLE
Serialize schematic dims as shorts

### DIFF
--- a/src/main/java/org/spongepowered/common/data/persistence/SchematicTranslator.java
+++ b/src/main/java/org/spongepowered/common/data/persistence/SchematicTranslator.java
@@ -376,9 +376,9 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
             throw new IllegalArgumentException(String.format(
                     "Schematic is larger than maximum allowable size (found: (%d, %d, %d) max: (%d, %<d, %<d)", width, height, length, Constants.Sponge.Schematic.MAX_SIZE));
         }
-        data.set(Constants.Sponge.Schematic.WIDTH, width);
-        data.set(Constants.Sponge.Schematic.HEIGHT, height);
-        data.set(Constants.Sponge.Schematic.LENGTH, length);
+        data.set(Constants.Sponge.Schematic.WIDTH, (short) width);
+        data.set(Constants.Sponge.Schematic.HEIGHT, (short) height);
+        data.set(Constants.Sponge.Schematic.LENGTH, (short) length);
 
         data.set(Constants.Sponge.Schematic.VERSION, Constants.Sponge.Schematic.CURRENT_VERSION);
         data.set(Constants.Sponge.Schematic.DATA_VERSION, Constants.MINECRAFT_DATA_VERSION);


### PR DESCRIPTION
This correctly passes the dimensions to the `DataView` as `short`s, not `int`s, and therefore serializes them correctly when translated to NBT.

I saved this with the CopyPasta plugin:
![schematic NBT](https://url.octyl.net/33hhe5-j4hqmx32idmfu)

Fixes #3084 