### PR TITLE
data: Correct translation starting from a non-root node.

### DIFF
--- a/src/test/java/org/spongepowered/common/data/translator/ConfigurateDataViewTest.java
+++ b/src/test/java/org/spongepowered/common/data/translator/ConfigurateDataViewTest.java
@@ -201,4 +201,23 @@ public class ConfigurateDataViewTest {
 
         ConfigurateTranslator.instance().translate(node);
     }
+
+    @Test
+    public void testNonRootNodeToData() {
+        final ConfigurationNode root = CommentedConfigurationNode.root(n -> {
+            n.getNode("test").act(c -> {
+                c.getNode("child").setValue("hello");
+                c.getNode("other").setValue("world");
+            });
+        });
+
+        final DataView view = ConfigurateTranslator.instance().translate(root.getNode("test"));
+
+        assertEquals("hello", view.getString(DataQuery.of("child")).get());
+        assertEquals("world", view.getString(DataQuery.of("other")).get());
+
+        ConfigurateTranslator.instance().translateDataToNode(root.getNode("test2"), view);
+        assertEquals(root.getNode("test").getValue(), root.getNode("test2").getValue());
+    }
+
 }


### PR DESCRIPTION
The reasoning for this fix is described in the issue -- added a test to verify fix as well.

Fixes #3103