### PR TITLE
Add ability to get the executed Command.Parameterized from the CommandContext

### DIFF
--- a/src/main/java/org/spongepowered/common/command/SpongeParameterizedCommand.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeParameterizedCommand.java
@@ -168,13 +168,7 @@ public final class SpongeParameterizedCommand implements Command.Parameterized {
         if (this.executor == null) {
             return (LiteralCommandNode<CommandSource>) SpongeParameterTranslator.createCommandTreeWithSubcommandsOnly(primary, this.subcommands);
         } else {
-            return (LiteralCommandNode<CommandSource>) SpongeParameterTranslator.createCommandTree(
-                    primary,
-                    this.flags,
-                    this.parameters,
-                    this.subcommands,
-                    this
-            );
+            return (LiteralCommandNode<CommandSource>) SpongeParameterTranslator.createCommandTree(primary, this);
         }
     }
 
@@ -187,7 +181,7 @@ public final class SpongeParameterizedCommand implements Command.Parameterized {
             final LiteralArgumentBuilder<CommandSource> secondary = LiteralArgumentBuilder.literal(iterable.next());
             secondary.executes(built.getCommand());
             secondary.requires(built.getRequirement());
-            nodes.add(new SpongeLiteralCommandNode(secondary.redirect(built)));
+            nodes.add(new SpongeLiteralCommandNode(secondary.redirect(built), this));
         }
 
         return nodes;

--- a/src/main/java/org/spongepowered/common/command/brigadier/SpongeParameterTranslator.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/SpongeParameterTranslator.java
@@ -32,7 +32,6 @@ import com.mojang.brigadier.tree.LiteralCommandNode;
 import net.minecraft.command.CommandSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.spongepowered.api.command.CommandExecutor;
 import org.spongepowered.api.command.parameter.Parameter;
 import org.spongepowered.api.command.parameter.managed.Flag;
 import org.spongepowered.api.command.parameter.managed.ValueCompleter;
