### PR TITLE
Ensure mapIdUUIDIndex is initialized for getting a mapinfo.

### DIFF
--- a/src/main/java/org/spongepowered/common/map/SpongeMapStorage.java
+++ b/src/main/java/org/spongepowered/common/map/SpongeMapStorage.java
@@ -81,6 +81,7 @@ public final class SpongeMapStorage implements MapStorage {
 
 	@Override
 	public Optional<MapInfo> mapInfo(final UUID uuid) {
+		ensureHasMapUUIDIndex();
 		MapInfo mapInfo = this.loadedMapUUIDs.get(uuid);
 		if (mapInfo != null) {
 			return Optional.of(mapInfo);


### PR DESCRIPTION
Its possible (though very unlikely) for a NPE if you try to retrieve a MapInfo by UUID, before any maps have been loaded in the world (e.g in the player's hand). Just ensure its grabbed in this rare case.