### PR TITLE
Fix deserialization of the name of map decorations

### DIFF
--- a/src/main/java/org/spongepowered/common/map/decoration/SpongeMapDecorationBuilder.java
+++ b/src/main/java/org/spongepowered/common/map/decoration/SpongeMapDecorationBuilder.java
@@ -25,7 +25,8 @@
 package org.spongepowered.common.map.decoration;
 
 import com.google.common.base.Preconditions;
-import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.Component;
+import org.spongepowered.api.adventure.SpongeComponents;
 import org.spongepowered.api.data.persistence.DataQuery;
 import org.spongepowered.api.data.persistence.DataView;
 import org.spongepowered.api.data.persistence.InvalidDataException;
@@ -49,7 +50,7 @@ public class SpongeMapDecorationBuilder implements MapDecoration.Builder {
     private int y;
     private MapDecorationOrientation rot = MapDecorationOrientations.NORTH.get();
     @Nullable
-    private TextComponent customName = null;
+    private Component customName = null;
 
     @Override
     public MapDecoration.Builder type(MapDecorationType type) {
@@ -95,7 +96,7 @@ public class SpongeMapDecorationBuilder implements MapDecoration.Builder {
     }
 
     @Override
-    public MapDecoration.Builder customName(TextComponent customName) {
+    public MapDecoration.Builder customName(Component customName) {
         this.customName = customName;
         return this;
     }
@@ -134,6 +135,14 @@ public class SpongeMapDecorationBuilder implements MapDecoration.Builder {
             final byte y = getByteFromContainer(container, Constants.Map.DECORATION_Y);
 
             this.position(Vector2i.from(x, y));
+        }
+
+        if (container.contains(Constants.Map.NAME)) {
+            final Component component = SpongeComponents.gsonSerializer().deserialize(
+                    container.getString(Constants.Map.NAME)
+                            .orElseThrow(() -> new InvalidDataException("Invalid data type for " + Constants.Map.NAME + ". Should be String"))
+            );
+            this.customName(component);
         }
 
         return this;

--- a/testplugins/src/main/java/org/spongepowered/test/map/MapTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/map/MapTest.java
@@ -33,6 +33,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.block.entity.Banner;
 import org.spongepowered.api.command.Command;
 import org.spongepowered.api.command.CommandExecutor;
@@ -205,8 +206,8 @@ public class MapTest implements LoadableModule {
             throw new CommandException(Component.text("You must hold a map in your hand"));
         }
         MapDecoration decoration = MapDecoration.builder()
-                .type(MapDecorationTypes.BLUE_MARKER)
-                .customName(Component.text("I AM A BLOO MARKER"))
+                .type(MapDecorationTypes.BANNER_BLUE)
+                .customName(Component.text("I AM A ").color(NamedTextColor.BLUE).append(BlockTypes.BLUE_BANNER.get()))
                 .rotation(MapDecorationOrientations.NORTH)
                 .build();
         heldMap.require(Keys.MAP_INFO).offer(Keys.MAP_DECORATIONS, Sets.newHashSet(decoration));


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2306) | Sponge
Currently if you have a custom named map decoration, it is serialized, but not deserialized. This commit fixes this. It also expands TextComponent -> Component since TranslatableComponents can also be used. 