### PR TITLE
Another fix of IgniteEntityEvent

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/EntityMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/EntityMixin.java
@@ -1097,7 +1097,7 @@ public abstract class EntityMixin implements EntityBridge, PlatformEntityBridge,
                     return;
                 }
                 final DataTransactionResult transaction = DataTransactionResult.builder()
-                    .replace(new ImmutableSpongeValue<>(Keys.FIRE_TICKS, Ticks.of(this.remainingFireTicks)))
+                    .replace(new ImmutableSpongeValue<>(Keys.FIRE_TICKS, Ticks.of(Math.max(this.remainingFireTicks, 0))))
                     .success(new ImmutableSpongeValue<>(Keys.FIRE_TICKS, Ticks.of(event.fireTicks())))
                     .result(DataTransactionResult.Type.SUCCESS)
                     .build();


### PR DESCRIPTION
When the skeletons catch fire during the day, it still throws a negative tick exception, so I just raised the lower bound to zero. This time the final fix, there should be no more exceptions.