### PR TITLE
Rebuild the SpongeParameterTranslator

### DIFF
--- a/src/main/java/org/spongepowered/common/command/SpongeParameterizedCommand.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeParameterizedCommand.java
@@ -26,7 +26,6 @@ package org.spongepowered.common.command;
 
 import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.StringReader;
-import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import net.kyori.adventure.text.Component;
@@ -36,19 +35,16 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.command.Command;
 import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.command.CommandExecutor;
-import org.spongepowered.api.command.CommandResult;
-import org.spongepowered.api.command.exception.CommandException;
 import org.spongepowered.api.command.parameter.CommandContext;
 import org.spongepowered.api.command.parameter.Parameter;
 import org.spongepowered.api.command.parameter.managed.Flag;
 import org.spongepowered.common.command.brigadier.SpongeParameterTranslator;
 import org.spongepowered.common.command.brigadier.dispatcher.SpongeCommandDispatcher;
-import org.spongepowered.common.command.brigadier.tree.SpongeLiteralCommandNode;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -167,29 +163,11 @@ public final class SpongeParameterizedCommand implements Command.Parameterized {
         return this.cachedDispatcher;
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public LiteralCommandNode<CommandSource> buildWithAlias(final String primaryAlias) {
-        final LiteralArgumentBuilder<CommandSource> primary = LiteralArgumentBuilder.literal(primaryAlias);
-        primary.requires((Predicate) this.getExecutionRequirements());
-        if (this.executor == null) {
-            return (LiteralCommandNode<CommandSource>) SpongeParameterTranslator.createCommandTreeWithSubcommandsOnly(primary, this.subcommands);
-        } else {
-            return (LiteralCommandNode<CommandSource>) SpongeParameterTranslator.createCommandTree(primary, this);
-        }
+        return this.buildWithAliases(Collections.singleton(primaryAlias)).iterator().next();
     }
 
-    public Collection<LiteralCommandNode<CommandSource>> buildWithAliases(final Iterable<String> aliases) {
-        final Iterator<String> iterable = aliases.iterator();
-        final LiteralCommandNode<CommandSource> built = this.buildWithAlias(iterable.next());
-        final List<LiteralCommandNode<CommandSource>> nodes = new ArrayList<>();
-        nodes.add(built);
-        while (iterable.hasNext()) {
-            final LiteralArgumentBuilder<CommandSource> secondary = LiteralArgumentBuilder.literal(iterable.next());
-            secondary.executes(built.getCommand());
-            secondary.requires(built.getRequirement());
-            nodes.add(new SpongeLiteralCommandNode(secondary.redirect(built), this));
-        }
-
-        return nodes;
+    public Collection<LiteralCommandNode<CommandSource>> buildWithAliases(final Collection<String> aliases) {
+        return SpongeParameterTranslator.INSTANCE.createCommandTree(this, aliases);
     }
 }

--- a/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeArgumentCommandNodeBuilder.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeArgumentCommandNodeBuilder.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.command.parameter.managed.ValueCompleter;
 import org.spongepowered.api.command.parameter.managed.ValueUsage;
 import org.spongepowered.common.command.brigadier.argument.ArgumentParser;
 import org.spongepowered.common.command.brigadier.argument.StandardCatalogedArgumentParser;
+import org.spongepowered.common.command.parameter.SpongeDefaultValueParser;
 import org.spongepowered.common.command.parameter.SpongeParameterKey;
 
 // We use the ArgumentBuilder primarily for setting redirects properly.
@@ -42,16 +43,7 @@ public final class SpongeArgumentCommandNodeBuilder<T> extends ArgumentBuilder<C
     @Nullable private final ValueCompleter completer;
     @Nullable private final String suffix;
     @Nullable private final ValueUsage usage;
-    private final boolean isEmptyOptional;
-
-    public SpongeArgumentCommandNodeBuilder(
-            final SpongeParameterKey<? super T> key,
-            final ArgumentParser<? extends T> type,
-            final ValueCompleter completer,
-            @Nullable final ValueUsage usage,
-            final boolean isEmptyOptional) {
-        this(key, type, completer, usage, null, isEmptyOptional);
-    }
+    @Nullable private final SpongeDefaultValueParser<? extends T> defaultValueParser;
 
     public SpongeArgumentCommandNodeBuilder(
             final SpongeParameterKey<? super T> key,
@@ -59,22 +51,18 @@ public final class SpongeArgumentCommandNodeBuilder<T> extends ArgumentBuilder<C
             final ValueCompleter completer,
             @Nullable final ValueUsage usage,
             @Nullable final String suffix,
-            final boolean isEmptyOptional) {
+            @Nullable final SpongeDefaultValueParser<? extends T> defaultValueParser) {
         this.key = key;
         this.type = type;
         this.completer = type == completer && type instanceof StandardCatalogedArgumentParser ? null : completer;
         this.usage = usage;
         this.suffix = suffix;
-        this.isEmptyOptional = isEmptyOptional;
+        this.defaultValueParser = defaultValueParser;
     }
 
     @Override
     protected SpongeArgumentCommandNodeBuilder<T> getThis() {
         return this;
-    }
-
-    public boolean isEmptyOptional() {
-        return this.isEmptyOptional;
     }
 
     @Override
@@ -89,7 +77,8 @@ public final class SpongeArgumentCommandNodeBuilder<T> extends ArgumentBuilder<C
                 this.getRedirect(),
                 this.getRedirectModifier(),
                 this.isFork(),
-                this.suffix == null ? this.key.key() : this.key.key() + "_" + this.suffix
+                this.suffix == null ? this.key.key() : this.key.key() + "_" + this.suffix,
+                this.defaultValueParser
         );
         for (final CommandNode<CommandSource> child : this.getArguments()) {
             node.addChild(child);

--- a/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeLiteralCommandNode.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeLiteralCommandNode.java
@@ -42,6 +42,9 @@ public class SpongeLiteralCommandNode extends LiteralCommandNode<CommandSource> 
     // used so we can have insertion order.
     private final UnsortedNodeHolder nodeHolder = new UnsortedNodeHolder();
     private final Command.@Nullable Parameterized subcommandIfApplicable;
+    private CommandNode<CommandSource> forcedRedirect;
+
+    private com.mojang.brigadier.Command<CommandSource> executor;
 
     public SpongeLiteralCommandNode(final LiteralArgumentBuilder<CommandSource> argumentBuilder) {
         this(argumentBuilder, null);
@@ -78,4 +81,41 @@ public class SpongeLiteralCommandNode extends LiteralCommandNode<CommandSource> 
             ((SpongeCommandContextBuilder) contextBuilder).setCurrentTargetCommand(this.subcommandIfApplicable);
         }
     }
