### PR TITLE
[API7] [WIP] Expose portal agents

### DIFF
--- a/src/main/java/org/spongepowered/common/config/category/WorldCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/WorldCategory.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.config.category;
 import net.minecraft.launchwrapper.Launch;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+import org.spongepowered.api.Sponge;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -206,6 +207,15 @@ public class WorldCategory extends ConfigCategory {
 
     public Map<String, String> getPortalAgents() {
         return this.portalAgents;
+    }
+
+    public String getPortalDestination(String dimensionName) {
+        // TODO I would like to know how to retrieve the default world name from here, in a better way than below
+        return this.portalAgents.getOrDefault(dimensionName, Sponge.getServer().getDefaultWorldName());
+    }
+
+    public void setPortalDestination(String dimensionName, String destinationWorldName) {
+        this.portalAgents.put(dimensionName, destinationWorldName);
     }
 
     public boolean getDenyChunkRequests() {

--- a/src/main/java/org/spongepowered/common/config/category/WorldCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/WorldCategory.java
@@ -209,13 +209,12 @@ public class WorldCategory extends ConfigCategory {
         return this.portalAgents;
     }
 
-    public String getPortalDestination(String dimensionName) {
-        // TODO I would like to know how to retrieve the default world name from here, in a better way than below
-        return this.portalAgents.getOrDefault(dimensionName, Sponge.getServer().getDefaultWorldName());
+    public String getPortalDestination(final String portalAgentName) {
+        return this.portalAgents.getOrDefault(portalAgentName, Sponge.getServer().getDefaultWorldName());
     }
 
-    public void setPortalDestination(String dimensionName, String destinationWorldName) {
-        this.portalAgents.put(dimensionName, destinationWorldName);
+    public void setPortalDestination(final String portalAgentName, final String destinationWorldName) {
+        this.portalAgents.put(portalAgentName, destinationWorldName);
     }
 
     public boolean getDenyChunkRequests() {

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/world/storage/WorldInfoMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/world/storage/WorldInfoMixin_API.java
@@ -42,8 +42,11 @@ import org.spongepowered.api.data.DataView;
 import org.spongepowered.api.data.persistence.DataFormats;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.world.DimensionType;
+import org.spongepowered.api.world.DimensionTypes;
 import org.spongepowered.api.world.GeneratorType;
 import org.spongepowered.api.world.PortalAgentType;
+import org.spongepowered.api.world.PortalType;
+import org.spongepowered.api.world.PortalTypes;
 import org.spongepowered.api.world.SerializationBehavior;
 import org.spongepowered.api.world.SerializationBehaviors;
 import org.spongepowered.api.world.difficulty.Difficulty;
@@ -172,6 +175,43 @@ public abstract class WorldInfoMixin_API implements WorldProperties {
     @Override
     public PortalAgentType getPortalAgentType() {
         return ((WorldInfoBridge) this).bridge$getPortalAgent();
+    }
+
+    @Override
+    public Map<String, String> getPortalAgents() {
+        return ((WorldInfoBridge) this).bridge$getConfigAdapter().getConfig().getWorld().getPortalAgents();
+    }
+
+    @Override
+    public String getPortalDestination(PortalType portalType) {
+        String portalName = "minecraft:default_overworld";
+
+        if (DimensionTypes.OVERWORLD.equals(((WorldInfoBridge) this).bridge$getDimensionType())) {
+            if (PortalTypes.NETHER.equals(portalType)) {
+                portalName = "minecraft:default_the_nether";
+            } else if (PortalTypes.END.equals(portalType)) {
+                portalName = "minecraft:default_the_end";
+            }
+        }
+
+        return ((WorldInfoBridge) this).bridge$getConfigAdapter().getConfig().getWorld().getPortalDestination(portalName);
+    }
+
+    @Override
+    public void setPortalDestination(PortalType portalType, String destinationWorldName) {
+        checkNotNull(destinationWorldName, "The destination world name cannot be null!");
+
+        String portalName = "minecraft:default_overworld";
+
+        if (DimensionTypes.OVERWORLD.equals(((WorldInfoBridge) this).bridge$getDimensionType())) {
+            if (PortalTypes.NETHER.equals(portalType)) {
+                portalName = "minecraft:default_the_nether";
+            } else if (PortalTypes.END.equals(portalType)) {
+                portalName = "minecraft:default_the_end";
+            }
+        }
+
+        ((WorldInfoBridge) this).bridge$getConfigAdapter().getConfig().getWorld().setPortalDestination(portalName, destinationWorldName);
     }
 
     @Intrinsic

--- a/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
@@ -404,6 +404,7 @@ public final class CommonModuleRegistry {
                 .registerModule(PlantType.class, new PlantTypeModuleRegistry())
                 .registerModule(PopulatorObject.class, new PopulatorObjectRegistryModule())
                 .registerModule(PopulatorType.class, PopulatorTypeRegistryModule.getInstance())
+                .registerModule(PortalType.class, new PortalTypeRegistryModule())
                 .registerModule(PortionType.class, new PortionTypeRegistryModule())
                 .registerModule(PotionType.class, PotionTypeRegistryModule.getInstance())
                 .registerModule(PotionEffectType.class, PotionEffectTypeRegistryModule.getInstance())

--- a/src/main/java/org/spongepowered/common/registry/type/world/PortalTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/world/PortalTypeRegistryModule.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ * This file is part of Sponge, licensed under the MIT License (MIT).
  *
  * Copyright (c) SpongePowered <https://www.spongepowered.org>
  * Copyright (c) contributors

--- a/src/main/java/org/spongepowered/common/registry/type/world/PortalTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/world/PortalTypeRegistryModule.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.common.registry.type.world;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/src/main/java/org/spongepowered/common/registry/type/world/PortalTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/world/PortalTypeRegistryModule.java
@@ -1,0 +1,44 @@
+package org.spongepowered.common.registry.type.world;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableMap;
+import org.spongepowered.api.registry.util.RegisterCatalog;
+import org.spongepowered.api.world.PortalType;
+import org.spongepowered.api.world.PortalTypes;
+import org.spongepowered.common.registry.SpongeAdditionalCatalogRegistryModule;
+import org.spongepowered.common.world.SpongePortalType;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+public class PortalTypeRegistryModule implements SpongeAdditionalCatalogRegistryModule<PortalType> {
+
+    @RegisterCatalog(PortalTypes.class)
+    private final Map<String, PortalType> portalTypeMap = ImmutableMap.<String, PortalType>builder()
+            .put("end", new SpongePortalType("end", "End"))
+            .put("nether", new SpongePortalType("nether", "Nether"))
+            .build();
+
+    @Override
+    public boolean allowsApiRegistration() {
+        return false;
+    }
+
+    @Override
+    public void registerAdditionalCatalog(PortalType extraCatalog) {
+    }
+
+    @Override
+    public Optional<PortalType> getById(String id) {
+        return Optional.ofNullable(this.portalTypeMap.get(checkNotNull(id, "PortalType ID cannot be null!")
+                .toLowerCase(Locale.ENGLISH)));
+    }
+
+    @Override
+    public Collection<PortalType> getAll() {
+        return this.portalTypeMap.values();
+    }
+}

--- a/src/main/java/org/spongepowered/common/world/SpongePortalType.java
+++ b/src/main/java/org/spongepowered/common/world/SpongePortalType.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ * This file is part of Sponge, licensed under the MIT License (MIT).
  *
  * Copyright (c) SpongePowered <https://www.spongepowered.org>
  * Copyright (c) contributors

--- a/src/main/java/org/spongepowered/common/world/SpongePortalType.java
+++ b/src/main/java/org/spongepowered/common/world/SpongePortalType.java
@@ -1,0 +1,19 @@
+package org.spongepowered.common.world;
+
+import org.spongepowered.api.world.PortalType;
+import org.spongepowered.common.SpongeCatalogType;
+
+public class SpongePortalType extends SpongeCatalogType implements PortalType {
+
+    private final String name;
+
+    public SpongePortalType(String id, String name) {
+        super(id);
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+}

--- a/src/main/java/org/spongepowered/common/world/SpongePortalType.java
+++ b/src/main/java/org/spongepowered/common/world/SpongePortalType.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.common.world;
 
 import org.spongepowered.api.world.PortalType;


### PR DESCRIPTION
**SpongeCommon | [SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2264)**


In this PR I'm trying to expose the management of portal agents directly from the API.

There is a bit of logic in both methods WorldInfoMixin_API, based on these facts : 

- From the overworld, going through a Nether portal will trigger the "minecraft:default_the_nether" portal agent.
- From the overworld, going through a End portal will trigger the "minecraft:default_the_end" portal agent.
- From the Nether, going through a Nether/End portal will trigger the "minecraft:default_overworld" portal agent.
- From the End, going through a Nether/End portal will trigger the "minecraft:default_overworld" portal agent.


There is a third portal type known as END_GATEWAY in Minecraft, but since this type of portal is not even firing MoveEntityEvent, I guess it deserves its own PR.


I have a TODO to find a way to retrieve the default world name in the server as this world is the default world redirection if no portal-agent is set, or if destination worlds are not loaded.


Thanks for reading this PR.