### PR TITLE
Update jansi dep to support ARM64

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,9 @@ pluginSpiVersion=0.2.0
 guavaVersion=21.0
 junitVersion=5.7.0
 jlineVersion=3.20.0
+# If JLine is updated and it updates the jansi dep, remove the following
+# (and update the SV build.gradle)
+jansiVersion=2.3.3
 timingsVersion=1.0-SNAPSHOT
 tinyLogVersion=2.3.2
 

--- a/vanilla/build.gradle.kts
+++ b/vanilla/build.gradle.kts
@@ -204,6 +204,7 @@ dependencies {
     val asmVersion: String by project
     val guavaVersion: String by project
     val jlineVersion: String by project
+    val jansiVersion: String by project
     val log4jVersion: String by project
     val mixinVersion: String by project
     val modlauncherVersion: String by project
@@ -276,7 +277,13 @@ dependencies {
     libraries("net.minecrell:terminalconsoleappender:1.3.0-SNAPSHOT")
     libraries("org.jline:jline-terminal:$jlineVersion")
     libraries("org.jline:jline-reader:$jlineVersion")
-    libraries("org.jline:jline-terminal-jansi:$jlineVersion")
+    libraries("org.jline:jline-terminal-jansi:$jlineVersion") {
+        exclude(group = "org.fusesource.jansi", module = "jansi")
+    }
+    // If JLine is updated and updates the jansi dep, the above exclusion
+    // and below library can be removed.
+    // https://github.com/SpongePowered/Sponge/issues/3429
+    libraries("org.fusesource.jansi:jansi:$jansiVersion")
     libraries("org.spongepowered:timings:$timingsVersion")
 
     // Launch Dependencies - Needed to bootstrap the engine(s)


### PR DESCRIPTION
See #3429

I haven't got an ARM64 machine up and running to test this (will have to dust off my Raspberry Pi which I _think_ is 64 bit, but I'm hoping someone else will be able to tell me if it works before I get to that tomorrow)

This might not work, or it might not be the best way to do this...

[If someone wants to test this, give this a go - spongevanilla-1.16.5-8.0.0-RC0-universal.jar.zip](https://github.com/SpongePowered/Sponge/files/6658950/spongevanilla-1.16.5-8.0.0-RC0-universal.jar.zip)