+
+    @Override
+    public void forceExecutor(final com.mojang.brigadier.Command<CommandSource> forcedExecutor) {
+        this.executor = forcedExecutor;
+    }
+
+    @Override
+    public boolean canForceRedirect() {
+        return this.getChildren() == null || this.getChildren().isEmpty();
+    }
+
+    @Override
+    public void forceRedirect(final CommandNode<CommandSource> forcedRedirect) {
+        this.forcedRedirect = forcedRedirect;
+    }
+
+    @Override
+    public CommandNode<CommandSource> getRedirect() {
+        final CommandNode<CommandSource> redirect = super.getRedirect();
+        if (redirect != null) {
+            return redirect;
+        }
+        if (this.canForceRedirect()) {
+            return this.forcedRedirect;
+        }
+        return null;
+    }
+
+    @Override
+    public com.mojang.brigadier.Command<CommandSource> getCommand() {
+        final com.mojang.brigadier.Command<CommandSource> command = super.getCommand();
+        if (command != null) {
+            return command;
+        }
+        return this.executor;
+    }
+
 }

--- a/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeNode.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeNode.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.command.brigadier.tree;
 
+import com.mojang.brigadier.Command;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
@@ -51,4 +52,9 @@ public interface SpongeNode {
         return this.getChildrenForSuggestions();
     }
 
+    void forceExecutor(Command<CommandSource> forcedExecutor);
+
+    boolean canForceRedirect();
+
+    void forceRedirect(CommandNode<CommandSource> forcedRedirect);
 }

--- a/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongePermissionWrappedLiteralCommandNode.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongePermissionWrappedLiteralCommandNode.java
@@ -24,14 +24,18 @@
  */
 package org.spongepowered.common.command.brigadier.tree;
 
+import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.tree.CommandNode;
 import net.minecraft.command.CommandSource;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Used as a marker to indicate that this root node is not Sponge native.
  */
 public final class SpongePermissionWrappedLiteralCommandNode extends SpongeLiteralCommandNode {
+
+    @Nullable private Command<CommandSource> executor;
 
     public SpongePermissionWrappedLiteralCommandNode(
             final LiteralArgumentBuilder<CommandSource> builder) {
@@ -40,6 +44,20 @@ public final class SpongePermissionWrappedLiteralCommandNode extends SpongeLiter
         for (final CommandNode<CommandSource> argument : builder.getArguments()) {
             this.addChild(argument);
         }
+    }
+
+    @Override
+    public void forceExecutor(final Command<CommandSource> forcedExecutor) {
+        this.executor = forcedExecutor;
+    }
+
+    @Override
+    public Command<CommandSource> getCommand() {
+        final Command<CommandSource> command = super.getCommand();
+        if (command != null) {
+            return command;
+        }
+        return this.executor;
     }
 
 }

