### PR TITLE
Fire ChangeWorldGameRuleEvent

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/world/storage/WorldInfoMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/world/storage/WorldInfoMixin_API.java
@@ -44,7 +44,12 @@ import org.spongepowered.api.data.persistence.DataFormats;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.world.ChangeWorldGameRuleEvent;
-import org.spongepowered.api.world.*;
+import org.spongepowered.api.world.DimensionType;
+import org.spongepowered.api.world.GeneratorType;
+import org.spongepowered.api.world.PortalAgentType;
+import org.spongepowered.api.world.SerializationBehavior;
+import org.spongepowered.api.world.SerializationBehaviors;
+import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.difficulty.Difficulty;
 import org.spongepowered.api.world.gen.WorldGeneratorModifier;
 import org.spongepowered.api.world.storage.WorldProperties;
@@ -391,7 +396,7 @@ public abstract class WorldInfoMixin_API implements WorldProperties {
         checkNotNull(gameRule, "The gamerule cannot be null!");
         checkNotNull(value, "The gamerule value cannot be null!");
 
-        Optional<World> optionalTargetWorld = Sponge.getServer().getWorld(getUniqueId());
+        final Optional<World> optionalTargetWorld = Sponge.getServer().getWorld(getUniqueId());
 
         if (optionalTargetWorld.isPresent()) {
             final ChangeWorldGameRuleEvent event = SpongeEventFactory.createChangeWorldGameRuleEvent(

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/world/storage/WorldInfoMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/world/storage/WorldInfoMixin_API.java
@@ -36,16 +36,15 @@ import net.minecraft.world.GameRules;
 import net.minecraft.world.GameType;
 import net.minecraft.world.WorldType;
 import net.minecraft.world.storage.WorldInfo;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataQuery;
 import org.spongepowered.api.data.DataView;
 import org.spongepowered.api.data.persistence.DataFormats;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
-import org.spongepowered.api.world.DimensionType;
-import org.spongepowered.api.world.GeneratorType;
-import org.spongepowered.api.world.PortalAgentType;
-import org.spongepowered.api.world.SerializationBehavior;
-import org.spongepowered.api.world.SerializationBehaviors;
+import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.world.ChangeWorldGameRuleEvent;
+import org.spongepowered.api.world.*;
 import org.spongepowered.api.world.difficulty.Difficulty;
 import org.spongepowered.api.world.gen.WorldGeneratorModifier;
 import org.spongepowered.api.world.storage.WorldProperties;
@@ -391,6 +390,23 @@ public abstract class WorldInfoMixin_API implements WorldProperties {
     public void setGameRule(final String gameRule, final String value) {
         checkNotNull(gameRule, "The gamerule cannot be null!");
         checkNotNull(value, "The gamerule value cannot be null!");
+
+        Optional<World> optionalTargetWorld = Sponge.getServer().getWorld(getUniqueId());
+
+        if (optionalTargetWorld.isPresent()) {
+            final ChangeWorldGameRuleEvent event = SpongeEventFactory.createChangeWorldGameRuleEvent(
+                    Sponge.getCauseStackManager().getCurrentCause(),
+                    gameRules.getString(gameRule),
+                    value,
+                    gameRule,
+                    optionalTargetWorld.get()
+            );
+
+            if (Sponge.getEventManager().post(event)) {
+                return;
+            }
+        }
+
         ((GameRulesBridge) this.gameRules).bridge$setOrCreateGameRule(gameRule, value);
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/command/multiworld/CommandGameRuleMixin_MultiWorldCommand.java
+++ b/src/main/java/org/spongepowered/common/mixin/command/multiworld/CommandGameRuleMixin_MultiWorldCommand.java
@@ -47,7 +47,7 @@ import org.spongepowered.common.bridge.world.WorldServerBridge;
 public abstract class CommandGameRuleMixin_MultiWorldCommand {
 
     private static int currentDimension;
-    private final ThreadLocal<Boolean> modificationCancelled = ThreadLocal.withInitial(() -> false);
+    private boolean modificationCancelled = false;
 
     private static GameRules multiWorldcommand$getGameRules(final ICommandSender sender) {
         currentDimension = ((WorldServerBridge) sender.getEntityWorld()).bridge$getDimensionId();
@@ -64,9 +64,9 @@ public abstract class CommandGameRuleMixin_MultiWorldCommand {
     @Inject(method = "execute", cancellable = true,
             at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = "Lnet/minecraft/world/GameRules;setOrCreateGameRule(Ljava/lang/String;Ljava/lang/String;)V"))
     private void multiWorldCommand$cancelAfterSetOrCreateGameRule(CallbackInfo ci) {
-        if (modificationCancelled.get()) {
+        if (modificationCancelled) {
             ci.cancel();
-            modificationCancelled.set(false);
+            modificationCancelled = false;
         }
     }
 
@@ -82,7 +82,7 @@ public abstract class CommandGameRuleMixin_MultiWorldCommand {
         );
 
         if (Sponge.getEventManager().post(event)) {
-            modificationCancelled.set(true);
+            modificationCancelled = true;
             return;
         }
 


### PR DESCRIPTION
Hey,

As @dualspiral advised me, I'm trying to develop by my own as much as I can instead of reporting issues.
So, I try to make Sponge fire the ChangeWorldGameRuleEvent which was not used.

There is two (_maybe 3_) places where we have to fire this event :

- When using the vanilla command /gamerule
- When using the API to modify game rule
- _And maybe when using the API to remove game rule_. I need your opinion to decide.


This is my first time using the mixins so this is why I marked this PR as WIP, if you have any remarks just let me know.


There is also another point. I would like to give the information for plugin makers that modification of a game rule is cancellable. It means that in the API, WorldProperties#setGameRule should return a `boolean` instead of `void`.
Is this possible or is this a breaking change ?


Thank you for reading this PR.