@@ -72,13 +71,10 @@ public final class SpongeParameterTranslator {
     @SuppressWarnings({"unchecked"})
     public static CommandNode<CommandSource> createCommandTree(
             @NonNull final ArgumentBuilder<CommandSource, ?> rootNode,
-            @NonNull final List<Flag> flags,
-            @NonNull final List<Parameter> parameters,
-            @NonNull final List<Parameter.Subcommand> subcommands,
-            @NonNull final CommandExecutor executor) {
+            @NonNull final SpongeParameterizedCommand command) {
 
-        final SpongeCommandExecutorWrapper executorWrapper = new SpongeCommandExecutorWrapper(executor);
-        final ListIterator<Parameter> parameterListIterator = parameters.listIterator();
+        final SpongeCommandExecutorWrapper executorWrapper = new SpongeCommandExecutorWrapper(command);
+        final ListIterator<Parameter> parameterListIterator = command.parameters().listIterator();
 
         // If we have no parameters, or they are all optional, all literals will get an executor.
         final boolean isTerminal = SpongeParameterTranslator.createNode(
@@ -86,14 +82,14 @@ public final class SpongeParameterTranslator {
         if (isTerminal) {
             rootNode.executes(executorWrapper);
         }
-        SpongeParameterTranslator.createSubcommands(rootNode, subcommands);
+        SpongeParameterTranslator.createSubcommands(rootNode, command.subcommands());
         final CommandNode<CommandSource> builtNode;
         if (rootNode instanceof LiteralArgumentBuilder) {
-            builtNode = new SpongeLiteralCommandNode((LiteralArgumentBuilder<CommandSource>) rootNode);
+            builtNode = new SpongeLiteralCommandNode((LiteralArgumentBuilder<CommandSource>) rootNode, command);
         } else {
             builtNode = rootNode.build();
         }
-        SpongeParameterTranslator.createFlags(flags, builtNode, isTerminal ? executorWrapper : null);
+        SpongeParameterTranslator.createFlags(command.flags(), builtNode, isTerminal ? executorWrapper : null);
         return builtNode;
     }
 

--- a/src/main/java/org/spongepowered/common/command/brigadier/context/SpongeCommandContext.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/context/SpongeCommandContext.java
@@ -37,6 +37,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.kyori.adventure.text.Component;
 import net.minecraft.command.CommandSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.command.parameter.Parameter;
 import org.spongepowered.api.command.parameter.managed.Flag;
@@ -48,13 +49,12 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import javax.annotation.Nullable;
-
 public final class SpongeCommandContext extends CommandContext<CommandSource> implements org.spongepowered.api.command.parameter.CommandContext {
 
     private final Map<Parameter.Key<?>, Collection<?>> argumentMap;
     private final Object2IntOpenHashMap<String> flagMap;
     private final Map<String, ParsedArgument<CommandSource, ?>> brigArguments;
+    private final org.spongepowered.api.command.Command.@Nullable Parameterized targetCommand;
 
     public SpongeCommandContext(
             final CommandSource source,
@@ -68,7 +68,8 @@ public final class SpongeCommandContext extends CommandContext<CommandSource> im
             final StringRange range,
             @Nullable final CommandContext<CommandSource> child,
             @Nullable final RedirectModifier<CommandSource> modifier,
-            final boolean forks) {
+            final boolean forks,
+            final org.spongepowered.api.command.Command.@Nullable Parameterized currentTargetCommand) {
         super(source,
                 input,
                 brigArguments,
@@ -82,6 +83,13 @@ public final class SpongeCommandContext extends CommandContext<CommandSource> im
         this.brigArguments = brigArguments;
         this.argumentMap = arguments;
         this.flagMap = flags.clone();
+        this.targetCommand = currentTargetCommand;
+    }
+
+    @Override
+    @NonNull
+    public Optional<org.spongepowered.api.command.Command.Parameterized> getExecutedCommand() {
+        return Optional.ofNullable(this.targetCommand);
     }
 
     @Override
@@ -169,7 +177,8 @@ public final class SpongeCommandContext extends CommandContext<CommandSource> im
                 this.getRange(),
                 this.getChild(),
                 this.getRedirectModifier(),
-                this.isForked());
+                this.isForked(),
+                this.targetCommand);
     }
 
     @Nullable

--- a/src/main/java/org/spongepowered/common/command/brigadier/context/SpongeCommandContextBuilderTransaction.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/context/SpongeCommandContextBuilderTransaction.java
@@ -44,6 +44,7 @@ import java.util.LinkedList;
 public final class SpongeCommandContextBuilderTransaction implements CommandContext.Builder.Transaction {
 
     private static final LinkedList<SpongeCommandContextBuilderTransaction> TRANSACTION_POOL = new LinkedList<>();
+
     public static SpongeCommandContextBuilderTransaction getTransactionFromPool(final SpongeCommandContextBuilder builder) {
         SpongeCommandContextBuilderTransaction chosenTransaction = null;
         for (final SpongeCommandContextBuilderTransaction transaction : TRANSACTION_POOL) {
@@ -73,6 +74,7 @@ public final class SpongeCommandContextBuilderTransaction implements CommandCont
     private final LinkedList<Tuple<Parameter.@NonNull Key<?>, ?>> putEntryCapture = new LinkedList<>();
     private final LinkedList<CommandContextBuilder<CommandSource>> withChildCapture = new LinkedList<>();
     private final LinkedList<Command<CommandSource>> withCommandCapture = new LinkedList<>();
+    private org.spongepowered.api.command.Command.Parameterized currentTargetCommandCapture = null;
 
     private boolean isActive = false;
 
@@ -158,6 +160,10 @@ public final class SpongeCommandContextBuilderTransaction implements CommandCont
         return this.copyBuilder;
     }
 
+    public void setCurrentTargetCommand(final org.spongepowered.api.command.Command.Parameterized command) {
+        this.currentTargetCommandCapture = command;
+    }
+
     public boolean isActive() {
         if (this.isActive) {
             if (this.builder.get() != null) {
@@ -178,6 +184,9 @@ public final class SpongeCommandContextBuilderTransaction implements CommandCont
             this.withCommandCapture.forEach(builderRef::withCommand);
             this.putEntryCapture.forEach(x -> this.putEntryAbusingGenerics(builderRef, x.getFirst(), x.getSecond()));
             this.flagCapture.forEach(builderRef::addFlagInvocation);
+            if (this.currentTargetCommandCapture != null) {
+                builderRef.setCurrentTargetCommand(this.currentTargetCommandCapture);
+            }
         }
 
         // we're clearing anyway!
@@ -192,6 +201,7 @@ public final class SpongeCommandContextBuilderTransaction implements CommandCont
         this.withChildCapture.clear();
         this.putEntryCapture.clear();
         this.flagCapture.clear();
+        this.currentTargetCommandCapture = null;
         this.copyBuilder = null;
         this.builder = null;
     }

--- a/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeArgumentCommandNode.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeArgumentCommandNode.java
@@ -40,8 +40,6 @@ import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.mojang.brigadier.tree.CommandNode;
-import com.mojang.brigadier.tree.LiteralCommandNode;
-import jdk.nashorn.internal.runtime.RecompilableScriptFunctionData;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.ISuggestionProvider;
 import org.checkerframework.checker.nullness.qual.Nullable;

--- a/src/main/java/org/spongepowered/common/command/sponge/SpongeCommand.java
+++ b/src/main/java/org/spongepowered/common/command/sponge/SpongeCommand.java
@@ -180,7 +180,7 @@ public class SpongeCommand {
         final PluginContainer apiPlugin = Launch.getInstance().getApiPlugin();
         final PluginContainer minecraftPlugin = Launch.getInstance().getMinecraftPlugin();
 
-        context.getCause().sendMessage(TextComponent.builder().append(
+        context.sendMessage(TextComponent.builder().append(
                 TextComponent.of("SpongePowered", NamedTextColor.YELLOW, TextDecoration.BOLD).append(TextComponent.space()),
                 TextComponent.of("Plugin Platform (running on Minecraft " + minecraftPlugin.getMetadata().getVersion() + ")"),
                 TextComponent.newline(),
@@ -189,6 +189,25 @@ public class SpongeCommand {
                 TextComponent.of(platformPlugin.getMetadata().getName().get() + ": " + platformPlugin.getMetadata().getVersion())
             ).build()
         );
+
+        final Optional<Command.Parameterized> parameterized = context.getExecutedCommand();
+        if (parameterized.isPresent()) {
+            final String subcommands = parameterized.get()
+                    .subcommands()
+                    .stream()
+                    .filter(x -> x.getCommand().canExecute(context.getCause()))
+                    .flatMap(x -> x.getAliases().stream())
+                    .collect(Collectors.joining(", "));
+            if (!subcommands.isEmpty()) {
+                context.sendMessage(TextComponent.builder().append(
+                        TextComponent.newline(),
+                        TextComponent.of("Available subcommands:"),
+                        TextComponent.newline(),
+                        TextComponent.of(subcommands)).build()
+                );
+            }
+        }
+
         return CommandResult.success();
     }
 


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2227) | **SpongeCommon** | [Original Issue](https://github.com/SpongePowered/SpongeAPI/issues/2217)

As a bonus, I use this to add all available subcommands to `/sponge`.