### PR TITLE
Add dependency json output to file for use with installer/launcher

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,20 +4,6 @@ import java.util.StringJoiner
 import java.security.MessageDigest
 import kotlin.experimental.and
 
-buildscript {
-    repositories {
-        mavenLocal()
-        maven("https://files.minecraftforge.net/maven")
-        maven("https://repo-new.spongepowered.org/repository/maven-public")
-        maven("https://repo.spongepowered.org/maven")
-        mavenCentral()
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath("org.spongepowered:mixingradle:0.7-SNAPSHOT")
-    }
-}
-
 plugins {
     id("net.minecraftforge.gradle")
     `maven-publish`
@@ -26,11 +12,7 @@ plugins {
     eclipse
     id("net.minecrell.licenser") version "0.4.1"
     id("com.github.johnrengelman.shadow") version "5.2.0"
-}
-
-
-apply {
-    plugin("org.spongepowered.mixin")
+    id("org.spongepowered.mixin")
 }
 
 val apiProject = project.project("SpongeAPI")
@@ -276,7 +258,7 @@ dependencies {
     add(mixins.get().implementationConfigurationName, mixinsConfig)
     add(mixins.get().implementationConfigurationName, project(":SpongeAPI"))
 }
-configure<org.spongepowered.asm.gradle.plugins.MixinExtension> {
+mixin {
     add("mixins", "spongecommon.mixins.refmap.json")
     add("accessors", "spongecommon.accessors.refmap.json")
 }
@@ -621,7 +603,7 @@ project("SpongeVanilla") {
         }
     }
 
-    configure<org.spongepowered.asm.gradle.plugins.MixinExtension> {
+    mixin {
         add(vanillaMixins, "spongevanilla.mixins.refmap.json")
         add(vanillaAccessors, "spongevanilla.accessors.refmap.json")
     }
@@ -729,7 +711,7 @@ project("SpongeVanilla") {
             group = "sponge"
             val confName = vanillaAppLaunchConfig.name
             configuration = confName
-            outputFile.set(File(vanillaProject.buildDir, "$confName.json"))
+            outputFile.set(File(vanillaProject.buildDir, "libraries.json"))
         }
         shadowJar {
             mergeServiceFiles()
@@ -1027,7 +1009,7 @@ if (spongeForge != null) {
             }
         }
 
-        configure<org.spongepowered.asm.gradle.plugins.MixinExtension> {
+        mixin {
             add(forgeMixins, "spongeforge.mixins.refmap.json")
             add(forgeAccessors, "spongeforge.accessors.refmap.json")
         }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 }
 repositories {
     gradlePluginPortal()
-    jcenter()
-    maven("https://files.minecraftforge.net/maven")
-    maven("https://repo.spongepowered.org/maven")
+    maven("https://repo-new.spongepowered.org/repository/maven-public/")
+    mavenLocal()
 }
 
 
 dependencies {
     implementation("net.minecraftforge.gradle:ForgeGradle:3.0.+")
+    implementation("org.spongepowered:mixingradle:0.7-SNAPSHOT")
 }


### PR DESCRIPTION
Pretty basic usage of the dependencies needed, outputs a manual built json file (since I couldn't for the life of me get the buildscript to import something like gson or jackson etc.)

This can be tested with `./gradlew emitDependencies`

The output will look like
```json
{
 "dependencies":
  [
    {
      "group": "org.spongepowered",
      "module": "mixin",
      "version": "0.8.1-SNAPSHOT",
      "md5": "4ba6337b3724c7d107ad217"
    },
    {
      "group": "org.ow2.asm",
      "module": "asm-util",
      "version": "6.2",
      "md5": "f102f32ccf7fa2d7b2a751c4"
    },
    {
      "group": "com.google.guava",
      "module": "guava",
      "version": "21.0",
      "md5": "d91f850a617791ab5d4e4d1f6"
    },
    {
      "group": "org.spongepowered",
      "module": "plugin-spi",
      "version": "0.1.3-SNAPSHOT",
      "md5": "025d7261b54104c6bbfa5145"
    },
    {
      "group": "javax.inject",
      "module": "javax.inject",
      "version": "1",
      "md5": "280754b0ee7469153631d2e"
    },
    {
      "group": "org.apache.logging.log4j",
      "module": "log4j-api",
      "version": "2.11.2",
      "md5": "3f7e51e3d030d79a090243d"
    },
    {
      "group": "org.apache.logging.log4j",
      "module": "log4j-core",
      "version": "2.11.2",
      "md5": "8db5c5aa07a3db57d01c266"
    },
    {
      "group": "com.zaxxer",
      "module": "HikariCP",
      "version": "2.6.3",
      "md5": "c3f015f12eb7b50e53ae"
    },
    {
      "group": "org.apache.logging.log4j",
      "module": "log4j-slf4j-impl",
      "version": "2.11.2",
      "md5": "362e4c465c99f41154d8"
    },
    {
      "group": "org.spongepowered",
      "module": "configurate-core",
      "version": "3.7.1",
      "md5": "152b2b316e022328acc2b36e7"
    },
    {
      "group": "org.spongepowered",
      "module": "configurate-hocon",
      "version": "3.7.1",
      "md5": "478b29e0c473925801629"
    },
    {
      "group": "org.spongepowered",
      "module": "configurate-json",
      "version": "3.7.1",
      "md5": "b29803563b1091227155802"
    },
    {
      "group": "org.cadixdev",
      "module": "lorenz",
      "version": "0.6.0-SNAPSHOT",
      "md5": "c680f3a52a44587a56547b1a"
    },
    {
      "group": "org.cadixdev",
      "module": "atlas",
      "version": "0.3.0-SNAPSHOT",
      "md5": "2b19057ae14359a87672b414ca"
    },
    {
      "group": "cpw.mods",
      "module": "modlauncher",
      "version": "4.1.0",
      "md5": "56e665167083946b16736237"
    },
    {
      "group": "cpw.mods",
      "module": "grossjava9hacks",
      "version": "1.1.0",
      "md5": "1ad27730734a786f461e0484400"
    },
    {
      "group": "net.minecraftforge",
      "module": "accesstransformers",
      "version": "1.0.5",
      "md5": "c7707320fe71e36556e2"
    },
    {
      "group": "org.ow2.asm",
      "module": "asm-commons",
      "version": "7.1",
      "md5": "53524b59255e482e0aa285"
    },
    {
      "group": "org.ow2.asm",
      "module": "asm-tree",
      "version": "7.1",
      "md5": "e019fe1e642e122b52f58d74b"
    }
  ]
}

``