### PR TITLE
Add getWorldUUID to SaveChunkEvent.

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/ChunkProviderServerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/ChunkProviderServerMixin.java
@@ -71,6 +71,7 @@ import org.spongepowered.common.world.storage.WorldStorageUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
@@ -358,7 +359,7 @@ public abstract class ChunkProviderServerMixin implements ChunkProviderServerBri
         if (ShouldFire.SAVE_CHUNK_EVENT_PRE) {
             final org.spongepowered.api.world.Chunk apiChunk = (org.spongepowered.api.world.Chunk) chunkIn;
             if (SpongeImpl.postEvent(SpongeEventFactory.createSaveChunkEventPre(SpongeImpl.getCauseStackManager().getCurrentCause(),
-                apiChunk.getPosition(), apiChunk))) {
+                apiChunk.getPosition(), Optional.of(apiChunk.getWorld().getUniqueId()), apiChunk))) {
                 ci.cancel();
             }
         }

--- a/src/main/java/org/spongepowered/common/util/WorldChunkPos.java
+++ b/src/main/java/org/spongepowered/common/util/WorldChunkPos.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.util;
+
+import net.minecraft.util.math.ChunkPos;
+
+import java.util.UUID;
+
+// Used in AnvilChunkLoaderMixin
+public final class WorldChunkPos extends ChunkPos {
+
+    private final UUID uuid;
+
+    public WorldChunkPos(final UUID uuid, final int x, final int z) {
+        super(x, z);
+        this.uuid = uuid;
+    }
+
+    public UUID getWorldUUID() {
+        return this.uuid;
+    }
+
+}


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2234) | **SpongeCommon** | [Original Issue](https://github.com/SpongePowered/SpongeAPI/issues/2233)

I cheat a little bit to get the world UUID by sticking it into a `WorldChunkPos` object that contains the world UUID.