### PR TITLE
Fix MC-49577 re-introduced by MixinWorldEntitySpawner.findChunksForSpawning refactor

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/WorldEntitySpawnerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/WorldEntitySpawnerMixin.java
@@ -270,12 +270,13 @@ public abstract class WorldEntitySpawnerMixin {
                                             }
 
                                             entityliving.setLocationAndAngles(spawnX, spawnY, spawnZ, world.rand.nextFloat() * 360.0F, 0.0F);
-                                            final boolean entityNotColliding = entityliving.isNotColliding();
+                                            boolean entityNotColliding = entityliving.isNotColliding();
 
                                             final SpawnerSpawnType type = SpongeImplHooks.canEntitySpawnHere(entityliving, entityNotColliding);
                                             if (type != SpawnerSpawnType.NONE) {
                                                 if (type == SpawnerSpawnType.NORMAL) {
                                                     ientitylivingdata = entityliving.onInitialSpawn(world.getDifficultyForLocation(new BlockPos(entityliving)), ientitylivingdata);
+                                                    entityNotColliding = entityliving.isNotColliding();
                                                 }
 
                                                 if (entityNotColliding) {


### PR DESCRIPTION
**I am currently running**
- SpongeForge version: 1.12.2-2838-7.3.1-RC4093

**Issue Description**

https://bugs.mojang.com/browse/MC-49577
In the process of refactoring, committed in 9e28680, one boolean value was cached into a variable. `entityNotColliding`, to be exact.
The problem is that Slimes and Magma Cubes are initialized in `entityInit()` as small, and change their size (grow) in their `onInitialSpawn()` method, which changes their hitboxes, thus `isNotColliding()` check needs to be ran again.
Which doesn't happen in optimized Sponge code.

Relevant code snippets:
Sponge:
```java
final boolean entityNotColliding = entityliving.isNotColliding();
final SpawnerSpawnType type = SpongeImplHooks.canEntitySpawnHere(entityliving, entityNotColliding);
if (type != SpawnerSpawnType.NONE) {
	if (type == SpawnerSpawnType.NORMAL) {
		ientitylivingdata = entityliving.onInitialSpawn(world.getDifficultyForLocation(new BlockPos(entityliving)), ientitylivingdata);
	}
	if (entityNotColliding) {  // uses value calculated before growth in onInitialSpawn()
		++spawnCount;
		world.spawnEntity(entityliving);
	} else {
		entityliving.setDead();
	}
```
Vanilla:
```java
if (entityliving.getCanSpawnHere() && entityliving.isNotColliding()) {
	ientitylivingdata = entityliving.onInitialSpawn(worldServerIn.getDifficultyForLocation(new BlockPos(entityliving)), ientitylivingdata);
	if (entityliving.isNotColliding()) {  // check ran twice, taking hitbox changes into account
		++j2;
		worldServerIn.spawnEntity(entityliving);
	} else {
		entityliving.setDead();
	}
```

Proposed change: re-check `isNotColliding()`, if `onInitialSpawn()` was called.