### PR TITLE
Implement recipe, biome, and sound ClientCompletionKeys

### DIFF
--- a/src/main/java/org/spongepowered/common/command/registrar/tree/builder/ArgumentCommandTreeNode.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/tree/builder/ArgumentCommandTreeNode.java
@@ -25,12 +25,15 @@
 package org.spongepowered.common.command.registrar.tree.builder;
 
 import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.CommandNode;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.commands.synchronization.SuggestionProviders;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.command.registrar.tree.ClientCompletionKey;
 import org.spongepowered.api.command.registrar.tree.CommandTreeNode;
 import org.spongepowered.common.command.brigadier.tree.ForcedRedirectArgumentSuggestionNode;
+import org.spongepowered.common.command.registrar.tree.key.SpongeCustomSuggestionProviderClientCompletionKey;
 
 public abstract class ArgumentCommandTreeNode<T extends CommandTreeNode<T>>
         extends AbstractCommandTreeNode<T, CommandNode<SharedSuggestionProvider>> {
@@ -47,8 +50,18 @@ public abstract class ArgumentCommandTreeNode<T extends CommandTreeNode<T>>
                 nodeKey,
                 this.getArgumentType(),
                 this.isExecutable() ? AbstractCommandTreeNode.EXECUTABLE : null,
-                this.isCustomSuggestions() ? SuggestionProviders.ASK_SERVER : null
+                this.suggestionsProvider()
         );
+    }
+
+    private @Nullable SuggestionProvider<SharedSuggestionProvider> suggestionsProvider() {
+        if (this.isCustomSuggestions()) {
+            return SuggestionProviders.ASK_SERVER;
+        }
+        if (this.parameterType instanceof SpongeCustomSuggestionProviderClientCompletionKey) {
+            return ((SpongeCustomSuggestionProviderClientCompletionKey) this.parameterType).defaultSuggestionProvider();
+        }
+        return null;
     }
 
     protected abstract ArgumentType<?> getArgumentType();

--- a/src/main/java/org/spongepowered/common/command/registrar/tree/key/SpongeCustomSuggestionProviderClientCompletionKey.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/tree/key/SpongeCustomSuggestionProviderClientCompletionKey.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.command.registrar.tree.key;
+
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import net.minecraft.commands.SharedSuggestionProvider;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.spongepowered.api.ResourceKey;
+import org.spongepowered.api.command.registrar.tree.ClientCompletionKey;
+import org.spongepowered.api.command.registrar.tree.CommandTreeNode;
+import org.spongepowered.common.AbstractResourceKeyed;
+import org.spongepowered.common.command.registrar.tree.builder.BasicCommandTreeNode;
+
+public final class SpongeCustomSuggestionProviderClientCompletionKey extends AbstractResourceKeyed implements ClientCompletionKey<CommandTreeNode.@NonNull Basic> {
+
+    private final ArgumentType<?> argumentType;
+    private final SuggestionProvider<? extends SharedSuggestionProvider> defaultSuggestionProvider;
+
+    public SpongeCustomSuggestionProviderClientCompletionKey(final ResourceKey key, final ArgumentType<?> argumentType, SuggestionProvider<? extends SharedSuggestionProvider> defaultSuggestionProvider) {
+        super(key);
+
+        this.argumentType = argumentType;
+        this.defaultSuggestionProvider = defaultSuggestionProvider;
+    }
+
+    @Override
+    public CommandTreeNode.@NonNull Basic createNode() {
+        return new BasicCommandTreeNode(this, this.argumentType);
+    }
+
+    @SuppressWarnings("unchecked")
+    public SuggestionProvider<SharedSuggestionProvider> defaultSuggestionProvider() {
+        return (SuggestionProvider<SharedSuggestionProvider>) this.defaultSuggestionProvider;
+    }
+}

--- a/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
@@ -47,6 +47,7 @@ import net.minecraft.commands.arguments.coordinates.Vec2Argument;
 import net.minecraft.commands.arguments.coordinates.Vec3Argument;
 import net.minecraft.commands.arguments.item.ItemArgument;
 import net.minecraft.commands.arguments.selector.EntitySelectorParser;
+import net.minecraft.commands.synchronization.SuggestionProviders;
 import net.minecraft.commands.synchronization.brigadier.DoubleArgumentSerializer;
 import net.minecraft.commands.synchronization.brigadier.FloatArgumentSerializer;
 import net.minecraft.commands.synchronization.brigadier.IntegerArgumentSerializer;
