### PR TITLE
Add a shutdown hook to await the termination of the subprocess

### DIFF
--- a/vanilla/src/installer/java/org/spongepowered/vanilla/installer/InstallerMain.java
+++ b/vanilla/src/installer/java/org/spongepowered/vanilla/installer/InstallerMain.java
@@ -108,6 +108,13 @@ public final class InstallerMain {
 
         final ProcessBuilder processBuilder = new ProcessBuilder(command);
         final Process process = processBuilder.inheritIO().start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                process.waitFor();
+            } catch (InterruptedException e) {
+                installer.getLogger().error("Waiting for server termination failed!", e);
+            }
+        }));
         process.waitFor();
     }
 


### PR DESCRIPTION
This allows the server to cleanly shut down after receiving SIGINT or SIGTERM in e.g. container environment

This is the bare minimum that should be done for #3251 it seems.