### PR TITLE
Implement BlockType#getStateProperties and BlockType#getStatePropertyByName

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/api/mcp/block/BlockMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/mcp/block/BlockMixin_API.java
@@ -30,16 +30,19 @@ import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
+import net.minecraft.state.StateContainer;
 import net.minecraft.util.registry.Registry;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.block.BlockSoundGroup;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.state.StateProperty;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
+import java.util.Collection;
 import java.util.Optional;
 
 @Mixin(value = Block.class, priority = 999)
@@ -47,6 +50,7 @@ public abstract class BlockMixin_API implements BlockType {
 
     @Shadow @Final @org.spongepowered.asm.mixin.Mutable protected boolean ticksRandomly;
     @Shadow @Final protected SoundType soundType;
+    @Shadow @Final protected StateContainer<Block, net.minecraft.block.BlockState> stateContainer;
     @Shadow public abstract Item shadow$asItem();
     @Shadow public abstract String shadow$getTranslationKey();
     @Shadow public abstract net.minecraft.block.BlockState shadow$getDefaultState();
@@ -93,5 +97,16 @@ public abstract class BlockMixin_API implements BlockType {
     @Override
     public Component asComponent() {
         return TranslatableComponent.of(this.shadow$getTranslationKey());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Collection<StateProperty<?>> getStateProperties() {
+        return (Collection<StateProperty<?>>) (Object) stateContainer.getProperties();
+    }
+
+    @Override
+    public Optional<StateProperty<?>> getStatePropertyByName(String name) {
+        return Optional.ofNullable((StateProperty<?>) stateContainer.getProperty(name));
     }
 }


### PR DESCRIPTION
Implements these two methods. Unsure if this is the "correct" way of doing it, haven't touched Sponge in a fair while. It feels a bit messy to just ignore all the type warnings here, unsure if there's a cleaner way to do this with Mixins.