### PR TITLE
Fix incorrect use of display slot indexes, support getting sidebar display slot by NamedTeamColor

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/server/ServerScoreboardBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/server/ServerScoreboardBridge.java
@@ -49,6 +49,8 @@ public interface ServerScoreboardBridge {
 
     void bridge$updateDisplaySlot(@Nullable Objective objective, DisplaySlot displaySlot) throws IllegalStateException;
 
+    void bridge$updateDisplaySlot(@Nullable Objective objective, int slot) throws IllegalStateException;
+
     Optional<Objective> bridge$getObjective(DisplaySlot slot);
 
     Set<Objective> bridge$getObjectivesByCriterion(Criterion criterion);

--- a/src/main/java/org/spongepowered/common/registry/SpongeFactoryProvider.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeFactoryProvider.java
@@ -56,6 +56,7 @@ import org.spongepowered.api.registry.RegistryReference;
 import org.spongepowered.api.registry.RegistryType;
 import org.spongepowered.api.registry.TypeNotFoundException;
 import org.spongepowered.api.resourcepack.ResourcePack;
+import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
 import org.spongepowered.api.state.StateMatcher;
 import org.spongepowered.api.util.AABB;
 import org.spongepowered.api.util.MinecraftDayTime;
@@ -110,6 +111,7 @@ import org.spongepowered.common.profile.SpongeGameProfile;
 import org.spongepowered.common.profile.SpongeProfilePropertyFactory;
 import co.aikar.timings.sponge.SpongeTimingsFactory;
 import org.spongepowered.common.resourcepack.SpongeResourcePack;
+import org.spongepowered.common.scoreboard.SpongeDisplaySlotFactory;
 import org.spongepowered.common.state.SpongeStateMatcherFactory;
 import org.spongepowered.common.util.SpongeAABB;
 import org.spongepowered.common.util.SpongeDamageSourceFactory;
@@ -235,6 +237,7 @@ public final class SpongeFactoryProvider implements FactoryProvider {
                 .registerFactory(ItemStackComparators.Factory.class, new SpongeItemStackComparatorFactory())
                 .registerFactory(Favicon.Factory.class, new SpongeFavicon.FactoryImpl())
                 .registerFactory(CommandCompletion.Factory.class, new SpongeCommandCompletionFactory())
+                .registerFactory(DisplaySlot.Factory.class, new SpongeDisplaySlotFactory())
         ;
     }
 }

--- a/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
@@ -32,7 +32,6 @@ import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import net.kyori.adventure.text.Component;
-import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.ComponentArgument;
 import net.minecraft.commands.arguments.CompoundTagArgument;
@@ -72,10 +71,10 @@ import org.spongepowered.api.command.parameter.managed.operator.Operator;
 import org.spongepowered.api.command.parameter.managed.operator.Operators;
 import org.spongepowered.api.command.parameter.managed.standard.ResourceKeyedValueParameters;
 import org.spongepowered.api.command.registrar.CommandRegistrarType;
-import org.spongepowered.api.command.registrar.tree.CommandTreeNodeType;
-import org.spongepowered.api.command.registrar.tree.CommandTreeNodeTypes;
 import org.spongepowered.api.command.registrar.tree.CommandCompletionProvider;
 import org.spongepowered.api.command.registrar.tree.CommandCompletionProviders;
+import org.spongepowered.api.command.registrar.tree.CommandTreeNodeType;
+import org.spongepowered.api.command.registrar.tree.CommandTreeNodeTypes;
 import org.spongepowered.api.command.selector.SelectorSortAlgorithm;
 import org.spongepowered.api.command.selector.SelectorSortAlgorithms;
 import org.spongepowered.api.command.selector.SelectorType;
@@ -269,6 +268,8 @@ import org.spongepowered.common.map.decoration.SpongeMapDecorationType;
 import org.spongepowered.common.map.decoration.orientation.SpongeMapDecorationOrientation;
 import org.spongepowered.common.placeholder.SpongePlaceholderParserBuilder;
 import org.spongepowered.common.scoreboard.SpongeDisplaySlot;
+import org.spongepowered.common.scoreboard.SpongeDisplaySlotFactory;
+import org.spongepowered.common.util.Constants;
 import org.spongepowered.common.util.VecHelper;
 import org.spongepowered.common.world.portal.EndPortalType;
 import org.spongepowered.common.world.portal.NetherPortalType;
