### PR TITLE
Implement handling for Adventure's translation registry

### DIFF
--- a/src/accessors/java/org/spongepowered/common/accessor/network/NetworkManagerAccessor.java
+++ b/src/accessors/java/org/spongepowered/common/accessor/network/NetworkManagerAccessor.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.accessor.network;
 
+import io.netty.channel.Channel;
 import net.minecraft.network.NetworkManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
@@ -32,6 +33,8 @@ import java.net.SocketAddress;
 
 @Mixin(NetworkManager.class)
 public interface NetworkManagerAccessor {
+
+    @Accessor("channel") Channel accessor$getChannel();
 
     @Accessor("socketAddress") void accessor$setSocketAddress(SocketAddress socketAddress);
 }

--- a/src/main/java/org/spongepowered/common/adventure/NativeComponentRenderer.java
+++ b/src/main/java/org/spongepowered/common/adventure/NativeComponentRenderer.java
@@ -1,0 +1,162 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.adventure;
+
+import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
+import net.kyori.adventure.translation.GlobalTranslator;
+import net.kyori.adventure.translation.TranslationRegistry;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.text.AttributedCharacterIterator;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * An implementation of the functionality of {@link TranslatableComponentRenderer} on native MC chat components.
+ *
+ * This performs *in-place modification* of components. Only pass cloned components in
+ *
+ * @param <C>
+ */
+public abstract class NativeComponentRenderer<C> {
+
+    static final NativeComponentRenderer<Locale> INSTANCE = new NativeComponentRenderer<Locale>() {
+        @Override
+        public MessageFormat translate(final @NonNull String key, final @NonNull Locale locale) {
+            return GlobalTranslator.get().translate(key, locale);
+        }
+    };
+
+    /**
+     * Gets the default translatable component renderer.
+     *
+     * @return a translatable component renderer
+     * @see TranslationRegistry
+     */
+    public static @NonNull NativeComponentRenderer<Locale> get() {
+        return INSTANCE;
+    }
+
+    /**
+     * Gets a message format from a key and context.
+     *
+     * @param key a translation key
+     * @param context a context
+     * @return a message format or {@code null} to skip translation
+     */
+    protected abstract @Nullable MessageFormat translate(final @NonNull String key, final @NonNull C context);
+
+    public ITextComponent render(@NonNull ITextComponent component, final @NonNull C context) {
+        if (component instanceof TranslationTextComponent) {
+            component = this.renderTranslatable((TranslationTextComponent) component, context);
+        } else {
+            this.renderSiblings(component, context);
+        }
+
+        final net.minecraft.util.text.event.HoverEvent hover = component.getStyle().getHoverEvent();
+        if (hover != null) {
+            final ITextComponent original = hover.getValue();
+            final ITextComponent rendered = this.render(original, context);
+            if (original != rendered) {
+                component.getStyle().setHoverEvent(new net.minecraft.util.text.event.HoverEvent(hover.getAction(), rendered));
+            }
+        }
+        return component;
+    }
+
+    protected @NonNull ITextComponent renderTranslatable(final @NonNull TranslationTextComponent component, final @NonNull C context) {
+        final /* @Nullable */ MessageFormat format = this.translate(component.getKey(), context);
+        if (format == null) {
+            // we don't have a translation for this component, but the arguments or children
+            // of this component might need additional rendering
+            final Object[] args = component.getFormatArgs();
+            if (args.length > 0) {
+                for (int i = 0, size = args.length; i < size; i++) {
+                    if (args[i] instanceof ITextComponent) {
+                        args[i] = this.render((ITextComponent) args[i], context);
+                    }
+                }
+            }
+            this.renderSiblings(component, context);
+            return component;
+        }
+
+        final Object[] args = component.getFormatArgs();
+        final StringTextComponent result;
+        // no arguments makes this render very simple
+        if(args.length == 0) {
+            result = new StringTextComponent(format.format(null, new StringBuffer(), null).toString());
+        } else {
+            result = new StringTextComponent("");
+
+            final Object[] nulls = new Object[args.length];
+            final StringBuffer sb = format.format(nulls, new StringBuffer(), null);
+            final AttributedCharacterIterator it = format.formatToCharacterIterator(nulls);
+
+            while (it.getIndex() < it.getEndIndex()) {
+                final int end = it.getRunLimit();
+                final Integer index = (Integer) it.getAttribute(MessageFormat.Field.ARGUMENT);
+                if (index != null && args[index] instanceof ITextComponent) {
+                    result.appendSibling(this.render((ITextComponent) args[index], context));
+                } else {
+                    result.appendSibling(new StringTextComponent(sb.substring(it.getIndex(), end)));
+                }
+                it.setIndex(end);
+            }
+        }
+
+        result.setStyle(component.getStyle());
+        this.renderSiblings(component, context, (idx, rendered) -> result.appendSibling(rendered));
+
+        return result;
+    }
+
+    private void renderSiblings(final ITextComponent component, final C context) {
+        this.renderSiblings(component, context, component.getSiblings()::set);
+    }
+
+    private void renderSiblings(final ITextComponent component, final C context, final SiblingConsumer consumer) {
+        final List<ITextComponent> siblings = component.getSiblings();
+        for (int i = 0; i < siblings.size(); i++) {
+            final ITextComponent original = siblings.get(i);
+            final ITextComponent rendered = this.render(original, context);
+            consumer.accept(i, rendered);
+        }
+    }
+
+    @FunctionalInterface
+    interface SiblingConsumer {
+
+        // Receives every sibling
+        void accept(final int idx, final ITextComponent rendered);
+
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/bridge/network/PacketBufferBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/network/PacketBufferBridge.java
@@ -22,13 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.bridge.util.text;
+package org.spongepowered.common.bridge.network;
 
-import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import java.util.Locale;
 
-public interface TextComponentBridge {
-    Component bridge$asAdventureComponent();
+public interface PacketBufferBridge {
 
-    @Nullable Component bridge$adventureComponentIfPresent();
+    void bridge$setLocale(final Locale locale);
+
 }

--- a/src/main/java/org/spongepowered/common/bridge/world/BossInfoBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/world/BossInfoBridge.java
@@ -25,12 +25,11 @@
 package org.spongepowered.common.bridge.world;
 
 import net.kyori.adventure.bossbar.BossBar;
+import net.minecraft.entity.player.ServerPlayerEntity;
 
 public interface BossInfoBridge {
     /**
      * Update this bar's info from its adventure equivalent.
-     *
-     * <p>The adventure bits</p>
      *
      * @param adventure adventure boss bar
      */
@@ -39,4 +38,6 @@ public interface BossInfoBridge {
     BossBar bridge$asAdventure();
 
     void bridge$setAdventure(BossBar adventure);
+
+    void bridge$replacePlayer(ServerPlayerEntity oldPlayer, ServerPlayerEntity newPlayer);
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/client/util/text/TranslationTextComponentMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/client/util/text/TranslationTextComponentMixin.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.client.util.text;
+
+import net.kyori.adventure.translation.GlobalTranslator;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+import org.spongepowered.api.util.locale.Locales;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.common.adventure.NativeComponentRenderer;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+@Mixin(TranslationTextComponent.class)
+public abstract class TranslationTextComponentMixin extends TextComponent {
+
+    @Shadow @Final private String key;
+    private String impl$lastLocale;
+    private ITextComponent impl$translated = this;
+
+    @Inject(method = "stream", at = @At("HEAD"), cancellable = true)
+    private void impl$translateForRendering(final CallbackInfoReturnable<Stream<ITextComponent>> ci) {
+        // TODO(zml): For 1.16, this logic moves to the styled visitor-accepting methods
+        final String currentLocale = Minecraft.getInstance().gameSettings.language;
+        if (!Objects.equals(currentLocale, this.impl$lastLocale)) { // retranslate
+            this.impl$lastLocale = currentLocale;
+            final Locale actualLocale = Locales.of(currentLocale);
+
+            // Only do a deep copy if actually necessary
+            if (GlobalTranslator.get().translate(this.key, actualLocale) != null) {
+                this.impl$translated = NativeComponentRenderer.get().render(this.deepCopy(), Locales.of(currentLocale));
+            } else {
+                this.impl$translated = this;
+            }
+        }
+
+        // If the result is a non-translated component, then Adventure found a translation that we should use
+        if (!(this.impl$translated instanceof TranslationTextComponent)) {
+            ci.setReturnValue(this.impl$translated.stream());
+        }
+    }
+}

--- a/src/mixins/java/org/spongepowered/common/mixin/core/network/NettyPacketEncoderMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/network/NettyPacketEncoderMixin.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.network;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import net.minecraft.network.IPacket;
+import net.minecraft.network.NettyPacketEncoder;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.ProtocolType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.spongepowered.common.adventure.SpongeAdventure;
+import org.spongepowered.common.bridge.network.PacketBufferBridge;
+
+@Mixin(NettyPacketEncoder.class)
+public class NettyPacketEncoderMixin {
+
+    @Inject(method = "encode", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;writeVarInt(I)"
+            + "Lnet/minecraft/network/PacketBuffer;"), locals = LocalCapture.CAPTURE_FAILHARD)
+    private void applyLocaleToBuffer(final ChannelHandlerContext ctx, final IPacket<?> pkt, final ByteBuf orig, final CallbackInfo ci,
+            final ProtocolType unused$proto, final Integer unused$id, final PacketBuffer buffer) {
+        ((PacketBufferBridge) buffer).bridge$setLocale(ctx.channel().attr(SpongeAdventure.CHANNEL_LOCALE).get());
+    }
+}

--- a/src/mixins/java/org/spongepowered/common/mixin/core/network/PacketBufferMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/network/PacketBufferMixin.java
@@ -22,13 +22,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.bridge.util.text;
+package org.spongepowered.common.mixin.core.network;
 
-import net.kyori.adventure.text.Component;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.text.ITextComponent;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.common.adventure.NativeComponentRenderer;
+import org.spongepowered.common.bridge.network.PacketBufferBridge;
 
-public interface TextComponentBridge {
-    Component bridge$asAdventureComponent();
+import java.util.Locale;
 
-    @Nullable Component bridge$adventureComponentIfPresent();
+@Mixin(PacketBuffer.class)
+public abstract class PacketBufferMixin implements PacketBufferBridge {
+
+    private @Nullable Locale impl$locale;
+
+    @ModifyVariable(method = "writeTextComponent", at = @At("HEAD"), argsOnly = true)
+    private ITextComponent localizeComponent(final ITextComponent input) {
+        if(this.impl$locale != null) {
+            return NativeComponentRenderer.get().render(input.deepCopy(), this.impl$locale);
+        }
+        return input;
+    }
+
+    @Override public void bridge$setLocale(final Locale locale) {
+        this.impl$locale = locale;
+    }
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/MinecraftServerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/MinecraftServerMixin.java
@@ -31,6 +31,7 @@ import net.minecraft.server.management.PlayerList;
 import net.minecraft.server.management.PlayerProfileCache;
 import net.minecraft.util.concurrent.RecursiveEventLoop;
 import net.minecraft.util.concurrent.TickDelayedTask;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.Difficulty;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraft.world.storage.SessionLockException;
@@ -53,11 +54,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.SpongeServer;
 import org.spongepowered.common.advancement.SpongeAdvancementProvider;
+import org.spongepowered.common.adventure.NativeComponentRenderer;
 import org.spongepowered.common.bridge.command.CommandSourceProviderBridge;
 import org.spongepowered.common.bridge.server.MinecraftServerBridge;
 import org.spongepowered.common.bridge.server.management.PlayerProfileCacheBridge;
@@ -76,6 +79,7 @@ import org.spongepowered.common.resourcepack.SpongeResourcePack;
 import org.spongepowered.common.service.server.SpongeServerScopedServiceProvider;
 
 import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.function.BooleanSupplier;
 
 import javax.annotation.Nullable;
@@ -309,6 +313,17 @@ public abstract class MinecraftServerMixin extends RecursiveEventLoop<TickDelaye
             this.impl$serviceProvider = new SpongeServerScopedServiceProvider(this, game, injector);
             this.impl$serviceProvider.init();
         }
+    }
+
+    /**
+     * Render localized chat components
+     *
+     * @param input original component
+     * @return converted message
+     */
+    @ModifyVariable(method = "sendMessage", at = @At("HEAD"), argsOnly = true)
+    private ITextComponent impl$applyTranslation(final ITextComponent input) {
+        return NativeComponentRenderer.get().render(input.deepCopy(), Locale.getDefault());
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/core/util/text/TextComponentMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/util/text/TextComponentMixin.java
@@ -35,6 +35,7 @@ import net.minecraft.util.text.SelectorTextComponent;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.common.adventure.SpongeAdventure;
 import org.spongepowered.common.bridge.util.text.StyleBridge;
@@ -89,6 +90,11 @@ public class TextComponentMixin implements TextComponentBridge {
             builder.style(((StyleBridge) ((ITextComponent) this).getStyle()).bridge$asAdventure());
             this.bridge$adventureComponent = builder.build();
         }
+        return this.bridge$adventureComponent;
+    }
+
+    @Override
+    public @Nullable Component bridge$adventureComponentIfPresent() {
         return this.bridge$adventureComponent;
     }
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/BossInfoMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/BossInfoMixin.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.mixin.core.world;
 
 import net.kyori.adventure.bossbar.BossBar;
+import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.BossInfo;
 import org.spongepowered.asm.mixin.Mixin;
@@ -73,6 +74,11 @@ public abstract class BossInfoMixin implements BossInfoBridge {
     @Override
     public void bridge$setAdventure(final BossBar adventure) {
         this.impl$adventure = adventure;
+    }
+
+    @Override
+    public void bridge$replacePlayer(final ServerPlayerEntity oldPlayer, final ServerPlayerEntity newPlayer) {
+        // no-op
     }
 
     // Redirect setters

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/server/ServerBossInfoMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/server/ServerBossInfoMixin.java
@@ -26,15 +26,19 @@ package org.spongepowered.common.mixin.core.world.server;
 
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
+import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.network.play.server.SUpdateBossInfoPacket;
 import net.minecraft.world.BossInfo;
 import net.minecraft.world.server.ServerBossInfo;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.common.adventure.SpongeAdventure;
 import org.spongepowered.common.mixin.core.world.BossInfoMixin;
 
 import java.util.Set;
@@ -47,6 +51,8 @@ public abstract class ServerBossInfoMixin extends BossInfoMixin implements BossB
     private float impl$lastSentPercent = 0f;
 
     @Shadow protected abstract void sendUpdate(final SUpdateBossInfoPacket.Operation operation);
+    @Shadow @Final private Set<ServerPlayerEntity> players;
+    @Shadow private boolean visible;
 
     @Override
     public void bridge$setAdventure(final BossBar adventure) {
@@ -67,8 +73,16 @@ public abstract class ServerBossInfoMixin extends BossInfoMixin implements BossB
         }
     }
 
+    @Override
+    public void bridge$replacePlayer(final ServerPlayerEntity oldPlayer, final ServerPlayerEntity newPlayer) {
+        super.bridge$replacePlayer(oldPlayer, newPlayer);
+        if(this.players.remove(oldPlayer)) {
+            this.players.add(newPlayer);
+        }
+    }
+
     @Inject(method = "setDarkenSky", at = @At("HEAD"))
-    private void forceDarkenSkyUpdate(final boolean darkenSky, final CallbackInfoReturnable<BossInfo> ci) {
+    private void impl$forceDarkenSkyUpdate(final boolean darkenSky, final CallbackInfoReturnable<BossInfo> ci) {
         this.darkenSky = !darkenSky;
     }
 
@@ -116,5 +130,37 @@ public abstract class ServerBossInfoMixin extends BossInfoMixin implements BossB
     @Override
     public void bossBarFlagsChanged(final BossBar bar, final Set<BossBar.Flag> flagsAdded, final Set<BossBar.Flag> flagsRemoved) {
         this.sendUpdate(SUpdateBossInfoPacket.Operation.UPDATE_PROPERTIES);
+    }
+
+    // Tracking for registration (designed for localization handling)
+
+    @Inject(method = "addPlayer", at = @At("TAIL"))
+    private void impl$addPlayer(final ServerPlayerEntity player, final CallbackInfo ci) {
+        if (!this.players.isEmpty() && this.visible) {
+            SpongeAdventure.registerBossBar((ServerBossInfo) (Object) this);
+        }
+    }
+
+    @Inject(method = "removePlayer", at = @At("TAIL"))
+    private void impl$removePlayer(final ServerPlayerEntity player, final CallbackInfo ci) {
+        if (this.players.isEmpty()) {
+            SpongeAdventure.unregisterBossBar((ServerBossInfo) (Object) this);
+        }
+    }
+
+    @Inject(method = "removeAllPlayers", at = @At("HEAD"))
+    private void impl$removeAllPlayers(final CallbackInfo ci) {
+        SpongeAdventure.unregisterBossBar((ServerBossInfo) (Object) this);
+    }
+
+    @Inject(method = "setVisible", at = @At("HEAD"))
+    private void impl$setVisible(final boolean visible, final CallbackInfo ci) {
+        if (!this.players.isEmpty()) {
+            if (visible) {
+                SpongeAdventure.registerBossBar((ServerBossInfo) (Object) this);
+            } else {
+                SpongeAdventure.unregisterBossBar((ServerBossInfo) (Object) this);
+            }
+        }
     }
 }

--- a/src/mixins/resources/mixins.common.core.json
+++ b/src/mixins/resources/mixins.common.core.json
@@ -80,6 +80,8 @@
         "item.ItemMixin",
         "item.ItemStackMixin",
         "network.NetworkManagerMixin",
+        "network.NettyPacketEncoderMixin",
+        "network.PacketBufferMixin",
         "network.handshake.ServerHandshakeNetHandlerMixin",
         "network.login.ServerLoginNetHandler_1Mixin",
         "network.login.ServerLoginNetHandlerMixin",
@@ -156,7 +158,8 @@
         "client.network.play.ClientPlayNetHandlerMixin",
         "client.renderer.LightTextureMixin",
         "client.renderer.WorldRendererMixin",
-        "client.world.ClientWorldMixin"
+        "client.world.ClientWorldMixin",
+        "client.util.text.TranslationTextComponentMixin"
     ],
     "server": [
         "server.dedicated.DedicatedServerMixin"

--- a/testplugins/src/main/java/org/spongepowered/test/chat/ChatTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/chat/ChatTest.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test.chat;
+
+import com.google.inject.Inject;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.inventory.Book;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.translation.GlobalTranslator;
+import net.kyori.adventure.translation.TranslationRegistry;
+import net.kyori.adventure.util.UTF8ResourceBundleControl;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.command.Command;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.parameter.CommandContext;
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.api.entity.living.player.server.ServerPlayer;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.filter.cause.Root;
+import org.spongepowered.api.event.lifecycle.ConstructPluginEvent;
+import org.spongepowered.api.event.lifecycle.RegisterCommandEvent;
+import org.spongepowered.api.event.message.PlayerChatEvent;
+import org.spongepowered.api.util.locale.Locales;
+import org.spongepowered.plugin.PluginContainer;
+import org.spongepowered.plugin.jvm.Plugin;
+import org.spongepowered.test.LoadableModule;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+@Plugin("chattest")
+public class ChatTest implements LoadableModule {
+    private static final BossBar INFO_BAR = BossBar.bossBar(Component.translatable("chattest.bars.info"), 1f, BossBar.Color.PINK,
+                                                      BossBar.Overlay.PROGRESS);
+
+    private final Game game;
+    private final PluginContainer container;
+    private boolean barVisible;
+
+    @Inject
+    ChatTest(final Game game, final PluginContainer container) {
+        this.game = game;
+        this.container = container;
+    }
+
+    @Listener
+    public void constructed(final ConstructPluginEvent event) {
+        // Register localization keys
+        final TranslationRegistry lang = TranslationRegistry.create(Key.key(this.container.getMetadata().getId(), "translations"));
+        Arrays.asList(Locales.EN_US, new Locale("en", "UD")).forEach(it ->
+                lang.registerAll(it, ResourceBundle.getBundle("org.spongepowered.test.chat.messages", it,
+                                                              UTF8ResourceBundleControl.get()), false));
+        GlobalTranslator.get().addSource(lang);
+    }
+
+    @Override
+    public void enable(final CommandContext ctx) {
+        this.game.getEventManager().registerListeners(this.container, new Listeners());
+    }
+
+    @Listener
+    public void registerCommands(final RegisterCommandEvent<Command.Parameterized> event) {
+        // /togglebossbar
+        event.register(this.container, Command.builder()
+                .setPermission("chattest.togglebossbar")
+                .setExecutor(ctx -> {
+                    if (this.barVisible) {
+                        this.game.getServer().hideBossBar(INFO_BAR);
+                    } else {
+                        this.game.getServer().showBossBar(INFO_BAR);
+                    }
+                    this.barVisible = !this.barVisible;
+                    return CommandResult.success();
+                })
+                .build(), "togglebossbar");
+
+        event.register(this.container, Command.builder()
+                      .setPermission("chattest.sendbook")
+                      .setExecutor(ctx -> {
+                          ctx.getCause().getAudience().openBook(Book.builder()
+                                                                        .title(Component.text("A story"))
+                                                                        .author(Component.text("You"))
+                                                                        .pages(Component.translatable("chattest.book.1"),
+                                                                               Component.translatable("chattest.book.2")));
+                          return CommandResult.success();
+                      }).build(), "sendbook");
+    }
+
+    public class Listeners {
+
+        @Listener(order = Order.LAST)
+        public void onChat(final PlayerChatEvent event, final @Root ServerPlayer player) {
+            ChatTest.this.game.getServer().sendMessage(Component.translatable("chattest.response.chat",
+                                                                              event.getMessage(),
+                                                                              player.require(Keys.DISPLAY_NAME)
+                                                                                      .decorate(TextDecoration.BOLD)
+                                                                                      .colorIfAbsent(NamedTextColor.AQUA))
+                                                               .color(NamedTextColor.DARK_AQUA));
+        }
+    }
+}

--- a/testplugins/src/main/resources/META-INF/plugins.json
+++ b/testplugins/src/main/resources/META-INF/plugins.json
@@ -377,6 +377,27 @@
                 "id": "spongeapi",
                 "version": "8.0.0"
             }]
+        },
+        {
+            "loader": "java_plain",
+            "id": "chattest",
+            "name": "Chat Test",
+            "version": "8.0.0",
+            "main-class": "org.spongepowered.test.chat.ChatTest",
+            "description": "Testing Chat and Adventure functionality",
+            "links": {
+                "homepage": "https://www.spongepowered.org",
+                "source": "https://www.spongepowered.org/source",
+                "issues": "https://www.spongepowered.org/issues"
+            },
+            "contributors": [{
+                "name": "SpongePowered",
+                "description": "Lead Developer"
+            }],
+            "dependencies": [{
+                "id": "spongeapi",
+                "version": "8.0.0"
+            }]
         }
     ]
 }

