### PR TITLE
Fix TileEntity/EntityActivation range

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/plugin/entityactivation/EntityActivationRange.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/entityactivation/EntityActivationRange.java
@@ -277,15 +277,15 @@ public class EntityActivationRange {
                 }
 
                 if (currentTick > spongeEntity.activation$getActivatedTick()) {
-                    if (spongeEntity.activation$getDefaultActivationState()) {
-                        spongeEntity.activation$setActivatedTick(currentTick);
-                        continue;
-                    }
-
                     // check if activation cache needs to be updated
                     if (spongeEntity.activation$requiresActivationCacheRefresh()) {
                         EntityActivationRange.initializeEntityActivationState(entity);
                         spongeEntity.activation$requiresActivationCacheRefresh(false);
+                    }
+
+                    if (spongeEntity.activation$getDefaultActivationState()) {
+                        spongeEntity.activation$setActivatedTick(currentTick);
+                        continue;
                     }
                     // check for entity type overrides
                     final byte activationType = spongeEntity.activation$getActivationType();

--- a/src/main/java/org/spongepowered/common/mixin/plugin/tileentityactivation/TileEntityActivation.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/tileentityactivation/TileEntityActivation.java
@@ -164,15 +164,15 @@ public class TileEntityActivation {
 
             final Vector3i tilePos = VecHelper.toVector3i(tileEntity.getPos());
             if (currentTick > ((ActivationCapability) tileEntity).activation$getActivatedTick()) {
-                if (spongeTileEntity.activation$getDefaultActivationState()) {
-                    ((ActivationCapability) tileEntity).activation$setActivatedTick(currentTick);
-                    continue;
-                }
-
                 // check if activation cache needs to be updated
                 if (spongeTileEntity.activation$requiresActivationCacheRefresh()) {
                     TileEntityActivation.initializeTileEntityActivationState(tileEntity);
                     spongeTileEntity.activation$requiresActivationCacheRefresh(false);
+                }
+
+                if (spongeTileEntity.activation$getDefaultActivationState()) {
+                    ((ActivationCapability) tileEntity).activation$setActivatedTick(currentTick);
+                    continue;
                 }
 
                 final int activationRange = ((ActivationCapability) tileEntity).activation$getActivationRange();


### PR DESCRIPTION
EntityActivation state was never initialised because the cache refresh check was after the `DefaultActivationState` check (the field is initialised to true).

Fix https://github.com/SpongePowered/SpongeCommon/issues/3081