### PR TITLE
Fix SlotAdapter#poll and SlotAdapter#freeCapacity

### DIFF
--- a/src/main/java/org/spongepowered/common/inventory/adapter/impl/slots/SlotAdapter.java
+++ b/src/main/java/org/spongepowered/common/inventory/adapter/impl/slots/SlotAdapter.java
@@ -72,7 +72,7 @@ public class SlotAdapter extends BasicInventoryAdapter implements Slot {
     public InventoryTransactionResult.Poll poll() {
         final net.minecraft.world.item.ItemStack stack = this.inventoryAdapter$getFabric().fabric$getStack(this.ordinal);
         if (stack.isEmpty()) {
-            return InventoryTransactionResult.builder().type(InventoryTransactionResult.Type.SUCCESS).poll(ItemStackSnapshot.empty()).build();
+            return InventoryTransactionResult.builder().type(InventoryTransactionResult.Type.FAILURE).poll(ItemStackSnapshot.empty()).build();
         }
 
         this.inventoryAdapter$getFabric().fabric$setStack(this.ordinal, net.minecraft.world.item.ItemStack.EMPTY);
@@ -171,7 +171,7 @@ public class SlotAdapter extends BasicInventoryAdapter implements Slot {
 
     @Override
     public int freeCapacity() {
-        return !this.slot.getStack(this.inventoryAdapter$getFabric()).isEmpty()? 1 : 0;
+        return this.slot.getStack(this.inventoryAdapter$getFabric()).isEmpty() ? 1 : 0;
     }
 
     @Override


### PR DESCRIPTION
Fixes the following methods so that their behavior matches the JavaDoc.

`freeCapacity` should return 1 when the slot is empty, and 0 when it is not.

`poll` should return a FAILURE result type for empty ItemStacks.