### PR TITLE
Fix typos in config docs

### DIFF
--- a/src/main/java/org/spongepowered/common/config/category/EntityCollisionCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/EntityCollisionCategory.java
@@ -40,7 +40,7 @@ public class EntityCollisionCategory extends ConfigCategory {
     @Setting(value = "max-entities-within-aabb", comment = ""
             + "Maximum amount of entities any given entity or block can collide with.\n"
             + "This improves performance when there are more than 8 entities on top of each other\n"
-            + "such as a 1x1 spawn pen."
+            + "such as a 1x1 spawn pen.\n"
             + "Set to '0' to disable.")
     private int maxEntitiesWithinAABB = 8;
 

--- a/src/main/java/org/spongepowered/common/config/category/ExploitCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/ExploitCategory.java
@@ -50,7 +50,7 @@ public class ExploitCategory extends ConfigCategory {
     private boolean chunkRegistrationOnMove = true;
 
     @Setting(value = "load-chunk-on-position-set", comment = ""
-            + "Enables focing a chunk load when an entity position is set.\n"
+            + "Enables forcing a chunk load when an entity position is set.\n"
             + "Usually due to teleportation, vehicle movement etc. can a position lead an entity to no longer exist\n"
             + "within it's currently marked and tracked chunk. This will enable that chunk for the position is loaded.\n"
             + "Part of several exploits.\n"

--- a/src/main/java/org/spongepowered/common/config/category/MetricsCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/MetricsCategory.java
@@ -38,7 +38,8 @@ public class MetricsCategory {
 
     @Setting(value = "global-state", comment = ""
             + "The global collection state that should be respected by all plugins that have no specified "
-            + "collection state. If 'undefined' then it is treated as disabled.")
+            + "collection state.\n"
+            + "If 'undefined' then it is treated as disabled.")
     private Tristate globalState = Tristate.UNDEFINED;
 
     @Setting(value = "plugin-states",

--- a/src/main/java/org/spongepowered/common/config/category/OptimizationCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/OptimizationCategory.java
@@ -93,7 +93,7 @@ public class OptimizationCategory extends ConfigCategory {
             + "If 'true', re-writes the incredibly inefficient Vanilla Map code.\n"
             + "This yields enormous performance enhancements when using many maps,\n"
             + "but has a tiny chance of breaking mods that invasively modify Vanilla.\n"
-            + "It is strongly reccomended to keep this on, unless explicitly advised otherwise by a Sponge developer")
+            + "It is strongly recommended to keep this on, unless explicitly advised otherwise by a Sponge developer")
     private boolean mapOptimization = true;
 
     @Setting(value = "optimize-hoppers", comment = ""
@@ -108,7 +108,7 @@ public class OptimizationCategory extends ConfigCategory {
     private boolean optimizeHoppers = false;
 
     @Setting(value = "use-active-chunks-for-collisions", comment = ""
-            + "Vanilla performs a lot of is area loaded checks during entity collision calculations with blocks,\n"
+            + "Vanilla performs a lot of \"is area loaded\" checks during entity collision calculations with blocks,\n"
             + "and because these calculations require fetching the chunks to see if they are loaded,\n"
             + "before getting the block states from those chunks, there can be some small performance\n"
             + "increase by checking the entity's owned active chunk it may currently reside in.\n"

--- a/src/main/java/org/spongepowered/common/config/category/StructureModCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/StructureModCategory.java
@@ -40,8 +40,8 @@ public class StructureModCategory extends ConfigCategory {
     private boolean isEnabled = true;
 
     @Setting(value = "structures", comment = ""
-            + "The configuration for each struture.\n"
-            + "A value of 'false' prevents that struture from being saved.\n"
+            + "The configuration for each structure.\n"
+            + "A value of 'false' prevents that structure from being saved.\n"
             + "Entries that are either missing in this list or have the value 'true' will still be saved,\n"
             + "unless the structure saving of the mod is globally disabled.")
     private Map<String, Boolean> structureList = new HashMap<>();

--- a/src/main/java/org/spongepowered/common/config/category/StructureSaveCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/StructureSaveCategory.java
@@ -36,9 +36,9 @@ public class StructureSaveCategory extends ConfigCategory {
     @Setting(value = "enabled", comment = ""
             + "Global switch to enable sponge's changes to the structure saving mechansim.\n"
             + "By default, this option is disabled, i.e. saving structures is not affected.\n"
-            + "If you want to prevent that a certain \"named\" structure is saved to the world's folder,\n"
+            + "If you want to prevent a certain \"named\" structure being saved to the world's folder,\n"
             + "you have to enable this module/setting and disable the structure in the further settings.\n"
-            + "An example of a structure that is costly and somewhat irrelevant is 'mineshaft',\n"
+            + "An example of a structure being costly and somewhat irrelevant is 'mineshaft',\n"
             + "as they build and save several structures even after the mine shafts have been completely generated.\n"
             + "However, this has the disadvantage that these structures may no longer be locatable by some mods.")
     private boolean isEnabled = false;

--- a/src/main/java/org/spongepowered/common/config/category/TimingsCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/TimingsCategory.java
@@ -40,7 +40,7 @@ public class TimingsCategory extends ConfigCategory {
     private boolean enabled = true;
 
     @Setting(value = "server-name-privacy",
-            comment = "Hides the server name in the Aikar webviewer to no leak the l33t server you are running")
+            comment = "Hides the server name in the Aikar webviewer to no leak the l337 server you are running")
     private boolean serverNamePrivacy = false;
 
     @Setting(value = "hidden-config-entries", comment = ""


### PR DESCRIPTION
Fixes the typos discovered by @Inscrutable in SpongePowered/SpongeDocs#832

We have to fix these in the source code, because that particular documentation is auto generated.