### PR TITLE
Fix compile errors (incompatible types)

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java
@@ -60,7 +60,6 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.SpongeEventFactory;
@@ -841,8 +840,7 @@ public abstract class EntityMixin implements EntityBridge, TrackableBridge, Vani
                     .stream()
                     .filter(d -> d.getKey() == Keys.FIRE_TICKS)
                     .findFirst()
-                    .map(BaseValue::get)
-                    .map(o -> (int) o)
+                    .map(immutableValue -> (Integer) immutableValue.get())
                     .orElse(0);
             }
         }
@@ -915,8 +913,7 @@ public abstract class EntityMixin implements EntityBridge, TrackableBridge, Vani
                     .stream()
                     .filter(d -> d.getKey() == Keys.FIRE_TICKS)
                     .findFirst()
-                    .map(BaseValue::get)
-                    .map(o -> (int) o)
+                    .map(immutableValue -> (Integer) immutableValue.get())
                     .orElse(this.fire); // Otherwise, if it's failed, just "set it back"
             }
         }


### PR DESCRIPTION
Fixes the following compilation errors:

```
org/spongepowered/common/mixin/core/entity/EntityMixin.java:845: error: incompatible types: CAP#1 cannot be converted to int
                    .map(o -> (int) o)
                                    ^
  where CAP#1 is a fresh type-variable:
    CAP#1 extends Object from capture of ?
org/spongepowered/common/mixin/core/entity/EntityMixin.java:846: error: incompatible types: Object cannot be converted to int
                    .orElse(0);
                           ^
org/spongepowered/common/mixin/core/entity/EntityMixin.java:919: error: incompatible types: CAP#1 cannot be converted to int
                    .map(o -> (int) o)
                                    ^
  where CAP#1 is a fresh type-variable:
    CAP#1 extends Object from capture of ?
org/spongepowered/common/mixin/core/entity/EntityMixin.java:920: error: incompatible types: Object cannot be converted to int
                    .orElse(this.fire); // Otherwise, if it's failed, just "set it back"
                           ^
```