### PR TITLE
Bump guice to 5.0.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,7 +153,6 @@ dependencies {
     implementation("org.mariadb.jdbc:mariadb-java-client:2.0.3")
     implementation("com.h2database:h2:1.4.196")
     implementation("org.xerial:sqlite-jdbc:3.20.0")
-    implementation("com.google.inject:guice:4.1.0")
     implementation("javax.inject:javax.inject:1")
 
     // ASM - required for generating event listeners
@@ -176,8 +175,6 @@ dependencies {
         exclude(group = "org.codehaus.mojo", module = "animal-sniffer-annotations")
         exclude(group = "com.google.errorprone", module = "error_prone_annotations")
     }
-    launchConfig("com.google.inject:guice:4.1.0")
-    launchConfig("javax.inject:javax.inject:1")
     launchConfig("com.google.code.gson:gson:2.8.0")
     launchConfig("org.ow2.asm:asm-tree:$asmVersion")
     launchConfig("org.ow2.asm:asm-util:$asmVersion")
@@ -255,6 +252,15 @@ license {
 }
 
 allprojects {
+
+    configurations.configureEach {
+        resolutionStrategy.dependencySubstitution {
+            // https://github.com/zml2008/guice/tree/backport/5.0.1
+            substitute(module("com.google.inject:guice:5.0.1"))
+                    .because("We need to run against Guava 21")
+                    .using(module("ca.stellardrift.guice-backport:guice:5.0.1"))
+        }
+    }
 
     apply(plugin = "java-library")
     apply(plugin = "maven-publish")
@@ -597,8 +603,7 @@ project("SpongeVanilla") {
                         base + listOf(
                                 "--illegal-access=deny", // enable strict mode in prep for Java 16
                                 "--add-exports=java.base/sun.security.util=ALL-UNNAMED", // ModLauncher
-                                "--add-opens=java.base/java.util.jar=ALL-UNNAMED", // ModLauncher
-                                "--add-opens=java.base/java.lang=ALL-UNNAMED" // Guice
+                                "--add-opens=java.base/java.util.jar=ALL-UNNAMED" // ModLauncher
                         )
                     } else {
                         base

--- a/src/main/java/org/spongepowered/common/inject/InjectionPointProvider.java
+++ b/src/main/java/org/spongepowered/common/inject/InjectionPointProvider.java
@@ -30,7 +30,6 @@ import com.google.inject.Module;
 import com.google.inject.Provider;
 import com.google.inject.matcher.AbstractMatcher;
 import com.google.inject.spi.Dependency;
-import com.google.inject.spi.DependencyAndSource;
 import com.google.inject.spi.ProviderInstanceBinding;
 import com.google.inject.spi.ProvisionListener;
 
@@ -45,6 +44,7 @@ import java.util.List;
 /**
  * Allows injecting the {@link SpongeInjectionPoint} in {@link Provider}s.
  */
+@SuppressWarnings("deprecation") // getDependencyChain, DependencyAndSource -- restored in our fork
 public final class InjectionPointProvider extends AbstractMatcher<Binding<?>> implements Module, ProvisionListener, Provider<SpongeInjectionPoint> {
 
     @Nullable private SpongeInjectionPoint injectionPoint;
@@ -71,7 +71,7 @@ public final class InjectionPointProvider extends AbstractMatcher<Binding<?>> im
     }
 
     @Nullable
-    private static SpongeInjectionPoint findInjectionPoint(List<DependencyAndSource> dependencyChain) {
+    private static SpongeInjectionPoint findInjectionPoint(List<com.google.inject.spi.DependencyAndSource> dependencyChain) {
         if (dependencyChain.size() < 3) {
             throw new AssertionError("Provider is not included in the dependency chain");
         }

--- a/src/main/java/org/spongepowered/common/inject/provider/PluginAssetProvider.java
+++ b/src/main/java/org/spongepowered/common/inject/provider/PluginAssetProvider.java
@@ -42,7 +42,7 @@ public class PluginAssetProvider implements Provider<Asset> {
 
     @Override
     public Asset get() {
-        String name = this.point.getAnnotation(AssetId.class).value();
+        final String name = this.point.getAnnotation(AssetId.class).value();
         return this.assetManager.asset(this.container, name)
                 .orElseThrow(() -> new NoSuchElementException("Cannot find asset " + name));
     }

--- a/testplugins/src/main/java/org/spongepowered/test/config/ConfigTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/config/ConfigTest.java
@@ -27,6 +27,8 @@ package org.spongepowered.test.config;
 import com.google.inject.Inject;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
+import org.spongepowered.api.asset.Asset;
+import org.spongepowered.api.asset.AssetId;
 import org.spongepowered.configurate.ConfigurateException;
 import org.spongepowered.configurate.CommentedConfigurationNode;
 import org.apache.logging.log4j.Logger;
@@ -47,6 +49,9 @@ public final class ConfigTest implements LoadableModule {
     private final ConfigurationReference<CommentedConfigurationNode> reference;
     private ValueReference<ExampleConfiguration, CommentedConfigurationNode> config;
 
+    @Inject @AssetId("test.txt") private Asset testOne;
+    @Inject @AssetId("test2.txt") private Asset secondTest;
+
     @Inject
     ConfigTest(final Logger logger, final @DefaultConfig(sharedRoot = true) ConfigurationReference<CommentedConfigurationNode> reference) {
         this.logger = logger;
@@ -55,6 +60,7 @@ public final class ConfigTest implements LoadableModule {
 
     @Listener
     public void onConstruction(final ConstructPluginEvent event) {
+        this.logger.info("Asset one: {}, asset two: {}", this.testOne.url(), this.secondTest.url());
         try {
             this.config = this.reference.referenceTo(ExampleConfiguration.class);
             this.reference.save();

--- a/testplugins/src/main/resources/assets/configtest/test.txt
+++ b/testplugins/src/main/resources/assets/configtest/test.txt
@@ -1,0 +1,1 @@
+hello world

--- a/testplugins/src/main/resources/assets/configtest/test2.txt
+++ b/testplugins/src/main/resources/assets/configtest/test2.txt
@@ -1,0 +1,1 @@
+goodbye world

--- a/vanilla/src/installer/java9/org/spongepowered/vanilla/installer/Agent.java
+++ b/vanilla/src/installer/java9/org/spongepowered/vanilla/installer/Agent.java
@@ -96,12 +96,10 @@ public class Agent {
         Agent.instrumentation.redefineModule(
             Manifest.class.getModule(),
             Set.of(),
-            Map.of("sun.security.util", systemUnnamed),
+            Map.of("sun.security.util", systemUnnamed), // ModLauncher
             Map.of(
                 // ModLauncher -- needs Manifest.jv, and various JarVerifier methods
-                "java.util.jar", systemUnnamed,
-                // Guice (cglib) -- needs java.lang.ClassLoader.defineClass
-                "java.lang", systemUnnamed
+                "java.util.jar", systemUnnamed
             ),
             Set.of(),
             Map.of()


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2311) | **Sponge**

This bumps Guice to an [API-compatible fork](https://github.com/zml2008/guice/compare/5.0.1...zml2008:backport/5.0.1) off of Guice 5.0.1

# Why bump?

- Plugin developers want to use Java versions newer that Java 8 for their own plugins
- Guice 4.1.0 has compatibility issues with Java 16 due to its use of internal JDK APIs. Curretly we use instrumentation to add extra opens for modules, but Guice 5 would let us avoid that.
- There are API breaks in Guice 5, and we might as well introduce them to plugins at the same time as the rest of the API breaks in API 8

# Why use a fork?

Unfortunately, the combination of upstream choices and the fact that we are fixed to the version of Guava shipped with Minecraft mean that we are unable to use standard Guice 5.0.1 at runtime

The dependency chain API on ProvisionListeners has been removed upstream, which is used for our SpongeInjectionPoint, and there is currently no suitable alternative API in guice.

Guice also shades its own copy of ASM -- in 4.1.0 that was an outdated version that caused problems when working with plugins. Google exposes shading as a build option, but does not publish unshaded Guice versions.

While Guice appears to compile on an older Guava version without changes, there is still the risk of unexpected binary changes causing problems if we use upstream guice.

For all of those reasons, I've produced a minimal Guice fork with the necessary changes to make Guice 5.0.1 work for Sponge. This fork is API-compatible, so it can be used in implementations without exposing the fact that we are using a fork to SpongeAPI. 


# Alternatives

- Stay with Guice 4.1.0 -- Drawbacks discussed above
- Find an alternative dependency injection solution -- perhaps the best long-term solution, but no obvious choice exists.
- Get upstream to provide an API alternative to the dependency chain system -- there is an open issue at https://github.com/google/guice/issues/1121 that has not had a response in the almost **4 years** since it was opened.

Given the alternatives, I think forking guice is our best way forward for now. It will keep us compatible with modern Java, remain closer to upstream than 4.1.0 was, and not require someone to go to the effort of finding a new DI system and migrating Sponge to use it.