### PR TITLE
registry: Pass specific catalog type from event

### DIFF
--- a/src/main/java/org/spongepowered/common/event/lifecycle/RegisterCatalogEventImpl.java
+++ b/src/main/java/org/spongepowered/common/event/lifecycle/RegisterCatalogEventImpl.java
@@ -52,7 +52,7 @@ public final class RegisterCatalogEventImpl<C extends CatalogType> extends Abstr
     public C register(C catalog) throws DuplicateRegistrationException {
         Preconditions.checkNotNull(catalog);
 
-        return ((SpongeCatalogRegistry) Sponge.getRegistry().getCatalogRegistry()).registerCatalog(catalog);
+        return ((SpongeCatalogRegistry) Sponge.getRegistry().getCatalogRegistry()).registerCatalog(this.token, catalog);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/registry/SpongeCatalogRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeCatalogRegistry.java
@@ -457,10 +457,10 @@ public final class SpongeCatalogRegistry implements CatalogRegistry {
         return registry;
     }
 
-    public <C extends CatalogType> C registerCatalog(final C catalogType) {
+    public <C extends CatalogType> C registerCatalog(final TypeToken<C> catalog, final C catalogType) {
         Objects.requireNonNull(catalogType);
 
-        final Registry<C> registry = (Registry<C>) this.registriesByType.get(catalogType.getClass());
+        final Registry<C> registry = (Registry<C>) this.registriesByType.get(catalog.getRawType());
         if (registry == null) {
             throw new UnknownTypeException(String.format("Catalog '%s' with id '%s' has no registry registered!", catalogType.getClass(), catalogType.getKey()));
         }


### PR DESCRIPTION
This allows registering implementations of types, not just
instances of concrete types

PEX runs into issues when registering its implementation of `CommandRegistrar` without this change.