@@ -559,25 +560,12 @@ public final class SpongeRegistryLoaders {
 
     public static RegistryLoader<DisplaySlot> displaySlot() {
         return RegistryLoader.of(l -> {
-            l.add(2, DisplaySlots.BELOW_NAME, k -> new SpongeDisplaySlot(2));
             l.add(0, DisplaySlots.LIST, k -> new SpongeDisplaySlot(0));
             l.add(1, DisplaySlots.SIDEBAR, k -> new SpongeDisplaySlot(1));
-            l.add(ChatFormatting.AQUA.getId() + 3, DisplaySlots.SIDEBAR_TEAM_AQUA, k -> new SpongeDisplaySlot(ChatFormatting.AQUA.getId() + 3));
-            l.add(ChatFormatting.BLACK.getId() + 3, DisplaySlots.SIDEBAR_TEAM_BLACK, k -> new SpongeDisplaySlot(ChatFormatting.BLACK.getId() + 3));
-            l.add(ChatFormatting.BLUE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_BLUE, k -> new SpongeDisplaySlot(ChatFormatting.BLUE.getId() + 3));
-            l.add(ChatFormatting.DARK_AQUA.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_AQUA, k -> new SpongeDisplaySlot(ChatFormatting.DARK_AQUA.getId() + 3));
-            l.add(ChatFormatting.DARK_BLUE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_BLUE, k -> new SpongeDisplaySlot(ChatFormatting.DARK_BLUE.getId() + 3));
-            l.add(ChatFormatting.DARK_GRAY.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_GRAY, k -> new SpongeDisplaySlot(ChatFormatting.DARK_GRAY.getId() + 3));
-            l.add(ChatFormatting.DARK_GREEN.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_GREEN, k -> new SpongeDisplaySlot(ChatFormatting.DARK_GREEN.getId() + 3));
-            l.add(ChatFormatting.DARK_PURPLE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_PURPLE, k -> new SpongeDisplaySlot(ChatFormatting.DARK_PURPLE.getId() + 3));
-            l.add(ChatFormatting.DARK_RED.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_RED, k -> new SpongeDisplaySlot(ChatFormatting.DARK_RED.getId() + 3));
-            l.add(ChatFormatting.GOLD.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GOLD, k -> new SpongeDisplaySlot(ChatFormatting.GOLD.getId() + 3));
-            l.add(ChatFormatting.GRAY.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GRAY, k -> new SpongeDisplaySlot(ChatFormatting.GRAY.getId() + 3));
-            l.add(ChatFormatting.GREEN.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GREEN, k -> new SpongeDisplaySlot(ChatFormatting.GREEN.getId() + 3));
-            l.add(ChatFormatting.LIGHT_PURPLE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_LIGHT_PURPLE, k -> new SpongeDisplaySlot(ChatFormatting.LIGHT_PURPLE.getId() + 3));
-            l.add(ChatFormatting.RED.getId() + 3, DisplaySlots.SIDEBAR_TEAM_RED, k -> new SpongeDisplaySlot(ChatFormatting.RED.getId() + 3));
-            l.add(ChatFormatting.WHITE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_WHITE, k -> new SpongeDisplaySlot(ChatFormatting.WHITE.getId() + 3));
-            l.add(ChatFormatting.YELLOW.getId() + 3, DisplaySlots.SIDEBAR_TEAM_YELLOW, k -> new SpongeDisplaySlot(ChatFormatting.YELLOW.getId() + 3));
+            l.add(2, DisplaySlots.BELOW_NAME, k -> new SpongeDisplaySlot(2));
+
+            SpongeDisplaySlotFactory.ColorMapping.COLOR_TO_DISPLAY_SLOT_MAP.forEach((color, s) ->
+                            l.add(SpongeDisplaySlot.slotIdFromFormatting(color), s, k -> new SpongeDisplaySlot(color)));
         });
     }
 

--- a/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
@@ -559,25 +559,25 @@ public final class SpongeRegistryLoaders {
 
     public static RegistryLoader<DisplaySlot> displaySlot() {
         return RegistryLoader.of(l -> {
-            l.add(2, DisplaySlots.BELOW_NAME, SpongeDisplaySlot::new);
-            l.add(0, DisplaySlots.LIST, SpongeDisplaySlot::new);
-            l.add(1, DisplaySlots.SIDEBAR_TEAM_NO_COLOR, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.AQUA.getId() + 3, DisplaySlots.SIDEBAR_TEAM_AQUA, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.BLACK.getId() + 3, DisplaySlots.SIDEBAR_TEAM_BLACK, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.BLUE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_BLUE, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.DARK_AQUA.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_AQUA, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.DARK_BLUE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_BLUE, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.DARK_GRAY.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_GRAY, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.DARK_GREEN.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_GREEN, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.DARK_PURPLE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_PURPLE, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.DARK_RED.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_RED, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.GOLD.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GOLD, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.GRAY.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GRAY, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.GREEN.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GREEN, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.LIGHT_PURPLE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_LIGHT_PURPLE, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.RED.getId() + 3, DisplaySlots.SIDEBAR_TEAM_RED, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.WHITE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_WHITE, SpongeDisplaySlot::new);
-            l.add(ChatFormatting.YELLOW.getId() + 3, DisplaySlots.SIDEBAR_TEAM_YELLOW, SpongeDisplaySlot::new);
+            l.add(2, DisplaySlots.BELOW_NAME, k -> new SpongeDisplaySlot(2));
+            l.add(0, DisplaySlots.LIST, k -> new SpongeDisplaySlot(0));
+            l.add(1, DisplaySlots.SIDEBAR, k -> new SpongeDisplaySlot(1));
+            l.add(ChatFormatting.AQUA.getId() + 3, DisplaySlots.SIDEBAR_TEAM_AQUA, k -> new SpongeDisplaySlot(ChatFormatting.AQUA.getId() + 3));
+            l.add(ChatFormatting.BLACK.getId() + 3, DisplaySlots.SIDEBAR_TEAM_BLACK, k -> new SpongeDisplaySlot(ChatFormatting.BLACK.getId() + 3));
+            l.add(ChatFormatting.BLUE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_BLUE, k -> new SpongeDisplaySlot(ChatFormatting.BLUE.getId() + 3));
+            l.add(ChatFormatting.DARK_AQUA.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_AQUA, k -> new SpongeDisplaySlot(ChatFormatting.DARK_AQUA.getId() + 3));
+            l.add(ChatFormatting.DARK_BLUE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_BLUE, k -> new SpongeDisplaySlot(ChatFormatting.DARK_BLUE.getId() + 3));
+            l.add(ChatFormatting.DARK_GRAY.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_GRAY, k -> new SpongeDisplaySlot(ChatFormatting.DARK_GRAY.getId() + 3));
+            l.add(ChatFormatting.DARK_GREEN.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_GREEN, k -> new SpongeDisplaySlot(ChatFormatting.DARK_GREEN.getId() + 3));
+            l.add(ChatFormatting.DARK_PURPLE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_PURPLE, k -> new SpongeDisplaySlot(ChatFormatting.DARK_PURPLE.getId() + 3));
+            l.add(ChatFormatting.DARK_RED.getId() + 3, DisplaySlots.SIDEBAR_TEAM_DARK_RED, k -> new SpongeDisplaySlot(ChatFormatting.DARK_RED.getId() + 3));
+            l.add(ChatFormatting.GOLD.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GOLD, k -> new SpongeDisplaySlot(ChatFormatting.GOLD.getId() + 3));
+            l.add(ChatFormatting.GRAY.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GRAY, k -> new SpongeDisplaySlot(ChatFormatting.GRAY.getId() + 3));
+            l.add(ChatFormatting.GREEN.getId() + 3, DisplaySlots.SIDEBAR_TEAM_GREEN, k -> new SpongeDisplaySlot(ChatFormatting.GREEN.getId() + 3));
+            l.add(ChatFormatting.LIGHT_PURPLE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_LIGHT_PURPLE, k -> new SpongeDisplaySlot(ChatFormatting.LIGHT_PURPLE.getId() + 3));
+            l.add(ChatFormatting.RED.getId() + 3, DisplaySlots.SIDEBAR_TEAM_RED, k -> new SpongeDisplaySlot(ChatFormatting.RED.getId() + 3));
+            l.add(ChatFormatting.WHITE.getId() + 3, DisplaySlots.SIDEBAR_TEAM_WHITE, k -> new SpongeDisplaySlot(ChatFormatting.WHITE.getId() + 3));
+            l.add(ChatFormatting.YELLOW.getId() + 3, DisplaySlots.SIDEBAR_TEAM_YELLOW, k -> new SpongeDisplaySlot(ChatFormatting.YELLOW.getId() + 3));
         });
     }
 

--- a/src/main/java/org/spongepowered/common/scoreboard/SpongeDisplaySlot.java
+++ b/src/main/java/org/spongepowered/common/scoreboard/SpongeDisplaySlot.java
@@ -26,42 +26,39 @@ package org.spongepowered.common.scoreboard;
 
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.minecraft.ChatFormatting;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
 import org.spongepowered.common.adventure.SpongeAdventure;
 
 import java.util.Optional;
-import java.util.function.Function;
 
 public final class SpongeDisplaySlot implements DisplaySlot {
 
     private final int id;
     private final @Nullable ChatFormatting formatting;
-    private final @Nullable Function<ChatFormatting, DisplaySlot> withColorFunction;
 
     private @Nullable NamedTextColor color;
 
-    public SpongeDisplaySlot(final int id) {
-        this(id, null, null);
+    public static int slotIdFromFormatting(final ChatFormatting formatting) {
+        return formatting.getId() + 3;
     }
 
-    public SpongeDisplaySlot(final int id, final @Nullable ChatFormatting color, final @Nullable Function<ChatFormatting, DisplaySlot> withColorFunction) {
+    public SpongeDisplaySlot(final int id) {
+        this(id, null);
+    }
+
+    public SpongeDisplaySlot(final ChatFormatting color) {
+        this(SpongeDisplaySlot.slotIdFromFormatting(color), color);
+    }
+
+    private SpongeDisplaySlot(final int id, final @Nullable ChatFormatting color) {
         this.id = id;
-        this.withColorFunction = withColorFunction;
         this.formatting = color;
     }
 
     @Override
-    public DisplaySlot withTeamColor(final @Nullable NamedTextColor color) {
-        if (this.withColorFunction == null) {
-            return this;
-        }
-        final DisplaySlot slot = this.withColorFunction.apply(
-                color == null ? ChatFormatting.RESET : SpongeAdventure.asVanilla(color));
-        return slot == null ? this : slot;
-    }
-
-    @Override
+    @NonNull
     public Optional<NamedTextColor> teamColor() {
         if (this.color == null) {
             this.color = SpongeAdventure.asAdventureNamed(this.formatting);
@@ -69,7 +66,8 @@ public final class SpongeDisplaySlot implements DisplaySlot {
         return Optional.ofNullable(this.color);
     }
 
-    public int getIndex() {
+    public int index() {
         return this.id;
     }
+
 }

--- a/src/main/java/org/spongepowered/common/scoreboard/SpongeDisplaySlot.java
+++ b/src/main/java/org/spongepowered/common/scoreboard/SpongeDisplaySlot.java
@@ -35,16 +35,18 @@ import java.util.function.Function;
 
 public final class SpongeDisplaySlot implements DisplaySlot {
 
+    private final int id;
     private final @Nullable ChatFormatting formatting;
     private final @Nullable Function<ChatFormatting, DisplaySlot> withColorFunction;
 
     private @Nullable NamedTextColor color;
 
-    public SpongeDisplaySlot() {
-        this(null, null);
+    public SpongeDisplaySlot(final int id) {
+        this(id, null, null);
     }
 
-    public SpongeDisplaySlot(final @Nullable ChatFormatting color, final @Nullable Function<ChatFormatting, DisplaySlot> withColorFunction) {
+    public SpongeDisplaySlot(final int id, final @Nullable ChatFormatting color, final @Nullable Function<ChatFormatting, DisplaySlot> withColorFunction) {
+        this.id = id;
         this.withColorFunction = withColorFunction;
         this.formatting = color;
     }
@@ -65,5 +67,9 @@ public final class SpongeDisplaySlot implements DisplaySlot {
             this.color = SpongeAdventure.asAdventureNamed(this.formatting);
         }
         return Optional.ofNullable(this.color);
+    }
+
+    public int getIndex() {
+        return this.id;
     }
 }

--- a/src/main/java/org/spongepowered/common/scoreboard/SpongeDisplaySlotFactory.java
+++ b/src/main/java/org/spongepowered/common/scoreboard/SpongeDisplaySlotFactory.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.scoreboard;
+
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.minecraft.ChatFormatting;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.spongepowered.api.registry.DefaultedRegistryReference;
+import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
+import org.spongepowered.api.scoreboard.displayslot.DisplaySlots;
+import org.spongepowered.common.adventure.SpongeAdventure;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Optional;
+
+public final class SpongeDisplaySlotFactory implements DisplaySlot.Factory {
+
+    @Override
+    @NonNull
+    public Optional<DisplaySlot> findByTeamColor(final @NonNull NamedTextColor color) {
+        final DefaultedRegistryReference<DisplaySlot> slot =
+                SpongeDisplaySlotFactory.ColorMapping.COLOR_TO_DISPLAY_SLOT_MAP.get(SpongeAdventure.asVanilla(color));
+        if (slot != null) {
+            return slot.find();
+        }
+        return Optional.empty();
+    }
+
+    public static final class ColorMapping {
+        public static final java.util.Map<ChatFormatting, DefaultedRegistryReference<DisplaySlot>> COLOR_TO_DISPLAY_SLOT_MAP;
+
+        static {
+            final java.util.Map<ChatFormatting, DefaultedRegistryReference<DisplaySlot>> map = new HashMap<>();
+            map.put(ChatFormatting.AQUA, DisplaySlots.SIDEBAR_TEAM_AQUA);
+            map.put(ChatFormatting.BLACK, DisplaySlots.SIDEBAR_TEAM_BLACK);
+            map.put(ChatFormatting.BLUE, DisplaySlots.SIDEBAR_TEAM_BLUE);
+            map.put(ChatFormatting.DARK_AQUA, DisplaySlots.SIDEBAR_TEAM_DARK_AQUA);
+            map.put(ChatFormatting.DARK_BLUE, DisplaySlots.SIDEBAR_TEAM_DARK_BLUE);
+            map.put(ChatFormatting.DARK_GRAY, DisplaySlots.SIDEBAR_TEAM_DARK_GRAY);
+            map.put(ChatFormatting.DARK_GREEN, DisplaySlots.SIDEBAR_TEAM_DARK_GREEN);
+            map.put(ChatFormatting.DARK_PURPLE, DisplaySlots.SIDEBAR_TEAM_DARK_PURPLE);
+            map.put(ChatFormatting.DARK_RED, DisplaySlots.SIDEBAR_TEAM_DARK_RED);
+            map.put(ChatFormatting.GOLD, DisplaySlots.SIDEBAR_TEAM_GOLD);
+            map.put(ChatFormatting.GRAY, DisplaySlots.SIDEBAR_TEAM_GRAY);
+            map.put(ChatFormatting.GREEN, DisplaySlots.SIDEBAR_TEAM_GREEN);
+            map.put(ChatFormatting.LIGHT_PURPLE, DisplaySlots.SIDEBAR_TEAM_LIGHT_PURPLE);
+            map.put(ChatFormatting.RED, DisplaySlots.SIDEBAR_TEAM_RED);
+            map.put(ChatFormatting.WHITE, DisplaySlots.SIDEBAR_TEAM_WHITE);
+            map.put(ChatFormatting.YELLOW, DisplaySlots.SIDEBAR_TEAM_YELLOW);
+            COLOR_TO_DISPLAY_SLOT_MAP = Collections.unmodifiableMap(map);
+        }
+
+        private ColorMapping() {
+        }
+    }
+
+}

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/ServerScoreboardMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/ServerScoreboardMixin.java
@@ -25,8 +25,6 @@
 package org.spongepowered.common.mixin.core.server;
 
 import net.kyori.adventure.text.Component;
-import net.minecraft.core.MappedRegistry;
-import net.minecraft.core.Registry;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundSetDisplayObjectivePacket;
 import net.minecraft.network.protocol.game.ClientboundSetObjectivePacket;
@@ -40,8 +38,6 @@ import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.Score;
 import net.minecraft.world.scores.Scoreboard;
 import net.minecraft.world.scores.criteria.ObjectiveCriteria;
-import org.spongepowered.api.Sponge;
-import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.scoreboard.Team;
 import org.spongepowered.api.scoreboard.criteria.Criterion;
 import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
@@ -61,6 +57,7 @@ import org.spongepowered.common.adventure.SpongeAdventure;
 import org.spongepowered.common.bridge.world.scores.ScoreBridge;
 import org.spongepowered.common.bridge.world.scores.ObjectiveBridge;
 import org.spongepowered.common.bridge.server.ServerScoreboardBridge;
+import org.spongepowered.common.scoreboard.SpongeDisplaySlot;
 import org.spongepowered.common.scoreboard.SpongeObjective;
 import org.spongepowered.common.scoreboard.SpongeScore;
 import org.spongepowered.common.util.Constants;
@@ -88,13 +85,16 @@ public abstract class ServerScoreboardMixin extends Scoreboard implements Server
 
     @Override
     public void bridge$updateDisplaySlot(@Nullable final Objective objective, final DisplaySlot displaySlot) throws IllegalStateException {
+        this.bridge$updateDisplaySlot(objective, ((SpongeDisplaySlot) displaySlot).getIndex());
+    }
+
+    @Override
+    public void bridge$updateDisplaySlot(@Nullable final Objective objective, final int slot) throws IllegalStateException {
         if (objective != null && !objective.scoreboards().contains(this)) {
             throw new IllegalStateException("Attempting to set an objective's display slot that does not exist on this scoreboard!");
         }
-        final MappedRegistry<DisplaySlot> registry = (MappedRegistry<DisplaySlot>) (Object) Sponge.game().registries().registry(RegistryTypes.DISPLAY_SLOT);
-        final int index = registry.getId(displaySlot);
-        ((ScoreboardAccessor) this).accessor$displayObjectives()[index] = objective == null ? null: ((SpongeObjective) objective).getObjectiveFor(this);
-        ((ServerScoreboardBridge) this).bridge$sendToPlayers(new ClientboundSetDisplayObjectivePacket(index, ((ScoreboardAccessor) this).accessor$displayObjectives()[index]));
+        ((ScoreboardAccessor) this).accessor$displayObjectives()[slot] = objective == null ? null: ((SpongeObjective) objective).getObjectiveFor(this);
+        ((ServerScoreboardBridge) this).bridge$sendToPlayers(new ClientboundSetDisplayObjectivePacket(slot, ((ScoreboardAccessor) this).accessor$displayObjectives()[slot]));
     }
 
     // Get objectives
@@ -128,8 +128,7 @@ public abstract class ServerScoreboardMixin extends Scoreboard implements Server
 
     @Override
     public Optional<Objective> bridge$getObjective(final DisplaySlot slot) {
-        final MappedRegistry<DisplaySlot> registry = (MappedRegistry<DisplaySlot>) (Object) Sponge.game().registries().registry(RegistryTypes.DISPLAY_SLOT);
-        final net.minecraft.world.scores.Objective objective = ((ScoreboardAccessor) this).accessor$displayObjectives()[registry.getId(slot)];
+        final net.minecraft.world.scores.Objective objective = ((ScoreboardAccessor) this).accessor$displayObjectives()[((SpongeDisplaySlot) slot).getIndex()];
         if (objective != null) {
             return Optional.of(((ObjectiveBridge) objective).bridge$getSpongeObjective());
         }
@@ -330,8 +329,7 @@ public abstract class ServerScoreboardMixin extends Scoreboard implements Server
     @Overwrite
     public void setDisplayObjective(final int slot, @Nullable final net.minecraft.world.scores.Objective objective) {
         final Objective apiObjective = objective == null ? null : ((ObjectiveBridge) objective).bridge$getSpongeObjective();
-        final DisplaySlot displaySlot = (DisplaySlot) ((Registry) Sponge.game().registries().registry(RegistryTypes.DISPLAY_SLOT)).byId(slot);
-        this.bridge$updateDisplaySlot(apiObjective, displaySlot);
+        this.bridge$updateDisplaySlot(apiObjective, slot);
     }
 
     @Redirect(method = "addPlayerToTeam",

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/ServerScoreboardMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/ServerScoreboardMixin.java
@@ -85,7 +85,7 @@ public abstract class ServerScoreboardMixin extends Scoreboard implements Server
 
     @Override
     public void bridge$updateDisplaySlot(@Nullable final Objective objective, final DisplaySlot displaySlot) throws IllegalStateException {
-        this.bridge$updateDisplaySlot(objective, ((SpongeDisplaySlot) displaySlot).getIndex());
+        this.bridge$updateDisplaySlot(objective, ((SpongeDisplaySlot) displaySlot).index());
     }
 
     @Override
@@ -128,7 +128,7 @@ public abstract class ServerScoreboardMixin extends Scoreboard implements Server
 
     @Override
     public Optional<Objective> bridge$getObjective(final DisplaySlot slot) {
-        final net.minecraft.world.scores.Objective objective = ((ScoreboardAccessor) this).accessor$displayObjectives()[((SpongeDisplaySlot) slot).getIndex()];
+        final net.minecraft.world.scores.Objective objective = ((ScoreboardAccessor) this).accessor$displayObjectives()[((SpongeDisplaySlot) slot).index()];
         if (objective != null) {
             return Optional.of(((ObjectiveBridge) objective).bridge$getSpongeObjective());
         }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2350) | **Sponge**

This superscedes #3283 (thanks to @thibaulthenry for the initial commit!)

This adds a mapping of `ChatFormatting` -> `SpongeDisplaySlot` for use in the `findByTeamColor` method in the API PR. I don't know if the map itself would be better in Constants as it contains registry references, happy to transplant that if we decide it's better there.