### PR TITLE
Expose entity tags

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/EntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/EntityMixin_API.java
@@ -106,6 +106,7 @@ import org.spongepowered.common.util.VecHelper;
 import org.spongepowered.common.world.WorldManager;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -141,6 +142,7 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
     @Shadow protected EntityDataManager dataManager;
     @Shadow public int dimension;
     @Shadow protected UUID entityUniqueID;
+    @Shadow public Set<String> tags;
 
     @Shadow public abstract void setPosition(double x, double y, double z);
     @Shadow public abstract void setDead();
@@ -680,6 +682,34 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
         this.get(TargetedLocationData.class).ifPresent(manipulators::add);
         this.get(VehicleData.class).ifPresent(manipulators::add);
         this.get(VelocityData.class).ifPresent(manipulators::add);
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.unmodifiableSet(this.tags);
+    }
+
+    @Override
+    public boolean addTag(final String tag) {
+        checkNotNull(tag);
+
+        if (this.tags.size() >= 1024) {
+            return false;
+        }
+
+        return this.tags.add(tag);
+    }
+
+    @Override
+    public boolean removeTag(final String tag) {
+        checkNotNull(tag);
+        return this.tags.remove(tag);
+    }
+
+    @Override
+    public boolean hasTag(final String tag) {
+        checkNotNull(tag);
+        return this.tags.contains(tag);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/EntityMixin_API.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/mcp/entity/EntityMixin_API.java
@@ -163,6 +163,8 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
     @Shadow public abstract void playSound(SoundEvent soundIn, float volume, float pitch);
     @Shadow public abstract boolean hasNoGravity();
     @Shadow protected abstract void shadow$setRotation(float yaw, float pitch);
+    @Shadow public abstract boolean shadow$addTag(String tag);
+    @Shadow public abstract boolean shadow$removeTag(String tag);
 
     // @formatter:on
 
@@ -685,25 +687,18 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
     }
 
     @Override
-    public Set<String> getTags() {
+    public Collection<String> getTags() {
         return Collections.unmodifiableSet(this.tags);
     }
 
-    @Override
-    public boolean addTag(final String tag) {
-        checkNotNull(tag);
-
-        if (this.tags.size() >= 1024) {
-            return false;
-        }
-
-        return this.tags.add(tag);
+    @Intrinsic
+    public boolean entity$addTag(final String tag) {
+        return this.shadow$addTag(tag);
     }
 
-    @Override
-    public boolean removeTag(final String tag) {
-        checkNotNull(tag);
-        return this.tags.remove(tag);
+    @Intrinsic
+    public boolean entity$removeTag(final String tag) {
+        return this.shadow$removeTag(tag);
     }
 
     @Override


### PR DESCRIPTION
**SpongeCommon | [SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2266)**

Hey,

Here is a small PR trying to expose entity tags which can be used as selector arguments in commands.
Until now they were not exposed in the API.

Learn more about tags: https://minecraft.gamepedia.com/Scoreboard#Tags

Thanks for reading this PR.