### PR TITLE
Fix case-sensitivity bug in SpongeUserStorageService#match(String)

### DIFF
--- a/src/main/java/org/spongepowered/common/service/user/SpongeUserStorageService.java
+++ b/src/main/java/org/spongepowered/common/service/user/SpongeUserStorageService.java
@@ -113,7 +113,8 @@ public class SpongeUserStorageService implements UserStorageService {
         Collection<GameProfile> allProfiles = UserDiscoverer.getAllProfiles();
         Collection<GameProfile> matching = Sets.newHashSet();
         for (GameProfile profile : allProfiles) {
-            if (profile.getName().isPresent() && profile.getName().get().startsWith(lastKnownName)) {
+            Optional<String> name = profile.getName();
+            if (name.isPresent() && name.get().toLowerCase(Locale.ROOT).startsWith(lastKnownName)) {
                 matching.add(profile);
             }
         }


### PR DESCRIPTION
The current implementation of `SpongeUserStorageService#match(String)` converts the provided `lastKnownName` to lowercase but does not convert the `GameProfile` name to lowercase before comparing it. This means that `GameProfile` names with uppercase characters will never match the lowercase `lastKnownName`.
