### PR TITLE
Allow GitHub Actions to archive built artifacts for builds

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -34,6 +34,15 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew -PenableTestPlugins=true -PenableSpongeForge=true build
+      - name: Archive artifacts for build
+        uses: actions/upload-artifact@v2
+        with:
+          name: Sponge Jars
+          path: |
+            ${{ github.workspace }}/SpongeAPI/build/libs/*.jar
+            ${{ github.workspace }}/build/libs/*.jar
+            ${{ github.workspace }}/vanilla/build/libs/*.jar
+            ${{ github.workspace }}/forge/build/libs/*.jar
       # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
       # the publishing section of your build.gradle
       - name: Publish to Sponge Maven & GitHub Packages


### PR DESCRIPTION
This is more of an interim (but maybe as well not) solution to see about archiving the builds for each job of PR's as well as pushes to the repo in the `api-8` branch.

I'm convinced that we can take advantage of having the jars available not just on sonatype, but as well on individual builds (which is pretty nifty to be able to download the jar for a particular PR instead of having to clone and build the code yourself)

Pinging @Zidane and @dualspiral to get some thoughts on it.

Here's the proof of concept:
<img width="1071" alt="Screen Shot 2020-10-09 at 2 12 59 AM" src="https://user-images.githubusercontent.com/1203877/95565501-2944f080-09d5-11eb-9b64-cffcb14ab057.png">
Effectively can be viewed, downloaded, and ran with the understanding that the job specifically builds the code from the PR only.