### PR TITLE
Fix issue with UpdateAnvilEvent call that can lead to duplication issues

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/inventory/ContainerRepairMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/inventory/ContainerRepairMixin.java
@@ -92,7 +92,8 @@ public abstract class ContainerRepairMixin extends ContainerMixin implements Len
         final ItemStack itemstack = this.inputSlots.getStackInSlot(0);
         final ItemStack itemstack2 = this.inputSlots.getStackInSlot(1);
         final ItemStack result = this.outputSlot.getStackInSlot(0);
-        final UpdateAnvilEvent event = SpongeCommonEventFactory.callUpdateAnvilEvent((ContainerRepair) (Object) this, itemstack, itemstack2, result, this.repairedItemName, this.maximumCost, this.materialCost);
+
+        final UpdateAnvilEvent event = SpongeCommonEventFactory.callUpdateAnvilEvent((ContainerRepair) (Object) this, itemstack, itemstack2, result, this.repairedItemName == null ? "" : this.repairedItemName, this.maximumCost, this.materialCost);
 
         final ItemStackSnapshot finalItem = event.getResult().getFinal();
         if (event.isCancelled() || finalItem.isEmpty()) {


### PR DESCRIPTION
This is a rather simple fix. If the first slot interacted with in an anvil is the second input slot, the repair item name will never be set. This caused the update event to fail as the event manager requires that value to be non-null. To remedy, I simply made the event call force an empty string (typical value when putting an item into the first slot) should that value be null.

This event issue seemed to provoke interesting situations in that items could be lost or gained. This was only detected when a plugin had decided to listen to the anvil update event.

This aims to fix https://github.com/SpongePowered/Sponge/issues/3227