### PR TITLE
Fix player leaking to world on login cancellation

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/players/PlayerListMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/players/PlayerListMixin.java
@@ -304,7 +304,7 @@ public abstract class PlayerListMixin implements PlayerListBridge {
         )
     )
     private void impl$onInitPlayer_BeforeSetWorld(final Connection p_72355_1_, final net.minecraft.server.level.ServerPlayer p_72355_2_, final CallbackInfo ci) {
-        if (p_72355_2_.level == null) {
+        if (!p_72355_1_.isConnected()) {
             ci.cancel();
         }
     }


### PR DESCRIPTION
The world isn't set to the player immediately, and before it is set, there's a null check to ensure the world isn't null and defaults to overworld. Changed so that we check if the player was disconnect instead.

This fixes that the player is no longer spawned in the world if the login event is cancelled.