### PR TITLE
Implement ServerPlayerData#Keys.HAS_VIEWED_CREDITS

### DIFF
--- a/src/accessors/java/org/spongepowered/common/accessor/entity/player/ServerPlayerEntityAccessor.java
+++ b/src/accessors/java/org/spongepowered/common/accessor/entity/player/ServerPlayerEntityAccessor.java
@@ -33,4 +33,8 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 public interface ServerPlayerEntityAccessor {
 
     @Accessor("enteredNetherPosition") Vec3d accessor$getEnteredNetherPosition();
+
+    @Accessor("seenCredits") boolean accessor$getSeenCredits();
+
+    @Accessor("seenCredits") void accessor$setSeenCredits(boolean value);
 }

--- a/src/main/java/org/spongepowered/common/data/provider/entity/ServerPlayerData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/ServerPlayerData.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.profile.property.ProfileProperty;
 import org.spongepowered.api.statistic.Statistic;
+import org.spongepowered.common.accessor.entity.player.ServerPlayerEntityAccessor;
 import org.spongepowered.common.bridge.entity.player.ServerPlayerEntityBridge;
 import org.spongepowered.common.bridge.stats.StatisticsManagerBridge;
 import org.spongepowered.common.data.provider.DataProviderRegistrator;
@@ -60,6 +61,10 @@ public final class ServerPlayerData {
                         .get(h -> ((StatisticsManagerBridge) h.getStats()).bridge$getStatsData().entrySet().stream()
                                 .collect(Collectors.toMap(e -> (Statistic)e.getKey(), e -> e.getValue().longValue())))
                         .set((h, v) -> v.forEach((ik, iv) -> h.getStats().setValue(h, (Stat<?>) ik, iv.intValue())))
+                .asMutable(ServerPlayerEntityAccessor.class)
+                    .create(Keys.HAS_VIEWED_CREDITS)
+                        .get(ServerPlayerEntityAccessor::accessor$getSeenCredits)
+                        .set(ServerPlayerEntityAccessor::accessor$setSeenCredits)
                 .asMutable(ServerPlayerEntityBridge.class)
                     .create(Keys.HEALTH_SCALE)
                         .defaultValue(Constants.Entity.Player.DEFAULT_HEALTH_SCALE)

--- a/src/mixins/java/org/spongepowered/common/mixin/api/mcp/entity/player/ServerPlayerEntityMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/mcp/entity/player/ServerPlayerEntityMixin_API.java
@@ -402,6 +402,7 @@ public abstract class ServerPlayerEntityMixin_API extends PlayerEntityMixin_API 
         values.add(this.firstJoined().asImmutable());
         values.add(this.lastPlayed().asImmutable());
         values.add(this.sleepingIgnored().asImmutable());
+        values.add(this.hasViewedCredits().asImmutable());
 
         // If getSpectatingEntity returns this player, then we are not spectating any other entity, so spectatorTarget would be an Optional.empty()
         this.spectatorTarget().map(Value::asImmutable).ifPresent(values::add);


### PR DESCRIPTION
Supersedes #3068, credit to i509VCB for the work. This simply converts it to the new data registration format.

Signed-off-by: Steven Downer <grinch@outlook.com>