--- a/testplugins/src/main/resources/org/spongepowered/test/chat/messages.properties
+++ b/testplugins/src/main/resources/org/spongepowered/test/chat/messages.properties
@@ -1,0 +1,4 @@
+chattest.bars.info=Have you eaten your FLARD yet?
+chattest.response.chat=Message "{0}" sent by {1}
+chattest.book.1=First page of the book!
+chattest.book.2=Second page of the book!

--- a/testplugins/src/main/resources/org/spongepowered/test/chat/messages_en_UD.properties
+++ b/testplugins/src/main/resources/org/spongepowered/test/chat/messages_en_UD.properties
@@ -1,0 +1,4 @@
+chattest.bars.info=¿ʇǝʎ ᗡꓤ∀⅂ᖵ ɹnoʎ uǝʇɐǝ noʎ ǝʌɐH
+chattest.response.chat={1} ʎq ʇuǝs „{0}„ ǝƃɐssǝꟽ
+chattest.book.1=¡ʞooq ǝɥʇ ⅎo ǝƃɐd ʇsɹᴉᖵ
+chattest.book.2=¡ʞooq ǝɥʇ ⅎo ǝƃɐd puoɔǝS


### PR DESCRIPTION
This PR, when complete, will process any text sent to render localization keys provided on the server using Adventure's global TranslationRegistry.

I'm unsure about the placement of the client-only `TranslationText` mixin -- It's necessary for localization to happen on the client, and has to be client-only due to its references to the client's options, but it breaks the package structure a bit.