### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: required
 dist: trusty
 
+cache:
+  directories:
+  - $HOME/.gradle
+
 language: java
 jdk:
   - openjdk8


### PR DESCRIPTION
Would be interested to know why gradle dependencies haven't been cached on Travis. Thank you.