### PR TITLE
timings: *IfSync methods now check for server thread

### DIFF
--- a/src/main/java/org/spongepowered/common/relocate/co/aikar/timings/TimingHandler.java
+++ b/src/main/java/org/spongepowered/common/relocate/co/aikar/timings/TimingHandler.java
@@ -88,11 +88,13 @@ class TimingHandler implements Timing {
 
     @Override
     public void startTimingIfSync() {
-        if (!this.enabled ) {
+        if (!this.enabled) {
             return;
         }
 
-        this.startTiming();
+        if (Sponge.isServerAvailable() && SpongeCommon.getServer().isOnExecutionThread()) {
+            this.startTiming();
+        }
     }
 
     @Override
@@ -101,7 +103,9 @@ class TimingHandler implements Timing {
             return;
         }
 
-        this.stopTiming();
+        if (Sponge.isServerAvailable() && SpongeCommon.getServer().isOnExecutionThread()) {
+            this.stopTiming();
+        }
     }
 
     @Override


### PR DESCRIPTION
This prevents issues in areas that use the *IfSync methods.

Timings probably needs more love eventually, to figure out what makes most sense for client/server-side divisions.