### PR TITLE
Small fixes to multi-block captures

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/world/level/block/TrackedBlockBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/world/level/block/TrackedBlockBridge.java
@@ -28,4 +28,6 @@ public interface TrackedBlockBridge {
 
     boolean bridge$overridesNeighborNotificationLogic();
 
+    boolean bridge$hasEntityInsideLogic();
+
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/IPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/IPhaseState.java
@@ -25,6 +25,17 @@
 package org.spongepowered.common.event.tracking;
 
 import com.google.common.collect.ImmutableList;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.level.TickNextTickData;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.storage.loot.LootContext;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -44,10 +55,10 @@ import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.SerializationBehavior;
 import org.spongepowered.api.world.World;
 import org.spongepowered.common.block.SpongeBlockSnapshot;
-import org.spongepowered.common.bridge.world.level.TrackerBlockEventDataBridge;
 import org.spongepowered.common.bridge.server.TickTaskBridge;
 import org.spongepowered.common.bridge.server.level.ServerLevelBridge;
 import org.spongepowered.common.bridge.world.TrackedWorldBridge;
+import org.spongepowered.common.bridge.world.level.TrackerBlockEventDataBridge;
 import org.spongepowered.common.bridge.world.level.chunk.LevelChunkBridge;
 import org.spongepowered.common.entity.PlayerTracker;
 import org.spongepowered.common.event.tracking.context.transaction.ChangeBlock;
@@ -67,17 +78,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.level.TickNextTickData;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraft.world.level.storage.loot.LootContext;
 
 /**
  * A literal phase state of which the {@link World} is currently running
@@ -577,7 +577,9 @@ public interface IPhaseState<C extends PhaseContext<C>> {
     default void foldContextForThread(final C context, final TickTaskBridge returnValue) {
     }
 
-    default void associateScheduledTickUpdate(C asContext, TickNextTickData<?> entry) {
+    default void associateScheduledTickUpdate(final C asContext, final ServerLevel level,
+        final TickNextTickData<?> entry
+    ) {
 
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/PhaseStateProxy.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/PhaseStateProxy.java
@@ -25,6 +25,15 @@
 package org.spongepowered.common.event.tracking;
 
 import com.google.common.collect.ImmutableList;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.TickNextTickData;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.storage.loot.LootContext;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.block.BlockSnapshot;
@@ -39,9 +48,9 @@ import org.spongepowered.api.util.Tuple;
 import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.SerializationBehavior;
 import org.spongepowered.common.block.SpongeBlockSnapshot;
-import org.spongepowered.common.bridge.world.level.TrackerBlockEventDataBridge;
 import org.spongepowered.common.bridge.server.TickTaskBridge;
 import org.spongepowered.common.bridge.world.TrackedWorldBridge;
+import org.spongepowered.common.bridge.world.level.TrackerBlockEventDataBridge;
 import org.spongepowered.common.entity.PlayerTracker;
 import org.spongepowered.common.event.tracking.context.transaction.ChangeBlock;
 import org.spongepowered.common.event.tracking.context.transaction.GameTransaction;
@@ -56,15 +65,6 @@ import java.util.Random;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.TickNextTickData;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraft.world.level.storage.loot.LootContext;
 
 public interface PhaseStateProxy<C extends PhaseContext<C>> {
 
@@ -480,19 +480,19 @@ public interface PhaseStateProxy<C extends PhaseContext<C>> {
         return this.getState().recordsEntitySpawns(this.asContext());
     }
 
-    default void populateLootContext(LootContext.Builder lootBuilder) {
+    default void populateLootContext(final LootContext.Builder lootBuilder) {
         this.getState().populateLootContext(this.asContext(), lootBuilder);
     }
 
-    default Operation getBlockOperation(SpongeBlockSnapshot original, BlockChange blockChange) {
+    default Operation getBlockOperation(final SpongeBlockSnapshot original, final BlockChange blockChange) {
         return this.getState().getBlockOperation(original, blockChange);
     }
 
-    default void foldContextForThread(TickTaskBridge returnValue) {
+    default void foldContextForThread(final TickTaskBridge returnValue) {
         this.getState().foldContextForThread(this.asContext(), returnValue);
     }
 
-    default void associateScheduledTickUpdate(TickNextTickData<?> entry) {
-        this.getState().associateScheduledTickUpdate(this.asContext(), entry);
+    default void associateScheduledTickUpdate(final ServerLevel level, final TickNextTickData<?> entry) {
+        this.getState().associateScheduledTickUpdate(this.asContext(), level, entry);
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/AddBlockEventTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/AddBlockEventTransaction.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.common.event.tracking.context.transaction;
 
+import net.minecraft.world.level.BlockEventData;
+import net.minecraft.world.level.block.state.BlockState;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.event.CauseStackManager;
@@ -34,9 +36,8 @@ import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.util.PrettyPrinter;
 
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.BiConsumer;
-import net.minecraft.world.level.BlockEventData;
-import net.minecraft.world.level.block.state.BlockState;
 
 public class AddBlockEventTransaction extends BlockEventBasedTransaction {
 
@@ -78,5 +79,17 @@ public class AddBlockEventTransaction extends BlockEventBasedTransaction {
     @Override
     public void restore() {
         this.original.getServerWorld().ifPresent(world -> ((ServerLevelAccessor) world).accessor$blockEvents().remove(this.blockEvent));
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", AddBlockEventTransaction.class.getSimpleName() + "[", "]")
+            .add("blockEvent=" + this.blockEvent)
+            .add("original=" + this.original)
+            .add("affectedPosition=" + this.affectedPosition)
+            .add("originalState=" + this.originalState)
+            .add("worldKey=" + this.worldKey)
+            .add("cancelled=" + this.cancelled)
+            .toString();
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/AddTileEntity.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/AddTileEntity.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.common.event.tracking.context.transaction;
 
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -36,9 +38,8 @@ import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.util.PrettyPrinter;
 
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.BiConsumer;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
 
 @DefaultQualifier(NonNull.class)
 public final class AddTileEntity extends BlockEventBasedTransaction {
@@ -83,5 +84,16 @@ public final class AddTileEntity extends BlockEventBasedTransaction {
     @Override
     protected SpongeBlockSnapshot getOriginalSnapshot() {
         return this.oldSnapshot;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", AddTileEntity.class.getSimpleName() + "[", "]")
+            .add("added=" + this.added)
+            .add("affectedPosition=" + this.affectedPosition)
+            .add("originalState=" + this.originalState)
+            .add("worldKey=" + this.worldKey)
+            .add("cancelled=" + this.cancelled)
+            .toString();
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/BlockEventBasedTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/BlockEventBasedTransaction.java
@@ -136,6 +136,9 @@ abstract class BlockEventBasedTransaction extends GameTransaction<ChangeBlockEve
         final ImmutableList<? extends GameTransaction<ChangeBlockEvent.All>> blockTransactions
     ) {
         boolean cancelledAny = false;
+        if (event.isCancelled()) {
+            event.transactions().forEach(BlockTransaction::invalidate);
+        }
         for (final Transaction<BlockSnapshot> transaction : event.transactions()) {
             if (!transaction.isValid()) {
                 cancelledAny = true;
@@ -154,5 +157,11 @@ abstract class BlockEventBasedTransaction extends GameTransaction<ChangeBlockEve
         }
 
         return cancelledAny;
+    }
+
+    @Override
+    public void markEventAsCancelledIfNecessary(final ChangeBlockEvent.All event) {
+        super.markEventAsCancelledIfNecessary(event);
+        event.transactions().forEach(BlockTransaction::invalidate);
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/BlockEventBasedTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/BlockEventBasedTransaction.java
@@ -28,6 +28,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.ResourceKey;
@@ -51,8 +53,6 @@ import org.spongepowered.math.vector.Vector3i;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.state.BlockState;
 
 abstract class BlockEventBasedTransaction extends GameTransaction<ChangeBlockEvent.All> {
 
@@ -117,6 +117,9 @@ abstract class BlockEventBasedTransaction extends GameTransaction<ChangeBlockEve
             .map(Optional::get)
             .collect(ImmutableList.toImmutableList());
 
+        if (eventTransactions.isEmpty()) {
+            return Optional.empty();
+        }
         return Optional.of(SpongeEventFactory.createChangeBlockEventAll(
             currentCause,
             eventTransactions,

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/ChangeBlock.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/ChangeBlock.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.common.event.tracking.context.transaction;
 
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -47,9 +49,8 @@ import org.spongepowered.common.util.PrettyPrinter;
 import org.spongepowered.common.world.SpongeBlockChangeFlag;
 
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.BiConsumer;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
 
 @DefaultQualifier(NonNull.class)
 public final class ChangeBlock extends BlockEventBasedTransaction {
@@ -90,6 +91,21 @@ public final class ChangeBlock extends BlockEventBasedTransaction {
         builder.addEffect(BlockAddedEffect.getInstance());
         builder.addEffect(UpdateOrCreateNewTileEntityPostPlacementEffect.getInstance());
         builder.addEffect(ChunkChangeCompleteEffect.getInstance());
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ChangeBlock.class.getSimpleName() + "[", "]")
+            .add("affectedPosition=" + this.affectedPosition)
+            .add("originalState=" + this.originalState)
+            .add("originalOpacity=" + this.originalOpacity)
+            .add("newState=" + this.newState)
+            .add("blockChangeFlag=" + this.blockChangeFlag)
+            .add("queuedRemoval=" + this.queuedRemoval)
+            .add("queuedAdd=" + this.queuedAdd)
+            .add("worldKey=" + this.worldKey)
+            .add("cancelled=" + this.cancelled)
+            .toString();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/ChangeBlock.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/ChangeBlock.java
@@ -46,6 +46,7 @@ import org.spongepowered.common.event.tracking.context.transaction.effect.Update
 import org.spongepowered.common.event.tracking.context.transaction.pipeline.ChunkPipeline;
 import org.spongepowered.common.util.Constants;
 import org.spongepowered.common.util.PrettyPrinter;
+import org.spongepowered.common.world.BlockChange;
 import org.spongepowered.common.world.SpongeBlockChangeFlag;
 
 import java.util.Optional;
@@ -181,5 +182,12 @@ public final class ChangeBlock extends BlockEventBasedTransaction {
     @Override
     protected SpongeBlockSnapshot getOriginalSnapshot() {
         return this.original;
+    }
+
+    @Override
+    boolean acceptDrops(final PrepareBlockDropsTransaction transaction) {
+        return this.original.blockChange == BlockChange.BREAK
+            && this.affectedPosition.equals(transaction.affectedPosition)
+            && this.original.state() == transaction.getOriginalSnapshot().state();
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/EntityPerformingDropsTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/EntityPerformingDropsTransaction.java
@@ -26,6 +26,11 @@ package org.spongepowered.common.event.tracking.context.transaction;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.MobSpawnType;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.event.Cause;
@@ -40,13 +45,9 @@ import org.spongepowered.common.event.tracking.context.transaction.type.Transact
 import org.spongepowered.common.util.PrettyPrinter;
 
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.MobSpawnType;
 
 public final class EntityPerformingDropsTransaction extends GameTransaction<HarvestEntityEvent> {
 
@@ -119,5 +120,15 @@ public final class EntityPerformingDropsTransaction extends GameTransaction<Harv
         final ImmutableList<? extends GameTransaction<HarvestEntityEvent>> gameTransactions
     ) {
         return false;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", EntityPerformingDropsTransaction.class.getSimpleName() + "[", "]")
+            .add("destroyingEntity=" + this.destroyingEntity)
+            .add("lastAttacker=" + this.lastAttacker)
+            .add("worldKey=" + this.worldKey)
+            .add("cancelled=" + this.cancelled)
+            .toString();
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/GameTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/GameTransaction.java
@@ -169,4 +169,8 @@ public abstract class GameTransaction<E extends Event & Cancellable> {
             event.setCancelled(true);
         }
     }
+
+    boolean acceptDrops(final PrepareBlockDropsTransaction transaction) {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/GameTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/GameTransaction.java
@@ -26,6 +26,8 @@ package org.spongepowered.common.event.tracking.context.transaction;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -43,8 +45,6 @@ import java.util.LinkedList;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.function.BiConsumer;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
 @DefaultQualifier(NonNull.class)
 public abstract class GameTransaction<E extends Event & Cancellable> {
@@ -136,6 +136,10 @@ public abstract class GameTransaction<E extends Event & Cancellable> {
         Cause currentCause,
         ImmutableMultimap.Builder<TransactionType, ? extends Event> transactionPostEventBuilder
     );
+
+    void handleEmptyEvent() {
+        this.markCancelled();
+    }
 
     public abstract void restore();
 

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/GameTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/GameTransaction.java
@@ -164,4 +164,9 @@ public abstract class GameTransaction<E extends Event & Cancellable> {
 
     }
 
+    public void markEventAsCancelledIfNecessary(final E event) {
+        if (this.cancelled) {
+            event.setCancelled(true);
+        }
+    }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/NeighborNotification.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/NeighborNotification.java
@@ -192,4 +192,9 @@ final class NeighborNotification extends GameTransaction<NotifyNeighborBlockEven
         return cancelledAny;
     }
 
+    @Override
+    public void markEventAsCancelledIfNecessary(final NotifyNeighborBlockEvent event) {
+        super.markEventAsCancelledIfNecessary(event);
+        event.tickets().forEach(NotificationTicket::invalidate);
+    }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/PrepareBlockDropsTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/PrepareBlockDropsTransaction.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.common.event.tracking.context.transaction;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.event.CauseStackManager;
@@ -34,9 +36,8 @@ import org.spongepowered.common.util.Constants;
 import org.spongepowered.common.util.PrettyPrinter;
 
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.BiConsumer;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.state.BlockState;
 
 public final class PrepareBlockDropsTransaction extends BlockEventBasedTransaction {
 
@@ -72,7 +73,25 @@ public final class PrepareBlockDropsTransaction extends BlockEventBasedTransacti
     }
 
     @Override
+    void handleEmptyEvent() {
+        if (this.hasChildTransactions()) {
+            this.markCancelled();
+        }
+    }
+
+    @Override
     public void restore() {
         this.originalState.restore(true, BlockChangeFlagManager.fromNativeInt(Constants.BlockChangeFlags.FORCED_RESTORE));
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", PrepareBlockDropsTransaction.class.getSimpleName() + "[", "]")
+            .add("affectedPosition=" + this.affectedPosition)
+            .add("originalState=" + this.originalState)
+            .add("worldKey=" + this.worldKey)
+            .add("cancelled=" + this.cancelled)
+            .add("originalState=" + this.originalState)
+            .toString();
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/PrepareBlockDropsTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/PrepareBlockDropsTransaction.java
@@ -74,9 +74,8 @@ public final class PrepareBlockDropsTransaction extends BlockEventBasedTransacti
 
     @Override
     void handleEmptyEvent() {
-        if (this.hasChildTransactions()) {
-            this.markCancelled();
-        }
+        // this can mean that there were no possible block changes to associate
+        // but the spawns were still captured, maybe...
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/RemoveTileEntity.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/RemoveTileEntity.java
@@ -24,6 +24,9 @@
  */
 package org.spongepowered.common.event.tracking.context.transaction;
 
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -37,10 +40,8 @@ import org.spongepowered.common.util.PrettyPrinter;
 import org.spongepowered.math.vector.Vector3i;
 
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.BiConsumer;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
 
 @DefaultQualifier(NonNull.class)
 public final class RemoveTileEntity extends BlockEventBasedTransaction {
@@ -87,5 +88,16 @@ public final class RemoveTileEntity extends BlockEventBasedTransaction {
     @Override
     protected SpongeBlockSnapshot getOriginalSnapshot() {
         return this.tileSnapshot;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", RemoveTileEntity.class.getSimpleName() + "[", "]")
+            .add("affectedPosition=" + this.affectedPosition)
+            .add("originalState=" + this.originalState)
+            .add("worldKey=" + this.worldKey)
+            .add("cancelled=" + this.cancelled)
+            .add("removed=" + this.removed)
+            .toString();
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/ReplaceTileEntity.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/ReplaceTileEntity.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.common.event.tracking.context.transaction;
 
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -35,9 +37,8 @@ import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.util.PrettyPrinter;
 
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.BiConsumer;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
 
 @DefaultQualifier(NonNull.class)
 public final class ReplaceTileEntity extends BlockEventBasedTransaction {
@@ -96,5 +97,17 @@ public final class ReplaceTileEntity extends BlockEventBasedTransaction {
     @Override
     protected SpongeBlockSnapshot getOriginalSnapshot() {
         return this.removedSnapshot;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ReplaceTileEntity.class.getSimpleName() + "[", "]")
+            .add("affectedPosition=" + this.affectedPosition)
+            .add("originalState=" + this.originalState)
+            .add("worldKey=" + this.worldKey)
+            .add("cancelled=" + this.cancelled)
+            .add("added=" + this.added)
+            .add("removed=" + this.removed)
+            .toString();
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/ScheduleUpdateTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/ScheduleUpdateTransaction.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.event.tracking.context.transaction;
+
+import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.common.block.SpongeBlockSnapshot;
+import org.spongepowered.common.bridge.world.level.TickNextTickDataBridge;
+import org.spongepowered.common.event.tracking.PhaseContext;
+import org.spongepowered.common.util.PrettyPrinter;
+
+import net.minecraft.world.level.TickNextTickData;
+import net.minecraft.world.level.block.state.BlockState;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Optional;
+import java.util.StringJoiner;
+import java.util.function.BiConsumer;
+
+public class ScheduleUpdateTransaction extends BlockEventBasedTransaction {
+
+    private final TickNextTickData<?> data;
+    private final SpongeBlockSnapshot original;
+
+
+    ScheduleUpdateTransaction(final SpongeBlockSnapshot original, final TickNextTickData<?> data) {
+        super(original.getBlockPos(), (BlockState) original.state(), original.world());
+        this.data = data;
+        this.original = original;
+    }
+
+    @Override
+    protected SpongeBlockSnapshot getResultingSnapshot() {
+        return this.getOriginalSnapshot();
+    }
+
+    @Override
+    protected SpongeBlockSnapshot getOriginalSnapshot() {
+        return this.original;
+    }
+
+    @Override
+    public Optional<BiConsumer<PhaseContext<@NonNull ?>, CauseStackManager.StackFrame>> getFrameMutator(
+        final @Nullable GameTransaction<@NonNull ?> parent
+    ) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void addToPrinter(final PrettyPrinter printer) {
+        printer.add("AddBlockEvent")
+            .add(" %s : %s", "Original Block", this.original)
+            .add(" %s : %s", "Original State", this.originalState)
+            .add(" %s : %s", "EventData", this.data);
+    }
+
+    @Override
+    public void restore() {
+        ((TickNextTickDataBridge<?>) this.data).bridge$cancelForcibly();
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ScheduleUpdateTransaction.class.getSimpleName() + "[", "]")
+            .add("scheduledUpdate=" + this.data)
+            .add("original=" + this.original)
+            .add("affectedPosition=" + this.affectedPosition)
+            .add("originalState=" + this.originalState)
+            .add("worldKey=" + this.worldKey)
+            .add("cancelled=" + this.cancelled)
+            .toString();
+    }
+}

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/SpawnEntityTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/SpawnEntityTransaction.java
@@ -26,6 +26,9 @@ package org.spongepowered.common.event.tracking.context.transaction;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -44,11 +47,9 @@ import org.spongepowered.common.util.PrettyPrinter;
 import org.spongepowered.math.vector.Vector3d;
 
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.entity.Entity;
 
 @DefaultQualifier(NonNull.class)
 public final class SpawnEntityTransaction extends GameTransaction<SpawnEntityEvent> {
@@ -143,5 +144,14 @@ public final class SpawnEntityTransaction extends GameTransaction<SpawnEntityEve
     @Override
     public void postProcessEvent(final PhaseContext<@NonNull ?> context, final SpawnEntityEvent event) {
 
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", SpawnEntityTransaction.class.getSimpleName() + "[", "]")
+            .add("worldKey=" + this.worldKey)
+            .add("entityToSpawn=" + this.entityToSpawn)
+            .add("originalPosition=" + this.originalPosition)
+            .toString();
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/TransactionalCaptureSupplier.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/TransactionalCaptureSupplier.java
@@ -267,7 +267,9 @@ public final class TransactionalCaptureSupplier implements ICaptureSupplier {
         );
         original.blockChange = BlockChange.MODIFY;
         final PrepareBlockDropsTransaction transaction = new PrepareBlockDropsTransaction(pos, state, original);
-        this.logTransaction(transaction);
+        if (this.tail == null || !this.tail.acceptDrops(transaction)) {
+            this.logTransaction(transaction);
+        }
         return this.pushEffect(new ResultingTransactionBySideEffect(PrepareBlockDrops.getInstance()));
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/type/BlockTransactionType.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/type/BlockTransactionType.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
+import net.minecraft.core.BlockPos;
 import org.apache.logging.log4j.Marker;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.api.ResourceKey;
@@ -48,7 +49,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import net.minecraft.core.BlockPos;
 
 public final class BlockTransactionType extends TransactionType<ChangeBlockEvent.All> {
 
@@ -82,6 +82,11 @@ public final class BlockTransactionType extends TransactionType<ChangeBlockEvent
                     positions.put(original.getBlockPos(), (SpongeBlockSnapshot) transactions.finalReplacement());
                 });
 
+            // Do not bother turning the positions into receipts if it's empty
+            // just return.
+            if (positions.isEmpty()) {
+                return;
+            }
             final PhaseContext<@NonNull ?> context = PhaseTracker.getInstance().getPhaseContext();
             final ImmutableList<BlockTransactionReceipt> transactions = positions.asMap()
                 .values()

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/ChunkLoadPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/ChunkLoadPhaseState.java
@@ -24,12 +24,13 @@
  */
 package org.spongepowered.common.event.tracking.phase.generation;
 
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.TickNextTickData;
 import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.common.bridge.world.TickNextTickDataBridge;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 
 import java.util.function.BiConsumer;
-import net.minecraft.world.level.TickNextTickData;
 
 public final class ChunkLoadPhaseState extends GeneralGenerationPhaseState<ChunkLoadContext> {
 
@@ -53,7 +54,9 @@ public final class ChunkLoadPhaseState extends GeneralGenerationPhaseState<Chunk
     }
 
     @Override
-    public void associateScheduledTickUpdate(final ChunkLoadContext asContext, final TickNextTickData<?> entry) {
+    public void associateScheduledTickUpdate(
+        final ChunkLoadContext asContext, ServerLevel level, final TickNextTickData<?> entry
+    ) {
         ((TickNextTickDataBridge) entry).bridge$setIsPartOfWorldGeneration(true);
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/DeferredScheduledUpdatePhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/DeferredScheduledUpdatePhaseState.java
@@ -24,13 +24,14 @@
  */
 package org.spongepowered.common.event.tracking.phase.generation;
 
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.TickNextTickData;
 import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.common.bridge.world.TickNextTickDataBridge;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 
 import java.util.Objects;
 import java.util.function.BiConsumer;
-import net.minecraft.world.level.TickNextTickData;
 
 final class DeferredScheduledUpdatePhaseState extends GeneralGenerationPhaseState<DeferredScheduledUpdatePhaseState.Context> {
 
@@ -54,7 +55,9 @@ final class DeferredScheduledUpdatePhaseState extends GeneralGenerationPhaseStat
     }
 
     @Override
-    public void associateScheduledTickUpdate(final Context asContext, final TickNextTickData<?> entry) {
+    public void associateScheduledTickUpdate(
+        final Context asContext, ServerLevel level, final TickNextTickData<?> entry
+    ) {
         ((TickNextTickDataBridge) entry).bridge$setIsPartOfWorldGeneration(true);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -24,27 +24,7 @@
  */
 package org.spongepowered.common.event.tracking.phase.packet;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.spongepowered.api.entity.living.player.server.ServerPlayer;
-import org.spongepowered.api.event.CauseStackManager;
-import org.spongepowered.api.item.inventory.ItemStackSnapshot;
-import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
-import org.spongepowered.common.accessor.entity.passive.AbstractChestedHorseEntityAccessor;
-import org.spongepowered.common.accessor.network.protocol.game.ServerboundMovePlayerPacketAccessor;
-import org.spongepowered.common.accessor.world.entity.EntityAccessor;
-import org.spongepowered.common.accessor.world.entity.animal.PigAccessor;
-import org.spongepowered.common.accessor.world.entity.animal.SheepAccessor;
-import org.spongepowered.common.accessor.world.entity.animal.WolfAccessor;
-import org.spongepowered.common.accessor.world.inventory.SlotAccessor;
-import org.spongepowered.common.bridge.server.level.ServerPlayerBridge;
-import org.spongepowered.common.bridge.world.inventory.container.TrackedInventoryBridge;
-import org.spongepowered.common.event.tracking.IPhaseState;
-import org.spongepowered.common.event.tracking.PhaseContext;
-import org.spongepowered.common.event.tracking.PhaseTracker;
-import org.spongepowered.common.inventory.adapter.InventoryAdapter;
-import org.spongepowered.common.inventory.adapter.impl.slots.SlotAdapter;
-import org.spongepowered.common.item.util.ItemStackUtil;
-
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.PacketListener;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
@@ -70,7 +50,31 @@ import net.minecraft.world.item.DyeItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.phys.AABB;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.entity.living.player.server.ServerPlayer;
+import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
+import org.spongepowered.common.accessor.entity.passive.AbstractChestedHorseEntityAccessor;
+import org.spongepowered.common.accessor.network.protocol.game.ServerboundMovePlayerPacketAccessor;
+import org.spongepowered.common.accessor.world.entity.EntityAccessor;
+import org.spongepowered.common.accessor.world.entity.animal.PigAccessor;
+import org.spongepowered.common.accessor.world.entity.animal.SheepAccessor;
+import org.spongepowered.common.accessor.world.entity.animal.WolfAccessor;
+import org.spongepowered.common.accessor.world.inventory.SlotAccessor;
+import org.spongepowered.common.bridge.server.level.ServerPlayerBridge;
+import org.spongepowered.common.bridge.world.inventory.container.TrackedInventoryBridge;
+import org.spongepowered.common.bridge.world.level.block.TrackedBlockBridge;
+import org.spongepowered.common.event.tracking.IPhaseState;
+import org.spongepowered.common.event.tracking.PhaseContext;
+import org.spongepowered.common.event.tracking.PhaseTracker;
+import org.spongepowered.common.inventory.adapter.InventoryAdapter;
+import org.spongepowered.common.inventory.adapter.impl.slots.SlotAdapter;
+import org.spongepowered.common.item.util.ItemStackUtil;
+
 import java.util.List;
 
 public final class PacketPhaseUtil {
@@ -171,7 +175,7 @@ public final class PacketPhaseUtil {
         return true;
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings({"rawtypes", "unchecked", "deprecation"})
     public static void onProcessPacket(final Packet packetIn, final PacketListener netHandler) {
         if (netHandler instanceof ServerGamePacketListenerImpl) {
             net.minecraft.server.level.ServerPlayer packetPlayer = ((ServerGamePacketListenerImpl) netHandler).player;
@@ -186,7 +190,7 @@ public final class PacketPhaseUtil {
                 frame.pushCause(packetPlayer);
 
                 // Don't process movement capture logic if player hasn't moved
-                final boolean ignoreMovementCapture;
+                boolean ignoreMovementCapture;
                 if (packetIn instanceof ServerboundMovePlayerPacket) {
                     final ServerboundMovePlayerPacket movingPacket = ((ServerboundMovePlayerPacket) packetIn);
                     if (movingPacket instanceof ServerboundMovePlayerPacket.Rot) {
@@ -195,6 +199,29 @@ public final class PacketPhaseUtil {
                         ignoreMovementCapture = true;
                     } else {
                         ignoreMovementCapture = false;
+                    }
+                    // just a sanity check, if the entity is potentially colliding with some block
+                    // we cannot ignore movement capture
+                    if (ignoreMovementCapture) {
+                        // Basically, we need to sanity check the nearby blocks because if they have
+                        // any positional logic, we need to run captures
+                        final AABB boundingBox = packetPlayer.getBoundingBox();
+                        final BlockPos min = new BlockPos(boundingBox.minX + 0.001D, boundingBox.minY + 0.001D, boundingBox.minZ + 0.001D);
+                        final BlockPos max = new BlockPos(boundingBox.maxX - 0.001D, boundingBox.maxY - 0.001D, boundingBox.maxZ - 0.001D);
+                        final BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos();
+                        if (packetPlayer.level.hasChunksAt(min, max)) {
+                            for(int x = min.getX(); x <= max.getX(); ++x) {
+                                for(int y = min.getY(); y <= max.getY(); ++y) {
+                                    for(int z = min.getZ(); z <= max.getZ(); ++z) {
+                                        pos.set(x, y, z);
+                                        final Block block = packetPlayer.level.getBlockState(pos).getBlock();
+                                        if (((TrackedBlockBridge) block).bridge$hasEntityInsideLogic()) {
+                                            ignoreMovementCapture = false;
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 } else {
                     ignoreMovementCapture = false;

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketState.java
@@ -24,6 +24,12 @@
  */
 package org.spongepowered.common.event.tracking.phase.packet;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.TickNextTickData;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.chunk.LevelChunk;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
@@ -48,12 +54,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-
-import net.minecraft.core.BlockPos;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.chunk.LevelChunk;
 
 public abstract class PacketState<P extends PacketContext<P>> extends PooledPhaseState<P> implements IPhaseState<P> {
 
@@ -109,6 +109,13 @@ public abstract class PacketState<P extends PacketContext<P>> extends PooledPhas
         final P context, final net.minecraft.world.entity.Entity entityToSpawn
     ) {
         return SpawnTypes.PLACEMENT;
+    }
+
+    @Override
+    public void associateScheduledTickUpdate(
+        final P asContext, final ServerLevel level, final TickNextTickData<?> entry
+    ) {
+        asContext.getTransactor().logScheduledUpdate(level, entry);
     }
 
     public void populateContext(final net.minecraft.server.level.ServerPlayer playerMP, final Packet<?> packet, final P context) {

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/TickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/TickPhaseState.java
@@ -24,6 +24,10 @@
  */
 package org.spongepowered.common.event.tracking.phase.tick;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.TickNextTickData;
+import net.minecraft.world.level.block.Block;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.common.entity.PlayerTracker;
@@ -31,10 +35,6 @@ import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PooledPhaseState;
 import org.spongepowered.common.event.tracking.TrackingUtil;
 import org.spongepowered.common.event.tracking.phase.general.ExplosionContext;
-
-import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.block.Block;
 
 abstract class TickPhaseState<C extends TickContext<C>> extends PooledPhaseState<C> implements IPhaseState<C> {
 
@@ -55,6 +55,13 @@ abstract class TickPhaseState<C extends TickContext<C>> extends PooledPhaseState
     @Override
     public void appendNotifierPreBlockTick(final ServerLevel world, final BlockPos pos, final C context, final LocationBasedTickContext<@NonNull ?> phaseContext) {
 
+    }
+
+    @Override
+    public void associateScheduledTickUpdate(
+        final C asContext, final ServerLevel level, final TickNextTickData<?> entry
+    ) {
+        asContext.getTransactor().logScheduledUpdate(level, entry);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/util/ReflectionUtil.java
+++ b/src/main/java/org/spongepowered/common/util/ReflectionUtil.java
@@ -27,6 +27,12 @@ package org.spongepowered.common.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.commons.lang3.ClassUtils.isAssignable;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 import org.spongepowered.common.SpongeCommon;
@@ -38,10 +44,6 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
 
 /**
  * A handy utility for doing some neat things with generics and reflection.
@@ -63,6 +65,12 @@ public final class ReflectionUtil {
         BlockPos.class,
         boolean.class
     };
+    private static final Class<?>[] ENTITY_INSIDE_METHOD_ARGS = {
+        BlockState.class,
+        Level.class,
+        BlockPos.class,
+        Entity.class
+    };
 
     public static boolean isNeighborChangedDeclared(final Class<?> targetClass) {
         return ReflectionUtil.doesMethodExist(
@@ -70,6 +78,15 @@ public final class ReflectionUtil {
             Block.class,
             "neighborChanged",
             ReflectionUtil.NEIGHBOR_CHANGED_METHOD_ARGS
+        );
+    }
+
+    public static boolean isEntityInsideDeclared(final Class<?> targetClass) {
+        return ReflectionUtil.doesMethodExist(
+            targetClass,
+            BlockBehaviour.class,
+            "entityInside",
+            ReflectionUtil.ENTITY_INSIDE_METHOD_ARGS
         );
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/world/level/ServerTickListMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/world/level/ServerTickListMixin_Tracker.java
@@ -24,8 +24,10 @@
  */
 package org.spongepowered.common.mixin.tracker.world.level;
 
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ServerTickList;
 import net.minecraft.world.level.TickNextTickData;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -37,9 +39,11 @@ public abstract class ServerTickListMixin_Tracker<T> {
 
     @Shadow protected abstract void shadow$addTickData(TickNextTickData<T> p_219504_1_);
 
+    @Shadow @Final private ServerLevel level;
+
     @Redirect(method = "scheduleTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/ServerTickList;addTickData(Lnet/minecraft/world/level/TickNextTickData;)V"))
     private void tracker$associatePhaseContextWithTickEntry(final ServerTickList<T> thisList, final TickNextTickData<T> entry) {
-        PhaseTracker.getInstance().getPhaseContext().associateScheduledTickUpdate(entry);
+        PhaseTracker.getInstance().getPhaseContext().associateScheduledTickUpdate(this.level, entry);
         this.shadow$addTickData(entry);
     }
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/world/level/block/BlockMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/world/level/block/BlockMixin_Tracker.java
@@ -48,6 +48,7 @@ import org.spongepowered.common.util.ReflectionUtil;
 public abstract class BlockMixin_Tracker implements TrackedBlockBridge {
 
     private final boolean tracker$hasNeighborLogicOverridden = ReflectionUtil.isNeighborChangedDeclared(this.getClass());
+    private final boolean tracker$hasEntityInsideLogicOverridden = ReflectionUtil.isEntityInsideDeclared(this.getClass());
 
     @Nullable private static EffectTransactor tracker$effectTransactorForDrops = null;
 
@@ -55,6 +56,11 @@ public abstract class BlockMixin_Tracker implements TrackedBlockBridge {
     @Override
     public boolean bridge$overridesNeighborNotificationLogic() {
         return this.tracker$hasNeighborLogicOverridden;
+    }
+
+    @Override
+    public boolean bridge$hasEntityInsideLogic() {
+        return this.tracker$hasEntityInsideLogicOverridden;
     }
 
     /**

--- a/testplugins/src/main/java/org/spongepowered/test/changeblock/ChangeBlockTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/changeblock/ChangeBlockTest.java
@@ -59,6 +59,7 @@ public final class ChangeBlockTest implements LoadableModule {
 
     final PluginContainer plugin;
     boolean cancelAll = false;
+    boolean cancelTransactions = false;
     boolean waterProofRedstone = false;
     boolean printEntityHarvests = false;
     boolean printEntitySpawns = false;
@@ -123,6 +124,15 @@ public final class ChangeBlockTest implements LoadableModule {
                 return CommandResult.success();
             })
             .build(), "toggleEntitySpawnPrinting"
+        );
+        event.register(this.plugin, Command.builder()
+            .executor(context -> {
+                this.cancelTransactions = !this.cancelTransactions;
+                final Component newState = Component.text(this.cancelTransactions ? "ON" : "OFF", this.cancelTransactions ? NamedTextColor.GREEN : NamedTextColor.RED);
+                context.sendMessage(Identity.nil(), Component.text("Invalidating Transactions : ").append(newState));
+                return CommandResult.success();
+            })
+            .build(), "toggleBlockTransactions"
         );
     }
 
@@ -207,6 +217,9 @@ public final class ChangeBlockTest implements LoadableModule {
             }
             if (ChangeBlockTest.this.cancelAll) {
                 post.setCancelled(true);
+            }
+            if (ChangeBlockTest.this.cancelTransactions) {
+                post.transactions().forEach(BlockTransaction::invalidate);
             }
             if (ChangeBlockTest.this.waterProofRedstone) {
                 for (final BlockTransaction transaction : post.transactions()) {


### PR DESCRIPTION
This aims to resolve the case of how some blocks perform multiple changes as a reaction to being broken by a player, specifically beds. 
 
The resulting transaction lists look like:
- ChangeBlockEvent for the first half of the bed
- NeighborNotifications for said first half being broken
- ChangeBlockEvent for the second half of the bed
- NeighborNotifications for the said second half being broken

