### PR TITLE
Keys.INACCURACY

### DIFF
--- a/src/main/java/org/spongepowered/common/data/provider/item/stack/InaccuracyItemStackData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/item/stack/InaccuracyItemStackData.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.provider.item.stack;
+
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.common.bridge.data.SpongeDataHolderBridge;
+import org.spongepowered.common.data.provider.DataProviderRegistrator;
+
+public final class InaccuracyItemStackData {
+
+    private InaccuracyItemStackData() {
+    }
+
+    // @formatter:off
+    public static void register(final DataProviderRegistrator registrator) {
+        registrator.asMutable(ItemStack.class)
+                .create(Keys.INACCURACY)
+                .get(h -> ((SpongeDataHolderBridge) (Object) h).bridge$get(Keys.INACCURACY).orElse(1.0))
+                .set((h, v) -> ((SpongeDataHolderBridge) (Object) h).bridge$offer(Keys.INACCURACY, v));
+
+        registrator.spongeDataStore(Keys.INACCURACY.key(), ItemStack.class, Keys.INACCURACY);
+    }
+    // @formatter:on
+}

--- a/src/main/java/org/spongepowered/common/data/provider/item/stack/ItemStackDataProviders.java
+++ b/src/main/java/org/spongepowered/common/data/provider/item/stack/ItemStackDataProviders.java
@@ -40,6 +40,7 @@ public final class ItemStackDataProviders extends DataProviderRegistratorBuilder
         FireworkItemStackData.register(this.registrator);
         HideFlagsItemStackData.register(this.registrator);
         IDyeableArmorItemStackData.register(this.registrator);
+        InaccuracyItemStackData.register(this.registrator);
         ItemStackData.register(this.registrator);
         MusicDiscItemStackData.register(this.registrator);
         PotionItemStackData.register(this.registrator);

--- a/src/mixins/java/org/spongepowered/common/mixin/core/item/ThrowableInaccurateItemMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/item/ThrowableInaccurateItemMixin.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.item;
+
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.CrossbowItem;
+import net.minecraft.world.item.EggItem;
+import net.minecraft.world.item.EnderpearlItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.SnowballItem;
+import net.minecraft.world.item.ThrowablePotionItem;
+import net.minecraft.world.level.Level;
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin({EggItem.class, CrossbowItem.class, EnderpearlItem.class, SnowballItem.class, ThrowablePotionItem.class})
+public abstract class ThrowableInaccurateItemMixin {
+
+    @ModifyConstant(method = "use", constant = @Constant(floatValue = 1.0F, ordinal = 0))
+    public float impl$configureInaccuracy(final float inaccuracy, final Level level, final Player player, final InteractionHand hand) {
+        final ItemStack handItem = player.getItemInHand(hand);
+        return ((org.spongepowered.api.item.inventory.ItemStack) (Object) handItem).getOrElse(Keys.INACCURACY, (double) inaccuracy).floatValue();
+    }
+}

--- a/src/mixins/java/org/spongepowered/common/mixin/core/item/YeetableInaccurateItemMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/item/YeetableInaccurateItemMixin.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.item;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.BowItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TridentItem;
+import net.minecraft.world.level.Level;
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin({BowItem.class, TridentItem.class})
+public abstract class YeetableInaccurateItemMixin {
+
+    @ModifyConstant(method = "releaseUsing", constant = @Constant(floatValue = 1.0F, ordinal = 0))
+    public float impl$configureInaccuracy(final float inaccuracy, final ItemStack used, final Level level, final LivingEntity entity, final int usedDuration) {
+        return ((org.spongepowered.api.item.inventory.ItemStack) (Object) used).getOrElse(Keys.INACCURACY, (double) inaccuracy).floatValue();
+    }
+}

--- a/src/mixins/resources/mixins.sponge.core.json
+++ b/src/mixins/resources/mixins.sponge.core.json
@@ -31,6 +31,8 @@
         "core.dispenser.AbstractProjectileDispenseBehaviorMixin",
         "data.SpongeDataHolderMixin",
         "item.EmptyMapItemMixin",
+        "item.ThrowableInaccurateItemMixin",
+        "item.YeetableInaccurateItemMixin",
         "network.ConnectionMixin",
         "network.FriendlyByteBufMixin",
         "network.PacketEncoderMixin",

--- a/testplugins/src/main/java/org/spongepowered/test/data/DataTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/data/DataTest.java
@@ -660,6 +660,12 @@ public final class DataTest  {
         this.checkOfferData(horse, Keys.HORSE_COLOR, HorseColors.WHITE.get());
         this.checkOfferData(horse, Keys.HORSE_STYLE, HorseStyles.BLACK_DOTS.get());
 
+        final ItemStack snowball = ItemStack.of(ItemTypes.SNOWBALL, 16);
+        this.checkGetData(snowball, Keys.INACCURACY, 1.0);
+        this.checkOfferData(snowball, Keys.INACCURACY, 10.0);
+        snowball.offer(Keys.CUSTOM_NAME, Component.text("I am very inaccurate :)", NamedTextColor.RED));
+        player.inventory().offer(snowball);
+
         this.checkOfferData(itemEntity, Keys.INFINITE_DESPAWN_DELAY, true);
         this.checkOfferData(itemEntity, Keys.INFINITE_DESPAWN_DELAY, false);
         this.checkOfferData(itemEntity, Keys.INFINITE_PICKUP_DELAY, true);


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2370) | Sponge

Replaced the hardcoded value that determines the inaccuracy of projectile weapons with a `Key`. Looking for advice on where to store this configurable value in the ItemStack's NBT.