### PR TITLE
Make SystemSubject ICommandSource, add SystemSubject to cause when a Server command source is used.

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeGame.java
+++ b/src/main/java/org/spongepowered/common/SpongeGame.java
@@ -72,7 +72,7 @@ public final class SpongeGame implements Game {
     private Client client;
     private Server server;
 
-    private SystemSubject systemSubject;
+    private ServerConsoleSystemSubject systemSubject;
 
     @Inject
     public SpongeGame(final Platform platform, final GameRegistry registry, final DataManager dataManager, final PluginManager pluginManager,
@@ -100,7 +100,7 @@ public final class SpongeGame implements Game {
     }
 
     @Override
-    public SystemSubject getSystemSubject() {
+    public ServerConsoleSystemSubject getSystemSubject() {
         if (this.systemSubject == null) {
             this.systemSubject = new ServerConsoleSystemSubject();
         }

--- a/src/main/java/org/spongepowered/common/bridge/command/CommandSourceProviderBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/command/CommandSourceProviderBridge.java
@@ -26,10 +26,15 @@ package org.spongepowered.common.bridge.command;
 
 import net.minecraft.command.CommandSource;
 import org.spongepowered.api.event.Cause;
+import org.spongepowered.api.event.CauseStackManager;
 
 public interface CommandSourceProviderBridge {
 
     // we do this because of the lectern tile entity
     CommandSource bridge$getCommandSource(Cause cause);
+
+    default void bridge$addToCauseStack(final CauseStackManager.StackFrame frame) {
+        // no-op for most cases.
+    }
 
 }

--- a/src/main/java/org/spongepowered/common/bridge/command/CommandSourceProviderBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/command/CommandSourceProviderBridge.java
@@ -33,6 +33,8 @@ public interface CommandSourceProviderBridge {
     // we do this because of the lectern tile entity
     CommandSource bridge$getCommandSource(Cause cause);
 
+    // Used to forcibly redirect the server to the system subject to avoid issues with the
+    // server-wide forwarding audience.
     default void bridge$addToCauseStack(final CauseStackManager.StackFrame frame) {
         // no-op for most cases.
     }

--- a/src/main/java/org/spongepowered/common/server/ServerConsoleSystemSubject.java
+++ b/src/main/java/org/spongepowered/common/server/ServerConsoleSystemSubject.java
@@ -26,12 +26,25 @@ package org.spongepowered.common.server;
 
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.text.Component;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.ICommandSource;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.Vec2f;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.dimension.DimensionType;
+import org.apache.logging.log4j.LogManager;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.adventure.SpongeComponents;
+import org.spongepowered.api.event.Cause;
 import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.SpongeSystemSubject;
 import org.spongepowered.common.adventure.SpongeAdventure;
+import org.spongepowered.common.bridge.command.CommandSourceProviderBridge;
 
-public final class ServerConsoleSystemSubject extends SpongeSystemSubject {
+public final class ServerConsoleSystemSubject extends SpongeSystemSubject implements CommandSourceProviderBridge, ICommandSource {
     @Override
     public String getIdentifier() {
         return "console";
@@ -41,4 +54,38 @@ public final class ServerConsoleSystemSubject extends SpongeSystemSubject {
     public void sendMessage(@NonNull final Component message, @NonNull final MessageType type) {
         SpongeCommon.getServer().sendMessage(SpongeAdventure.asVanilla(message));
     }
+
+    @Override
+    public CommandSource bridge$getCommandSource(final Cause cause) {
+        return new CommandSource(this,
+                Vec3d.ZERO,
+                Vec2f.ZERO,
+                SpongeCommon.getServer().getWorld(DimensionType.OVERWORLD),
+                4,
+                "System Subject",
+                new StringTextComponent("System Subject"),
+                SpongeCommon.getServer(),
+                null);
+    }
+
+    @Override
+    public void sendMessage(final ITextComponent component) {
+        SpongeCommon.getLogger().info(component.getString());
+    }
+
+    @Override
+    public boolean shouldReceiveFeedback() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldReceiveErrors() {
+        return true;
+    }
+
+    @Override
+    public boolean allowLogging() {
+        return true;
+    }
+
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/command/CommandSourceMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/command/CommandSourceMixin.java
@@ -51,6 +51,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.common.accessor.entity.EntityAccessor;
 import org.spongepowered.common.bridge.command.CommandSourceBridge;
+import org.spongepowered.common.bridge.command.CommandSourceProviderBridge;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.service.server.permission.SpongePermissions;
 import org.spongepowered.common.util.VecHelper;
@@ -96,6 +97,9 @@ public abstract class CommandSourceMixin implements CommandSourceBridge {
     ) {
         try (final CauseStackManager.StackFrame frame = PhaseTracker.getCauseStackManager().pushCauseFrame()) {
             frame.pushCause(p_i49553_1_);
+            if (p_i49553_1_ instanceof CommandSourceProviderBridge) {
+                ((CommandSourceProviderBridge) p_i49553_1_).bridge$addToCauseStack(frame);
+            }
             this.impl$cause = frame.getCurrentCause();
             final EventContext context = this.impl$cause.getContext();
 


### PR DESCRIPTION
If you execute a command via the console, in vanilla miencraft, it is executed by `MinecraftServer`, in the API, `Server`. `Server` implements `ForwardingAudience`, which sends a message to everyone on the server, which means that if a plugin sends a message to the server when it executes a command, everyone will know about it. This is obviously a problem.

There are three potential solutions:

* In API 7/1.12.2, `MinecraftServer` implemented the `ConsoleSource`, and `sendMessage` just sent a message to the server console, not the entire server. Doing this is perhaps the simplest way to do it and will have the fewest surprises for mods, however, this means that `Server` would not be able to implement `ForwardingAudience`, @Faithcaio suggested creating a getter to do this instead if we go this way.
* Alternatively, this PR forces the system subject onto the stack if the Server is executing a command, but this is special cased. This is an idea, and I'm really not sure I want to do this.
* There was a suggestion that the `CommandSource` could implement `Audience`, but the notion of a `CommandSource` isn't exposed to the system, only the `CommandCause`. I _guess_ we could make `CommandCause` implement `Audience` and make it use `sendMessage(ITextCompoenent)` on `CommandSource`. I might do this, but that means that `CommandCause#getAudience()` would be different and the point of the `getAudience()` method was to get the audience from the context or the cause stack.

I'm really leaning towards wanting to do point 1, but that breaks the idea behind `sendMessage()` on `Server`, so unless we move the `ForwardingAudience` to getters on `Server` and `World`, we can't do that. Point 2 is this what is here... I just don't like it.

Open for discussion. All options are on the table.