--- a/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeRootCommandNode.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/tree/SpongeRootCommandNode.java
@@ -24,9 +24,12 @@
  */
 package org.spongepowered.common.command.brigadier.tree;
 
+import com.mojang.brigadier.Command;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
 import net.minecraft.command.CommandSource;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.command.CommandExecutor;
 
 import java.util.Collection;
 
@@ -34,6 +37,7 @@ public final class SpongeRootCommandNode extends RootCommandNode<CommandSource> 
 
     // used so we can have insertion order.
     private final UnsortedNodeHolder nodeHolder = new UnsortedNodeHolder();
+    @Nullable private Command<CommandSource> executor;
 
     @Override
     public void addChild(final CommandNode<CommandSource> node) {
@@ -44,6 +48,30 @@ public final class SpongeRootCommandNode extends RootCommandNode<CommandSource> 
     @Override
     public Collection<CommandNode<CommandSource>> getChildrenForSuggestions() {
         return this.nodeHolder.getChildrenForSuggestions();
+    }
+
+    @Override
+    public void forceExecutor(final Command<CommandSource> forcedExecutor) {
+        this.executor = forcedExecutor;
+    }
+
+    @Override
+    public boolean canForceRedirect() {
+        return false;
+    }
+
+    @Override
+    public void forceRedirect(final CommandNode<CommandSource> forcedRedirect) {
+        // no-op
+    }
+
+    @Override
+    public Command<CommandSource> getCommand() {
+        final Command<CommandSource> command = super.getCommand();
+        if (command != null) {
+            return command;
+        }
+        return this.executor;
     }
 
 }

--- a/src/main/java/org/spongepowered/common/command/parameter/SpongeParameterValue.java
+++ b/src/main/java/org/spongepowered/common/command/parameter/SpongeParameterValue.java
@@ -50,9 +50,6 @@ import java.util.stream.Collectors;
 
 public final class SpongeParameterValue<T> implements Parameter.Value<T> {
 
-   // private final static Text NEW_LINE = Text.of("\n");
-   // private final static Text GENERIC_EXCEPTION_ERROR = t("Could not parse element");
-
     private final ImmutableList<ValueParser<? extends T>> parsers;
     @Nullable private final SpongeDefaultValueParser<? extends T> defaultParser;
     private final ValueCompleter completer;
@@ -211,9 +208,10 @@ public final class SpongeParameterValue<T> implements Parameter.Value<T> {
 
     @Override
     public boolean isOptional() {
-        return this.isOptional;
+        return !this.hasDefault() && this.isOptional;
     }
 
+    @Nullable
     public SpongeDefaultValueParser<? extends T> getDefaultParser() {
         return this.defaultParser;
     }
@@ -233,6 +231,10 @@ public final class SpongeParameterValue<T> implements Parameter.Value<T> {
             }
         }
         return null;
+    }
+
+    public boolean hasDefault() {
+        return this.defaultParser != null;
     }
 
 }

--- a/src/main/java/org/spongepowered/common/command/parameter/multi/SpongeFirstOfParameter.java
+++ b/src/main/java/org/spongepowered/common/command/parameter/multi/SpongeFirstOfParameter.java
@@ -24,18 +24,9 @@
  */
 package org.spongepowered.common.command.parameter.multi;
 
