### PR TITLE
Fix per player scoreboard team friendly fire

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java
@@ -876,6 +876,11 @@ public abstract class ServerPlayerMixin extends PlayerMixin implements SubjectBr
         return (net.minecraft.world.scores.Scoreboard) this.impl$scoreboard;
     }
 
+    @Override
+    public Team shadow$getTeam() {
+        return ((net.minecraft.world.scores.Scoreboard) this.impl$scoreboard).getPlayersTeam(this.shadow$getScoreboardName());
+    }
+
     @Inject(method = "startSleepInBed", at = @At(value = "RETURN"), cancellable = true)
     private void impl$onReturnSleep(final BlockPos param0, final CallbackInfoReturnable<Either<Player.BedSleepingProblem, Unit>> cir) {
         final Either<Player.BedSleepingProblem, Unit> returnValue = cir.getReturnValue();

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/player/PlayerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/player/PlayerMixin.java
@@ -63,6 +63,7 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.pattern.BlockInWorld;
 import net.minecraft.world.scores.Scoreboard;
+import net.minecraft.world.scores.Team;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.entity.living.Humanoid;
 import org.spongepowered.api.entity.living.Living;
@@ -93,6 +94,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.bridge.authlib.GameProfileHolderBridge;
+import org.spongepowered.common.bridge.server.level.ServerPlayerBridge;
 import org.spongepowered.common.bridge.world.entity.PlatformEntityBridge;
 import org.spongepowered.common.bridge.world.entity.player.PlayerBridge;
 import org.spongepowered.common.bridge.server.level.ServerLevelBridge;
@@ -622,5 +624,19 @@ public abstract class PlayerMixin extends LivingEntityMixin implements PlayerBri
     @Override
     public boolean impl$canCallIgniteEntityEvent() {
         return !this.shadow$isSpectator() && !this.shadow$isCreative();
+    }
+
+    @Inject(method = "canHarmPlayer", at = @At("HEAD"), cancellable = true)
+    private void impl$onCanHarmPlayer(final net.minecraft.world.entity.player.Player other, final CallbackInfoReturnable<Boolean> cir) {
+        if (!(other instanceof org.spongepowered.api.entity.living.player.server.ServerPlayer)) {
+            return;
+        }
+
+        //Check whatever the other player can hit this player
+        //Fixes per player scoreboards which could have different team set up for each player
+        final Team otherTeam = other.getTeam();
+        final Team thisTeam = ((net.minecraft.world.scores.Scoreboard) ((ServerPlayerBridge) other).bridge$getScoreboard()).getPlayersTeam(this.shadow$getScoreboardName());
+
+        cir.setReturnValue(otherTeam == null || !otherTeam.isAlliedTo(thisTeam) || otherTeam.isAllowFriendlyFire());
     }
 }


### PR DESCRIPTION
The #getTeam was using the per world instance of scoreboard instead of the per player one.

Also change the #canHarmPlayer to use the attacker's scoreboard instead of the attacked player one to detect whatever its allowed to attack the player.