### PR TITLE
Some fixes for commands

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeGame.java
+++ b/src/main/java/org/spongepowered/common/SpongeGame.java
@@ -69,7 +69,6 @@ public final class SpongeGame implements Game {
     private final PluginConfigManager configManager;
     private final ChannelRegistry channelRegistry;
     private final MetricsConfigManager metricsConfigManager;
-    private final CommandManager commandManager;
     private final SqlManager sqlManager;
     private final ServiceProvider.GameScoped serviceProvider;
 
@@ -85,7 +84,7 @@ public final class SpongeGame implements Game {
     public SpongeGame(final Platform platform, final GameRegistry registry, final BuilderProvider builderProvider,
             final FactoryProvider factoryProvider, final DataManager dataManager, final PluginManager pluginManager,
             final EventManager eventManager, final AssetManager assetManager, final PluginConfigManager configManager,
-            final ChannelRegistry channelRegistry, final MetricsConfigManager metricsConfigManager, final CommandManager commandManager,
+            final ChannelRegistry channelRegistry, final MetricsConfigManager metricsConfigManager,
             final SqlManager sqlManager, final ServiceProvider.GameScoped serviceProvider) {
 
         this.platform = platform;
@@ -99,7 +98,6 @@ public final class SpongeGame implements Game {
         this.configManager = configManager;
         this.channelRegistry = channelRegistry;
         this.metricsConfigManager = metricsConfigManager;
-        this.commandManager = commandManager;
         this.sqlManager = sqlManager;
         this.serviceProvider = serviceProvider;
 
@@ -173,11 +171,6 @@ public final class SpongeGame implements Game {
     @Override
     public MetricsConfigManager getMetricsConfigManager() {
         return this.metricsConfigManager;
-    }
-
-    @Override
-    public CommandManager getCommandManager() {
-        return this.commandManager;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/SpongeLifecycle.java
+++ b/src/main/java/org/spongepowered/common/SpongeLifecycle.java
@@ -149,8 +149,10 @@ public final class SpongeLifecycle {
         ((SpongeServer) this.game.getServer()).getUsernameCache().load();
     }
 
-    public void establishCommands() {
-        ((SpongeCommandManager) this.game.getCommandManager()).init();
+    public SpongeCommandManager createCommandManager() {
+        final SpongeCommandManager result = this.injector.getInstance(SpongeCommandManager.class);
+        result.init();
+        return result;
     }
 
     public void registerPluginListeners() {

--- a/src/main/java/org/spongepowered/common/bridge/command/CommandsBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/command/CommandsBridge.java
@@ -22,26 +22,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common;
+package org.spongepowered.common.bridge.command;
 
-import org.spongepowered.api.Server;
 import org.spongepowered.common.command.manager.SpongeCommandManager;
-import org.spongepowered.common.scheduler.ServerScheduler;
-import org.spongepowered.common.util.UsernameCache;
-import org.spongepowered.common.world.server.SpongeWorldManager;
-import org.spongepowered.common.world.storage.SpongePlayerDataManager;
 
-public interface SpongeServer extends SpongeEngine, Server {
+public interface CommandsBridge {
 
-    @Override
-    ServerScheduler getScheduler();
-    
-    @Override
-    SpongeWorldManager getWorldManager();
-
-    SpongePlayerDataManager getPlayerDataManager();
-
-    UsernameCache getUsernameCache();
-
-    SpongeCommandManager getCommandManager();
+    SpongeCommandManager bridge$commandManager();
 }

--- a/src/main/java/org/spongepowered/common/command/SpongeParameterizedCommand.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeParameterizedCommand.java
@@ -35,10 +35,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.command.Command;
 import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.command.CommandExecutor;
+import org.spongepowered.api.command.parameter.ArgumentReader;
 import org.spongepowered.api.command.parameter.CommandContext;
 import org.spongepowered.api.command.parameter.Parameter;
 import org.spongepowered.api.command.parameter.managed.Flag;
 import org.spongepowered.common.command.brigadier.SpongeParameterTranslator;
+import org.spongepowered.common.command.brigadier.SpongeStringReader;
 import org.spongepowered.common.command.brigadier.dispatcher.SpongeCommandDispatcher;
 import org.spongepowered.common.command.manager.SpongeCommandManager;
 
@@ -91,11 +93,12 @@ public final class SpongeParameterizedCommand implements Command.Parameterized {
 
     @Override
     @NonNull
-    public List<String> getSuggestions(@NonNull final CommandCause cause, @NonNull final String arguments) {
+    public List<String> getSuggestions(final @NonNull CommandCause cause, final ArgumentReader.@NonNull Mutable arguments) {
         final SpongeCommandDispatcher dispatcher = this.getCachedDispatcher();
-        final ParseResults<CommandSource> parseResults = dispatcher.parse(arguments, (CommandSource) cause);
+        final String input = arguments.getRemaining();
+        final ParseResults<CommandSource> parseResults = dispatcher.parse((StringReader) arguments, (CommandSource) cause);
         final Suggestions suggestions = dispatcher.getCompletionSuggestions(parseResults).join();
-        return suggestions.getList().stream().map(x -> x.apply(arguments)).collect(Collectors.toList());
+        return suggestions.getList().stream().map(x -> x.apply(input)).collect(Collectors.toList());
     }
 
     @Override
@@ -152,9 +155,9 @@ public final class SpongeParameterizedCommand implements Command.Parameterized {
 
     @Override
     @NonNull
-    public CommandContext parseArguments(@NonNull final CommandCause cause, @NonNull final String arguments) {
-        final ParseResults<CommandSource> results = this.getCachedDispatcher().parse(new StringReader(arguments), (CommandSource) cause);
-        return (CommandContext) results.getContext().build(arguments);
+    public CommandContext parseArguments(@NonNull final CommandCause cause, final ArgumentReader.@NonNull Mutable arguments) {
+        final ParseResults<CommandSource> results = this.getCachedDispatcher().parse((SpongeStringReader) arguments, (CommandSource) cause);
+        return (CommandContext) results.getContext().build(arguments.getInput());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/command/SpongeParameterizedCommand.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeParameterizedCommand.java
@@ -38,8 +38,10 @@ import org.spongepowered.api.command.CommandExecutor;
 import org.spongepowered.api.command.parameter.CommandContext;
 import org.spongepowered.api.command.parameter.Parameter;
 import org.spongepowered.api.command.parameter.managed.Flag;
+import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.command.brigadier.SpongeParameterTranslator;
 import org.spongepowered.common.command.brigadier.dispatcher.SpongeCommandDispatcher;
+import org.spongepowered.common.command.manager.SpongeCommandManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -157,7 +159,8 @@ public final class SpongeParameterizedCommand implements Command.Parameterized {
 
     private SpongeCommandDispatcher getCachedDispatcher() {
         if (this.cachedDispatcher == null) {
-            this.cachedDispatcher = new SpongeCommandDispatcher();
+            // TODO: this is wrong -- need to clear out the cached dispatcher when the registrar we are in gets invalidated maybe?
+            this.cachedDispatcher = new SpongeCommandDispatcher(SpongeCommandManager.get(SpongeCommon.getServer()));
             this.cachedDispatcher.register(this.buildWithAlias("command"));
         }
         return this.cachedDispatcher;

--- a/src/main/java/org/spongepowered/common/command/brigadier/SpongeStringReader.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/SpongeStringReader.java
@@ -24,18 +24,21 @@
  */
 package org.spongepowered.common.command.brigadier;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.kyori.adventure.text.Component;
+import net.minecraft.nbt.JsonToNBT;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.TextComponentUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.command.exception.ArgumentParseException;
 import org.spongepowered.api.command.parameter.ArgumentReader;
+import org.spongepowered.api.data.persistence.DataContainer;
+import org.spongepowered.common.adventure.SpongeAdventure;
+import org.spongepowered.common.data.persistence.NBTTranslator;
 
 // ArgumentReader.Mutable specifies a non null getRead() method, StringReader suggests its
 // nullable - but it isn't. So we just need to suppress the warning.
@@ -161,21 +164,29 @@ public final class SpongeStringReader extends StringReader implements ArgumentRe
     }
 
     @Override
-    public String parseJson() throws ArgumentParseException {
+    public String parseNBTString() throws ArgumentParseException {
         final int startCursor = this.getCursor();
         try {
-            this.readStruct();
-        } catch (final ArgumentParseException e) {
+            new JsonToNBT(this).readStruct();
+        } catch (final CommandSyntaxException ex) {
             this.setCursor(startCursor);
-            throw e;
+            throw new ArgumentParseException(
+                SpongeAdventure.asAdventure(TextComponentUtils.fromMessage(ex.getRawMessage())),
+                ex.getInput(),
+                ex.getCursor()
+            );
         }
         final int endCursor = this.getCursor(); // this will be just after a }
         return this.getInput().substring(startCursor, endCursor);
     }
 
     @Override
-    public JsonObject parseJsonObject() throws ArgumentParseException {
-        return new Gson().fromJson(this.parseJson(), JsonObject.class);
+    public DataContainer parseDataContainer() throws ArgumentParseException {
+        try {
+            return NBTTranslator.INSTANCE.translate(new JsonToNBT(this).readStruct());
+        } catch (final CommandSyntaxException e) {
+            throw this.createException(SpongeAdventure.asAdventure(TextComponentUtils.fromMessage(e.getRawMessage())));
+        }
     }
 
     @Override
@@ -202,138 +213,6 @@ public final class SpongeStringReader extends StringReader implements ArgumentRe
     @NonNull
     public ArgumentParseException createException(@NonNull final Component errorMessage, @NonNull final Throwable inner) {
         return new ArgumentParseException(errorMessage, inner, this.getInput(), this.getCursor());
-    }
-
-    // JSON parsing. Mostly taken from JsonToNBT
-    protected String readKey() throws ArgumentParseException {
-        this.skipWhitespace();
-        if (!this.canRead()) {
-            throw this.createException(Component.text("Unable to read JSON key"));
-        } else {
-            return this.getString();
-        }
-    }
-
-    public void readValue() throws ArgumentParseException {
-        this.skipWhitespace();
-        if (!this.canRead()) {
-            throw this.createException(Component.text("Unable to read JSON value"));
-        } else {
-            final char c0 = this.peek();
-            if (c0 == '{') {
-                this.readStruct();
-            } else {
-                if (c0 == '[') {
-                    this.readList();
-                } else {
-                    this.readValue();
-                }
-            }
-        }
-    }
-
-    protected void readList() throws ArgumentParseException {
-        if (this.canRead(3) && !StringReader.isQuotedStringStart(this.peek(1)) && this.peek(2) == ';') {
-            this.readArrayTag();
-        } else {
-            this.readListTag();
-        }
-    }
-
-    public void readStruct() throws ArgumentParseException {
-        this.expectAfterWhitespace('{');
-        this.skipWhitespace();
-
-        while(this.canRead() && this.peek() != '}') {
-            final String s = this.readKey();
-            if (s.isEmpty()) {
-                throw this.createException(Component.text("Unable to read JSON key"));
-            }
-
-            try {
-                this.expect(':');
-            } catch (final CommandSyntaxException e) {
-                throw this.createException(Component.text(e.getMessage()));
-            }
-            if (!this.hasElementSeparator()) {
-                break;
-            }
-
-            if (!this.canRead()) {
-                throw this.createException(Component.text("Unable to read JSON key"));
-            }
-        }
-
-        this.expectAfterWhitespace('}');
-    }
-
-    private void readListTag() throws ArgumentParseException {
-        this.expectAfterWhitespace('[');
-        this.skipWhitespace();
-        if (!this.canRead()) {
-            throw this.createException(Component.text("Unable to read JSON list"));
-        } else {
-            while(this.peek() != ']') {
-                this.readValue();
-                if (!this.hasElementSeparator()) {
-                    break;
-                }
-
-                if (!this.canRead()) {
-                    throw this.createException(Component.text("Unable to read JSON value"));
-                }
-            }
-
-            this.expectAfterWhitespace(']');
-        }
-    }
-
-    private void readArrayTag() throws ArgumentParseException {
-        this.expectAfterWhitespace('[');
-        this.read();
-        this.read();
-        this.skipWhitespace();
-        if (!this.canRead()) {
-            throw this.createException(Component.text("Unable to read JSON array"));
-        }
-        this.readArray();
-    }
-
-    private void readArray() throws ArgumentParseException {
-        while(true) {
-            if (this.peek() != ']') {
-                this.readValue();
-                if (this.hasElementSeparator()) {
-                    if (!this.canRead()) {
-                        throw this.createException(Component.text("Unable to read JSON value"));
-                    }
-                    continue;
-                }
-            }
-
-            this.expectAfterWhitespace(']');
-            return;
-        }
-    }
-
-    private boolean hasElementSeparator() {
-        this.skipWhitespace();
-        if (this.canRead() && this.peek() == ',') {
-            this.skip();
-            this.skipWhitespace();
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    private void expectAfterWhitespace(final char expected) throws ArgumentParseException {
-        this.skipWhitespace();
-        try {
-            this.expect(expected);
-        } catch (final CommandSyntaxException e) {
-            throw this.createException(Component.text(e.getMessage()));
-        }
     }
 
     private ResourceKey readResourceLocation(@Nullable final String defaultNamespace) throws ArgumentParseException {

--- a/src/main/java/org/spongepowered/common/command/brigadier/context/SpongeCommandContextBuilder.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/context/SpongeCommandContextBuilder.java
@@ -51,7 +51,6 @@ import org.spongepowered.common.command.parameter.SpongeParameterKey;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/org/spongepowered/common/command/brigadier/dispatcher/DelegatingCommandDispatcher.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/dispatcher/DelegatingCommandDispatcher.java
@@ -43,80 +43,85 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public final class DelegatingCommandDispatcher extends CommandDispatcher<CommandSource> {
+    private final BrigadierCommandRegistrar brigadier;
+
+    public DelegatingCommandDispatcher(final BrigadierCommandRegistrar brigadier) {
+        this.brigadier = brigadier;
+    }
 
     @Override
     public LiteralCommandNode<CommandSource> register(final LiteralArgumentBuilder<CommandSource> command) {
         // might as well do this directly
-        return BrigadierCommandRegistrar.INSTANCE.register(command);
+        return this.brigadier.register(command);
     }
 
     @Override
     public void setConsumer(final ResultConsumer<CommandSource> consumer) {
-        BrigadierCommandRegistrar.INSTANCE.getDispatcher().setConsumer(consumer);
+        this.brigadier.getDispatcher().setConsumer(consumer);
     }
 
     @Override
     public int execute(final String input, final CommandSource source) throws CommandSyntaxException {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().execute(input, source);
+        return this.brigadier.getDispatcher().execute(input, source);
     }
 
     @Override
     public int execute(final StringReader input, final CommandSource source) throws CommandSyntaxException {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().execute(input, source);
+        return this.brigadier.getDispatcher().execute(input, source);
     }
 
     @Override
     public int execute(final ParseResults<CommandSource> parse) throws CommandSyntaxException {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().execute(parse);
+        return this.brigadier.getDispatcher().execute(parse);
     }
 
     @Override
     public ParseResults<CommandSource> parse(final String command, final CommandSource source) {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().parse(command, source);
+        return this.brigadier.getDispatcher().parse(command, source);
     }
 
     @Override
     public ParseResults<CommandSource> parse(final StringReader command, final CommandSource source) {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().parse(command, source);
+        return this.brigadier.getDispatcher().parse(command, source);
     }
 
     @Override
     public String[] getAllUsage(final CommandNode<CommandSource> node, final CommandSource source, final boolean restricted) {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().getAllUsage(node, source, restricted);
+        return this.brigadier.getDispatcher().getAllUsage(node, source, restricted);
     }
 
     @Override
     public Map<CommandNode<CommandSource>, String> getSmartUsage(final CommandNode<CommandSource> node, final CommandSource source) {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().getSmartUsage(node, source);
+        return this.brigadier.getDispatcher().getSmartUsage(node, source);
     }
 
     @Override
     public CompletableFuture<Suggestions> getCompletionSuggestions(final ParseResults<CommandSource> parse) {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().getCompletionSuggestions(parse);
+        return this.brigadier.getDispatcher().getCompletionSuggestions(parse);
     }
 
     @Override
     public CompletableFuture<Suggestions> getCompletionSuggestions(final ParseResults<CommandSource> parse, final int cursor) {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().getCompletionSuggestions(parse, cursor);
+        return this.brigadier.getDispatcher().getCompletionSuggestions(parse, cursor);
     }
 
     @Override
     public RootCommandNode<CommandSource> getRoot() {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().getRoot();
+        return this.brigadier.getDispatcher().getRoot();
     }
 
     @Override
     public Collection<String> getPath(final CommandNode<CommandSource> target) {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().getPath(target);
+        return this.brigadier.getDispatcher().getPath(target);
     }
 
     @Override
     public CommandNode<CommandSource> findNode(final Collection<String> path) {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().findNode(path);
+        return this.brigadier.getDispatcher().findNode(path);
     }
 
     @Override
     public void findAmbiguities(final AmbiguityConsumer<CommandSource> consumer) {
-        BrigadierCommandRegistrar.INSTANCE.getDispatcher().findAmbiguities(consumer);
+        this.brigadier.getDispatcher().findAmbiguities(consumer);
     }
 }

--- a/src/main/java/org/spongepowered/common/command/brigadier/dispatcher/SpongeNodePermissionCache.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/dispatcher/SpongeNodePermissionCache.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.command.brigadier.dispatcher;
 
-import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
 import net.minecraft.command.CommandSource;
@@ -49,7 +48,7 @@ public final class SpongeNodePermissionCache {
 
     public static boolean canUse(
             final boolean isRoot,
-            final CommandDispatcher<CommandSource> dispatcher,
+            final SpongeCommandDispatcher dispatcher,
             final CommandNode<CommandSource> node,
             final CommandSource source
     ) {
@@ -72,7 +71,7 @@ public final class SpongeNodePermissionCache {
     }
 
     public static String createFromNode(
-            final CommandDispatcher<CommandSource> dispatcher,
+            final SpongeCommandDispatcher dispatcher,
             final CommandNode<CommandSource> node) {
         final String permission;
         if (node.getRedirect() != null && !(node.getRedirect() instanceof RootCommandNode) && node.getCommand() == null) {
@@ -96,7 +95,7 @@ public final class SpongeNodePermissionCache {
                                 + "Unable to determine owning plugin - using \"unknown\" as plugin ID", permString);
             } else {
                 final String original = path.iterator().next();
-                pluginId = SpongeCommon.getGame().getCommandManager()
+                pluginId = dispatcher.getCommandManager()
                         .getCommandMapping(original)
                         .map(x -> x.getPlugin().getMetadata().getId()).orElseGet(() -> {
                             SpongeCommon.getLogger().error("Root command /{} does not have an associated plugin!", original);

--- a/src/main/java/org/spongepowered/common/command/exception/SpongeCommandSyntaxException.java
+++ b/src/main/java/org/spongepowered/common/command/exception/SpongeCommandSyntaxException.java
@@ -52,7 +52,13 @@ public final class SpongeCommandSyntaxException extends CommandSyntaxException {
     }
 
     @Override
-    public synchronized Throwable getCause() {
+    public synchronized Throwable fillInStackTrace() {
+        // Don't gather stacktrace, we are just wrapping the existing exception
+        return this;
+    }
+
+    @Override
+    public synchronized CommandException getCause() {
         return this.innerException;
     }
 

--- a/src/main/java/org/spongepowered/common/command/manager/SpongeCommandManager.java
+++ b/src/main/java/org/spongepowered/common/command/manager/SpongeCommandManager.java
@@ -43,6 +43,7 @@ import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.util.ComponentMessageThrowable;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.ISuggestionProvider;
 import net.minecraft.entity.player.ServerPlayerEntity;
@@ -356,8 +357,8 @@ public final class SpongeCommandManager implements CommandManager.Mutable {
             this.prettyPrintThrowableError(thr, command, args, cause);
 
             Component excBuilder;
-            if (thr instanceof ComponentMessageException) {
-                final Component text = ((ComponentMessageException) thr).componentMessage();
+            if (thr instanceof ComponentMessageThrowable) {
+                final Component text = ((ComponentMessageThrowable) thr).componentMessage();
                 excBuilder = text == null ? Component.text("null") : text;
             } else {
                 excBuilder = Component.text(String.valueOf(thr.getMessage()));
@@ -538,7 +539,6 @@ public final class SpongeCommandManager implements CommandManager.Mutable {
         if (this.brigadierRegistrar == null) {
             throw new IllegalStateException("Brigadier registrar was not detected");
         }
-        this.hasStarted = true;
     }
 
     private void registerInternalCommands(final CommandRegistrar<Parameterized> registrar) {

--- a/src/main/java/org/spongepowered/common/command/parameter/SpongeParameterValueBuilder.java
+++ b/src/main/java/org/spongepowered/common/command/parameter/SpongeParameterValueBuilder.java
@@ -90,7 +90,7 @@ public final class SpongeParameterValueBuilder<T> implements Parameter.Value.Bui
     @Override
     public Parameter.Value.@NonNull Builder<T> setRequiredPermission(@Nullable final String permission) {
         if (permission == null) {
-            return this.setUsage(null);
+            return this.setRequirements(null);
         } else {
             return this.setRequirements(commandCause -> commandCause.getSubject().hasPermission(permission));
         }

--- a/src/main/java/org/spongepowered/common/command/parameter/managed/builder/SpongeRegistryEntryParameterBuilder.java
+++ b/src/main/java/org/spongepowered/common/command/parameter/managed/builder/SpongeRegistryEntryParameterBuilder.java
@@ -37,13 +37,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
-public final class SpongeCatalogedElementParameterBuilder<T>
+public final class SpongeRegistryEntryParameterBuilder<T>
         implements VariableValueParameters.CatalogedTypeBuilder<T> {
 
     private final Function<CommandContext, @Nullable ? extends Registry<? extends T>> registryFunction;
     private final List<String> prefixes = new ArrayList<>();
 
-    public SpongeCatalogedElementParameterBuilder(final Function<CommandContext, @Nullable ? extends Registry<? extends T>> registryFunction) {
+    public SpongeRegistryEntryParameterBuilder(final Function<CommandContext, @Nullable ? extends Registry<? extends T>> registryFunction) {
         this.registryFunction = registryFunction;
     }
 

--- a/src/main/java/org/spongepowered/common/command/parameter/managed/factory/SpongeVariableValueParametersFactory.java
+++ b/src/main/java/org/spongepowered/common/command/parameter/managed/factory/SpongeVariableValueParametersFactory.java
@@ -29,7 +29,6 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import net.minecraft.util.text.StringTextComponent;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.parameter.CommandContext;
 import org.spongepowered.api.command.parameter.managed.ValueParameter;
 import org.spongepowered.api.command.parameter.managed.standard.VariableValueParameters;
@@ -38,7 +37,7 @@ import org.spongepowered.api.registry.Registry;
 import org.spongepowered.api.registry.RegistryHolder;
 import org.spongepowered.api.registry.RegistryType;
 import org.spongepowered.common.command.brigadier.argument.StandardArgumentParser;
-import org.spongepowered.common.command.parameter.managed.builder.SpongeCatalogedElementParameterBuilder;
+import org.spongepowered.common.command.parameter.managed.builder.SpongeRegistryEntryParameterBuilder;
 import org.spongepowered.common.command.parameter.managed.builder.SpongeDynamicChoicesBuilder;
 import org.spongepowered.common.command.parameter.managed.builder.SpongeLiteralBuilder;
 import org.spongepowered.common.command.parameter.managed.builder.SpongeNumberRangeBuilder;
@@ -79,7 +78,7 @@ public final class SpongeVariableValueParametersFactory implements VariableValue
     public <T> VariableValueParameters.@NonNull CatalogedTypeBuilder<T> createRegistryEntryBuilder(
             @NonNull final Function<CommandContext, @Nullable RegistryHolder> holderProvider,
             final RegistryType<T> registryKey) {
-        return new SpongeCatalogedElementParameterBuilder<>(in -> {
+        return new SpongeRegistryEntryParameterBuilder<>(in -> {
             final RegistryHolder holder = holderProvider.apply(in);
             if (holder != null) {
                 return holder.registry(registryKey);
@@ -91,12 +90,12 @@ public final class SpongeVariableValueParametersFactory implements VariableValue
     @Override
     public <T> VariableValueParameters.@NonNull CatalogedTypeBuilder<T> createRegistryEntryBuilder(
             @NonNull final Function<CommandContext, ? extends Registry<? extends T>> returnType) {
-        return new SpongeCatalogedElementParameterBuilder<>(returnType);
+        return new SpongeRegistryEntryParameterBuilder<>(returnType);
     }
 
     @Override
     public <T> VariableValueParameters.CatalogedTypeBuilder<T> createRegistryEntryBuilder(final DefaultedRegistryType<T> type) {
-        return new SpongeCatalogedElementParameterBuilder<>(in -> type.get());
+        return new SpongeRegistryEntryParameterBuilder<>(in -> type.get());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/command/parameter/managed/standard/SpongeColorValueParameter.java
+++ b/src/main/java/org/spongepowered/common/command/parameter/managed/standard/SpongeColorValueParameter.java
@@ -96,7 +96,11 @@ public final class SpongeColorValueParameter extends ResourceKeyedArgumentValueP
 
         // Hex code?
         if (SpongeColorValueParameter.HEX_CODE.matcher(string).matches()) {
-            // Hex code
+            try {
+                return Optional.of(Color.ofRgb(Integer.parseInt(string.substring(1), 16)));
+            } catch (final NumberFormatException ex) {
+                // handled below
+            }
         }
 
         final String[] rgb = string.split(",", 3);

--- a/src/main/java/org/spongepowered/common/command/parameter/managed/standard/SpongeDataContainerValueParameter.java
+++ b/src/main/java/org/spongepowered/common/command/parameter/managed/standard/SpongeDataContainerValueParameter.java
@@ -64,10 +64,6 @@ public final class SpongeDataContainerValueParameter extends ResourceKeyedArgume
     public Optional<? extends DataContainer> getValue(final Parameter.@NonNull Key<? super DataContainer> parameterKey,
                                                       final ArgumentReader.@NonNull Mutable reader,
                                                       final CommandContext.@NonNull Builder context) throws ArgumentParseException {
-        try {
-            return Optional.of(DataFormats.JSON.get().read(reader.parseJson()));
-        } catch (final IOException e) {
-            throw reader.createException(Component.text(e.getMessage()));
-        }
+        return Optional.of(reader.parseDataContainer());
     }
 }

--- a/src/main/java/org/spongepowered/common/command/registrar/BrigadierCommandRegistrar.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/BrigadierCommandRegistrar.java
@@ -96,7 +96,7 @@ public final class BrigadierCommandRegistrar implements BrigadierBasedRegistrar,
 
     @Override
     public @NonNull CommandRegistrarType<LiteralArgumentBuilder<CommandSource>> type() {
-        return TYPE;
+        return BrigadierCommandRegistrar.TYPE;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/command/registrar/SpongeCommandRegistrarType.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/SpongeCommandRegistrarType.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.command.registrar;
+
+import io.leangen.geantyref.TypeToken;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.api.command.manager.CommandManager;
+import org.spongepowered.api.command.registrar.CommandRegistrar;
+import org.spongepowered.api.command.registrar.CommandRegistrarType;
+
+import java.util.function.Function;
+
+public final class SpongeCommandRegistrarType<V> implements CommandRegistrarType<V> {
+    private final TypeToken<V> handledType;
+    private final Function<CommandManager.Mutable, CommandRegistrar<V>> supplier;
+
+    public SpongeCommandRegistrarType(
+            final TypeToken<V> handledType,
+            final Function<CommandManager.Mutable, CommandRegistrar<V>> supplier
+    ) {
+        this.handledType = handledType;
+        this.supplier = supplier;
+    }
+
+    public SpongeCommandRegistrarType(
+            final Class<V> handledType,
+            final Function<CommandManager.Mutable, CommandRegistrar<V>> supplier
+    ) {
+        this(TypeToken.get(handledType), supplier);
+    }
+
+    @Override
+    public @NotNull TypeToken<V> handledType() {
+        return this.handledType;
+    }
+
+    @Override
+    public @NotNull CommandRegistrar<V> create(final CommandManager.@NotNull Mutable manager) {
+        return this.supplier.apply(manager);
+    }
+}

--- a/src/main/java/org/spongepowered/common/command/registrar/SpongeCommandRegistrarTypes.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/SpongeCommandRegistrarTypes.java
@@ -26,7 +26,7 @@ package org.spongepowered.common.command.registrar;
 
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.command.registrar.CommandRegistrar;
+import org.spongepowered.api.command.registrar.CommandRegistrarType;
 import org.spongepowered.api.registry.DefaultedRegistryReference;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryScope;
@@ -35,26 +35,26 @@ import org.spongepowered.api.registry.RegistryTypes;
 
 @SuppressWarnings("unused")
 @RegistryScopes(scopes = RegistryScope.GAME)
-public final class SpongeCommandRegistrars {
+public final class SpongeCommandRegistrarTypes {
 
     // @formatter:off
 
     // SORTFIELDS:ON
 
-    public static final DefaultedRegistryReference<CommandRegistrar<?>> BRIGADIER = SpongeCommandRegistrars.key(ResourceKey.sponge("brigadier"));
+    public static final DefaultedRegistryReference<CommandRegistrarType<?>> BRIGADIER = SpongeCommandRegistrarTypes.key(ResourceKey.sponge("brigadier"));
 
-    public static final DefaultedRegistryReference<CommandRegistrar<?>> MANAGED = SpongeCommandRegistrars.key(ResourceKey.sponge("managed"));
+    public static final DefaultedRegistryReference<CommandRegistrarType<?>> MANAGED = SpongeCommandRegistrarTypes.key(ResourceKey.sponge("managed"));
 
-    public static final DefaultedRegistryReference<CommandRegistrar<?>> RAW = SpongeCommandRegistrars.key(ResourceKey.sponge("raw"));
+    public static final DefaultedRegistryReference<CommandRegistrarType<?>> RAW = SpongeCommandRegistrarTypes.key(ResourceKey.sponge("raw"));
 
     // SORTFIELDS:OFF
 
     // @formatter:on
 
-    private SpongeCommandRegistrars() {
+    private SpongeCommandRegistrarTypes() {
     }
 
-    private static DefaultedRegistryReference<CommandRegistrar<?>> key(final ResourceKey location) {
-        return RegistryKey.of(RegistryTypes.COMMAND_REGISTRAR, location).asDefaultedReference(() -> Sponge.getGame().registries());
+    private static DefaultedRegistryReference<CommandRegistrarType<?>> key(final ResourceKey location) {
+        return RegistryKey.of(RegistryTypes.COMMAND_REGISTRAR_TYPE, location).asDefaultedReference(() -> Sponge.getGame().registries());
     }
 }

--- a/src/main/java/org/spongepowered/common/command/registrar/SpongeParameterizedCommandRegistrar.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/SpongeParameterizedCommandRegistrar.java
@@ -102,6 +102,7 @@ public final class SpongeParameterizedCommandRegistrar implements BrigadierBased
         );
 
         this.createNode(mapping, command).forEach(this.commandManager().getDispatcher()::register);
+        ((SpongeParameterizedCommand) command).setCommandManager(this.commandManager());
         this.commandMap.put(mapping, command);
         return mapping;
     }

--- a/src/main/java/org/spongepowered/common/command/registrar/SpongeParameterizedCommandRegistrar.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/SpongeParameterizedCommandRegistrar.java
@@ -72,7 +72,7 @@ public final class SpongeParameterizedCommandRegistrar implements BrigadierBased
 
     @Override
     public @NonNull CommandRegistrarType<Command.Parameterized> type() {
-        return TYPE;
+        return SpongeParameterizedCommandRegistrar.TYPE;
     }
 
     private SpongeCommandManager commandManager() {

--- a/src/main/java/org/spongepowered/common/command/registrar/SpongeParameterizedCommandRegistrar.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/SpongeParameterizedCommandRegistrar.java
@@ -42,6 +42,7 @@ import org.spongepowered.api.command.manager.CommandMapping;
 import org.spongepowered.api.command.registrar.CommandRegistrar;
 import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.command.SpongeParameterizedCommand;
+import org.spongepowered.common.command.exception.SpongeCommandSyntaxException;
 import org.spongepowered.common.command.manager.SpongeCommandManager;
 import org.spongepowered.plugin.PluginContainer;
 
@@ -105,6 +106,8 @@ public final class SpongeParameterizedCommandRegistrar implements BrigadierBased
             return CommandResult.builder().setResult(
                     this.getDispatcher().execute(
                             this.getDispatcher().parse(this.createCommandString(command, arguments), (CommandSource) cause))).build();
+        } catch (final SpongeCommandSyntaxException ex) {
+            throw ex.getCause();
         } catch (final CommandSyntaxException e) {
             // We'll unwrap later.
             throw new CommandException(Component.text(e.getMessage()), e);

--- a/src/main/java/org/spongepowered/common/command/registrar/SpongeRawCommandRegistrar.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/SpongeRawCommandRegistrar.java
@@ -24,18 +24,18 @@
  */
 package org.spongepowered.common.command.registrar;
 
-import io.leangen.geantyref.TypeToken;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.Command;
 import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.exception.CommandException;
 import org.spongepowered.api.command.exception.CommandPermissionException;
 import org.spongepowered.api.command.manager.CommandFailedRegistrationException;
+import org.spongepowered.api.command.manager.CommandManager;
 import org.spongepowered.api.command.manager.CommandMapping;
 import org.spongepowered.api.command.registrar.CommandRegistrar;
+import org.spongepowered.api.command.registrar.CommandRegistrarType;
 import org.spongepowered.plugin.PluginContainer;
 
 import java.util.Collections;
@@ -48,15 +48,19 @@ import java.util.Optional;
  */
 public final class SpongeRawCommandRegistrar implements CommandRegistrar<Command.Raw> {
 
-    private static final TypeToken<Command.Raw> COMMAND_TYPE = TypeToken.get(Command.Raw.class);
-    public static final SpongeRawCommandRegistrar INSTANCE = new SpongeRawCommandRegistrar();
+    public static final CommandRegistrarType<Command.Raw> TYPE = new SpongeCommandRegistrarType<Command.Raw>(Command.Raw.class,
+            SpongeRawCommandRegistrar::new);
 
     private final HashMap<CommandMapping, Command.Raw> commands = new HashMap<>();
+    private final CommandManager.Mutable manager;
+
+    SpongeRawCommandRegistrar(final CommandManager.Mutable manager) {
+        this.manager = manager;
+    }
 
     @Override
-    @NonNull
-    public TypeToken<Command.@NonNull Raw> handledType() {
-        return SpongeRawCommandRegistrar.COMMAND_TYPE;
+    public @NonNull CommandRegistrarType<Command.Raw> type() {
+        return TYPE;
     }
 
     @Override
@@ -66,7 +70,7 @@ public final class SpongeRawCommandRegistrar implements CommandRegistrar<Command
             @NonNull final String primaryAlias,
             @NonNull final String @NonNull... secondaryAliases)
             throws CommandFailedRegistrationException {
-        final CommandMapping mapping = Sponge.getCommandManager().registerAlias(
+        final CommandMapping mapping = this.manager.registerAlias(
                 this,
                 container,
                 command.commandTree(),
@@ -107,12 +111,5 @@ public final class SpongeRawCommandRegistrar implements CommandRegistrar<Command
     @Override
     public boolean canExecute(final CommandCause cause, final CommandMapping mapping) {
         return this.commands.get(mapping).canExecute(cause);
-    }
-
-    @Override
-    public void reset() {
-        if (Sponge.getCommandManager().isResetting()) {
-            this.commands.clear();
-        }
     }
 }

--- a/src/main/java/org/spongepowered/common/command/registrar/SpongeRawCommandRegistrar.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/SpongeRawCommandRegistrar.java
@@ -36,6 +36,7 @@ import org.spongepowered.api.command.manager.CommandManager;
 import org.spongepowered.api.command.manager.CommandMapping;
 import org.spongepowered.api.command.registrar.CommandRegistrar;
 import org.spongepowered.api.command.registrar.CommandRegistrarType;
+import org.spongepowered.common.command.brigadier.SpongeStringReader;
 import org.spongepowered.plugin.PluginContainer;
 
 import java.util.Collections;
@@ -85,7 +86,7 @@ public final class SpongeRawCommandRegistrar implements CommandRegistrar<Command
     public CommandResult process(final CommandCause cause, final CommandMapping mapping, final String command, final String arguments) throws CommandException {
         final Command.Raw commandToExecute = this.commands.get(mapping);
         if (commandToExecute.canExecute(cause)) {
-            return commandToExecute.process(cause, arguments);
+            return commandToExecute.process(cause, new SpongeStringReader(arguments));
         }
         throw new CommandPermissionException(Component.text("You do not have permission to run /" + command));
     }
@@ -94,7 +95,7 @@ public final class SpongeRawCommandRegistrar implements CommandRegistrar<Command
     public List<String> suggestions(final CommandCause cause, final CommandMapping mapping, final String command, final String arguments) throws CommandException {
         final Command.Raw commandToExecute = this.commands.get(mapping);
         if (commandToExecute.canExecute(cause)) {
-            return commandToExecute.getSuggestions(cause, arguments);
+            return commandToExecute.getSuggestions(cause, new SpongeStringReader(arguments));
         }
         return Collections.emptyList();
     }

--- a/src/main/java/org/spongepowered/common/command/registrar/SpongeRawCommandRegistrar.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/SpongeRawCommandRegistrar.java
@@ -61,7 +61,7 @@ public final class SpongeRawCommandRegistrar implements CommandRegistrar<Command
 
     @Override
     public @NonNull CommandRegistrarType<Command.Raw> type() {
-        return TYPE;
+        return SpongeRawCommandRegistrar.TYPE;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/command/registrar/tree/builder/BasicCommandTreeNode.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/tree/builder/BasicCommandTreeNode.java
@@ -28,11 +28,11 @@ import com.mojang.brigadier.arguments.ArgumentType;
 import org.spongepowered.api.command.registrar.tree.ClientCompletionKey;
 import org.spongepowered.api.command.registrar.tree.CommandTreeNode;
 
-public final class EmptyCommandTreeNode extends ArgumentCommandTreeNode<CommandTreeNode.Basic> implements CommandTreeNode.Basic {
+public final class BasicCommandTreeNode extends ArgumentCommandTreeNode<CommandTreeNode.Basic> implements CommandTreeNode.Basic {
 
     private final ArgumentType<?> type;
 
-    public EmptyCommandTreeNode(final ClientCompletionKey<Basic> parameterType, final ArgumentType<?> type) {
+    public BasicCommandTreeNode(final ClientCompletionKey<Basic> parameterType, final ArgumentType<?> type) {
         super(parameterType);
         this.type = type;
     }

--- a/src/main/java/org/spongepowered/common/command/registrar/tree/key/SpongeBasicClientCompletionKey.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/tree/key/SpongeBasicClientCompletionKey.java
@@ -30,7 +30,7 @@ import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.command.registrar.tree.ClientCompletionKey;
 import org.spongepowered.api.command.registrar.tree.CommandTreeNode;
 import org.spongepowered.common.AbstractResourceKeyed;
-import org.spongepowered.common.command.registrar.tree.builder.EmptyCommandTreeNode;
+import org.spongepowered.common.command.registrar.tree.builder.BasicCommandTreeNode;
 
 public final class SpongeBasicClientCompletionKey extends AbstractResourceKeyed implements ClientCompletionKey<CommandTreeNode.@NonNull Basic> {
 
@@ -44,6 +44,6 @@ public final class SpongeBasicClientCompletionKey extends AbstractResourceKeyed 
 
     @Override
     public CommandTreeNode.@NonNull Basic createNode() {
-        return new EmptyCommandTreeNode(this, this.argumentType);
+        return new BasicCommandTreeNode(this, this.argumentType);
     }
 }

--- a/src/main/java/org/spongepowered/common/command/sponge/CommandAliasesParameter.java
+++ b/src/main/java/org/spongepowered/common/command/sponge/CommandAliasesParameter.java
@@ -31,7 +31,6 @@ import org.spongepowered.api.command.manager.CommandMapping;
 import org.spongepowered.api.command.parameter.ArgumentReader;
 import org.spongepowered.api.command.parameter.CommandContext;
 import org.spongepowered.api.command.parameter.Parameter;
-import org.spongepowered.api.command.parameter.managed.ValueCompleter;
 import org.spongepowered.api.command.parameter.managed.ValueParameter;
 import org.spongepowered.api.command.parameter.managed.clientcompletion.ClientCompletionType;
 import org.spongepowered.api.command.parameter.managed.clientcompletion.ClientCompletionTypes;
@@ -42,7 +41,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public final class CommandAliasesParameter implements ValueParameter<CommandMapping>, ValueCompleter {
+public final class CommandAliasesParameter implements ValueParameter<CommandMapping> {
 
     @Override
     public List<String> complete(final CommandContext context, final String input) {

--- a/src/main/java/org/spongepowered/common/command/sponge/CommandAliasesParameter.java
+++ b/src/main/java/org/spongepowered/common/command/sponge/CommandAliasesParameter.java
@@ -45,7 +45,7 @@ public final class CommandAliasesParameter implements ValueParameter<CommandMapp
 
     @Override
     public List<String> complete(final CommandContext context, final String input) {
-        return Sponge.getGame().getCommandManager().getKnownAliases().stream().filter(x -> x.startsWith(input)).collect(Collectors.toList());
+        return Sponge.getGame().getServer().getCommandManager().getKnownAliases().stream().filter(x -> x.startsWith(input)).collect(Collectors.toList());
     }
 
     @Override
@@ -58,7 +58,7 @@ public final class CommandAliasesParameter implements ValueParameter<CommandMapp
             alias += reader.parseChar() + reader.parseUnquotedString();
         }
         final Optional<CommandMapping> mapping =
-                Sponge.getGame().getCommandManager().getCommandMapping(alias);
+                Sponge.getGame().getServer().getCommandManager().getCommandMapping(alias);
         if (mapping.isPresent()) {
             return mapping;
         }

--- a/src/main/java/org/spongepowered/common/event/lifecycle/RegisterCommandEventImpl.java
+++ b/src/main/java/org/spongepowered/common/event/lifecycle/RegisterCommandEventImpl.java
@@ -40,7 +40,7 @@ public final class RegisterCommandEventImpl<C, R extends CommandRegistrar<C>> ex
     private final R registrar;
 
     public RegisterCommandEventImpl(final Cause cause, final Game game, final R registrar) {
-        super(cause, game, registrar.handledType());
+        super(cause, game, registrar.type().handledType());
         this.registrar = registrar;
     }
 
@@ -53,6 +53,11 @@ public final class RegisterCommandEventImpl<C, R extends CommandRegistrar<C>> ex
                 this.registrar.register(Objects.requireNonNull(container, "container"), Objects.requireNonNull(command, "command"),
                         Objects.requireNonNull(alias, "alias"), Objects.requireNonNull(aliases, "aliases"))
         );
+    }
+
+    @Override
+    public @NonNull CommandRegistrar<C> registrar() {
+        return this.registrar;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/event/lifecycle/RegisterCommandEventImpl.java
+++ b/src/main/java/org/spongepowered/common/event/lifecycle/RegisterCommandEventImpl.java
@@ -56,11 +56,6 @@ public final class RegisterCommandEventImpl<C, R extends CommandRegistrar<C>> ex
     }
 
     @Override
-    public @NonNull CommandRegistrar<C> registrar() {
-        return this.registrar;
-    }
-
-    @Override
     public String toString() {
         return "RegisterCommandEvent{cause=" + this.cause + ", token=" + this.token + "}";
     }

--- a/src/main/java/org/spongepowered/common/inject/SpongeCommonModule.java
+++ b/src/main/java/org/spongepowered/common/inject/SpongeCommonModule.java
@@ -83,7 +83,6 @@ public final class SpongeCommonModule extends PrivateModule {
         this.bindAndExpose(MetricsConfigManager.class).to(SpongeMetricsConfigManager.class);
         this.bindAndExpose(SqlManager.class).to(SpongeSqlManager.class);
         this.bindAndExpose(ServiceProvider.GameScoped.class).to(SpongeGameScopedServiceProvider.class);
-        this.bindAndExpose(CommandManager.class).to(SpongeCommandManager.class);
         this.bindAndExpose(FactoryProvider.class).to(SpongeFactoryProvider.class);
         this.bindAndExpose(BuilderProvider.class).to(SpongeBuilderProvider.class);
 

--- a/src/main/java/org/spongepowered/common/registry/SpongeRegistries.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeRegistries.java
@@ -40,7 +40,7 @@ public final class SpongeRegistries {
         holder.createRegistry(RegistryTypes.CAT_TYPE, SpongeRegistryLoaders.catType().values());
         holder.createRegistry(RegistryTypes.CLIENT_COMPLETION_KEY, SpongeRegistryLoaders.clientCompletionKey().values());
         holder.createRegistry(RegistryTypes.CLIENT_COMPLETION_TYPE, SpongeRegistryLoaders.clientCompletionType().values());
-        holder.createRegistry(RegistryTypes.COMMAND_REGISTRAR, () -> SpongeRegistryLoaders.commandRegistrar().values(), true);
+        holder.createRegistry(RegistryTypes.COMMAND_REGISTRAR_TYPE, () -> SpongeRegistryLoaders.commandRegistrarType().values(), true);
         holder.createRegistry(RegistryTypes.CURRENCY, null, true);
         holder.createRegistry(RegistryTypes.DAMAGE_TYPE, SpongeRegistryLoaders.damageType().values());
         holder.createRegistry(RegistryTypes.DAMAGE_MODIFIER_TYPE, SpongeRegistryLoaders.damageModifierType().values());

--- a/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
@@ -59,7 +59,7 @@ import org.spongepowered.api.command.parameter.managed.ValueParameter;
 import org.spongepowered.api.command.parameter.managed.clientcompletion.ClientCompletionType;
 import org.spongepowered.api.command.parameter.managed.clientcompletion.ClientCompletionTypes;
 import org.spongepowered.api.command.parameter.managed.standard.ResourceKeyedValueParameters;
-import org.spongepowered.api.command.registrar.CommandRegistrar;
+import org.spongepowered.api.command.registrar.CommandRegistrarType;
 import org.spongepowered.api.command.registrar.tree.ClientCompletionKey;
 import org.spongepowered.api.command.registrar.tree.ClientCompletionKeys;
 import org.spongepowered.api.command.selector.SelectorSortAlgorithm;
@@ -170,7 +170,7 @@ import org.spongepowered.common.command.parameter.managed.standard.SpongeTargetB
 import org.spongepowered.common.command.parameter.managed.standard.SpongeTargetEntityValueParameter;
 import org.spongepowered.common.command.parameter.managed.standard.SpongeUserValueParameter;
 import org.spongepowered.common.command.registrar.BrigadierCommandRegistrar;
-import org.spongepowered.common.command.registrar.SpongeCommandRegistrars;
+import org.spongepowered.common.command.registrar.SpongeCommandRegistrarTypes;
 import org.spongepowered.common.command.registrar.SpongeParameterizedCommandRegistrar;
 import org.spongepowered.common.command.registrar.SpongeRawCommandRegistrar;
 import org.spongepowered.common.command.registrar.tree.key.SpongeAmountClientCompletionKey;
@@ -453,11 +453,11 @@ public final class SpongeRegistryLoaders {
         });
     }
 
-    public static RegistryLoader<CommandRegistrar<?>> commandRegistrar() {
+    public static RegistryLoader<CommandRegistrarType<?>> commandRegistrarType() {
         return RegistryLoader.of(l -> {
-            l.add(SpongeCommandRegistrars.BRIGADIER, () -> BrigadierCommandRegistrar.INSTANCE);
-            l.add(SpongeCommandRegistrars.MANAGED, () -> SpongeParameterizedCommandRegistrar.INSTANCE);
-            l.add(SpongeCommandRegistrars.RAW, () -> SpongeRawCommandRegistrar.INSTANCE);
+            l.add(SpongeCommandRegistrarTypes.BRIGADIER, () -> BrigadierCommandRegistrar.TYPE);
+            l.add(SpongeCommandRegistrarTypes.MANAGED, () -> SpongeParameterizedCommandRegistrar.TYPE);
+            l.add(SpongeCommandRegistrarTypes.RAW, () -> SpongeRawCommandRegistrar.TYPE);
         });
     }
 

--- a/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
@@ -445,7 +445,7 @@ public final class SpongeRegistryLoaders {
     public static RegistryLoader<ClientCompletionType> clientCompletionType() {
         return RegistryLoader.of(l -> {
             l.add(ClientCompletionTypes.DECIMAL_NUMBER, k -> new SpongeClientCompletionType(DoubleArgumentType.doubleArg()));
-            l.add(ClientCompletionTypes.JSON, k -> new SpongeClientCompletionType(NBTCompoundTagArgument.compoundTag()));
+            l.add(ClientCompletionTypes.SNBT, k -> new SpongeClientCompletionType(NBTCompoundTagArgument.compoundTag()));
             l.add(ClientCompletionTypes.NONE, k -> SpongeClientCompletionType.NONE);
             l.add(ClientCompletionTypes.RESOURCE_KEY, k -> new SpongeClientCompletionType(ResourceLocationArgument.id()));
             l.add(ClientCompletionTypes.STRING, k -> new SpongeClientCompletionType(StringArgumentType.string()));

--- a/src/mixins/java/org/spongepowered/common/mixin/api/mcp/server/MinecraftServerMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/mcp/server/MinecraftServerMixin_API.java
@@ -36,6 +36,7 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
+import net.minecraft.command.Commands;
 import net.minecraft.resources.DataPackRegistries;
 import net.minecraft.resources.ResourcePackList;
 import net.minecraft.scoreboard.ServerScoreboard;
@@ -79,7 +80,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.SpongeServer;
 import org.spongepowered.common.adventure.SpongeAdventure;
+import org.spongepowered.common.bridge.command.CommandsBridge;
 import org.spongepowered.common.bridge.server.MinecraftServerBridge;
+import org.spongepowered.common.command.manager.SpongeCommandManager;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.profile.SpongeGameProfileManager;
 import org.spongepowered.common.registry.SpongeRegistryHolder;
@@ -120,6 +123,8 @@ public abstract class MinecraftServerMixin_API extends RecursiveEventLoop<TickDe
     @Shadow public abstract boolean shadow$isSpawningAnimals();
     @Shadow public abstract boolean shadow$isNetherEnabled();
     // @formatter:on
+
+    @Shadow public abstract Commands getCommands();
 
     private Iterable<? extends Audience> audiences;
     private ServerScheduler api$scheduler;
@@ -329,6 +334,11 @@ public abstract class MinecraftServerMixin_API extends RecursiveEventLoop<TickDe
         }
 
         return this.api$profileManager;
+    }
+
+    @Override
+    public SpongeCommandManager getCommandManager() {
+        return ((CommandsBridge) this.getCommands()).bridge$commandManager();
     }
 
     public Optional<ResourcePack> server$getResourcePack() {

--- a/src/mixins/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java
@@ -188,6 +188,7 @@ public abstract class EntityMixin implements EntityBridge, PlatformEntityBridge,
             TeleportationRepositioner.Result teleportationrepositioner$result);
     @Shadow protected abstract void shadow$removeAfterChangingDimensions();
     @Shadow public abstract void shadow$absMoveTo(double p_242281_1_, double p_242281_3_, double p_242281_5_);
+    @Shadow protected abstract int shadow$getPermissionLevel();
 
     // @formatter:on
 

--- a/src/mixins/java/org/spongepowered/common/mixin/core/entity/player/PlayerEntityMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/entity/player/PlayerEntityMixin.java
@@ -237,7 +237,11 @@ public abstract class PlayerEntityMixin extends LivingEntityMixin implements Pla
 
     @Redirect(method = "canUseGameMasterBlocks", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;getPermissionLevel()I"))
     private int impl$checkPermissionForCommandBlock(final PlayerEntity playerEntity) {
-        return ((Subject) this).hasPermission(Constants.Permissions.COMMAND_BLOCK_PERMISSION) ? Constants.Permissions.COMMAND_BLOCK_LEVEL : 0;
+        if (this instanceof Subject) {
+            return ((Subject) this).hasPermission(Constants.Permissions.COMMAND_BLOCK_PERMISSION) ? Constants.Permissions.COMMAND_BLOCK_LEVEL : 0;
+        } else {
+            return this.shadow$getPermissionLevel();
+        }
     }
 
     /**

--- a/src/mixins/java/org/spongepowered/common/mixin/core/network/play/ServerPlayNetHandlerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/network/play/ServerPlayNetHandlerMixin.java
@@ -108,7 +108,6 @@ import org.spongepowered.common.bridge.network.NetworkManagerHolderBridge;
 import org.spongepowered.common.bridge.server.management.PlayerListBridge;
 import org.spongepowered.common.command.manager.SpongeCommandManager;
 import org.spongepowered.common.command.registrar.BrigadierBasedRegistrar;
-import org.spongepowered.common.command.registrar.BrigadierCommandRegistrar;
 import org.spongepowered.common.data.value.ImmutableSpongeListValue;
 import org.spongepowered.common.event.ShouldFire;
 import org.spongepowered.common.event.SpongeCommonEventFactory;
@@ -165,7 +164,7 @@ public abstract class ServerPlayNetHandlerMixin implements NetworkManagerHolderB
         final String rawCommand = packet.getCommand();
         final String[] command = this.impl$extractCommandString(rawCommand);
         final CommandCause cause = CommandCause.create();
-        final SpongeCommandManager manager = ((SpongeCommandManager) Sponge.getCommandManager());
+        final SpongeCommandManager manager = SpongeCommandManager.get(this.server);
         if (!rawCommand.contains(" ")) {
             final SuggestionsBuilder builder = new SuggestionsBuilder(command[0], 0);
             if (command[0].isEmpty()) {
@@ -207,7 +206,7 @@ public abstract class ServerPlayNetHandlerMixin implements NetworkManagerHolderB
     private ParseResults<CommandSource> impl$informParserThisIsASuggestionCheck(final CommandDispatcher<CommandSource> commandDispatcher,
             final StringReader command,
             final Object source) {
-        return BrigadierCommandRegistrar.INSTANCE.getDispatcher().parse(command, (CommandSource) source, true);
+        return SpongeCommandManager.get(this.server).getDispatcher().parse(command, (CommandSource) source, true);
     }
 
     /**

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/MinecraftServerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/MinecraftServerMixin.java
@@ -371,13 +371,6 @@ public abstract class MinecraftServerMixin implements SpongeServer, MinecraftSer
         this.shadow$getPackRepository().reload();
     }
 
-    @Redirect(method = "*", at = @At(value = "INVOKE", target = "Lnet/minecraft/resources/DataPackRegistries;loadResources(Ljava/util/List;Lnet/minecraft/command/Commands$EnvironmentType;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;"))
-    public CompletableFuture<DataPackRegistries> impl$loadResources(List<IResourcePack> p_240961_0_, Commands.EnvironmentType p_240961_1_, int p_240961_2_, Executor p_240961_3_, Executor p_240961_4_) {
-        final CompletableFuture<DataPackRegistries> future = DataPackRegistries.loadResources(p_240961_0_, p_240961_1_, p_240961_2_, p_240961_3_, p_240961_4_);
-        SpongeBootstrap.getLifecycle().establishCommands();
-        return future;
-    }
-
     @Override
     public String toString() {
         return this.getClass().getSimpleName();

--- a/testplugins/src/main/java/org/spongepowered/test/advancement/AdvancementTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/advancement/AdvancementTest.java
@@ -93,7 +93,7 @@ public final class AdvancementTest implements LoadableModule {
         this.enabled = true;
         Sponge.getEventManager().registerListeners(this.plugin, this.listeners);
         try {
-            Sponge.getCommandManager().process("reload");
+            Sponge.getServer().getCommandManager().process("reload");
         } catch (final CommandException e) {
             e.printStackTrace();
         }
@@ -105,7 +105,7 @@ public final class AdvancementTest implements LoadableModule {
         this.enabled = false;
         Sponge.getEventManager().unregisterListeners(this.listeners);
         try {
-            Sponge.getCommandManager().process("reload");
+            Sponge.getServer().getCommandManager().process("reload");
         } catch (final CommandException e) {
             e.printStackTrace();
         }

--- a/testplugins/src/main/java/org/spongepowered/test/command/CommandTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/command/CommandTest.java
@@ -38,6 +38,7 @@ import org.spongepowered.api.SystemSubject;
 import org.spongepowered.api.adventure.SpongeComponents;
 import org.spongepowered.api.command.Command;
 import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.exception.CommandException;
 import org.spongepowered.api.command.parameter.CommandContext;
 import org.spongepowered.api.command.parameter.CommonParameters;
 import org.spongepowered.api.command.parameter.Parameter;
@@ -430,6 +431,20 @@ public final class CommandTest {
 
         event.register(this.plugin, parent, "testterminal");
 
+        // exceptions
+
+        event.register(this.plugin, Command.builder()
+                      .setShortDescription(Component.text("test throwing execptions"))
+                      .child(Command.builder()
+                            .setExecutor(ctx -> {
+                                throw new CommandException(Component.text("Exit via exception"));
+                            })
+                            .build(), "exception")
+                      .child(Command.builder()
+                            .setExecutor(ctx -> {
+                                return CommandResult.error(Component.text("Exit via failed result"));
+                            }).build(), "failedresult")
+                      .build(), "testfailure");
     }
 
     @Listener

--- a/testplugins/src/main/java/org/spongepowered/test/command/RawCommandTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/command/RawCommandTest.java
@@ -32,10 +32,12 @@ import org.spongepowered.api.command.Command;
 import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.exception.CommandException;
+import org.spongepowered.api.command.parameter.ArgumentReader;
 import org.spongepowered.api.command.registrar.tree.ClientCompletionKeys;
 import org.spongepowered.api.command.registrar.tree.CommandTreeNode;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -45,23 +47,28 @@ public class RawCommandTest implements Command.Raw {
 
     @Override
     @NonNull
-    public CommandResult process(@NonNull final CommandCause cause, @NonNull final String arguments) throws CommandException {
-        if (arguments.isEmpty()) {
+    public CommandResult process(final @NonNull CommandCause cause, final ArgumentReader.@NonNull Mutable arguments) throws CommandException {
+        if (!arguments.canRead()) {
             cause.sendMessage(Identity.nil(), Component.text("No arguments"));
         }
-        cause.sendMessage(Identity.nil(), Component.text(arguments));
+        cause.sendMessage(Identity.nil(), Component.text(arguments.getRemaining()));
         return CommandResult.success();
     }
 
     @Override
     @NonNull
-    public List<String> getSuggestions(@NonNull final CommandCause cause, @NonNull final String arguments) throws CommandException {
-        if (arguments.endsWith(" ")) {
+    public List<String> getSuggestions(final @NonNull CommandCause cause, final ArgumentReader.@NonNull Mutable arguments) throws CommandException {
+        if (arguments.getRemaining().endsWith(" ")) {
             return this.suggestions;
         }
 
-        final String[] args = arguments.split(" ");
-        return this.suggestions.stream().filter(x -> x.startsWith(args[args.length - 1].toLowerCase())).collect(Collectors.toList());
+        String word = "";
+        while (arguments.canRead()) {
+            word = arguments.parseString();
+            arguments.skipWhitespace();
+        }
+        final String finalWord = word;
+        return this.suggestions.stream().filter(x -> x.startsWith(finalWord.toLowerCase(Locale.ROOT))).collect(Collectors.toList());
     }
 
     @Override

--- a/testplugins/src/main/java/org/spongepowered/test/recipe/RecipeTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/recipe/RecipeTest.java
@@ -81,7 +81,7 @@ public final class RecipeTest implements LoadableModule {
     public void enable(CommandContext ctx) {
         this.enabled = true;
         try {
-            Sponge.getCommandManager().process("reload");
+            Sponge.getServer().getCommandManager().process("reload");
         } catch (CommandException e) {
             e.printStackTrace();
         }
@@ -91,7 +91,7 @@ public final class RecipeTest implements LoadableModule {
     public void disable(CommandContext ctx) {
         this.enabled = false;
         try {
-            Sponge.getCommandManager().process("reload");
+            Sponge.getServer().getCommandManager().process("reload");
         } catch (CommandException e) {
             e.printStackTrace();
         }

--- a/vanilla/src/mixins/java/org/spongepowered/vanilla/mixin/core/server/dedicated/DedicatedServerMixin_Vanilla.java
+++ b/vanilla/src/mixins/java/org/spongepowered/vanilla/mixin/core/server/dedicated/DedicatedServerMixin_Vanilla.java
@@ -52,7 +52,6 @@ public abstract class DedicatedServerMixin_Vanilla extends MinecraftServerMixin_
 
 
         lifecycle.establishServerFeatures();
-        lifecycle.establishCommands();
 
         lifecycle.establishServerRegistries(this);
         lifecycle.callStartingEngineEvent(this);

--- a/vanilla/src/mixins/java/org/spongepowered/vanilla/mixin/core/server/integrated/IntegratedServerMixin_Vanilla.java
+++ b/vanilla/src/mixins/java/org/spongepowered/vanilla/mixin/core/server/integrated/IntegratedServerMixin_Vanilla.java
@@ -69,7 +69,6 @@ public abstract class IntegratedServerMixin_Vanilla extends MinecraftServerMixin
         lifecycle.establishServerServices();
 
         lifecycle.establishServerFeatures();
-        lifecycle.establishCommands();
 
         lifecycle.establishServerRegistries(this);
         lifecycle.callStartingEngineEvent(this);


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2288) | **Sponge**

This fixes some minor issues with commands, from things that came up in Discord and a few things that I noticed while reading through the implementation.

I'd still like to look at:

- [x] Dispatcher lifecycle
      The function loading changes in 1.16 have meant that commands are initialized extremely early, and are re-initialized on every datapack reload. I'm thinking it'll probably make sense to convert the dispatcher registry into a dispatcher *factory* registry, and match the Mojang datapack lifecycle more closely with our registration sequence. Since Mojang's strategy is to fully register commands and load datapacks with the new set of commands before applying those commands to the active server, I think we'll want to just re-register commands on a whole new dispatcher, and remove all the singletons used.
- [x] The possibility of passing through an `ArgumentReader` to `Raw` commands rather than just a plain String
      This seems like the closest we can get to allowing custom commands systems to match vanilla behaviour without binding them to constructing their own `Parameterized` commands. Unfortunately, I think `CommandContext` takes in too much detail specific to parameterized/Brigadier commands for it to be exposed to raw commands without major design changes. I think the `ArgumentReader` can also expose enough low-level parsing to easily cover converting everything that is a `ClientCompletionType` 