### PR TITLE
Rename methods that don't do well without "get" to "findX/findXOrCreate" 

### DIFF
--- a/src/main/java/org/spongepowered/common/scheduler/SpongeScheduler.java
+++ b/src/main/java/org/spongepowered/common/scheduler/SpongeScheduler.java
@@ -101,7 +101,7 @@ public abstract class SpongeScheduler implements Scheduler {
     }
 
     @Override
-    public Optional<ScheduledTask> taskById(final UUID id) {
+    public Optional<ScheduledTask> findTask(final UUID id) {
         Objects.requireNonNull(id, "id");
         synchronized (this.taskMap) {
             return Optional.ofNullable(this.taskMap.get(id));
@@ -109,7 +109,7 @@ public abstract class SpongeScheduler implements Scheduler {
     }
 
     @Override
-    public Set<ScheduledTask> tasksByName(final String pattern) {
+    public Set<ScheduledTask> findTasks(final String pattern) {
         Objects.requireNonNull(pattern, "pattern");
         final Pattern searchPattern = Pattern.compile(pattern);
         final Set<ScheduledTask> matchingTasks = this.tasks();
@@ -133,7 +133,7 @@ public abstract class SpongeScheduler implements Scheduler {
     }
 
     @Override
-    public Set<ScheduledTask> tasksByPlugin(final PluginContainer plugin) {
+    public Set<ScheduledTask> tasks(final PluginContainer plugin) {
         Objects.requireNonNull(plugin, "plugin");
         final String testOwnerId = plugin.getMetadata().getId();
 

--- a/src/main/java/org/spongepowered/common/scoreboard/SpongeObjective.java
+++ b/src/main/java/org/spongepowered/common/scoreboard/SpongeObjective.java
@@ -127,12 +127,12 @@ public final class SpongeObjective implements Objective {
     }
 
     @Override
-    public Optional<Score> score(final Component name) {
+    public Optional<Score> findScore(final Component name) {
         return Optional.ofNullable(this.scores.get(name));
     }
 
     @Override
-    public Score scoreOrCreate(final Component name) {
+    public Score findOrCreateScore(final Component name) {
         if (this.scores.containsKey(name)) {
             return this.scores.get(name);
         }
@@ -179,7 +179,7 @@ public final class SpongeObjective implements Objective {
 
     @Override
     public boolean removeScore(final Component name) {
-        final Optional<Score> score = this.score(name);
+        final Optional<Score> score = this.findScore(name);
         return score.filter(this::removeScore).isPresent();
     }
 

--- a/src/main/java/org/spongepowered/common/user/ServerUserProvider.java
+++ b/src/main/java/org/spongepowered/common/user/ServerUserProvider.java
@@ -215,7 +215,7 @@ public final class ServerUserProvider {
 
     Stream<GameProfile> streamAll() {
         final GameProfileCache cache = ((Server) this.server).gameProfileManager().cache();
-        return this.knownUUIDs.stream().map(x -> cache.byId(x).orElseGet(() -> GameProfile.of(x)));
+        return this.knownUUIDs.stream().map(x -> cache.findById(x).orElseGet(() -> GameProfile.of(x)));
     }
 
     private Path getPlayerDataFile(final UUID uniqueId) {

--- a/src/mixins/java/org/spongepowered/common/mixin/api/mcp/block/BlockMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/mcp/block/BlockMixin_API.java
@@ -78,7 +78,7 @@ public abstract class BlockMixin_API extends AbstractBlockMixin_API {
     }
 
     @Override
-    public Optional<StateProperty<?>> statePropertyByName(final String name) {
+    public Optional<StateProperty<?>> findStateProperty(final String name) {
         return Optional.ofNullable((StateProperty<?>) this.stateDefinition.getProperty(name));
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/api/mcp/server/ServerScoreboardMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/mcp/server/ServerScoreboardMixin_API.java
@@ -125,7 +125,7 @@ public abstract class ServerScoreboardMixin_API implements Scoreboard {
 
         final Set<org.spongepowered.api.scoreboard.Score> scores = new HashSet<>();
         for (final net.minecraft.world.scores.Objective objective: ((ScoreboardAccessor) this).accessor$objectivesByName().values()) {
-            ((ObjectiveBridge) objective).bridge$getSpongeObjective().score(name).ifPresent(scores::add);
+            ((ObjectiveBridge) objective).bridge$getSpongeObjective().findScore(name).ifPresent(scores::add);
         }
         return scores;
     }
@@ -136,7 +136,7 @@ public abstract class ServerScoreboardMixin_API implements Scoreboard {
 
         for (final net.minecraft.world.scores.Objective objective: ((ScoreboardAccessor) this).accessor$objectivesByName().values()) {
             final SpongeObjective spongeObjective = ((ObjectiveBridge) objective).bridge$getSpongeObjective();
-            spongeObjective.score(name).ifPresent(spongeObjective::removeScore);
+            spongeObjective.findScore(name).ifPresent(spongeObjective::removeScore);
         }
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/api/mcp/server/players/GameProfileCacheMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/mcp/server/players/GameProfileCacheMixin_API.java
@@ -116,13 +116,13 @@ public abstract class GameProfileCacheMixin_API implements GameProfileCache {
     }
 
     @Override
-    public Optional<GameProfile> byId(final UUID uniqueId) {
+    public Optional<GameProfile> findById(final UUID uniqueId) {
         Objects.requireNonNull(uniqueId, "uniqueId");
         return Optional.ofNullable(this.shadow$get(uniqueId)).map(SpongeGameProfile::of);
     }
 
     @Override
-    public Map<UUID, Optional<GameProfile>> byIds(final Iterable<UUID> uniqueIds) {
+    public Map<UUID, Optional<GameProfile>> findByIds(final Iterable<UUID> uniqueIds) {
         Objects.requireNonNull(uniqueIds, "uniqueIds");
         final Map<UUID, Optional<GameProfile>> result = new HashMap<>();
         for (final UUID uniqueId : uniqueIds) {
@@ -132,7 +132,7 @@ public abstract class GameProfileCacheMixin_API implements GameProfileCache {
     }
 
     @Override
-    public Optional<GameProfile> byName(final String name) {
+    public Optional<GameProfile> findByName(final String name) {
         Objects.requireNonNull(name, "name");
         @Nullable GameProfileCache_GameProfileInfoAccessor entry = this.profilesByName.get(name.toLowerCase(Locale.ROOT));
 
@@ -147,11 +147,11 @@ public abstract class GameProfileCacheMixin_API implements GameProfileCache {
     }
 
     @Override
-    public Map<String, Optional<GameProfile>> byNames(final Iterable<String> names) {
+    public Map<String, Optional<GameProfile>> findByNames(final Iterable<String> names) {
         Objects.requireNonNull(names, "names");
         final Map<String, Optional<GameProfile>> result = Maps.newHashMap();
         for (final String name : names) {
-            result.put(name, this.byName(name));
+            result.put(name, this.findByName(name));
         }
         return ImmutableMap.copyOf(result);
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/mcp/world/level/block/state/StateHolderMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/mcp/world/level/block/state/StateHolderMixin_API.java
@@ -61,7 +61,7 @@ public abstract class StateHolderMixin_API<S extends State<S>, C> implements Sta
     }
 
     @Override
-    public Optional<StateProperty<?>> statePropertyByName(String name) {
+    public Optional<StateProperty<?>> findStateProperty(String name) {
         return this.stateProperties().stream().filter(p -> p.name().equals(name)).findFirst();
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/api/mcp/world/level/material/FluidMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/mcp/world/level/material/FluidMixin_API.java
@@ -59,7 +59,7 @@ public abstract class FluidMixin_API implements FluidType {
     }
 
     @Override
-    public Optional<StateProperty<?>> statePropertyByName(final String name) {
+    public Optional<StateProperty<?>> findStateProperty(final String name) {
         return Optional.ofNullable((StateProperty) this.shadow$getStateDefinition().getProperty(name));
     }
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/ServerScoreboardMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/ServerScoreboardMixin.java
@@ -264,7 +264,7 @@ public abstract class ServerScoreboardMixin extends Scoreboard implements Server
 
     @Override
     public Score getOrCreatePlayerScore(final String name, final net.minecraft.world.scores.Objective objective) {
-        return ((SpongeScore) ((ObjectiveBridge) objective).bridge$getSpongeObjective().scoreOrCreate(SpongeAdventure.legacySection(name)))
+        return ((SpongeScore) ((ObjectiveBridge) objective).bridge$getSpongeObjective().findOrCreateScore(SpongeAdventure.legacySection(name)))
                 .getScoreFor(objective);
     }
 
@@ -272,7 +272,7 @@ public abstract class ServerScoreboardMixin extends Scoreboard implements Server
     public void resetPlayerScore(final String name, final net.minecraft.world.scores.Objective objective) {
         if (objective != null) {
             final SpongeObjective spongeObjective = ((ObjectiveBridge) objective).bridge$getSpongeObjective();
-            final Optional<org.spongepowered.api.scoreboard.Score> score = spongeObjective.score(SpongeAdventure.legacySection(name));
+            final Optional<org.spongepowered.api.scoreboard.Score> score = spongeObjective.findScore(SpongeAdventure.legacySection(name));
             if (score.isPresent()) {
                 spongeObjective.removeScore(score.get());
             } else {

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/CreatorTrackedMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/CreatorTrackedMixin_Tracker.java
@@ -122,7 +122,7 @@ public abstract class CreatorTrackedMixin_Tracker implements CreatorTrackedBridg
         }
 
         // check mojang cache
-        final GameProfile profile = Sponge.server().gameProfileManager().cache().byId(uuid).orElse(null);
+        final GameProfile profile = Sponge.server().gameProfileManager().cache().findById(uuid).orElse(null);
         if (profile != null) {
             return Sponge.server().userManager().find(profile);
         }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2332) | **Sponge**

Companion to the API changes. See https://github.com/SpongePowered/SpongeAPI/issues/2320. Basically here to ensure that we're okay with the proposed renames.