### PR TITLE
Implement part of the Chunk API

### DIFF
--- a/src/main/java/org/spongepowered/common/util/ChunkUtil.java
+++ b/src/main/java/org/spongepowered/common/util/ChunkUtil.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.util;
+
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.chunk.ChunkBiomeContainer;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.world.biome.Biome;
+import org.spongepowered.common.accessor.world.level.chunk.ChunkBiomeContainerAccessor;
+
+public final class ChunkUtil {
+
+    private ChunkUtil() {
+    }
+
+    public static boolean setBiome(final @Nullable ChunkBiomeContainer biomeContainer,
+                                   final int x, final int y, final int z, final Biome biome) {
+        if (biomeContainer == null) {
+            return false;
+        }
+        final net.minecraft.world.level.biome.Biome[] biomes = ((ChunkBiomeContainerAccessor) biomeContainer).accessor$biomes();
+
+        final int maskedX = x & ChunkBiomeContainer.HORIZONTAL_MASK;
+        final int maskedY = Mth.clamp(y, 0, ChunkBiomeContainer.VERTICAL_MASK);
+        final int maskedZ = z & ChunkBiomeContainer.HORIZONTAL_MASK;
+
+        final int WIDTH_BITS = ChunkBiomeContainerAccessor.accessor$WIDTH_BITS();
+        final int posKey = maskedY << WIDTH_BITS + WIDTH_BITS | maskedZ << WIDTH_BITS | maskedX;
+        biomes[posKey] = (net.minecraft.world.level.biome.Biome) (Object) biome;
+
+        return true;
+    }
+
+}

--- a/src/mixins/java/org/spongepowered/common/mixin/api/mcp/world/level/chunk/ChunkStatusMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/mcp/world/level/chunk/ChunkStatusMixin_API.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.api.mcp.world.level.chunk;
+
+import net.minecraft.world.level.chunk.ChunkStatus;
+import org.spongepowered.api.world.chunk.ChunkState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(ChunkStatus.class)
+public abstract class ChunkStatusMixin_API implements ChunkState {
+
+    @Shadow public abstract boolean isOrAfter(ChunkStatus param0);
+
+    @Override
+    public boolean isAfter(final ChunkState state) {
+        return !this.equals(state) && this.isOrAfter((ChunkStatus) state);
+    }
+
+}

--- a/src/mixins/java/org/spongepowered/common/mixin/api/mcp/world/level/chunk/EmptyLevelChunkMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/mcp/world/level/chunk/EmptyLevelChunkMixin_API.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.api.mcp.world.level.chunk;
+
+import net.minecraft.world.level.chunk.EmptyLevelChunk;
+import org.spongepowered.api.world.biome.Biome;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(EmptyLevelChunk.class)
+public abstract class EmptyLevelChunkMixin_API extends LevelChunkMixin_API {
+
+    @Override
+    public boolean setBiome(final int x, final int y, final int z, final Biome biome) {
+        return false;
+    }
+
+}

--- a/src/mixins/java/org/spongepowered/common/mixin/api/mcp/world/level/chunk/ProtoChunkMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/mcp/world/level/chunk/ProtoChunkMixin_API.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.api.mcp.world.level.chunk;
+
+import net.minecraft.world.level.chunk.ChunkBiomeContainer;
+import net.minecraft.world.level.chunk.ChunkStatus;
+import net.minecraft.world.level.chunk.ProtoChunk;
+import org.spongepowered.api.util.Ticks;
+import org.spongepowered.api.world.biome.Biome;
+import org.spongepowered.api.world.generation.PrimitiveChunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.util.ChunkUtil;
+import org.spongepowered.common.util.SpongeTicks;
+
+@Mixin(ProtoChunk.class)
+public abstract class ProtoChunkMixin_API implements PrimitiveChunk {
+
+    // @formatter:off
+    @Shadow private ChunkBiomeContainer biomes;
+    @Shadow private long inhabitedTime;
+    @Shadow private volatile ChunkStatus status;
+    // @formatter:on
+
+    @Override
+    public boolean setBiome(final int x, final int y, final int z, final Biome biome) {
+        return ChunkUtil.setBiome(this.biomes, x, y, z, biome);
+    }
+
+    @Override
+    public Ticks inhabitedTime() {
+        return new SpongeTicks(this.inhabitedTime);
+    }
+
+    @Override
+    public void setInhabitedTime(final Ticks newInhabitedTime) {
+        this.inhabitedTime = newInhabitedTime.ticks();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.status == ChunkStatus.EMPTY;
+    }
+
+}

--- a/src/mixins/java/org/spongepowered/common/mixin/api/mcp/world/level/levelgen/Heightmap_TypeMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/mcp/world/level/levelgen/Heightmap_TypeMixin_API.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.api.mcp.world.level.levelgen;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.util.BlockReaderAwareMatcher;
+import org.spongepowered.api.world.HeightType;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.function.Predicate;
+import net.minecraft.world.level.levelgen.Heightmap;
+
+@Mixin(value = Heightmap.Types.class)
+public abstract class Heightmap_TypeMixin_API implements HeightType {
+
+    // @formatter:off
+    @Shadow @Final private Predicate<net.minecraft.world.level.block.state.BlockState> isOpaque;
+    // @formatter:on
+
+    @Override
+    @NonNull
+    public BlockReaderAwareMatcher<BlockState> matcher() {
+        return (state, volume, position) -> this.isOpaque.test((net.minecraft.world.level.block.state.BlockState) state);
+    }
+
+}

--- a/src/mixins/resources/mixins.sponge.api.json
+++ b/src/mixins/resources/mixins.sponge.api.json
@@ -339,10 +339,15 @@
         "mcp.world.level.block.state.properties.StairsShapeMixin_API",
         "mcp.world.level.block.state.properties.StructureModeMixin_API",
         "mcp.world.level.border.WorldBorderMixin_API",
+        "mcp.world.level.chunk.ChunkAccessMixin_API",
         "mcp.world.level.chunk.ChunkGeneratorMixin_API",
+        "mcp.world.level.chunk.ChunkStatusMixin_API",
+        "mcp.world.level.chunk.EmptyLevelChunkMixin_API",
         "mcp.world.level.chunk.LevelChunkMixin_API",
+        "mcp.world.level.chunk.ProtoChunkMixin_API",
         "mcp.world.level.dimension.DimensionTypeMixin_API",
         "mcp.world.level.levelgen.FlatLevelSourceMixin_API",
+        "mcp.world.level.levelgen.Heightmap_TypeMixin_API",
         "mcp.world.level.levelgen.NoiseBasedChunkGeneratorMixin_API",
         "mcp.world.level.levelgen.NoiseGeneratorSettingsMixin_API",
         "mcp.world.level.levelgen.NoiseSamplingSettingsMixin_API",
@@ -370,8 +375,7 @@
         "mcp.world.storage.MapItemSavedDataMixin",
         "mojang.authlib.properties.PropertyMixin_API",
         "service.permission.SubjectMixin_API",
-        "world.LocatableBlockMixin_API",
-        "world.gen.Heightmap_TypeMixin_API"
+        "world.LocatableBlockMixin_API"
     ],
     "client": [
         "mcp.client.MinecraftMixin_API",


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2272) | **Sponge**

~~Much of `ProtoChunk` can be implemented on `IChunk`, so I've done much of that there. MCP `Chunk` -> Sponge `Chunk`. MCP `ChunkPrimer` -> Sponge `PrimitiveChunk`.~~

Some of the Sponge APIs will likely need to change. This is nowhere near done.