### PR TITLE
Fix incorrect use of display slot indexes

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/scoreboard/ServerScoreboardBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/scoreboard/ServerScoreboardBridge.java
@@ -49,6 +49,8 @@ public interface ServerScoreboardBridge {
 
     void bridge$updateDisplaySlot(@Nullable Objective objective, DisplaySlot displaySlot) throws IllegalStateException;
 
+    void bridge$updateDisplaySlot(@Nullable Objective objective, int slot) throws IllegalStateException;
+
     Optional<Objective> bridge$getObjective(DisplaySlot slot);
 
     Set<Objective> bridge$getObjectivesByCriterion(Criterion criterion);

--- a/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
@@ -512,25 +512,25 @@ public final class SpongeRegistryLoaders {
 
     public static RegistryLoader<DisplaySlot> displaySlot() {
         return RegistryLoader.of(l -> {
-            l.add(2, DisplaySlots.BELOW_NAME, SpongeDisplaySlot::new);
-            l.add(0, DisplaySlots.LIST, SpongeDisplaySlot::new);
-            l.add(1, DisplaySlots.SIDEBAR_TEAM_NO_COLOR, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.AQUA.getId() + 3, DisplaySlots.SIDEBAR_TEAM_AQUA, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.BLACK.getId() + 3, DisplaySlots.SIDEBAR_TEAM_BLACK, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.BLUE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_BLUE, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.DARK_AQUA.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_AQUA, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.DARK_BLUE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_BLUE, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.DARK_GRAY.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_GRAY, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.DARK_GREEN.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_GREEN, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.DARK_PURPLE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_PURPLE, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.DARK_RED.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_RED, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.GOLD.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GOLD, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.GRAY.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GRAY, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.GREEN.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GREEN, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.LIGHT_PURPLE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_LIGHT_PURPLE, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.RED.getId() + 3, DisplaySlots.SIDEBAR_TEAM_RED, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.WHITE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_WHITE, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.YELLOW.getId() + 3, DisplaySlots.SIDEBAR_TEAM_YELLOW, SpongeDisplaySlot::new);
+            l.add(2, DisplaySlots.BELOW_NAME, k -> new SpongeDisplaySlot(2));
+            l.add(0, DisplaySlots.LIST, k -> new SpongeDisplaySlot(0));
+            l.add(1, DisplaySlots.SIDEBAR, k -> new SpongeDisplaySlot(1));
+            l.add(ChatFormatting.AQUA.getId() + 3, DisplaySlots.SIDEBAR_TEAM_AQUA, k -> new SpongeDisplaySlot(ChatFormatting.AQUA.getId() + 3));
+            l.add(ChatFormatting.BLACK.getId() + 3, DisplaySlots.SIDEBAR_TEAM_BLACK, k -> new SpongeDisplaySlot(ChatFormatting.BLACK.getId() + 3));
+            l.add(ChatFormatting.BLUE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_BLUE, k -> new SpongeDisplaySlot(ChatFormatting.BLUE.getId() + 3));
+            l.add(ChatFormatting.DARK_AQUA.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_AQUA, k -> new SpongeDisplaySlot(ChatFormatting.DARK_AQUA.getId() + 3));
+            l.add(ChatFormatting.DARK_BLUE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_BLUE, k -> new SpongeDisplaySlot(ChatFormatting.DARK_BLUE.getId() + 3));
+            l.add(ChatFormatting.DARK_GRAY.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_GRAY, k -> new SpongeDisplaySlot(ChatFormatting.DARK_GRAY.getId() + 3));
+            l.add(ChatFormatting.DARK_GREEN.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_GREEN, k -> new SpongeDisplaySlot(ChatFormatting.DARK_GREEN.getId() + 3));
+            l.add(ChatFormatting.DARK_PURPLE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_PURPLE, k -> new SpongeDisplaySlot(ChatFormatting.DARK_PURPLE.getId() + 3));
+            l.add(ChatFormatting.DARK_RED.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_RED, k -> new SpongeDisplaySlot(ChatFormatting.DARK_RED.getId() + 3));
+            l.add(ChatFormatting.GOLD.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GOLD, k -> new SpongeDisplaySlot(ChatFormatting.GOLD.getId() + 3));
+            l.add(ChatFormatting.GRAY.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GRAY, k -> new SpongeDisplaySlot(ChatFormatting.GRAY.getId() + 3));
+            l.add(ChatFormatting.GREEN.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GREEN, k -> new SpongeDisplaySlot(ChatFormatting.GREEN.getId() + 3));
+            l.add(ChatFormatting.LIGHT_PURPLE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_LIGHT_PURPLE, k -> new SpongeDisplaySlot(ChatFormatting.LIGHT_PURPLE.getId() + 3));
+            l.add(ChatFormatting.RED.getId() + 3, DisplaySlots.SIDEBAR_TEAM_RED, k -> new SpongeDisplaySlot(ChatFormatting.RED.getId() + 3));
+            l.add(ChatFormatting.WHITE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_WHITE, k -> new SpongeDisplaySlot(ChatFormatting.WHITE.getId() + 3));
+            l.add(ChatFormatting.YELLOW.getId() + 3, DisplaySlots.SIDEBAR_TEAM_YELLOW, k -> new SpongeDisplaySlot(ChatFormatting.YELLOW.getId() + 3));
         });
     }
 

--- a/src/main/java/org/spongepowered/common/scoreboard/SpongeDisplaySlot.java
+++ b/src/main/java/org/spongepowered/common/scoreboard/SpongeDisplaySlot.java
@@ -35,16 +35,18 @@ import java.util.function.Function;
 
 public final class SpongeDisplaySlot implements DisplaySlot {
 
+    private final int id;
     private final @Nullable ChatFormatting formatting;
     private final @Nullable Function<ChatFormatting, DisplaySlot> withColorFunction;
 
     private @Nullable NamedTextColor color;
 
-    public SpongeDisplaySlot() {
-        this(null, null);
+    public SpongeDisplaySlot(final int id) {
+        this(id, null, null);
     }
 
-    public SpongeDisplaySlot(@Nullable final ChatFormatting color, @Nullable final Function<ChatFormatting, DisplaySlot> withColorFunction) {
+    public SpongeDisplaySlot(final int id, @Nullable final ChatFormatting color, @Nullable final Function<ChatFormatting, DisplaySlot> withColorFunction) {
+        this.id = id;
         this.withColorFunction = withColorFunction;
         this.formatting = color;
     }
@@ -65,5 +67,9 @@ public final class SpongeDisplaySlot implements DisplaySlot {
             this.color = SpongeAdventure.asAdventureNamed(this.formatting);
         }
         return Optional.ofNullable(this.color);
+    }
+
+    public int getIndex() {
+        return this.id;
     }
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/ServerScoreboardMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/ServerScoreboardMixin.java
@@ -25,8 +25,6 @@
 package org.spongepowered.common.mixin.core.server;
 
 import net.kyori.adventure.text.Component;
-import net.minecraft.core.MappedRegistry;
-import net.minecraft.core.Registry;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundSetDisplayObjectivePacket;
 import net.minecraft.network.protocol.game.ClientboundSetObjectivePacket;
@@ -40,8 +38,6 @@ import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.Score;
 import net.minecraft.world.scores.Scoreboard;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria;
-import org.spongepowered.api.Sponge;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.scoreboard.Team;
 import org.spongepowered.api.scoreboard.criteria.Criterion;
 import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
@@ -61,6 +57,7 @@ import org.spongepowered.common.adventure.SpongeAdventure;
 import org.spongepowered.common.bridge.scoreboard.ScoreBridge;
 import org.spongepowered.common.bridge.scoreboard.ScoreObjectiveBridge;
 import org.spongepowered.common.bridge.scoreboard.ServerScoreboardBridge;
+import org.spongepowered.common.scoreboard.SpongeDisplaySlot;
 import org.spongepowered.common.scoreboard.SpongeObjective;
 import org.spongepowered.common.scoreboard.SpongeScore;
 import org.spongepowered.common.util.Constants;
@@ -88,13 +85,16 @@ public abstract class ServerScoreboardMixin extends Scoreboard implements Server
 
     @Override
     public void bridge$updateDisplaySlot(@Nullable final Objective objective, final DisplaySlot displaySlot) throws IllegalStateException {
+        this.bridge$updateDisplaySlot(objective, ((SpongeDisplaySlot) displaySlot).getIndex());
+    }
+
+    @Override
+    public void bridge$updateDisplaySlot(@Nullable final Objective objective, final int slot) throws IllegalStateException {
         if (objective != null && !objective.getScoreboards().contains(this)) {
             throw new IllegalStateException("Attempting to set an objective's display slot that does not exist on this scoreboard!");
         }
-        final MappedRegistry<DisplaySlot> registry = (MappedRegistry<DisplaySlot>) (Object) Sponge.getGame().registries().registry(RegistryTypes.DISPLAY_SLOT);
-        final int index = registry.getId(displaySlot);
-        ((ScoreboardAccessor) this).accessor$displayObjectives()[index] = objective == null ? null: ((SpongeObjective) objective).getObjectiveFor(this);
-        ((ServerScoreboardBridge) this).bridge$sendToPlayers(new ClientboundSetDisplayObjectivePacket(index, ((ScoreboardAccessor) this).accessor$displayObjectives()[index]));
+        ((ScoreboardAccessor) this).accessor$displayObjectives()[slot] = objective == null ? null: ((SpongeObjective) objective).getObjectiveFor(this);
+        ((ServerScoreboardBridge) this).bridge$sendToPlayers(new ClientboundSetDisplayObjectivePacket(slot, ((ScoreboardAccessor) this).accessor$displayObjectives()[slot]));
     }
 
     // Get objectives
@@ -128,8 +128,7 @@ public abstract class ServerScoreboardMixin extends Scoreboard implements Server
 
     @Override
     public Optional<Objective> bridge$getObjective(final DisplaySlot slot) {
-        final MappedRegistry<DisplaySlot> registry = (MappedRegistry<DisplaySlot>) (Object) Sponge.getGame().registries().registry(RegistryTypes.DISPLAY_SLOT);
-        final net.minecraft.world.scores.Objective objective = ((ScoreboardAccessor) this).accessor$displayObjectives()[registry.getId(slot)];
+        final net.minecraft.world.scores.Objective objective = ((ScoreboardAccessor) this).accessor$displayObjectives()[((SpongeDisplaySlot) slot).getIndex()];
         if (objective != null) {
             return Optional.of(((ScoreObjectiveBridge) objective).bridge$getSpongeObjective());
         }
@@ -330,8 +329,7 @@ public abstract class ServerScoreboardMixin extends Scoreboard implements Server
     @Overwrite
     public void setDisplayObjective(final int slot, @Nullable final net.minecraft.world.scores.Objective objective) {
         final Objective apiObjective = objective == null ? null : ((ScoreObjectiveBridge) objective).bridge$getSpongeObjective();
-        final DisplaySlot displaySlot = (DisplaySlot) ((Registry) Sponge.getGame().registries().registry(RegistryTypes.DISPLAY_SLOT)).byId(slot);
-        this.bridge$updateDisplaySlot(apiObjective, displaySlot);
+        this.bridge$updateDisplaySlot(apiObjective, slot);
     }
 
     @Redirect(method = "addPlayerToTeam",


### PR DESCRIPTION
**Sponge | [SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2295)**

In this PR I'm attempting to fix the bug I found updating display slots in API-8.

The use of the display slot indexes was wrong. So for example when I tried to display an objective to the sidebar, it actually appeared in the sidebar.aqua.

I decided to put an id field on the SpongeDisplaySlot. I tested every cases when display slots were used, and it seems to fix the bug.

Also, I noticed that some the parameters `ChatFormatting color, @Nullable final Function<ChatFormatting, DisplaySlot> withColorFunction` are always null, even for colored display slots.

I can update this PR to fill the `color` parameter, but for `withColorFunction` I don't know what I need to put into.
Need your feedbacks for this.

Also, I made a little change in the API, like we talked about a while ago with Zidane and Masa.

Thanks for reading this PR