### PR TITLE
Add max-chunk-lifetime setting used by chunk gc (#3167) - fixed

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/world/chunk/ChunkBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/world/chunk/ChunkBridge.java
@@ -106,6 +106,10 @@ public interface ChunkBridge {
 
     boolean bridge$isQueuedForUnload();
 
+    long bridge$getLastSaveTime();
+
+    boolean bridge$isChunkDirty();
+
     void bridge$markChunkDirty();
 
     boolean bridge$isActive();

--- a/src/main/java/org/spongepowered/common/config/category/WorldCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/WorldCategory.java
@@ -88,11 +88,21 @@ public class WorldCategory extends ConfigCategory {
 
     @Setting(value = "max-chunk-unloads-per-tick", comment = ""
             + "The maximum number of queued unloaded chunks that will be unloaded in a single tick.\n"
-            + "Note: With the chunk gc enabled, this setting only applies to the ticks\n"
-            + "where the gc runs (controlled by 'chunk-gc-tick-interval')\n"
+            + "Note: this setting only controls the amount chunk gc is allowed to save\n"
+            + "(controlled by 'chunk-gc-tick-interval' and 'chunk-gc-load-threshold')\n"
             + "Note: If the maximum unloads is too low, too many chunks may remain loaded on the world\n"
             + "and increases the chance for a drop in tps. (Default: 100)")
     private int maxChunkUnloads = 100;
+
+    @Setting(value = "max-chunk-lifetime", comment = ""
+            + "The number of ticks a chunk will stay in memory without saving.\n"
+            + "Note: this setting only applies to chunks gc forcibly saving chunks\n"
+            + "(controlled by 'chunk-gc-tick-interval' and 'chunk-gc-load-threshold')\n"
+            + "Note: Useless if 'auto-save-interval' is enabled and less than this value\n"
+            + "Note: 'auto-save-interval' becomes mostly useless if both are enabled and\n"
+            + "it is bigger than this value\n"
+            + "(Default: 0)")
+    private int maxChunkLifetime = 0;
 
     @Setting(value = "chunk-gc-load-threshold", comment = ""
             + "The number of newly loaded chunks before triggering a forced cleanup.\n"
@@ -226,6 +236,10 @@ public class WorldCategory extends ConfigCategory {
 
     public int getMaxChunkUnloads() {
         return this.maxChunkUnloads;
+    }
+
+    public int getMaxChunkLifetime() {
+        return this.maxChunkLifetime;
     }
 
     public double getItemMergeRadius() {

--- a/src/main/java/org/spongepowered/common/mixin/core/world/chunk/ChunkMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/chunk/ChunkMixin.java
@@ -121,6 +121,7 @@ public abstract class ChunkMixin implements ChunkBridge, CacheKeyBridge {
     @Shadow private boolean loaded;
     @Shadow private boolean dirty;
     @Shadow public boolean unloadQueued;
+    @Shadow private long lastSaveTime;
 
     @Shadow @Nullable public abstract TileEntity getTileEntity(BlockPos pos, net.minecraft.world.chunk.Chunk.EnumCreateEntityType p_177424_2_);
     @Shadow public abstract void generateSkylightMap();
@@ -156,8 +157,18 @@ public abstract class ChunkMixin implements ChunkBridge, CacheKeyBridge {
     }
 
     @Override
+    public boolean bridge$isChunkDirty() {
+        return this.dirty;
+    }
+
+    @Override
     public boolean bridge$isQueuedForUnload() {
         return this.unloadQueued;
+    }
+
+    @Override
+    public long bridge$getLastSaveTime() {
+        return this.lastSaveTime;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/ChunkProviderServerMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/ChunkProviderServerMixin.java
@@ -83,6 +83,7 @@ public abstract class ChunkProviderServerMixin implements ChunkProviderServerBri
     private boolean impl$forceChunkRequests = false;
     private long impl$chunkUnloadDelay = Constants.World.DEFAULT_CHUNK_UNLOAD_DELAY;
     private int impl$maxChunkUnloads = Constants.World.MAX_CHUNK_UNLOADS;
+    private int impl$maxChunkLifetime = Constants.World.MAX_CHUNK_LIFETIME;
 
     @Shadow @Final private WorldServer world;
     @Shadow @Final private IChunkLoader chunkLoader;
@@ -108,6 +109,7 @@ public abstract class ChunkProviderServerMixin implements ChunkProviderServerBri
         this.impl$denyChunkRequests = worldCategory.getDenyChunkRequests();
         this.impl$chunkUnloadDelay = worldCategory.getChunkUnloadDelay() * 1000;
         this.impl$maxChunkUnloads = worldCategory.getMaxChunkUnloads();
+        this.impl$maxChunkLifetime = worldCategory.getMaxChunkLifetime();
     }
 
     @Override
@@ -268,10 +270,14 @@ public abstract class ChunkProviderServerMixin implements ChunkProviderServerBri
             final Iterator<Chunk> iterator = this.loadedChunks.values().iterator();
             int chunksUnloaded = 0;
             final long now = System.currentTimeMillis();
+            final long world_time = this.world.getTotalWorldTime();
             while (chunksUnloaded < this.impl$maxChunkUnloads && iterator.hasNext()) {
                 final Chunk chunk = iterator.next();
                 final ChunkBridge spongeChunk = (ChunkBridge) chunk;
-                if (chunk != null && chunk.unloadQueued && !spongeChunk.bridge$isPersistedChunk()) {
+                if (chunk == null || spongeChunk.bridge$isPersistedChunk()) {
+                    continue;
+                }
+                if (chunk.unloadQueued) {
                     if (this.bridge$getChunkUnloadDelay() > 0) {
                         if ((now - spongeChunk.bridge$getScheduledForUnload()) < this.impl$chunkUnloadDelay) {
                             continue;
@@ -279,11 +285,19 @@ public abstract class ChunkProviderServerMixin implements ChunkProviderServerBri
                         spongeChunk.bridge$setScheduledForUnload(-1);
                     }
                     chunk.onUnload();
-                    this.saveChunkData(chunk);
-                    this.saveChunkExtraData(chunk);
-                    iterator.remove();
-                    chunksUnloaded++;
                 }
+                // max lifetime only applies to chunks that should stay loaded but still need saving once in a while
+                else if (this.impl$maxChunkLifetime <= 0 // if setting is disabled
+                        || !spongeChunk.bridge$isChunkDirty() // no need to save non-dirty chunks
+                        || world_time - spongeChunk.bridge$getLastSaveTime() < this.impl$maxChunkLifetime) {
+                    continue;  // don't save chunk data
+                }
+                this.saveChunkData(chunk);
+                this.saveChunkExtraData(chunk);
+                if (chunk.unloadQueued) {  // chunks not queued to unload stay loaded
+                    iterator.remove();
+                }
+                chunksUnloaded++;
             }
             ((WorldServerBridge) this.world).bridge$getTimingsHandler().doChunkUnload.stopTiming();
         }

--- a/src/main/java/org/spongepowered/common/util/Constants.java
+++ b/src/main/java/org/spongepowered/common/util/Constants.java
@@ -396,6 +396,7 @@ public final class Constants {
         public static final UUID INVALID_WORLD_UUID = java.util.UUID.fromString("00000000-0000-0000-0000-000000000000");
         public static final int DEFAULT_CHUNK_UNLOAD_DELAY = 15000;
         public static final int MAX_CHUNK_UNLOADS = 100;
+        public static final int MAX_CHUNK_LIFETIME = 0;
         public static final String GENERATE_BONUS_CHEST = "GenerateBonusChest";
         public static final int CHUNK_UNLOAD_DELAY = 30000;
         public static final int END_DIMENSION_ID = 1;


### PR DESCRIPTION
Fixed a bug in my previous edition of this PR.

> If the chunk is not queued for unload, and the max-lifetime setting is disabled - the chunk gets saved to disk. Every tick.
> That else if should look like `else if (max-lifetime <= 0 || !delay_expired || !isDirty) {continue;}`.

Now that else if looks like it should've. :)
(If only GitHub allowed to reopen merged pull-requests by reverting it's merge commit or something...)