### PR TITLE
Allow to change the installer's log4j2 config

### DIFF
--- a/vanilla/src/installer/java/org/spongepowered/vanilla/installer/InstallerMain.java
+++ b/vanilla/src/installer/java/org/spongepowered/vanilla/installer/InstallerMain.java
@@ -56,7 +56,10 @@ public final class InstallerMain {
     private static final Pattern CLASSPATH_SPLITTER = Pattern.compile(";", Pattern.LITERAL);
 
     static {
-        System.setProperty("log4j.configurationFile", "log4j2_launcher.xml");
+        final String log4jConfig = System.getProperty("log4j.configurationFile");
+        if (log4jConfig == null || log4jConfig.isEmpty()) {
+            System.setProperty("log4j.configurationFile", "log4j2_launcher.xml");
+        }
     }
 
     private final Installer installer;


### PR DESCRIPTION
Previously the installer conditionally overwrote the log4j.configurationFile property, which prevents extern configuration. The change only sets the property if it doesn't have a value yet.

This is another small PR to improve containerization of sponge