### PR TITLE
Properly shutdown the installer's child process

### DIFF
--- a/vanilla/src/installer/java/org/spongepowered/vanilla/installer/InstallerMain.java
+++ b/vanilla/src/installer/java/org/spongepowered/vanilla/installer/InstallerMain.java
@@ -118,7 +118,10 @@ public final class InstallerMain {
         final Process process = processBuilder.inheritIO().start();
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             try {
-                process.waitFor();
+                if (process.isAlive()) {
+                    process.destroy();
+                    process.waitFor();
+                }
             } catch (InterruptedException e) {
                 installer.getLogger().error("Waiting for server termination failed!", e);
             }


### PR DESCRIPTION
This is the proper solution for #3251. Without this change, shutting down the server only works by pressing ctrl-c while having a terminal open with the stdin of the child process (actual MC server), since the child is started with `inheritIO()`. When the stdin is not kept open, which would be normal for a swarm deployment, before this commit there was actually no way of cleanly shutting down the server, because PID1 received the INT/TERM signal, started its shutdown hook which then waits forever for the child to exit, since the child does not know it's supposed to exit. Now it does, I tested this in a few scenarios.

Again a tiny change to work better in container environments.