### PR TITLE
Implement enhanced InteractEvents [API8]

### DIFF
--- a/src/accessors/java/org/spongepowered/common/accessor/server/management/PlayerInteractionManagerAccessor.java
+++ b/src/accessors/java/org/spongepowered/common/accessor/server/management/PlayerInteractionManagerAccessor.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.accessor.server.management;
+
+import net.minecraft.server.management.PlayerInteractionManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(PlayerInteractionManager.class)
+public interface PlayerInteractionManagerAccessor {
+    @Accessor("isDestroyingBlock") boolean accessor$isDestroyingBlock();
+}

--- a/src/accessors/resources/mixins.sponge.accessors.json
+++ b/src/accessors/resources/mixins.sponge.accessors.json
@@ -195,7 +195,8 @@
         "world.gen.DimensionGeneratorSettingsAccessor",
         "world.storage.SaveFormat_LevelSaveAccessor",
         "util.registry.DynamicRegistriesAccessor",
-        "entity.projectile.ProjectileEntityAccessor"
+        "entity.projectile.ProjectileEntityAccessor",
+        "server.management.PlayerInteractionManagerAccessor"
     ],
     "server": [
         "server.dedicated.DedicatedServerAccessor",

--- a/src/main/java/org/spongepowered/common/event/ShouldFire.java
+++ b/src/main/java/org/spongepowered/common/event/ShouldFire.java
@@ -45,6 +45,7 @@ public final class ShouldFire {
     // since SpawnEntityEvent.CUSTOM is not in the hierarchy of DropItemEvent.DISPENSE
 
     public static boolean ANIMATE_HAND_EVENT = false;
+    public static boolean INTERACT_ITEM_EVENT_PRIMARY = false;
 
     public static boolean SPAWN_ENTITY_EVENT = false;
     public static boolean SPAWN_ENTITY_EVENT_CHUNK_LOAD = false;

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/server/management/PlayerInteractionManagerMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/server/management/PlayerInteractionManagerMixin_Tracker.java
@@ -42,6 +42,7 @@ import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.world.GameType;
 import net.minecraft.world.World;
 import org.spongepowered.api.block.BlockSnapshot;
+import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.EventContextKeys;
 import org.spongepowered.api.event.block.InteractBlockEvent;
@@ -81,7 +82,7 @@ public abstract class PlayerInteractionManagerMixin_Tracker {
     public void impl$callInteractItemSecondary(final ServerPlayerEntity player, final World p_187250_2_, final ItemStack stack, final Hand hand,
         final CallbackInfoReturnable<ActionResultType> cir
     ) {
-        final InteractItemEvent.Secondary event = SpongeCommonEventFactory.callInteractItemEventSecondary(player, stack, hand, null, null);
+        final InteractItemEvent.Secondary event = SpongeCommonEventFactory.callInteractItemEventSecondary(player, stack, hand);
         if (event.isCancelled()) {
             cir.setReturnValue(ActionResultType.FAIL);
         }
@@ -90,8 +91,8 @@ public abstract class PlayerInteractionManagerMixin_Tracker {
     @Inject(method = "handleBlockBreakAction", cancellable = true, at = @At(value = "HEAD"))
     public void impl$callInteractBlockPrimaryEvent(final BlockPos p_225416_1_, final CPlayerDiggingPacket.Action p_225416_2_, final Direction p_225416_3_, final int p_225416_4_, final CallbackInfo ci) {
         final BlockSnapshot snapshot = ((ServerWorld) (this.level)).createSnapshot(VecHelper.toVector3i(p_225416_1_));
-        final InteractBlockEvent.Primary event = SpongeCommonEventFactory.callInteractBlockEventPrimary(this.player, this.player.getItemInHand(Hand.MAIN_HAND), snapshot, Hand.MAIN_HAND, p_225416_3_, null);
-        if (event.isCancelled()) {
+        final InteractBlockEvent.Primary event = SpongeCommonEventFactory.callInteractBlockEventPrimary(p_225416_2_, this.player, this.player.getItemInHand(Hand.MAIN_HAND), snapshot, Hand.MAIN_HAND, p_225416_3_);
+        if (event instanceof Cancellable && ((Cancellable) event).isCancelled()) {
             this.player.connection.send(new SPlayerDiggingPacket(p_225416_1_, this.level.getBlockState(p_225416_1_), p_225416_2_, false, "block action restricted"));
             ci.cancel();
         }

--- a/testplugins/src/main/java/org/spongepowered/test/interact/InteractTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/interact/InteractTest.java
@@ -85,7 +85,7 @@ public final class InteractTest implements LoadableModule {
             Sponge.getServer().getBroadcastAudience().sendMessage(Identity.nil(), Component.text().append(Component.text("/* Event: ")).append(Component.text(event.getClass().getSimpleName())).build());
             Sponge.getServer().getBroadcastAudience().sendMessage(Identity.nil(),
                     Component.text().append(Component.text("/* Hand: "))
-                            .append(Component.text(event.getContext().get(EventContextKeys.USED_HAND).map(h -> RegistryTypes.HAND_TYPE.keyFor(event.getEntity().getWorld().registries(), h).getFormatted()).orElse("UNKNOWN")))
+                            .append(Component.text(event.getContext().get(EventContextKeys.USED_HAND).map(h -> RegistryTypes.HAND_TYPE.keyFor(Sponge.getGame().registries(), h).getFormatted()).orElse("UNKNOWN")))
                             .build()
             );
             Sponge.getGame().getSystemSubject().sendMessage(Identity.nil(), Component.text().append(Component.text("/ Cause: ")).append(Component.text(event.getCause().all().toString())).build());

--- a/testplugins/src/main/java/org/spongepowered/test/projectile/ProjectileTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/projectile/ProjectileTest.java
@@ -210,21 +210,18 @@ public class ProjectileTest implements LoadableModule {
 
         @Listener
         public void onClickBlock(final InteractBlockEvent.Secondary event, @First final ServerPlayer player) {
-            if (event.getInteractionPoint().isPresent()) {
-                final Vector3d interactionPoint = event.getInteractionPoint().get();
-                final ServerWorld world = player.getWorld();
-                final EntityType<? extends Projectile> nextType = this.projectileTypes.poll();
-                this.projectileTypes.offer(nextType);
-                final Optional<? extends BlockEntity> blockEntity = world.getBlockEntity(interactionPoint.toInt());
-                if (blockEntity.isPresent() && blockEntity.get() instanceof Dispenser) {
-                    ((Dispenser) blockEntity.get()).launchProjectile(nextType);
-                } else {
-                    player.launchProjectile(nextType);
-                }
-                event.setCancelled(true);
-                player.sendMessage(Identity.nil(), Component.text(RegistryTypes.ENTITY_TYPE.keyFor(Sponge.getGame().registries(), nextType).toString()));
+            final Vector3d interactionPoint = event.getInteractionPoint();
+            final ServerWorld world = player.getWorld();
+            final EntityType<? extends Projectile> nextType = this.projectileTypes.poll();
+            this.projectileTypes.offer(nextType);
+            final Optional<? extends BlockEntity> blockEntity = world.getBlockEntity(interactionPoint.toInt());
+            if (blockEntity.isPresent() && blockEntity.get() instanceof Dispenser) {
+                ((Dispenser) blockEntity.get()).launchProjectile(nextType);
+            } else {
+                player.launchProjectile(nextType);
             }
-
+            event.setCancelled(true);
+            player.sendMessage(Identity.nil(), Component.text(RegistryTypes.ENTITY_TYPE.keyFor(Sponge.getGame().registries(), nextType).toString()));
         }
 
     }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2278) | **SpongeCommon**


Notes for Implementation:
`CPlayerDiggingPacket` is sent multiple times with different actions (start digging/cancel digging/finish digging) in survival when digging a block
creative only uses the start digging action.
`CAnimateHandPacket` is sent for a bunch of different actions. 
We need to filter out packets that are not for just swinging in air to use in InteractItemEvent.Primary. (e.g. while digging, after throwing out an item)
`CUseEntityPacket` is sent twice: first with `INTERACT_AT` then `INTERACT`
