### PR TITLE
Fix cursor reset when opening an inventory

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMPMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMPMixin.java
@@ -172,6 +172,8 @@ public abstract class EntityPlayerMPMixin extends EntityPlayerMixin implements S
 
     @Shadow public abstract WorldServer getServerWorld();
 
+    @Shadow public abstract void closeContainer();
+
     // Used to restore original item received in a packet after canceling an event
     private ItemStack impl$packetItem = ItemStack.EMPTY;
     private final User impl$user = impl$getUserObjectOnConstruction();
@@ -898,6 +900,11 @@ public abstract class EntityPlayerMPMixin extends EntityPlayerMixin implements S
     @Override
     public void bridge$setContainerDisplay(final Text displayName) {
         this.impl$displayName = displayName;
+    }
+
+    @Redirect(method = {"displayGUIChest", "openGuiHorseInventory"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;closeScreen()V"))
+    private void impl$closePreviousContainer(EntityPlayerMP self) {
+        closeContainer();
     }
 
     @Redirect(method = "displayGUIChest", at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/IInventory;getDisplayName()Lnet/minecraft/util/text/ITextComponent;"))


### PR DESCRIPTION
Currently, opening an inventory while another is already open makes the mouse cursor reset his position to the center of the screen. This PR prevents sending a close packet when opening a new inventory (The only difference between `closeScreen` and `closeContainer` is the packet). Client-side, the user sees the new inventory opening and replacing the previous one as usual except that the cursor doesn't reset his position. This change allows plugins to easily create navigateable UIs using multiple inventories.