### PR TITLE
Add default value for map uuid index if there is no level.dat

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/level/storage/PrimaryLevelDataMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/level/storage/PrimaryLevelDataMixin.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.mixin.core.world.level.storage;
 
 import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.DynamicOps;
@@ -104,7 +105,7 @@ public abstract class PrimaryLevelDataMixin implements WorldData, PrimaryLevelDa
     private boolean impl$customDifficulty = false, impl$customGameType = false, impl$customSpawnPosition = false, impl$loadOnStartup,
         impl$performsSpawnLogic;
 
-    private BiMap<Integer, UUID> impl$mapUUIDIndex;
+    private BiMap<Integer, UUID> impl$mapUUIDIndex = HashBiMap.create();
 
     @Override
     public ResourceKey bridge$getKey() {


### PR DESCRIPTION
Fixes NPE in #3320, but does not fix the MapLike error. (I can't get the MapLike error with or without this commit).