@@ -205,6 +206,7 @@ import org.spongepowered.common.command.registrar.SpongeParameterizedCommandRegi
 import org.spongepowered.common.command.registrar.SpongeRawCommandRegistrar;
 import org.spongepowered.common.command.registrar.tree.key.SpongeAmountClientCompletionKey;
 import org.spongepowered.common.command.registrar.tree.key.SpongeBasicClientCompletionKey;
+import org.spongepowered.common.command.registrar.tree.key.SpongeCustomSuggestionProviderClientCompletionKey;
 import org.spongepowered.common.command.registrar.tree.key.SpongeEntityClientCompletionKey;
 import org.spongepowered.common.command.registrar.tree.key.SpongeRangeClientCompletionKey;
 import org.spongepowered.common.command.registrar.tree.key.SpongeStringClientCompletionKey;
@@ -440,6 +442,9 @@ public final class SpongeRegistryLoaders {
     public static RegistryLoader<ClientCompletionKey<?>> clientCompletionKey() {
         final Function<ResourceKey, ArgumentType<?>> fn = key -> ((EmptyArgumentSerializerAccessor<?>) ArgumentTypesAccessor.accessor$BY_NAME().get(key).accessor$serializer()).accessor$constructor().get();
         return RegistryLoader.of(l -> {
+            l.add(ClientCompletionKeys.ALL_RECIPES, k -> new SpongeCustomSuggestionProviderClientCompletionKey(k, ResourceLocationArgument.id(), SuggestionProviders.ALL_RECIPES));
+            l.add(ClientCompletionKeys.AVAILABLE_BIOMES, k -> new SpongeCustomSuggestionProviderClientCompletionKey(k, ResourceLocationArgument.id(), SuggestionProviders.AVAILABLE_BIOMES));
+            l.add(ClientCompletionKeys.AVAILABLE_SOUNDS, k -> new SpongeCustomSuggestionProviderClientCompletionKey(k, ResourceLocationArgument.id(), SuggestionProviders.AVAILABLE_SOUNDS));
             l.add(ClientCompletionKeys.BLOCK_PREDICATE, k -> new SpongeBasicClientCompletionKey(k, fn.apply(k)));
             l.add(ClientCompletionKeys.BLOCK_STATE, k -> new SpongeBasicClientCompletionKey(k, fn.apply(k)));
             l.add(ClientCompletionKeys.BOOL, k -> new SpongeBasicClientCompletionKey(k, fn.apply(k)));
@@ -449,7 +454,7 @@ public final class SpongeRegistryLoaders {
             l.add(ClientCompletionKeys.DOUBLE, k -> SpongeRangeClientCompletionKey.createFrom(k, new DoubleArgumentSerializer()));
             l.add(ClientCompletionKeys.ENTITY, SpongeEntityClientCompletionKey::new);
             l.add(ClientCompletionKeys.ENTITY_ANCHOR, k -> new SpongeBasicClientCompletionKey(k, fn.apply(k)));
-            l.add(ClientCompletionKeys.ENTITY_SUMMON, k -> new SpongeBasicClientCompletionKey(k, fn.apply(k)));
+            l.add(ClientCompletionKeys.ENTITY_SUMMON, k -> new SpongeCustomSuggestionProviderClientCompletionKey(k, fn.apply(k), SuggestionProviders.SUMMONABLE_ENTITIES));
             l.add(ClientCompletionKeys.FLOAT, k -> SpongeRangeClientCompletionKey.createFrom(k, new FloatArgumentSerializer()));
             l.add(ClientCompletionKeys.FUNCTION, k -> new SpongeBasicClientCompletionKey(k, fn.apply(k)));
             l.add(ClientCompletionKeys.GAME_PROFILE, k -> new SpongeBasicClientCompletionKey(k, fn.apply(k)));


### PR DESCRIPTION
Sponge | [SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2333)

Implements the `all_recipes`, `available_biomes`, and `available_sounds` `ClientCompletionKey`s. These are not specific argument types, only suggestion providers. In Vanilla, these suggestion providers are always used in combination with the `ResourceLocationArgument`, so that is how they are used here.

One thing I was kind of unsure about in implementing this is that the suggestion providers are of type `SuggestionProvider<CommandSourceStack>`, not `SuggestionProvider<SharedSuggestionProvider>`. To work around this I used an unchecked cast, but like I said I am unsure if it's the right approach.

This PR also fixes an issue where the `ENTITY_SUMMON` `ClientCompletionKey` would not provide any suggestions.