-import com.mojang.brigadier.builder.ArgumentBuilder;
-import com.mojang.brigadier.tree.CommandNode;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import net.minecraft.command.CommandSource;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.command.parameter.Parameter;
-import org.spongepowered.common.command.brigadier.SpongeParameterTranslator;
-import org.spongepowered.common.command.brigadier.tree.SpongeCommandExecutorWrapper;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 
 public final class SpongeFirstOfParameter extends SpongeMultiParameter {
 
@@ -43,94 +34,4 @@ public final class SpongeFirstOfParameter extends SpongeMultiParameter {
         super(parameterCandidates, isOptional, isTerminal);
     }
 
-    @Override
-    public boolean createNode(
-            final SpongeCommandExecutorWrapper executorWrapper,
-            final Consumer<CommandNode<CommandSource>> builtNodeConsumer,
-            final Consumer<ArgumentBuilder<CommandSource, ?>> nodeCallback,
-            final List<CommandNode<CommandSource>> potentialOptionalRedirects,
-            final boolean isTermination,
-            final boolean previousWasOptional,
-            @Nullable final String suffix,
-            final boolean isContainerAtEnd) {
-        final boolean hasExecutor = isTermination || this.isTerminal();
-
-        // If we have a termination, this is easy!
-        // If not, it's a little more complicated. But it's all handled by `nodeCallback` anyway.
-        boolean first = true;
-
-        // This will grab the first built node, that is, the last in a tree list.
-        final Grabber grabber = new Grabber(builtNodeConsumer);
-
-        // The redirector redirects to the grabbed node - which will continue execution to the node after this.
-        final Consumer<ArgumentBuilder<CommandSource, ?>> redirector = node -> node.redirect(grabber.grabbed);
-
-        final Object2IntOpenHashMap<String> counter = new Object2IntOpenHashMap<>();
-        for (final Parameter parameter : this.getParameterCandidates()) {
-            final int original;
-            if (parameter instanceof Parameter.Value<?>) {
-                original = counter.addTo(((Value<?>) parameter).getKey().key(), 1);
-            } else if (parameter instanceof Parameter.Subcommand) {
-                ((Subcommand) parameter).getAliases().forEach(x -> counter.addTo(x, 1));
-                original = 0;
-            } else {
-                original = 0;
-            }
-            if (parameter instanceof SpongeSequenceParameter) {
-                final SpongeSequenceParameter sequenceParameter = ((SpongeSequenceParameter) parameter);
-                final boolean grab = first && !sequenceParameter.endsWithSubcommand();
-                ((SpongeSequenceParameter) parameter).createNode(
-                        executorWrapper,
-                        grab ? grabber : builtNodeConsumer,
-                        first ? nodeCallback : redirector, // latter is used for merging command paths back together.
-                        potentialOptionalRedirects,
-                        hasExecutor,
-                        previousWasOptional,
-                        suffix,
-                        isContainerAtEnd);
-            } else {
-                final List<Parameter> parameters = new ArrayList<>();
-                parameters.add(parameter);
-                SpongeParameterTranslator.createNode(
-                    parameters.listIterator(),
-                    executorWrapper,
-                    first && !(parameter instanceof Parameter.Subcommand) ? grabber : builtNodeConsumer,
-                    grabber.grabbed == null ? nodeCallback : redirector, // latter is used for merging command paths back together.
-
-                    // we don't want to redirect to secondary branches, so we hand a copy of the list, BUT we will want there to be
-                    // redirects within the branch, and to later nodes.
-                    first ? potentialOptionalRedirects : new ArrayList<>(potentialOptionalRedirects),
-                    hasExecutor,
-                    previousWasOptional,
-                    original == 0 ? null : String.valueOf(original),
-                    isContainerAtEnd);
-            }
-
-            if (first && grabber.isValid()) {
-                first = false;
-            }
-        }
-
-        return this.getParameterCandidates().stream().anyMatch(Parameter::isOptional);
-    }
-
-    private static class Grabber implements Consumer<CommandNode<CommandSource>> {
-
-        private final Consumer<CommandNode<CommandSource>> original;
-        private CommandNode<CommandSource> grabbed;
-
-        public Grabber(final Consumer<CommandNode<CommandSource>> original) {
-            this.original = original;
-        }
-
-        @Override
-        public void accept(final CommandNode<CommandSource> commandSourceCommandNode) {
-            this.grabbed = commandSourceCommandNode;
-            this.original.accept(commandSourceCommandNode);
-        }
-
-        public boolean isValid() {
-            return this.original != null;
-        }
-    }
 }

--- a/src/main/java/org/spongepowered/common/command/parameter/multi/SpongeMultiParameter.java
+++ b/src/main/java/org/spongepowered/common/command/parameter/multi/SpongeMultiParameter.java
@@ -72,12 +72,4 @@ public abstract class SpongeMultiParameter implements Parameter {
         return this.isTerminal;
     }
 
-    public abstract boolean createNode(SpongeCommandExecutorWrapper executorWrapper,
-            Consumer<CommandNode<CommandSource>> parentNode,
-            Consumer<ArgumentBuilder<CommandSource, ?>> nodeCallback,
-            List<CommandNode<CommandSource>> potentialOptionalRedirects,
-            boolean isTermination,
-            boolean previousWasOptional,
-            String suffix,
-            boolean isContainerAtEnd);
 }

