### PR TITLE
Fix incorrect TotalExperienceValueProcessor

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/TotalExperienceValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/TotalExperienceValueProcessor.java
@@ -30,10 +30,10 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.common.bridge.entity.player.EntityPlayerMPBridge;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.processor.common.ExperienceHolderUtils;
 import org.spongepowered.common.data.value.SpongeValueFactory;
-import org.spongepowered.common.bridge.entity.player.EntityPlayerMPBridge;
 
 import java.util.Optional;
 
@@ -60,31 +60,9 @@ public class TotalExperienceValueProcessor extends AbstractSpongeValueProcessor<
 
     @Override
     protected boolean set(final EntityPlayer container, final Integer value) {
-        int level = -1;
-
-        int experienceForCurrentLevel;
-        int experienceAtNextLevel = -1;
-
-        // We work iteratively to get the level. Remember, the level variable contains the CURRENT level and the method
-        // calculates what we need to get to the NEXT level, so we work our way up, summing up all these intervals, until
-        // we get an experience value that is larger than the value. This gives us our level.
-        //
-        // If the cumulative experience required for level+1 is still below that (or in the edge case, equal to) our
-        // value, we need to go up a level. So, if the boundary is at 7 exp, and we have 7 exp, we need one more loop
-        // to increment the level as we are at 100% and therefore should be at level+1.
-        do {
-            // We need this later.
-            experienceForCurrentLevel = experienceAtNextLevel;
-
-            // Increment level, as we know we are at least that level (in the first instance -1 -> 0)
-            // and add the next amount of experience to the variable.
-            experienceAtNextLevel += ExperienceHolderUtils.getExpBetweenLevels(++level);
-        } while (experienceAtNextLevel <= value && experienceAtNextLevel > 0);
-
-        // Once we're here, we have the correct level. The experience is the decimal fraction that we are through the
-        // current level. This is why we require the experienceForCurrentLevel variable, we need the difference between
-        // the current value and the beginning of the level.
-        container.experience = (float)(value - experienceForCurrentLevel) / ExperienceHolderUtils.getExpBetweenLevels(level);
+        final int level = ExperienceHolderUtils.getLevelForExp(value);
+        final int experienceSinceLevelStart = value - ExperienceHolderUtils.xpAtLevel(level);
+        container.experience = (float) (experienceSinceLevelStart) / ExperienceHolderUtils.getExpBetweenLevels(level);
         container.experienceLevel = level;
         container.experienceTotal = value;
         ((EntityPlayerMPBridge) container).bridge$refreshExp();


### PR DESCRIPTION
This fixes #3345. I'm not sure why this calculation was done with a loop. The `experienceForCurrentLevel` value was off by one, causing `EntityPlayerMixin` to recalculate the total experience based off of the incorrect experience percentage, which was the cause of the off-by-one error.

https://github.com/SpongePowered/Sponge/blob/aa86ca4ec0d768a17c5daebdb9aebce748663be0/src/main/java/org/spongepowered/common/mixin/core/entity/player/EntityPlayerMixin.java#L207

Also, should there be a precondition making sure that the provided total experience is not negative? `ExperienceHolderUtils#getLevelForExp(int)` preforms a squareroot on its argument, so it's a potential runtime exception that did not exist in the previous algorithm.