### PR TITLE
[API-8] Bump modlauncher and mixin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -549,7 +549,7 @@ project("SpongeVanilla") {
         add(vanillaLaunch.implementationConfigurationName, vanillaMinecraftConfig)
 
         vanillaInstallerConfig("com.google.code.gson:gson:2.8.0")
-        vanillaInstallerConfig("net.sf.jopt-simple:jopt-simple:5.0.3")
+        vanillaInstallerConfig("net.sf.jopt-simple:jopt-simple:5.0.4")
         vanillaInstallerConfig("org.apache.logging.log4j:log4j-api:2.11.2")
         vanillaInstallerConfig("org.apache.logging.log4j:log4j-core:2.11.2")
         vanillaInstallerConfig("org.cadixdev:atlas:0.2.0")
@@ -585,11 +585,11 @@ project("SpongeVanilla") {
 
         // Launch Dependencies - Needed to bootstrap the engine(s)
         // The ModLauncher compatibility launch layer
-        vanillaAppLaunchConfig("cpw.mods:modlauncher:4.1.+") {
+        vanillaAppLaunchConfig("cpw.mods:modlauncher:7.0.+") {
             exclude(group = "org.apache.logging.log4j")
         }
         vanillaAppLaunchConfig("org.ow2.asm:asm-commons:6.2")
-        vanillaAppLaunchConfig("cpw.mods:grossjava9hacks:1.1.+") {
+        vanillaAppLaunchConfig("cpw.mods:grossjava9hacks:1.3.+") {
             exclude(group = "org.apache.logging.log4j")
         }
         vanillaAppLaunchConfig("net.minecraftforge:accesstransformers:1.0.+:service") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ minecraftDep=joined
 mcpType=snapshot
 mcpMappings=20200826-1.15.1
 recommendedVersion=0-SNAPSHOT
-mixinVersion=0.8.1-SNAPSHOT
+mixinVersion=0.8.2
 pluginSpiVersion=0.1.4-SNAPSHOT
 guavaVersion=21.0
 


### PR DESCRIPTION
Bumped:
* `modlauncher` from `4.1.x` to `7.0.x`
* `mixin` from `0.8.1-SNAPSHOT` to `0.8.2`

Also bumped these because Modlauncher bumped them:
* `jopt-simple` from `5.0.3` to `5.0.4`
* `grossjava9hacks` from `1.1.x` to `1.3.x`

It doesn't seem to matter that Modlauncher depends on ASM v7 while Mixin depends on v6, because mixins are still correctly applied. Also no other work needs to be done on our part for applaunch, everything still compiles with this update.

I've also gone ahead and checked that one of my plugins works without the `ServiceLoader` workaround, so `ServiceLoader`s work now as well (also plugin lang services shouldn't be blocked by that now either).