--- a/src/main/java/org/spongepowered/common/command/parameter/multi/SpongeSequenceParameter.java
+++ b/src/main/java/org/spongepowered/common/command/parameter/multi/SpongeSequenceParameter.java
@@ -24,52 +24,14 @@
  */
 package org.spongepowered.common.command.parameter.multi;
 
-import com.mojang.brigadier.builder.ArgumentBuilder;
-import com.mojang.brigadier.tree.CommandNode;
-import net.minecraft.command.CommandSource;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.command.parameter.Parameter;
-import org.spongepowered.common.command.brigadier.SpongeParameterTranslator;
-import org.spongepowered.common.command.brigadier.tree.SpongeCommandExecutorWrapper;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 
 public final class SpongeSequenceParameter extends SpongeMultiParameter {
 
     protected SpongeSequenceParameter(final List<Parameter> parameterCandidates, final boolean isOptional, final boolean isTerminal) {
         super(parameterCandidates, isOptional, isTerminal);
     }
-
-    public boolean endsWithSubcommand() {
-        final int size = this.getParameterCandidates().size();
-        return this.getParameterCandidates().get(size - 1) instanceof Parameter.Subcommand;
-    }
-
-    @Override
-    public boolean createNode(
-            final SpongeCommandExecutorWrapper executorWrapper,
-            final Consumer<CommandNode<CommandSource>> parentNode,
-            final Consumer<ArgumentBuilder<CommandSource, ?>> nodeCallback,
-            final List<CommandNode<CommandSource>> potentialOptionalRedirects,
-            final boolean isTermination,
-            final boolean previousWasOptional,
-            @Nullable final String suffix,
-            final boolean isContainerAtEnd) {
-
-        final boolean isTerminal = SpongeParameterTranslator.createNode(
-                this.getParameterCandidates().listIterator(),
-                executorWrapper,
-                parentNode,
-                nodeCallback,
-                potentialOptionalRedirects,
-                isTermination || this.isTerminal(),
-                previousWasOptional,
-                suffix,
-                isContainerAtEnd);
-        return this.isOptional() || isTerminal;
-    }
-
 
 }

--- a/testplugins/src/main/java/org/spongepowered/test/command/CommandTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/command/CommandTest.java
@@ -413,6 +413,38 @@ public final class CommandTest {
                 .parameters(opt1, topt, req1).build(), "optional_toptional_optional");
 
         event.register(this.plugin, builder.build(), "testcommand", "testcmd");
+
+        // Adapted from https://github.com/SpongePowered/Sponge/issues/3238#issuecomment-750456173
+
+        final Command.Parameterized firstSub = Command.builder()
+                .parameter(CommonParameters.BOOLEAN)
+                .setExecutor(c -> {
+                    c.sendMessage(Identity.nil(), Component.text("first"));
+                    return CommandResult.success();
+                })
+                .build();
+        final Command.Parameterized secondSub = Command.builder()
+                .parameter(CommonParameters.BOOLEAN)
+                .setExecutor(c -> {
+                    c.sendMessage(Identity.nil(), Component.text("second"));
+                    return CommandResult.success();
+                })
+                .build();
+        final Command.Parameterized parent = Command.builder()
+                .setExecutor(c -> {
+                    c.sendMessage(Identity.nil(), Component.text("parent"));
+                    return CommandResult.success();
+                })
+                .parameters(CommonParameters.ONLINE_WORLD_PROPERTIES_ONLY_OPTIONAL)
+                .parameters(Parameter.firstOf(
+                        Parameter.subcommand(firstSub, "first"),
+                        Parameter.subcommand(secondSub, "second")
+                ))
+                .setTerminal(true)
+                .build();
+
+        event.register(this.plugin, parent, "testterminal");
+
     }
 
     @Listener


### PR DESCRIPTION
Mostly here as a final sanity check, and for the chance for any _final_ things to be checked out.

The original design of the system was designed to build a tree from the end so we know about optionals and terminating parameters ahead of time using a recursive algorithm. It turns out that the idea was quite frankly insane and has led to numerous issues with optional and default parameters, as well as indicating when something is terminal. The idea was to not add to Brig as much as possible, but it turned out that we actually just went and made many changes anyway. It was unsustainable.

This algorithm modifies the nodes such that we can force an executor or redirection on our nodes only. That way, we can build a node and retroactively apply these properties, meaning less messing about in the Brig core code and an easier time maintaining things... maybe (such updating core Brig code we've copied into Sponge is for another commit).

This should fix most of the issues people have been having - most of the test commands (those that I've tested that don't either need a little bit more thought on defaults handling, or is world stuff and that means we're waiting for that to be done)