### PR TITLE
Implement ParticleOptions.SCALE for dust particles

### DIFF
--- a/src/main/java/org/spongepowered/common/effect/particle/SpongeParticleHelper.java
+++ b/src/main/java/org/spongepowered/common/effect/particle/SpongeParticleHelper.java
@@ -133,11 +133,12 @@ public final class SpongeParticleHelper {
         } else if (internalType.getDeserializer() == DustParticleOptions.DESERIALIZER) {
             // This particle type supports a color option.
             final Color color = effect.optionOrDefault(ParticleOptions.COLOR).get();
+            final double scale = effect.optionOrDefault(ParticleOptions.SCALE).get();
             final DustParticleOptions particleData = new DustParticleOptions(
                     (float) color.red() / 255,
                     (float) color.green() / 255,
                     (float) color.blue() / 255,
-                    1.0f);
+                    (float) scale);
             return new NamedCachedPacket(particleData, offset, quantity, velocity);
         }
 

--- a/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
@@ -748,6 +748,7 @@ public final class SpongeRegistryLoaders {
             l.add(ParticleOptions.OFFSET, k -> new SpongeParticleOption<>(Vector3d.class));
             l.add(ParticleOptions.POTION_EFFECT_TYPE, k -> new SpongeParticleOption<>(PotionEffectType.class));
             l.add(ParticleOptions.QUANTITY, k -> new SpongeParticleOption<>(Integer.class, v -> v < 1 ? new IllegalArgumentException("Quantity must be at least one") : null));
+            l.add(ParticleOptions.SCALE, k -> new SpongeParticleOption<>(Double.class, v -> v < 0 ? new IllegalArgumentException("Scale must not be negative") : null));
             l.add(ParticleOptions.VELOCITY, k -> new SpongeParticleOption<>(Vector3d.class));
         });
     }

--- a/src/main/java/org/spongepowered/common/util/ParticleOptionUtil.java
+++ b/src/main/java/org/spongepowered/common/util/ParticleOptionUtil.java
@@ -56,6 +56,7 @@ public final class ParticleOptionUtil {
             options.put(ParticleOptions.ITEM_STACK_SNAPSHOT.get(), ItemStackSnapshot.empty());
         } else if (type.getDeserializer() == DustParticleOptions.DESERIALIZER) {
             options.put(ParticleOptions.COLOR.get(), Color.RED);
+            options.put(ParticleOptions.SCALE.get(), 1.0d);
         }
 
         return ImmutableMap.copyOf(options);


### PR DESCRIPTION
Dust particles can have their size modified in vanilla, this PR implements that ability. There already was a SCALE option that was commented out, and there was a convenient spot in `SpongeParticleHelper` where the scale was set to `1.0f` as a default.

### Test Evidence

Code:
```
ServerPlayer player = ...;
ParticleOption<DOUBLE> SCALE = ...;  // I queried the registry to get this, I couldn't get cross-compiling working.
ParticleEffect.Builder dust = ParticleEffect.builder().type(ParticleTypes.DUST);
player.world().spawnParticles(dust.option(SCALE, 3.0d).build(), player.eyePosition().get().add(1, 0, 0));
player.world().spawnParticles(dust.option(SCALE, 1.0d).build(), player.eyePosition().get().add(2, 0, 0));
player.world().spawnParticles(dust.option(SCALE, 0.5d).build(), player.eyePosition().get().add(3, 0, 0));
player.world().spawnParticles(dust.option(SCALE, 0.0d).build(), player.eyePosition().get().add(4, 0, 0));
```

Result:
https://i.imgur.com/jbTaLre.png