### PR TITLE
Proxy PhaseState method access to avoid raw typing

### DIFF
--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -130,7 +130,6 @@ import org.spongepowered.common.bridge.world.chunk.ChunkBridge;
 import org.spongepowered.common.entity.EntityUtil;
 import org.spongepowered.common.entity.PlayerTracker;
 import org.spongepowered.common.entity.projectile.UnknownProjectileSource;
-import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.phase.general.GeneralPhase;
@@ -426,7 +425,7 @@ public final class SpongeCommonEventFactory {
                 }
             }
 
-            if (!((IPhaseState) phaseContext.state).shouldProvideModifiers(phaseContext)) {
+            if (!phaseContext.shouldProvideModifiers()) {
                 phaseContext.getSource(BlockBridge.class).ifPresent(bridge -> {
                     bridge.bridge$getTickFrameModifier().accept(frame, worldIn);
                 });

--- a/src/main/java/org/spongepowered/common/event/tracking/PhaseStateProxy.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/PhaseStateProxy.java
@@ -1,0 +1,470 @@
+package org.spongepowered.common.event.tracking;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraft.world.storage.loot.LootContext;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.block.BlockSnapshot;
+import org.spongepowered.api.block.transaction.Operation;
+import org.spongepowered.api.data.Transaction;
+import org.spongepowered.api.event.Cause;
+import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.api.event.cause.entity.SpawnType;
+import org.spongepowered.api.event.entity.SpawnEntityEvent;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.util.Tuple;
+import org.spongepowered.api.world.BlockChangeFlag;
+import org.spongepowered.api.world.SerializationBehavior;
+import org.spongepowered.common.block.SpongeBlockSnapshot;
+import org.spongepowered.common.bridge.block.TrackerBlockEventDataBridge;
+import org.spongepowered.common.bridge.util.concurrent.TrackedTickDelayedTaskBridge;
+import org.spongepowered.common.bridge.world.TrackedWorldBridge;
+import org.spongepowered.common.entity.PlayerTracker;
+import org.spongepowered.common.event.tracking.context.transaction.ChangeBlock;
+import org.spongepowered.common.event.tracking.context.transaction.GameTransaction;
+import org.spongepowered.common.event.tracking.context.transaction.SpawnEntityTransaction;
+import org.spongepowered.common.event.tracking.phase.general.ExplosionContext;
+import org.spongepowered.common.event.tracking.phase.generation.GenerationPhase;
+import org.spongepowered.common.event.tracking.phase.tick.LocationBasedTickContext;
+import org.spongepowered.common.world.BlockChange;
+
+import java.util.List;
+import java.util.Random;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public interface PhaseStateProxy<C extends PhaseContext<C>> {
+
+    IPhaseState<C> getState();
+
+    C asContext();
+
+    /**
+     * Gets the frame modifier for default frame modifications, like pushing
+     * the source of the phase, owner, notifier, etc. of the context. Used specifically
+     * for lazy evaluating stack frames to push causes and contexts guaranteed at any point
+     * in this state.
+     * @return
+     */
+    default BiConsumer<CauseStackManager.StackFrame, C> getFrameModifier() {
+        return this.getState().getFrameModifier();
+    }
+
+    /**
+     * Gets whether this phase is expected to potentially re-enter itself, in some cases where
+     * other operations tend to cause extra operations being performed. Examples include but are
+     * not limited to: World Generation, {@link GenerationPhase.State#TERRAIN_GENERATION} or
+     * {@link GenerationPhase.State#POPULATOR_RUNNING}. If thi
+     *
+     * @return True if this phase is potentially expected to re-enter on itself
+     */
+    default boolean isNotReEntrant() {
+        return this.getState().isNotReEntrant();
+    }
+
+    /**
+     * Gets whether this state is considered an interaction, specifically to determine
+     * whether a pre-block event check can be performed prior to actual block modifications
+     * are done and potentially "captured" as a result. This is specific to allow mod compatibility
+     * with common protection plugins having the ability to determine whether a proposed block
+     * change is allowed or not.
+     *
+     * @return Whether this state is considered a player caused interaction or not
+     */
+    default boolean isInteraction() {
+        return this.getState().isInteraction();
+    }
+
+    /**
+     * Gets whether this state is considered a "ticking" state. Specifically such that when
+     * {@link Chunk#getEntitiesWithinAABBForEntity(Entity, AxisAlignedBB, List, Predicate)} is used,
+     * we are not filtering any of the lists, whereas if this state is a ticking state, it will
+     * filter the proposed list of entities to supply any potentially captured entities.
+     *
+     * @return Whether this state is a ticking state or not
+     */
+    default boolean isTicking() {
+        return this.getState().isTicking();
+    }
+
+    /**
+     * Gets whether this state is considered a "world generation" state. Usually world generation
+     * is a common flag to say "hey, don't bother capturing anything". So, as it would be expected,
+     * block changes, entity spawns, and whatnot are not tracked in any way during generation
+     * states.
+     *
+     * @return Whether this state is a world generation state or not
+     */
+    default boolean isWorldGeneration() {
+        return this.getState().isWorldGeneration();
+    }
+
+    /**
+     * If this returns {@link true}, block decays will be processed in this
+     * phase state. If this returns {@link false}, block decays will be
+     * processed in a separate phase state.
+     *
+     * @return Whether this phase should track decays
+     */
+    default boolean includesDecays() {
+        return this.getState().includesDecays();
+    }
+
+    /**
+     * Specifically designed to allow certain registries use the event listener hooks to prevent unnecessary off-threaded
+     * checks and allows for registries to restrict additional registrations ouside of events.
+     *
+     * @return True if this is an event listener state
+     */
+    default boolean isEvent() {
+        return this.getState().isEvent();
+    }
+
+    /**
+     * Performs any necessary custom logic after the provided {@link BlockSnapshot}
+     * {@link Transaction} has taken place.
+     *
+     * @param blockChange The block change performed
+     * @param snapshotTransaction The transaction of the old and new snapshots
+     */
+    default void postBlockTransactionApplication(final BlockChange blockChange, final Transaction<? extends BlockSnapshot> snapshotTransaction) {
+        this.getState().postBlockTransactionApplication(blockChange, snapshotTransaction, this.asContext());
+    }
+
+    /**
+     * Specifically gets whether this state ignores any attempts at storing
+     * or retrieving an owner/notifier from a particular {@link BlockPos}
+     * within a {@link net.minecraft.world.World} or {@link Chunk}.
+     *
+     * <p>Specifically used in
+     * {@code ChunkMixin_OwnershipTracked#bridge$addTrackedBlockPosition(Block, BlockPos, User, PlayerTracker.Type)}
+     * to make sure that the current state would be providing said information,
+     * instead of spending the processing to query for it.</p>
+     *
+     * @return Simple true false to determine whether this phase is providing owner/notifier information
+     */
+    default boolean tracksCreatorsAndNotifiers() {
+        return this.getState().tracksCreatorsAndNotifiers();
+    }
+
+    /**
+     * Gets whether this state will allow entities to spawn, in general, not whether they're captured,
+     * directly spawned, or throw an event, but whether the entity will be *able* to spawn. In general
+     * this is returned {@code false} for block restoration, since restoring blocks is a restorative
+     * process, we should not be respawning any entities as a side effect.
+     *
+     * @return True if entities are allowed to spawn
+     */
+    default boolean doesAllowEntitySpawns() {
+        return this.getState().doesAllowEntitySpawns();
+    }
+
+    /**
+     * Whether this state can deny chunk load/generation requests. Certain states can allow them
+     * and certain others can deny them. Usually the denials are coming from states like ticks
+     * where we are not intending to allow chunks to be loaded due to possible generation and
+     * runaway chunk loading.
+     *
+     * @return Whether this state denies chunk requests, usually false
+     */
+    default boolean doesDenyChunkRequests() {
+        return this.getState().doesDenyChunkRequests(this.asContext());
+    }
+
+    default boolean doesBlockEventTracking() {
+        return this.getState().doesBlockEventTracking(this.asContext());
+    }
+
+    /**
+     * Gets whether this state fires {@link org.spongepowered.api.event.entity.CollideEntityEvent}s.
+     * This is used for firing the events and for related optimizations.
+     *
+     * @return Whether this state should fire entity collision events
+     */
+    default boolean isCollision() {
+        return this.getState().isCollision();
+    }
+
+    /**
+     * Gets whether this state will ignore {@link net.minecraft.world.World#addBlockEvent(BlockPos, Block, int, int)}
+     * additions when potentially performing notification updates etc. Usually true for world generation.
+     *
+     * @return False if block events are to be processed in some way by the state
+     */
+    default boolean ignoresBlockEvent() {
+        return this.getState().ignoresBlockEvent();
+    }
+
+    /**
+     * Gets whether this state will already consider any captures or extra processing for a
+     * {@link Block#tick(BlockState, net.minecraft.world.World, BlockPos, Random)}. Again usually
+     * considered for world generation or post states or block restorations.
+     *
+     * @return True if it's going to be ignored
+     */
+    default boolean ignoresBlockUpdateTick() {
+        return this.getState().ignoresBlockUpdateTick(this.asContext());
+    }
+
+    /**
+     * Gets whether this state will need to perform any extra processing for
+     * scheduled block updates, specifically linking the block update event to
+     * the world, the state and possibly context. Usually only necessary for
+     * post states so that no extra processing takes place.
+     *
+     * @return False if scheduled block updates are normally processed
+     */
+    default boolean ignoresScheduledUpdates() {
+        return this.getState().ignoresScheduledUpdates();
+    }
+
+    /**
+     * Gets whether this state is already capturing block tick changes, specifically in
+     * that some states (like post) will be smart enough to capture multiple changes for
+     * multiple block positions without the need to enter new phases. Currently gone unused
+     * since some refactor.
+     * // TODO - clean up usage? Find out where this came from and why it was used
+     *
+     * @return
+     */
+    default boolean alreadyCapturingBlockTicks() {
+        return this.getState().alreadyCapturingBlockTicks(this.asContext());
+    }
+
+    /**
+     * Gets whether this state is already capturing custom entity spawns from plugins.
+     * Examples include listener states, post states, or explosion states.
+     *
+     * @return True if entity spawns are already expected to be processed
+     */
+    default boolean alreadyCapturingEntitySpawns() {
+        return this.getState().alreadyCapturingEntitySpawns();
+    }
+
+    /**
+     * Gets whether this state is already expecting to capture or process changes from
+     * entity ticks. Usually only used for Post states.
+     *
+     * @return True if entity tick processing is already handled in this state
+     */
+    default boolean alreadyCapturingEntityTicks() {
+        return this.getState().alreadyCapturingEntityTicks();
+    }
+
+    /**
+     * Gets whether this state is already expecting to capture or process changes from
+     * tile entity ticks. Used in Post states. (this avoids re-entering new phases during post processing)
+     *
+     * @return True if entity tick processing is already handled in this state
+     */
+    default boolean alreadyCapturingTileTicks() {
+        return this.getState().alreadyCapturingTileTicks();
+    }
+
+    /**
+     * Gets whether this state requires a post state entry for any captured objects. Usually
+     * does not, get used uless this is already a post state, or an invalid packet state.
+     * TODO - Investigate whether world generation states could use this.
+     *
+     * @return True if this state is expecting to be unwound with an unwinding state to cpature additional changes
+     */
+    default boolean requiresPost() {
+        return this.getState().requiresPost();
+    }
+
+
+    /**
+     * Gets whether this state is going to complete itself for plugin provided
+     * changes. Used for BlockWorkers.
+     * TODO - Investigate whether we can enable listener phase states to handle
+     * this as well.
+     * @return True if this state does not need a custom block worker state for plugin changes
+     */
+    default boolean handlesOwnStateCompletion() {
+        return this.getState().handlesOwnStateCompletion();
+    }
+
+    /**
+     * Associates any notifier/owner information from expected states that will assuredly provide
+     * said information. In some states, like world gen, there is no information to provide.
+     *
+     * @param sourcePos The source position performing the notification
+     * @param block The block type providing the notification
+     * @param notifyPos The notified position
+     * @param minecraftWorld The world
+     * @param notifier The tracker type (owner or notifier)
+     */
+    default void associateNeighborStateNotifier(@Nullable final BlockPos sourcePos, final Block block, final BlockPos notifyPos,
+        final ServerWorld minecraftWorld, final PlayerTracker.Type notifier) {
+        this.getState().associateNeighborStateNotifier(this.asContext(), sourcePos, block, notifyPos,minecraftWorld, notifier);
+    }
+
+    /**
+     * Provides additional information from this state in the event an explosion is going to be
+     * performed, providing information like entity owners, notifiers, or potentially even sources
+     * from blocks.
+     *
+     * @param explosionContext The explosion context to populate
+     */
+    default void appendContextPreExplosion(final ExplosionContext explosionContext) {
+        this.getState().appendContextPreExplosion(explosionContext, this.asContext());
+    }
+
+    /**
+     * Appends additional information from the block's position in the world to provide notifier/owner
+     * information. Overridden in world generation states to reduce chunk lookup costs and since
+     * world generation does not track owners/notifiers.
+     *  @param world The world reference
+     * @param pos The position being updated
+     * @param phaseContext the block tick context being entered
+     */
+    default void appendNotifierPreBlockTick(final ServerWorld world, final BlockPos pos, final LocationBasedTickContext<@NonNull ?> phaseContext) {
+        this.getState().appendNotifierPreBlockTick(world, pos, this.asContext(), phaseContext);
+    }
+
+    /**
+     * Appends any additional information to the block tick context from this context.
+     */
+    default void appendNotifierToBlockEvent(
+        final TrackedWorldBridge mixinWorldServer, final BlockPos pos, final TrackerBlockEventDataBridge blockEvent
+    ) {
+        this.getState().appendNotifierToBlockEvent(this.asContext(), mixinWorldServer, pos, blockEvent);
+    }
+
+    /**
+     * Attempts to capture the player using the item stack in this state. Some states do not care for
+     * this information. Usually packets do care and some scheduled tasks.
+     *
+     * @param itemStack
+     * @param playerIn
+     */
+    default void capturePlayerUsingStackToBreakBlock(final ItemStack itemStack, final @Nullable ServerPlayerEntity playerIn) {
+        this.getState().capturePlayerUsingStackToBreakBlock(itemStack, playerIn, this.asContext());
+    }
+
+    /**
+     * Used in the {@link org.spongepowered.api.event.EventManager} and mod event manager equivalent for
+     * world generation tasks to avoid event listener state entrance due to listeners
+     * during world generation performing various operations that should not be tracked.
+     *
+     * <p>Refer to spongeforge issue:
+     * https://github.com/SpongePowered/SpongeForge/issues/2407#issuecomment-415850841
+     * for more information and context of why this is needed.
+     * </p>
+     *
+     * @return True if an {@link org.spongepowered.common.event.tracking.phase.plugin.PluginPhase.Listener#GENERAL_LISTENER}
+     *     is to be entered during this state
+     */
+    default boolean allowsEventListener() {
+        return this.getState().allowsEventListener();
+    }
+
+    default boolean isRegeneration() {
+        return this.getState().isRegeneration();
+    }
+
+    /**
+     * Specifically captures a block change by {@link org.spongepowered.common.event.tracking.context.transaction.TransactionalCaptureSupplier#logBlockChange(SpongeBlockSnapshot, BlockState, BlockChangeFlag)}
+     * such that the change of a {@link BlockState} will be appropriately logged, along with any changes of tile entities being removed
+     * or added, likewise, this will avoid duplicating transactions later after the fact, in the event that multiple changes are taking
+     * place, including but not withstanding, tile entity replacements after the fact.
+     * @return
+     */
+    default ChangeBlock createTransaction(final SpongeBlockSnapshot originalBlockSnapshot, final BlockState newState,
+        final BlockChangeFlag flags
+    ) {
+        return this.getState().createTransaction(this.asContext(), originalBlockSnapshot, newState, flags);
+    }
+
+    default boolean doesCaptureNeighborNotifications() {
+        return this.getState().doesCaptureNeighborNotifications(this.asContext());
+    }
+
+    default BlockChange associateBlockChangeWithSnapshot(final BlockState newState, final Block newBlock,
+        final BlockState currentState, final SpongeBlockSnapshot snapshot,
+        final Block originalBlock
+    ) {
+        return this.getState().associateBlockChangeWithSnapshot(this.asContext(), newState, newBlock,currentState, snapshot, originalBlock);
+    }
+
+    /**
+     * Gets whether this {@link IPhaseState} entry with a provided {@link PhaseContext}
+     * will be allowed to register it's {@link #getFrameModifier()} to push along the
+     * {@link CauseStackManager}. In certain cases, there are states that can have
+     * excessive modifiers being pushed and popped with and without causes that may cause
+     * performance degredation due to the excessive amounts of how many recyclings occur
+     * with {@link CauseStackManager#getCurrentCause()} lacking a cached context
+     * and therefor needing to re-create the context each and every time.
+     *
+     * @return True if the modifiers should be pushed to the manager
+     */
+    default boolean shouldProvideModifiers() {
+        return this.getState().shouldProvideModifiers(this.asContext());
+    }
+    default boolean isRestoring() {
+        return this.getState().isRestoring();
+    }
+
+    /**
+     * When false, prevents directories from being created during the creation
+     * of an {@link }. Used
+     * for {@link SerializationBehavior#NONE}.
+     *
+     * @return True if directories can be created; false otherwise
+     */
+    default boolean shouldCreateWorldDirectories() {
+        return this.getState().shouldCreateWorldDirectories(this.asContext());
+    }
+
+    default boolean isConvertingMaps() {
+        return this.getState().isConvertingMaps();
+    }
+    default boolean allowsGettingQueuedRemovedTiles() {
+        return this.getState().allowsGettingQueuedRemovedTiles();
+    }
+
+    /**
+     * Allows phases to be notified when an entity successfully teleports
+     * between dimensions.
+     *
+     */
+    default void markTeleported() {
+        this.getState().markTeleported(this.asContext());
+    }
+
+    default Supplier<SpawnType> getSpawnTypeForTransaction(final Entity entityToSpawn) {
+        return this.getState().getSpawnTypeForTransaction(this.asContext(), entityToSpawn);
+    }
+
+    default SpawnEntityEvent createSpawnEvent(final GameTransaction<@NonNull ?> parent,
+        final ImmutableList<Tuple<Entity, SpawnEntityTransaction.DummySnapshot>> collect,
+        final Cause currentCause
+    ) {
+        return this.getState().createSpawnEvent(this.asContext(), parent, collect, currentCause);
+    }
+
+    default boolean recordsEntitySpawns() {
+        return this.getState().recordsEntitySpawns(this.asContext());
+    }
+
+    default void populateLootContext(LootContext.Builder lootBuilder) {
+        this.getState().populateLootContext(this.asContext(), lootBuilder);
+    }
+
+    default Operation getBlockOperation(SpongeBlockSnapshot original, BlockChange blockChange) {
+        return this.getState().getBlockOperation(original, blockChange);
+    }
+
+    default void foldContextForThread(TrackedTickDelayedTaskBridge returnValue) {
+        this.getState().foldContextForThread(this.asContext(), returnValue);
+    }
+}

--- a/src/main/java/org/spongepowered/common/event/tracking/PhaseStateProxy.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/PhaseStateProxy.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.common.event.tracking;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/spongepowered/common/event/tracking/PhaseTracker.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/PhaseTracker.java
@@ -346,7 +346,7 @@ public final class PhaseTracker implements CauseStackManager {
             }
         }
 
-        if (((IPhaseState) state).shouldProvideModifiers(phaseContext)) {
+        if (phaseContext.shouldProvideModifiers()) {
             this.registerPhaseContextProvider(phaseContext);
         }
         this.stack.push(state, phaseContext);

--- a/src/main/java/org/spongepowered/common/event/tracking/TrackingUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/TrackingUtil.java
@@ -265,12 +265,11 @@ public final class TrackingUtil {
         final BlockTickContext phaseContext = TickPhase.Tick.BLOCK.createPhaseContext(PhaseTracker.SERVER).source(locatable);
 
         // We have to associate any notifiers in case of scheduled block updates from other sources
-        final PhaseContext<?> currentContext = PhaseTracker.getInstance().getPhaseContext();
-        final IPhaseState<?> currentState = currentContext.state;
-        ((IPhaseState) currentState).appendNotifierPreBlockTick(world, pos, currentContext, phaseContext);
+        final PhaseContext<@NonNull ?> currentContext = PhaseTracker.getInstance().getPhaseContext();
+        currentContext.appendNotifierPreBlockTick(world, pos, phaseContext);
         // Now actually switch to the new phase
 
-        try (final PhaseContext<?> context = phaseContext;
+        try (final PhaseContext<@NonNull ?> context = phaseContext;
              final Timing timing = ((TimingBridge) block.getBlock()).bridge$getTimingsHandler()) {
             timing.startTiming();
             context.buildAndSwitch();
@@ -305,8 +304,7 @@ public final class TrackingUtil {
 
         // We have to associate any notifiers in case of scheduled block updates from other sources
         final PhaseContext<@NonNull ?> currentContext = PhaseTracker.getInstance().getPhaseContext();
-        final IPhaseState<@NonNull ?> currentState = currentContext.state;
-        ((IPhaseState) currentState).appendNotifierPreBlockTick(world, pos, currentContext, phaseContext);
+        currentContext.appendNotifierPreBlockTick(world, pos, phaseContext);
         // Now actually switch to the new phase
 
         try (final PhaseContext<?> context = phaseContext;
@@ -346,11 +344,10 @@ public final class TrackingUtil {
         final BlockTickContext phaseContext = TickPhase.Tick.RANDOM_BLOCK.createPhaseContext(PhaseTracker.SERVER).source(locatable);
 
         // We have to associate any notifiers in case of scheduled block updates from other sources
-        final PhaseContext<?> currentContext = PhaseTracker.getInstance().getPhaseContext();
-        final IPhaseState<?> currentState = currentContext.state;
-        ((IPhaseState) currentState).appendNotifierPreBlockTick(world, pos, currentContext, phaseContext);
+        final PhaseContext<@NonNull ?> currentContext = PhaseTracker.getInstance().getPhaseContext();
+        currentContext.appendNotifierPreBlockTick(world, pos, phaseContext);
         // Now actually switch to the new phase
-        try (final PhaseContext<?> context = phaseContext) {
+        try (final PhaseContext<@NonNull ?> context = phaseContext) {
             context.buildAndSwitch();
             PhaseTracker.LOGGER.trace(TrackingUtil.BLOCK_TICK, () -> "Wrapping Random Block Tick: " + state.toString());
             state.randomTick(world, pos, random);
@@ -384,10 +381,9 @@ public final class TrackingUtil {
 
         // We have to associate any notifiers in case of scheduled block updates from other sources
         final PhaseContext<@NonNull ?> currentContext = PhaseTracker.getInstance().getPhaseContext();
-        final IPhaseState<@NonNull ?> currentState = currentContext.state;
-        ((IPhaseState) currentState).appendNotifierPreBlockTick(world, pos, currentContext, phaseContext);
+        currentContext.appendNotifierPreBlockTick(world, pos, phaseContext);
         // Now actually switch to the new phase
-        try (final PhaseContext<?> context = phaseContext) {
+        try (final PhaseContext<@NonNull ?> context = phaseContext) {
             context.buildAndSwitch();
             PhaseTracker.LOGGER.trace(TrackingUtil.FLUID_TICK, () -> "Wrapping Random Fluid Tick: " + state.toString());
             state.randomTick(world, pos, random);

--- a/src/main/java/org/spongepowered/common/event/tracking/UnwindingPhaseContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/UnwindingPhaseContext.java
@@ -59,7 +59,7 @@ public final class UnwindingPhaseContext extends PhaseContext<UnwindingPhaseCont
         super(GeneralPhase.Post.UNWINDING, unwindingContext.createdTracker);
         this.unwindingState = unwindingState;
         this.unwindingContext = unwindingContext;
-        this.setBlockEvents(((IPhaseState) unwindingState).doesBlockEventTracking(unwindingContext));
+        this.setBlockEvents(unwindingContext.doesBlockEventTracking());
         // Basically put, the post state needs to understand that if we're expecting potentially chained block changes
         // to worlds, AND we're potentially getting any neighbor notification requests OR tile entity requests,
         // we'll need to switch on to capture such objects. If for example, we do not track tile changes, but we track

--- a/src/main/java/org/spongepowered/common/event/tracking/UnwindingState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/UnwindingState.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.event.tracking;
 import net.minecraft.block.Block;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.server.ServerWorld;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.common.entity.PlayerTracker;
 import org.spongepowered.common.event.tracking.phase.general.ExplosionContext;
 
@@ -90,27 +91,24 @@ public final class UnwindingState implements IPhaseState<UnwindingPhaseContext> 
     @SuppressWarnings("unchecked")
     @Override
     public void appendContextPreExplosion(final ExplosionContext explosionContext, final UnwindingPhaseContext context) {
-        final IPhaseState<?> phaseState = context.getUnwindingState();
-        final PhaseContext<?> unwinding = context.getUnwindingContext();
-        ((IPhaseState) phaseState).appendContextPreExplosion(explosionContext, unwinding);
+        final PhaseContext<@NonNull ?> unwinding = context.getUnwindingContext();
+        unwinding.appendContextPreExplosion(explosionContext);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void associateNeighborStateNotifier(final UnwindingPhaseContext context, @Nullable final BlockPos sourcePos, final Block block, final BlockPos notifyPos,
                                                final ServerWorld minecraftWorld, final PlayerTracker.Type notifier) {
-        final IPhaseState<?> unwindingState = context.getUnwindingState();
-        final PhaseContext<?> unwindingContext = context.getUnwindingContext();
-        ((IPhaseState) unwindingState).associateNeighborStateNotifier(unwindingContext, sourcePos, block, notifyPos, minecraftWorld, notifier);
+        final PhaseContext<@NonNull ?> unwindingContext = context.getUnwindingContext();
+        unwindingContext.associateNeighborStateNotifier(sourcePos, block, notifyPos, minecraftWorld, notifier);
     }
 
-    @SuppressWarnings({"unchecked", "try"})
+    @SuppressWarnings({"try"})
     @Override
     public void unwind(final UnwindingPhaseContext context) {
-        final IPhaseState<?> unwindingState = context.getUnwindingState();
-        final PhaseContext<?> unwindingContext = context.getUnwindingContext();
+        final PhaseContext<@NonNull ?> unwindingContext = context.getUnwindingContext();
         try {
-
+            // TODO - figure out what goes here.
+//            TrackingUtil.processBlockCaptures(unwindingContext);
         } catch (final Exception e) {
             PhasePrinter.printExceptionFromPhase(PhaseTracker.getInstance().stack, e, context);
         }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/GeneralizedContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/GeneralizedContext.java
@@ -29,7 +29,7 @@ import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 
 public class GeneralizedContext extends PhaseContext<GeneralizedContext> {
-    public GeneralizedContext(final IPhaseState<? extends GeneralizedContext> state, final PhaseTracker tracker) {
+    public GeneralizedContext(final IPhaseState<GeneralizedContext> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/SpawnEntityTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/SpawnEntityTransaction.java
@@ -40,7 +40,6 @@ import org.spongepowered.api.event.cause.entity.SpawnType;
 import org.spongepowered.api.event.entity.SpawnEntityEvent;
 import org.spongepowered.api.util.Tuple;
 import org.spongepowered.common.accessor.world.server.ServerWorldAccessor;
-import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.context.transaction.type.TransactionType;
 import org.spongepowered.common.event.tracking.context.transaction.type.TransactionTypes;
@@ -118,7 +117,7 @@ public final class SpawnEntityTransaction extends GameTransaction<SpawnEntityEve
                     new DummySnapshot(spawnRequest.originalPosition, spawnRequest.entityTag, spawnRequest.worldSupplier)
                 );
             }).collect(ImmutableList.toImmutableList());
-        return Optional.of(((IPhaseState) context.state).createSpawnEvent(context, parent, collect, currentCause));
+        return Optional.of(context.createSpawnEvent(parent, collect, currentCause));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/TransactionalCaptureSupplier.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/TransactionalCaptureSupplier.java
@@ -53,7 +53,6 @@ import org.spongepowered.common.accessor.util.CombatTrackerAccessor;
 import org.spongepowered.common.block.SpongeBlockSnapshot;
 import org.spongepowered.common.bridge.block.TrackerBlockEventDataBridge;
 import org.spongepowered.common.bridge.world.TrackedWorldBridge;
-import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.TrackingUtil;
@@ -208,7 +207,7 @@ public final class TransactionalCaptureSupplier implements ICaptureSupplier {
         final Entity entityIn) {
         final WeakReference<ServerWorld> worldRef = new WeakReference<>((ServerWorld) serverWorld);
         final Supplier<ServerWorld> worldSupplier = () -> Objects.requireNonNull(worldRef.get(), "ServerWorld dereferenced");
-        final Supplier<SpawnType> contextualType = ((IPhaseState) current.state).getSpawnTypeForTransaction(current, entityIn);
+        final Supplier<SpawnType> contextualType = current.getSpawnTypeForTransaction(entityIn);
         final SpawnEntityTransaction transaction = new SpawnEntityTransaction(worldSupplier, entityIn, contextualType);
         this.logTransaction(transaction);
     }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/effect/AddBlockLootDropsEffect.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/effect/AddBlockLootDropsEffect.java
@@ -33,7 +33,6 @@ import net.minecraft.world.storage.loot.LootContext;
 import net.minecraft.world.storage.loot.LootParameters;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.context.transaction.pipeline.BlockPipeline;
@@ -52,7 +51,6 @@ public final class AddBlockLootDropsEffect implements ProcessingSideEffect {
 
     AddBlockLootDropsEffect() {}
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public EffectResult processSideEffect(
         final BlockPipeline pipeline, final PipelineCursor oldState, final BlockState newState, final SpongeBlockChangeFlag flag
@@ -69,7 +67,7 @@ public final class AddBlockLootDropsEffect implements ProcessingSideEffect {
             .withParameter(LootParameters.TOOL, ItemStack.EMPTY)
             .withNullableParameter(LootParameters.BLOCK_ENTITY, existingTile);
 
-        ((IPhaseState) phaseContext.state).populateLootContext(phaseContext, lootBuilder);
+        phaseContext.populateLootContext(lootBuilder);
 
         return new EffectResult(newState, oldState.state.getDrops(lootBuilder), false);
     }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/block/GrowablePhaseContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/block/GrowablePhaseContext.java
@@ -50,7 +50,7 @@ public class GrowablePhaseContext extends PhaseContext<GrowablePhaseContext> {
     BlockPos pos;
     SpongeBlockSnapshot snapshot;
 
-    protected GrowablePhaseContext(final IPhaseState<? extends GrowablePhaseContext> state, final PhaseTracker tracker) {
+    protected GrowablePhaseContext(final IPhaseState<GrowablePhaseContext> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/entity/BasicEntityContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/entity/BasicEntityContext.java
@@ -29,7 +29,7 @@ import org.spongepowered.common.event.tracking.PhaseTracker;
 
 public class BasicEntityContext extends EntityContext<BasicEntityContext> {
 
-    BasicEntityContext(final IPhaseState<? extends BasicEntityContext> state, PhaseTracker tracker) {
+    BasicEntityContext(final IPhaseState<BasicEntityContext> state, PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/entity/EntityContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/entity/EntityContext.java
@@ -25,10 +25,10 @@
 package org.spongepowered.common.event.tracking.phase.entity;
 
 import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
-import org.spongepowered.common.util.PrettyPrinter;
 import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
+import org.spongepowered.common.util.PrettyPrinter;
 
 import javax.annotation.Nullable;
 
@@ -36,7 +36,7 @@ public class EntityContext<E extends EntityContext<E>> extends PhaseContext<E> {
 
     @Nullable protected DamageSource damageSource;
 
-    public EntityContext(final IPhaseState<? extends E> state, final PhaseTracker tracker) {
+    public EntityContext(final IPhaseState<E> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/entity/TeleportContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/entity/TeleportContext.java
@@ -32,7 +32,7 @@ public final class TeleportContext extends EntityContext<TeleportContext> {
     private boolean isPlayer;
     private boolean isWorldChange;
 
-    public TeleportContext(final IPhaseState<? extends TeleportContext> state, PhaseTracker tracker) {
+    public TeleportContext(final IPhaseState<TeleportContext> state, PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/general/ExplosionContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/general/ExplosionContext.java
@@ -27,11 +27,11 @@ package org.spongepowered.common.event.tracking.phase.general;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.server.ServerWorld;
-import org.spongepowered.common.util.PrettyPrinter;
-import org.spongepowered.common.event.tracking.IPhaseState;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.spongepowered.common.accessor.world.ExplosionAccessor;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
-import org.spongepowered.common.accessor.world.ExplosionAccessor;
+import org.spongepowered.common.util.PrettyPrinter;
 
 import javax.annotation.Nullable;
 
@@ -43,10 +43,9 @@ public final class ExplosionContext extends GeneralPhaseContext<ExplosionContext
         super(GeneralPhase.State.EXPLOSION, tracker);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     ExplosionContext populateFromCurrentState() {
-        final PhaseContext<?> context = PhaseTracker.getInstance().getPhaseContext();
-        ((IPhaseState) context.state).appendContextPreExplosion(this, context);
+        final PhaseContext<@NonNull ?> context = PhaseTracker.getInstance().getPhaseContext();
+        context.appendContextPreExplosion(this);
         return this;
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/general/GeneralPhaseContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/general/GeneralPhaseContext.java
@@ -30,7 +30,7 @@ import org.spongepowered.common.event.tracking.PhaseTracker;
 
 public class GeneralPhaseContext<C extends GeneralPhaseContext<C>> extends PhaseContext<C> {
 
-    GeneralPhaseContext(final IPhaseState<? extends C> state, final PhaseTracker tracker) {
+    GeneralPhaseContext(final IPhaseState<C> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/general/SaveHandlerCreationContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/general/SaveHandlerCreationContext.java
@@ -32,7 +32,7 @@ public class SaveHandlerCreationContext extends PhaseContext<SaveHandlerCreation
 
     private boolean createFiles;
 
-    protected SaveHandlerCreationContext(final IPhaseState<? extends SaveHandlerCreationContext> state, final PhaseTracker tracker) {
+    protected SaveHandlerCreationContext(final IPhaseState<SaveHandlerCreationContext> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/ChunkLoadContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/ChunkLoadContext.java
@@ -25,9 +25,9 @@
 package org.spongepowered.common.event.tracking.phase.generation;
 
 import org.spongepowered.api.world.chunk.Chunk;
-import org.spongepowered.common.util.PrettyPrinter;
 import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseTracker;
+import org.spongepowered.common.util.PrettyPrinter;
 
 import javax.annotation.Nullable;
 
@@ -35,7 +35,7 @@ public class ChunkLoadContext extends GenerationContext<ChunkLoadContext> {
 
     @Nullable private Chunk chunk;
 
-    public ChunkLoadContext(final IPhaseState<? extends ChunkLoadContext> state, final PhaseTracker tracker) {
+    public ChunkLoadContext(final IPhaseState<ChunkLoadContext> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/ChunkRegenerateContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/ChunkRegenerateContext.java
@@ -25,9 +25,9 @@
 package org.spongepowered.common.event.tracking.phase.generation;
 
 import org.spongepowered.api.world.chunk.Chunk;
-import org.spongepowered.common.util.PrettyPrinter;
 import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseTracker;
+import org.spongepowered.common.util.PrettyPrinter;
 
 import javax.annotation.Nullable;
 
@@ -35,7 +35,7 @@ public class ChunkRegenerateContext extends GenerationContext<ChunkRegenerateCon
 
     @Nullable private Chunk chunk;
 
-    public ChunkRegenerateContext(final IPhaseState<? extends ChunkRegenerateContext> state, final PhaseTracker tracker) {
+    public ChunkRegenerateContext(final IPhaseState<ChunkRegenerateContext> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/FeaturePhaseContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/FeaturePhaseContext.java
@@ -29,16 +29,15 @@ import net.minecraft.world.gen.feature.Feature;
 import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 
-import java.util.Objects;
-
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 public final class FeaturePhaseContext extends GenerationContext<FeaturePhaseContext> {
 
     @Nullable private Feature<?> feature;
     @Nullable private BlockPos origin;
 
-    FeaturePhaseContext(final IPhaseState<? extends FeaturePhaseContext> state, final PhaseTracker tracker) {
+    FeaturePhaseContext(final IPhaseState<FeaturePhaseContext> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GenerationCompatibileContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GenerationCompatibileContext.java
@@ -26,9 +26,9 @@ package org.spongepowered.common.event.tracking.phase.generation;
 
 import net.minecraft.world.chunk.AbstractChunkProvider;
 import net.minecraft.world.gen.ChunkGenerator;
-import org.spongepowered.common.util.PrettyPrinter;
 import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseTracker;
+import org.spongepowered.common.util.PrettyPrinter;
 
 import javax.annotation.Nullable;
 
@@ -37,7 +37,7 @@ public final class GenerationCompatibileContext extends GenerationContext<Genera
     @Nullable AbstractChunkProvider provider;
     @Nullable ChunkGenerator<?> generator;
 
-    GenerationCompatibileContext(final IPhaseState<? extends GenerationCompatibileContext> state, final PhaseTracker tracker) {
+    GenerationCompatibileContext(final IPhaseState<GenerationCompatibileContext> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GenerationContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GenerationContext.java
@@ -27,14 +27,13 @@ package org.spongepowered.common.event.tracking.phase.generation;
 import net.minecraft.world.gen.ChunkGenerator;
 import net.minecraft.world.gen.GenerationSettings;
 import net.minecraft.world.server.ServerWorld;
-import org.spongepowered.common.util.PrettyPrinter;
 import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
-
-import java.util.Objects;
+import org.spongepowered.common.util.PrettyPrinter;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 @SuppressWarnings("unchecked")
 public abstract class GenerationContext<G extends GenerationContext<G>> extends PhaseContext<G> {
@@ -42,7 +41,7 @@ public abstract class GenerationContext<G extends GenerationContext<G>> extends 
     @Nullable private ServerWorld world;
     @Nullable private ChunkGenerator<? extends GenerationSettings> generator;
 
-    GenerationContext(final IPhaseState<? extends G> state, final PhaseTracker tracker) {
+    GenerationContext(final IPhaseState<G> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GenericGenerationContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GenericGenerationContext.java
@@ -29,7 +29,7 @@ import org.spongepowered.common.event.tracking.PhaseTracker;
 
 public class GenericGenerationContext extends GenerationContext<GenericGenerationContext> {
 
-    GenericGenerationContext(final IPhaseState<? extends GenericGenerationContext> state, PhaseTracker tracker) {
+    GenericGenerationContext(final IPhaseState<GenericGenerationContext> state, PhaseTracker tracker) {
         super(state, tracker);
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/PopulatorPhaseContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/PopulatorPhaseContext.java
@@ -24,12 +24,12 @@
  */
 package org.spongepowered.common.event.tracking.phase.generation;
 
-import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.IPhaseState;
+import org.spongepowered.common.event.tracking.PhaseTracker;
 
 public final class PopulatorPhaseContext extends GenerationContext<PopulatorPhaseContext> {
 
-    PopulatorPhaseContext(final IPhaseState<? extends PopulatorPhaseContext> state, final PhaseTracker tracker) {
+    PopulatorPhaseContext(final IPhaseState<PopulatorPhaseContext> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/BasicPacketContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/BasicPacketContext.java
@@ -26,17 +26,17 @@ package org.spongepowered.common.event.tracking.phase.packet;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import net.minecraft.inventory.container.Container;
+import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.util.PrettyPrinter;
 
 import javax.annotation.Nullable;
-import net.minecraft.inventory.container.Container;
-import org.spongepowered.common.event.tracking.PhaseTracker;
 
 public class BasicPacketContext extends PacketContext<BasicPacketContext> {
 
     @Nullable private Container container;
 
-    public BasicPacketContext(final PacketState<? extends BasicPacketContext> state, final PhaseTracker tracker) {
+    public BasicPacketContext(final PacketState<BasicPacketContext> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketContext.java
@@ -48,7 +48,7 @@ public class PacketContext<P extends PacketContext<P>> extends PhaseContext<P> {
     private boolean ignoreCreative;
     private boolean interactItemChanged;
 
-    protected PacketContext(final PacketState<? extends P> state, final PhaseTracker tracker) {
+    protected PacketContext(final PacketState<P> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/InventoryPacketContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/InventoryPacketContext.java
@@ -24,19 +24,19 @@
  */
 package org.spongepowered.common.event.tracking.phase.packet.inventory;
 
-import org.spongepowered.common.util.PrettyPrinter;
 import org.spongepowered.common.bridge.inventory.container.TrackedContainerBridge;
 import org.spongepowered.common.bridge.inventory.container.TrackedInventoryBridge;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.phase.packet.PacketContext;
 import org.spongepowered.common.event.tracking.phase.packet.PacketPhase;
 import org.spongepowered.common.event.tracking.phase.packet.PacketState;
+import org.spongepowered.common.util.PrettyPrinter;
 
 public class InventoryPacketContext extends PacketContext<InventoryPacketContext> {
 
     private int oldHighlightedSlotId;
 
-    public InventoryPacketContext(final PacketState<? extends InventoryPacketContext> state, final PhaseTracker tracker) {
+    public InventoryPacketContext(final PacketState<InventoryPacketContext> state, final PhaseTracker tracker) {
         super(state, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/InteractionPacketContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/InteractionPacketContext.java
@@ -35,7 +35,7 @@ public class InteractionPacketContext extends PacketContext<InteractionPacketCon
     private BlockSnapshot targetBlock = BlockSnapshot.empty();
     private ItemStack activeItem = ItemStack.empty();
 
-    InteractionPacketContext(PacketState<? extends InteractionPacketContext> state, PhaseTracker tracker) {
+    InteractionPacketContext(PacketState<InteractionPacketContext> state, PhaseTracker tracker) {
         super(state, tracker);
         this.addCaptures();
         this.addEntityDropCaptures();

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/plugin/BasicPluginContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/plugin/BasicPluginContext.java
@@ -35,7 +35,7 @@ public class BasicPluginContext extends PluginPhaseContext<BasicPluginContext> {
 
     @Nullable PluginContainer container;
 
-    public BasicPluginContext(final IPhaseState<? extends BasicPluginContext> phaseState, final PhaseTracker tracker) {
+    public BasicPluginContext(final IPhaseState<BasicPluginContext> phaseState, final PhaseTracker tracker) {
         super(phaseState, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/plugin/DelayedTaskPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/plugin/DelayedTaskPhaseState.java
@@ -67,9 +67,9 @@ class DelayedTaskPhaseState extends PluginPhaseState<DelayedTaskPhaseState.Conte
     public static class Context extends PluginPhaseContext<Context> {
 
         @Nullable PluginContainer container;
-        @Nullable BiConsumer<PhaseContext<?>, CauseStackManager.StackFrame> delayedContextPopulator;
+        @Nullable BiConsumer<PhaseContext<@NonNull ?>, CauseStackManager.StackFrame> delayedContextPopulator;
 
-        public Context(final IPhaseState<? extends Context> phaseState, final PhaseTracker tracker) {
+        public Context(final IPhaseState<Context> phaseState, final PhaseTracker tracker) {
             super(phaseState, tracker);
         }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/plugin/PluginPhaseContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/plugin/PluginPhaseContext.java
@@ -31,7 +31,7 @@ import org.spongepowered.common.event.tracking.PhaseTracker;
 public class PluginPhaseContext<P extends PluginPhaseContext<P>> extends PhaseContext<P> {
 
 
-    protected PluginPhaseContext(final IPhaseState<? extends P> phaseState, final PhaseTracker tracker) {
+    protected PluginPhaseContext(final IPhaseState<P> phaseState, final PhaseTracker tracker) {
         super(phaseState, tracker);
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/EntityTickContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/EntityTickContext.java
@@ -30,7 +30,7 @@ import org.spongepowered.common.event.tracking.PhaseTracker;
 
 public final class EntityTickContext extends TickContext<EntityTickContext> {
 
-    EntityTickContext(final IPhaseState<? extends EntityTickContext> phaseState, PhaseTracker tracker) {
+    EntityTickContext(final IPhaseState<EntityTickContext> phaseState, PhaseTracker tracker) {
         super(phaseState, tracker);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/ServerTickState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/ServerTickState.java
@@ -71,7 +71,7 @@ public final class ServerTickState extends TickPhaseState<ServerTickState.Server
         }
 
 
-        ServerTickContext(final IPhaseState<? extends ServerTickContext> phaseState, final PhaseTracker tracker) {
+        ServerTickContext(final IPhaseState<ServerTickContext> phaseState, final PhaseTracker tracker) {
             super(phaseState, tracker);
         }
     }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/TickContext.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/TickContext.java
@@ -30,13 +30,13 @@ import org.spongepowered.common.event.tracking.PhaseTracker;
 
 public class TickContext<T extends TickContext<T>> extends PhaseContext<T> {
 
-    TickContext(final IPhaseState<? extends T> phaseState, final PhaseTracker tracker) {
+    TickContext(final IPhaseState<T> phaseState, final PhaseTracker tracker) {
         super(phaseState, tracker);
     }
 
     public static class General extends TickContext<General> {
 
-        public General(final IPhaseState<? extends General> phaseState, final PhaseTracker tracker) {
+        public General(final IPhaseState<General> phaseState, final PhaseTracker tracker) {
             super(phaseState, tracker);
         }
     }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/WorldTickState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/WorldTickState.java
@@ -71,7 +71,7 @@ final class WorldTickState extends TickPhaseState<WorldTickState.WorldTickContex
         }
 
 
-        WorldTickContext(final IPhaseState<? extends WorldTickContext> phaseState, final PhaseTracker tracker) {
+        WorldTickContext(final IPhaseState<WorldTickContext> phaseState, final PhaseTracker tracker) {
             super(phaseState, tracker);
         }
     }

--- a/src/main/java/org/spongepowered/common/inventory/util/ContainerUtil.java
+++ b/src/main/java/org/spongepowered/common/inventory/util/ContainerUtil.java
@@ -59,7 +59,6 @@ import org.spongepowered.common.accessor.inventory.container.MerchantContainerAc
 import org.spongepowered.common.accessor.inventory.container.RepairContainerAccessor;
 import org.spongepowered.common.bridge.inventory.InventoryBridge;
 import org.spongepowered.common.bridge.inventory.container.ContainerBridge;
-import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.inventory.SpongeLocationCarrier;
@@ -117,8 +116,7 @@ public final class ContainerUtil {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static void performBlockInventoryDrops(final ServerWorld worldServer, final double x, final double y, final double z, final IInventory inventory) {
         final PhaseContext<@NonNull ?> context = PhaseTracker.getInstance().getPhaseContext();
-        final IPhaseState<@NonNull ?> currentState = context.state;
-        if (((IPhaseState) currentState).doesBlockEventTracking(context)) {
+        if (context.doesBlockEventTracking()) {
             // this is where we could perform item stack pre-merging.
             // TODO - figure out how inventory drops will work?
             for (int j = 0; j < inventory.getSizeInventory(); j++) {

--- a/src/mixins/java/org/spongepowered/common/mixin/core/item/ItemStackMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/item/ItemStackMixin.java
@@ -47,13 +47,11 @@ import org.spongepowered.common.bridge.data.DataCompoundHolder;
 import org.spongepowered.common.bridge.world.WorldBridge;
 import org.spongepowered.common.data.provider.nbt.NBTDataType;
 import org.spongepowered.common.data.provider.nbt.NBTDataTypes;
-import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 
-import java.util.Optional;
-
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 @Mixin(net.minecraft.item.ItemStack.class)
 public abstract class ItemStackMixin implements CustomDataHolderBridge, DataCompoundHolder {
@@ -142,25 +140,21 @@ public abstract class ItemStackMixin implements CustomDataHolderBridge, DataComp
     }
 
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Inject(method = "onBlockDestroyed", at = @At("HEAD"))
     private void impl$capturePlayerUsingItemstack(final World worldIn, final BlockState blockIn, final BlockPos pos, final PlayerEntity playerIn,
         final CallbackInfo ci) {
         if (!((WorldBridge) worldIn).bridge$isFake()) {
             final PhaseContext<@NonNull ?> context = PhaseTracker.getInstance().getPhaseContext();
-            final IPhaseState state = context.state;
-            state.capturePlayerUsingStackToBreakBlock((org.spongepowered.api.item.inventory.ItemStack) this, (ServerPlayerEntity) playerIn, context);
+            context.capturePlayerUsingStackToBreakBlock((org.spongepowered.api.item.inventory.ItemStack) this, (ServerPlayerEntity) playerIn);
         }
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Inject(method = "onBlockDestroyed", at = @At("RETURN"))
     private void impl$nullOutCapturedPlayer(final World worldIn, final BlockState blockIn, final BlockPos pos, final PlayerEntity playerIn,
         final CallbackInfo ci) {
         if (!((WorldBridge) worldIn).bridge$isFake()) {
             final PhaseContext<@NonNull ?> context = PhaseTracker.getInstance().getPhaseContext();
-            final IPhaseState state = context.state;
-            state.capturePlayerUsingStackToBreakBlock((org.spongepowered.api.item.inventory.ItemStack) this, null, context);
+            context.capturePlayerUsingStackToBreakBlock((org.spongepowered.api.item.inventory.ItemStack) this, null);
         }
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/block/BlockMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/block/BlockMixin_Tracker.java
@@ -39,7 +39,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.bridge.block.TrackedBlockBridge;
-import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.context.transaction.EffectTransactor;
@@ -102,7 +101,7 @@ public abstract class BlockMixin_Tracker implements TrackedBlockBridge {
             return;
         }
         final PhaseContext<@NonNull ?> context = server.getPhaseContext();
-        if(!((IPhaseState) context.state).recordsEntitySpawns(context)) {
+        if(!context.recordsEntitySpawns()) {
             return;
         }
         BlockMixin_Tracker.tracker$effectTransactorForDrops = context.getTransactor()
@@ -122,7 +121,7 @@ public abstract class BlockMixin_Tracker implements TrackedBlockBridge {
             return;
         }
         final PhaseContext<@NonNull ?> context = server.getPhaseContext();
-        if (!((IPhaseState) context.state).recordsEntitySpawns(context)) {
+        if (!context.recordsEntitySpawns()) {
             return;
         }
         BlockMixin_Tracker.tracker$effectTransactorForDrops = context.getTransactor()
@@ -141,7 +140,7 @@ public abstract class BlockMixin_Tracker implements TrackedBlockBridge {
             return;
         }
         final PhaseContext<@NonNull ?> context = server.getPhaseContext();
-        if(!((IPhaseState) context.state).recordsEntitySpawns(context)) {
+        if(!context.recordsEntitySpawns()) {
             return;
         }
         BlockMixin_Tracker.tracker$effectTransactorForDrops = context.getTransactor()
@@ -163,7 +162,7 @@ public abstract class BlockMixin_Tracker implements TrackedBlockBridge {
             return;
         }
         final PhaseContext<@NonNull ?> context = server.getPhaseContext();
-        if(!((IPhaseState) context.state).recordsEntitySpawns(context)) {
+        if(!context.recordsEntitySpawns()) {
             return;
         }
         context.getTransactor().completeBlockDrops(BlockMixin_Tracker.tracker$effectTransactorForDrops);

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/entity/EntityMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/entity/EntityMixin_Tracker.java
@@ -51,7 +51,6 @@ import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.bridge.TrackableBridge;
 import org.spongepowered.common.bridge.entity.EntityTrackedBridge;
 import org.spongepowered.common.bridge.world.WorldBridge;
-import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.context.transaction.EffectTransactor;
@@ -130,7 +129,7 @@ public abstract class EntityMixin_Tracker implements TrackableBridge, EntityTrac
             return;
         }
         final PhaseContext<@NonNull ?> context = instance.getPhaseContext();
-        if (!((IPhaseState) context.state).doesBlockEventTracking(context)) {
+        if (!context.doesBlockEventTracking()) {
             return;
         }
         if (this.tracker$dropsTransactor == null) {
@@ -140,7 +139,6 @@ public abstract class EntityMixin_Tracker implements TrackableBridge, EntityTrac
 
     protected @MonotonicNonNull EffectTransactor tracker$dropsTransactor = null;
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Inject(method = "remove()V", at = @At("RETURN"))
     private void tracker$ensureDropEffectCompleted(final CallbackInfo ci) {
         final PhaseTracker instance = PhaseTracker.SERVER;
@@ -151,7 +149,7 @@ public abstract class EntityMixin_Tracker implements TrackableBridge, EntityTrac
             return;
         }
         final PhaseContext<@NonNull ?> context = instance.getPhaseContext();
-        if (!((IPhaseState) context.state).doesBlockEventTracking(context)) {
+        if (!context.doesBlockEventTracking()) {
             return;
         }
         if (this.tracker$dropsTransactor != null) {

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/entity/LivingEntityMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/entity/LivingEntityMixin_Tracker.java
@@ -34,14 +34,12 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.common.bridge.world.WorldBridge;
-import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.context.transaction.EffectTransactor;
 
 import javax.annotation.Nullable;
 
-@SuppressWarnings({"unchecked", "rawtypes"})
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin_Tracker extends EntityMixin_Tracker {
 
@@ -87,7 +85,7 @@ public abstract class LivingEntityMixin_Tracker extends EntityMixin_Tracker {
             return;
         }
         final PhaseContext<@NonNull ?> context = instance.getPhaseContext();
-        if (!((IPhaseState) context.state).doesBlockEventTracking(context)) {
+        if (!context.doesBlockEventTracking()) {
             this.shadow$onDeathUpdate();
             return;
         }
@@ -116,7 +114,7 @@ public abstract class LivingEntityMixin_Tracker extends EntityMixin_Tracker {
             return;
         }
         final PhaseContext<@NonNull ?> context = instance.getPhaseContext();
-        if (!((IPhaseState) context.state).doesBlockEventTracking(context)) {
+        if (!context.doesBlockEventTracking()) {
             return;
         }
         try (final EffectTransactor ignored = context.getTransactor().ensureEntityDropTransactionEffect((LivingEntity) (Object) this)) {

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/entity/item/FallingBlockEntityMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/entity/item/FallingBlockEntityMixin_Tracker.java
@@ -30,13 +30,13 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.item.FallingBlockEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.bridge.world.WorldBridge;
 import org.spongepowered.common.event.ShouldFire;
-import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.TrackingUtil;
@@ -72,7 +72,6 @@ public abstract class FallingBlockEntityMixin_Tracker extends Entity {
      *
      * @param ci
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Inject(method = "tick()V",
             at = @At(value = "INVOKE",
                     target = "Lnet/minecraft/world/World;removeBlock(Lnet/minecraft/util/math/BlockPos;Z)Z",
@@ -94,9 +93,9 @@ public abstract class FallingBlockEntityMixin_Tracker extends Entity {
         // of falling blocks, but, since the world already supposedly set the block to air,
         // we don't need to re-set the block state at the position, just need to check
         // if the processing succeeded or not.
-        final PhaseContext<?> currentContext = PhaseTracker.getInstance().getPhaseContext();
+        final PhaseContext<@NonNull ?> currentContext = PhaseTracker.getInstance().getPhaseContext();
         // By this point, we should have some sort of captured block
-        if (((IPhaseState) currentContext.state).doesBlockEventTracking(currentContext)) {
+        if (currentContext.doesBlockEventTracking()) {
             if (!TrackingUtil.processBlockCaptures(currentContext)) {
                 // So, it's been cancelled, we want to absolutely remove this entity.
                 // And we want to stop the entity update at this point.

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/item/BoneMealItemMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/item/BoneMealItemMixin_Tracker.java
@@ -30,13 +30,13 @@ import net.minecraft.item.BoneMealItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.server.ServerWorld;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.api.event.block.ChangeBlockEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.common.bridge.world.WorldBridge;
 import org.spongepowered.common.event.ShouldFire;
-import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.phase.block.BlockPhase;
@@ -58,7 +58,7 @@ public abstract class BoneMealItemMixin_Tracker {
      * phases's capturing.
      */
 
-    @SuppressWarnings({"unchecked", "Duplicates", "rawtypes"})
+    @SuppressWarnings({"Duplicates"})
     // Pending https://github.com/SpongePowered/Mixin/issues/312
     // @Group(name = "org.spongepowered.tracker:bonemeal", min = 1, max = 1)
     @Redirect(
@@ -78,9 +78,8 @@ public abstract class BoneMealItemMixin_Tracker {
             return;
         }
 
-        final PhaseContext<?> current = PhaseTracker.getInstance().getPhaseContext();
-        final IPhaseState phaseState = current.state;
-        final boolean doesEvent = phaseState.doesBlockEventTracking(current);
+        final PhaseContext<@NonNull ?> current = PhaseTracker.getInstance().getPhaseContext();
+        final boolean doesEvent = current.doesBlockEventTracking();
         if (doesEvent) {
             // We can enter the new phase state.
             try (GrowablePhaseContext context = BlockPhase.State.GROWING.createPhaseContext(PhaseTracker.SERVER)

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/server/MinecraftServerMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/server/MinecraftServerMixin_Tracker.java
@@ -39,7 +39,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.common.bridge.util.concurrent.TrackedTickDelayedTaskBridge;
 import org.spongepowered.common.event.tracking.CauseTrackerCrashHandler;
-import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.phase.plugin.PluginPhase;
@@ -112,7 +111,7 @@ public abstract class MinecraftServerMixin_Tracker extends ThreadTaskExecutorMix
             if (phaseContext.isEmpty()) {
                 return;
             }
-            ((IPhaseState) phaseContext.state).foldContextForThread(phaseContext, ((TrackedTickDelayedTaskBridge) returnValue));
+            phaseContext.foldContextForThread(((TrackedTickDelayedTaskBridge) returnValue));
         }
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/world/chunk/ChunkMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/world/chunk/ChunkMixin_Tracker.java
@@ -155,10 +155,9 @@ public abstract class ChunkMixin_Tracker implements TrackedChunkBridge {
         final Block newBlock = newState.getBlock();
         final Block currentBlock = currentState.getBlock();
 
-        final ChangeBlock transaction = state.createTransaction(context, snapshot, newState, flag);
+        final ChangeBlock transaction = context.createTransaction(snapshot, newState, flag);
 
-        snapshot.blockChange = state.associateBlockChangeWithSnapshot(
-            context,
+        snapshot.blockChange = context.associateBlockChangeWithSnapshot(
             newState,
             newBlock,
             currentState,


### PR DESCRIPTION
Mostly a QOL change, as I've been thinking about it, the proxy access by PhaseContext is handy, and can be kept tidy in PhaseStateProxy.

Demonstration of changes can be seen in ContainerUtil:
```diff
-       final IPhaseState<@NonNull ?> currentState = context.state;
-        if (((IPhaseState) currentState).doesBlockEventTracking(context)) {
+        if (context.doesBlockEventTracking()) {
```

I've not given thought to profile the difference as it is replacing an explicit raw type cast to a method invocation by proxy. Seeing how it's already relatively small, I can't imagine this would be an expensive change.