### PR TITLE
Fix getting the currently active scoreboard for player

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java
@@ -862,6 +862,10 @@ public abstract class ServerPlayerMixin extends PlayerMixin implements SubjectBr
         }
     }
 
+    @Override
+    public net.minecraft.world.scores.Scoreboard shadow$getScoreboard() {
+        return (net.minecraft.world.scores.Scoreboard) this.impl$scoreboard;
+    }
 }
 
 


### PR DESCRIPTION
Currently the #getScoreboard incorrectly returns the per world scoreboard instead of the per player one, which results that read-only criterias aren't updated at all.

The root problem mentioned in #3386 still persists but this at least allows the criterias to update.