### PR TITLE
Restore postApplicationTransaction handling

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/IPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/IPhaseState.java
@@ -40,6 +40,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import org.spongepowered.api.block.BlockSnapshot;
+import org.spongepowered.api.block.transaction.BlockTransactionReceipt;
 import org.spongepowered.api.block.transaction.Operation;
 import org.spongepowered.api.block.transaction.Operations;
 import org.spongepowered.api.data.Transaction;
@@ -216,13 +217,14 @@ public interface IPhaseState<C extends PhaseContext<C>> {
     /**
      * Performs any necessary custom logic after the provided {@link BlockSnapshot}
      * {@link Transaction} has taken place.
-     *
-     * @param blockChange The block change performed
-     * @param snapshotTransaction The transaction of the old and new snapshots
      * @param context The context for information
+     * @param blockChange The block change performed
+     * @param receipt The transaction of the old and new snapshots
      */
-    default void postBlockTransactionApplication(final BlockChange blockChange, final Transaction<? extends BlockSnapshot> snapshotTransaction,
-        final C context) { }
+    default void postBlockTransactionApplication(
+        final C context, final BlockChange blockChange,
+        final BlockTransactionReceipt receipt
+    ) { }
 
     /**
      * Specifically gets whether this state ignores any attempts at storing

--- a/src/main/java/org/spongepowered/common/event/tracking/PhaseStateProxy.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/PhaseStateProxy.java
@@ -37,6 +37,7 @@ import net.minecraft.world.level.storage.loot.LootContext;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.block.BlockSnapshot;
+import org.spongepowered.api.block.transaction.BlockTransactionReceipt;
 import org.spongepowered.api.block.transaction.Operation;
 import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.event.Cause;
@@ -156,12 +157,11 @@ public interface PhaseStateProxy<C extends PhaseContext<C>> {
     /**
      * Performs any necessary custom logic after the provided {@link BlockSnapshot}
      * {@link Transaction} has taken place.
-     *
-     * @param blockChange The block change performed
-     * @param snapshotTransaction The transaction of the old and new snapshots
+     *  @param blockChange The block change performed
+     * @param receipt The transaction of the old and new snapshots
      */
-    default void postBlockTransactionApplication(final BlockChange blockChange, final Transaction<? extends BlockSnapshot> snapshotTransaction) {
-        this.getState().postBlockTransactionApplication(blockChange, snapshotTransaction, this.asContext());
+    default void postBlockTransactionApplication(final BlockChange blockChange, final BlockTransactionReceipt receipt) {
+        this.getState().postBlockTransactionApplication(this.asContext(), blockChange, receipt);
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/event/tracking/TrackingUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/TrackingUtil.java
@@ -28,6 +28,16 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import co.aikar.timings.Timing;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.BlockEventData;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.RedstoneLampBlock;
+import net.minecraft.world.level.block.RedstoneTorchBlock;
+import net.minecraft.world.level.block.RepeaterBlock;
+import net.minecraft.world.level.block.entity.TickableBlockEntity;
+import net.minecraft.world.level.material.FluidState;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
@@ -36,6 +46,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.entity.BlockEntity;
+import org.spongepowered.api.block.transaction.BlockTransactionReceipt;
 import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.player.User;
@@ -50,9 +61,9 @@ import org.spongepowered.common.block.SpongeBlockSnapshotBuilder;
 import org.spongepowered.common.bridge.CreatorTrackedBridge;
 import org.spongepowered.common.bridge.TimingBridge;
 import org.spongepowered.common.bridge.TrackableBridge;
+import org.spongepowered.common.bridge.world.TrackedWorldBridge;
 import org.spongepowered.common.bridge.world.level.TrackerBlockEventDataBridge;
 import org.spongepowered.common.bridge.world.level.block.entity.BlockEntityBridge;
-import org.spongepowered.common.bridge.world.TrackedWorldBridge;
 import org.spongepowered.common.bridge.world.level.chunk.ActiveChunkReferantBridge;
 import org.spongepowered.common.bridge.world.level.chunk.LevelChunkBridge;
 import org.spongepowered.common.bridge.world.level.chunk.TrackedLevelChunkBridge;
@@ -71,16 +82,6 @@ import org.spongepowered.common.util.VecHelper;
 import org.spongepowered.common.world.BlockChange;
 import org.spongepowered.common.world.server.SpongeLocatableBlockBuilder;
 
-import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.BlockEventData;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.RedstoneLampBlock;
-import net.minecraft.world.level.block.RedstoneTorchBlock;
-import net.minecraft.world.level.block.RepeaterBlock;
-import net.minecraft.world.level.block.entity.TickableBlockEntity;
-import net.minecraft.world.level.material.FluidState;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
@@ -455,8 +456,8 @@ public final class TrackingUtil {
         return transactor.processTransactions(context);
     }
 
-    public static void associateTrackerToTarget(final BlockChange blockChange, final Transaction<? extends BlockSnapshot> transaction, final User user) {
-        final BlockSnapshot finalSnapshot = transaction.finalReplacement();
+    public static void associateTrackerToTarget(final BlockChange blockChange, final BlockTransactionReceipt receipt, final User user) {
+        final BlockSnapshot finalSnapshot = receipt.finalBlock();
         final SpongeBlockSnapshot spongeSnapshot = (SpongeBlockSnapshot) finalSnapshot;
         final BlockPos pos = spongeSnapshot.getBlockPos();
         final Block block = ((net.minecraft.world.level.block.state.BlockState) spongeSnapshot.state()).getBlock();

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/TransactionalCaptureSupplier.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/TransactionalCaptureSupplier.java
@@ -24,6 +24,24 @@
  */
 package org.spongepowered.common.event.tracking.context.transaction;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.damagesource.CombatEntry;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.TickNextTickData;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.CauseStackManager;
@@ -46,25 +64,6 @@ import org.spongepowered.common.event.tracking.context.transaction.type.Transact
 import org.spongepowered.common.util.Constants;
 import org.spongepowered.common.world.BlockChange;
 import org.spongepowered.common.world.SpongeBlockChangeFlag;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMultimap;
-import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.damagesource.CombatEntry;
-import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.TickNextTickData;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.chunk.LevelChunk;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.ref.WeakReference;
 import java.util.Iterator;
@@ -462,7 +461,7 @@ public final class TransactionalCaptureSupplier implements ICaptureSupplier {
             }
         }
         builder.build().asMap()
-            .forEach(TransactionType::createAndProcessPostEvents);
+            .forEach((transactionType, events) -> transactionType.createAndProcessPostEvents(context, events));
         return !cancelledAny;
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/type/BlockTransactionType.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/type/BlockTransactionType.java
@@ -29,7 +29,6 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import net.minecraft.core.BlockPos;
-import org.apache.logging.log4j.Marker;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.block.transaction.BlockTransaction;
@@ -57,7 +56,10 @@ public final class BlockTransactionType extends TransactionType<ChangeBlockEvent
     }
 
     @Override
-    protected void consumeEventsAndMarker(final Collection<? extends ChangeBlockEvent.All> changeBlockEvents, final Marker marker) {
+    protected void consumeEventsAndMarker(
+        PhaseContext<@NonNull ?> context,
+        final Collection<? extends ChangeBlockEvent.All> changeBlockEvents
+    ) {
 
         final Multimap<ResourceKey, ChangeBlockEvent.All> eventsByWorld = LinkedListMultimap.create();
         changeBlockEvents.forEach(event -> eventsByWorld.put(event.world().key(), event));
@@ -87,7 +89,6 @@ public final class BlockTransactionType extends TransactionType<ChangeBlockEvent
             if (positions.isEmpty()) {
                 return;
             }
-            final PhaseContext<@NonNull ?> context = PhaseTracker.getInstance().getPhaseContext();
             final ImmutableList<BlockTransactionReceipt> transactions = positions.asMap()
                 .values()
                 .stream()
@@ -101,6 +102,7 @@ public final class BlockTransactionType extends TransactionType<ChangeBlockEvent
                     final SpongeBlockSnapshot result = snapshots.get(snapshots.size() - 1);
                     final Operation operation = context.getBlockOperation(original, result);
                     final BlockTransactionReceipt eventTransaction = new BlockTransactionReceipt(original, result, operation);
+                    context.postBlockTransactionApplication(original.blockChange, eventTransaction);
                     return Optional.of(eventTransaction);
                 })
                 .filter(Optional::isPresent)

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/type/TransactionType.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/type/TransactionType.java
@@ -26,8 +26,10 @@ package org.spongepowered.common.event.tracking.context.transaction.type;
 
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.event.Event;
+import org.spongepowered.common.event.tracking.PhaseContext;
 
 import java.util.Collection;
 import java.util.Objects;
@@ -84,11 +86,16 @@ public abstract class TransactionType<E extends Event> {
         return Objects.hash(this.isPrimary, this.name);
     }
 
-    public void createAndProcessPostEvents(final Collection<? extends E> events) {
-        this.consumeEventsAndMarker(events, this.marker);
+    public void createAndProcessPostEvents(
+        PhaseContext<@NonNull ?> context,
+        final Collection<? extends E> events
+    ) {
+        this.consumeEventsAndMarker(context, events);
     }
 
-    protected void consumeEventsAndMarker(final Collection<? extends E> events, final Marker marker) {
+    protected void consumeEventsAndMarker(
+        PhaseContext<@NonNull ?> context, final Collection<? extends E> events
+    ) {
 
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/general/CommandState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/general/CommandState.java
@@ -25,8 +25,7 @@
 package org.spongepowered.common.event.tracking.phase.general;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.spongepowered.api.block.BlockSnapshot;
-import org.spongepowered.api.data.Transaction;
+import org.spongepowered.api.block.transaction.BlockTransactionReceipt;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
@@ -71,8 +70,10 @@ final class CommandState extends GeneralState<CommandPhaseContext> {
     }
 
     @Override
-    public void postBlockTransactionApplication(final BlockChange blockChange, final Transaction<? extends BlockSnapshot> transaction,
-        final CommandPhaseContext context) {
+    public void postBlockTransactionApplication(
+        final CommandPhaseContext context, final BlockChange blockChange,
+        final BlockTransactionReceipt transaction
+    ) {
         // We want to investigate if there is a user on the cause stack
         // and if possible, associate the notiifer/owner based on the change flag
         // We have to check if there is a player, because command blocks can be triggered

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/AttackEntityPacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/AttackEntityPacketState.java
@@ -57,7 +57,7 @@ public final class AttackEntityPacketState extends BasicPacketState {
     }
 
     @Override
-    public boolean isPacketIgnored(Packet<?> packetIn, ServerPlayer packetPlayer) {
+    public boolean isPacketIgnored(final Packet<?> packetIn, final ServerPlayer packetPlayer) {
         final ServerboundInteractPacket useEntityPacket = (ServerboundInteractPacket) packetIn;
         // There are cases where a player is interacting with an entity that
         // doesn't exist on the server.
@@ -66,14 +66,14 @@ public final class AttackEntityPacketState extends BasicPacketState {
     }
 
     @Override
-    public void populateContext(ServerPlayer playerMP, Packet<?> packet, BasicPacketContext context) {
+    public void populateContext(final ServerPlayer playerMP, final Packet<?> packet, final BasicPacketContext context) {
         context.itemUsed(ItemStackUtil.cloneDefensive(playerMP.getMainHandItem()))
             .handUsed(HandTypes.MAIN_HAND.get());
     }
 
 
     @Override
-    public void unwind(BasicPacketContext context) {
+    public void unwind(final BasicPacketContext context) {
         final ServerPlayer player = context.getPacketPlayer();
         final ServerboundInteractPacket useEntityPacket = context.getPacket();
         final net.minecraft.world.entity.Entity entity = useEntityPacket.getTarget(player.level);
@@ -86,7 +86,7 @@ public final class AttackEntityPacketState extends BasicPacketState {
             // TODO Minecraft 1.14 - How can attacking an Entity mean you created it??
             ((CreatorTrackedBridge) entity).tracked$setCreatorReference(((ServerPlayerBridge) player).bridge$getUser());
         } else {
-            ((Entity) entity).offer(Keys.NOTIFIER, player.getUUID());
+            ((CreatorTrackedBridge) entity).tracked$setNotifier(((ServerPlayerBridge) player).bridge$getUser());
         }
 
         // TODO - Determine if we need to pass the supplier or perform some parameterized

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/PacketCommandState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/PacketCommandState.java
@@ -27,8 +27,7 @@ package org.spongepowered.common.event.tracking.phase.packet.player;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.world.entity.Entity;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.spongepowered.api.block.BlockSnapshot;
-import org.spongepowered.api.data.Transaction;
+import org.spongepowered.api.block.transaction.BlockTransactionReceipt;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.event.Cause;
 import org.spongepowered.api.event.CauseStackManager;
@@ -71,8 +70,10 @@ public final class PacketCommandState extends PacketState<PlayerCommandPhaseCont
     }
 
     @Override
-    public void postBlockTransactionApplication(final BlockChange blockChange, final Transaction<? extends BlockSnapshot> transaction,
-        final PlayerCommandPhaseContext context) {
+    public void postBlockTransactionApplication(
+        final PlayerCommandPhaseContext context, final BlockChange blockChange,
+        final BlockTransactionReceipt transaction
+    ) {
         // We want to investigate if there is a user on the cause stack
         // and if possible, associate the notiifer/owner based on the change flag
         // We have to check if there is a player, because command blocks can be triggered

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/PlaceBlockPacketState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/PlaceBlockPacketState.java
@@ -24,9 +24,13 @@
  */
 package org.spongepowered.common.event.tracking.phase.packet.player;
 
-import org.spongepowered.api.block.BlockSnapshot;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ServerboundUseItemOnPacket;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.SpawnEggItem;
 import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.data.Transaction;
+import org.spongepowered.api.block.transaction.BlockTransactionReceipt;
 import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
@@ -38,9 +42,9 @@ import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.world.LocatableBlock;
 import org.spongepowered.api.world.server.ServerWorld;
-import org.spongepowered.common.bridge.world.level.TrackerBlockEventDataBridge;
-import org.spongepowered.common.bridge.world.inventory.container.TrackedInventoryBridge;
 import org.spongepowered.common.bridge.world.TrackedWorldBridge;
+import org.spongepowered.common.bridge.world.inventory.container.TrackedInventoryBridge;
+import org.spongepowered.common.bridge.world.level.TrackerBlockEventDataBridge;
 import org.spongepowered.common.event.tracking.IPhaseState;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.TrackingUtil;
@@ -52,11 +56,6 @@ import org.spongepowered.common.world.BlockChange;
 import org.spongepowered.common.world.server.SpongeLocatableBlockBuilder;
 
 import java.util.function.BiConsumer;
-import net.minecraft.core.BlockPos;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ServerboundUseItemOnPacket;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.item.SpawnEggItem;
 
 @SuppressWarnings("unchecked")
 public final class PlaceBlockPacketState extends BasicPacketState {
@@ -91,8 +90,10 @@ public final class PlaceBlockPacketState extends BasicPacketState {
     }
 
     @Override
-    public void postBlockTransactionApplication(final BlockChange blockChange, final Transaction<? extends BlockSnapshot> transaction,
-        final BasicPacketContext context) {
+    public void postBlockTransactionApplication(
+        final BasicPacketContext context, final BlockChange blockChange,
+        final BlockTransactionReceipt transaction
+    ) {
         TrackingUtil.associateTrackerToTarget(blockChange, transaction, ((ServerPlayer) context.getPacketPlayer()).user());
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/BlockEventTickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/BlockEventTickPhaseState.java
@@ -25,8 +25,7 @@
 package org.spongepowered.common.event.tracking.phase.tick;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.spongepowered.api.block.BlockSnapshot;
-import org.spongepowered.api.data.Transaction;
+import org.spongepowered.api.block.transaction.BlockTransactionReceipt;
 import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.EventContextKeys;
 import org.spongepowered.api.event.cause.entity.SpawnTypes;
@@ -83,10 +82,12 @@ class BlockEventTickPhaseState extends TickPhaseState<BlockEventTickContext> {
     }
 
     @Override
-    public void postBlockTransactionApplication(final BlockChange blockChange,
-        final Transaction<? extends BlockSnapshot> snapshotTransaction, final BlockEventTickContext context) {
-        final Block block = (Block) snapshotTransaction.original().state().type();
-        final SpongeBlockSnapshot original = (SpongeBlockSnapshot) snapshotTransaction.original();
+    public void postBlockTransactionApplication(
+        final BlockEventTickContext context, final BlockChange blockChange,
+        final BlockTransactionReceipt receipt
+    ) {
+        final Block block = (Block) receipt.originalBlock().state().type();
+        final SpongeBlockSnapshot original = (SpongeBlockSnapshot) receipt.originalBlock();
         final BlockPos changedBlockPos = original.getBlockPos();
         original.getServerWorld().ifPresent(worldServer -> {
             final LevelChunkBridge changedMixinChunk = (LevelChunkBridge) worldServer.getChunkAt(changedBlockPos);

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/EntityTickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/EntityTickPhaseState.java
@@ -24,8 +24,7 @@
  */
 package org.spongepowered.common.event.tracking.phase.tick;
 
-import org.spongepowered.api.block.BlockSnapshot;
-import org.spongepowered.api.data.Transaction;
+import org.spongepowered.api.block.transaction.BlockTransactionReceipt;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.EventContextKeys;
@@ -168,11 +167,13 @@ class EntityTickPhaseState extends TickPhaseState<EntityTickContext> {
     }
 
     @Override
-    public void postBlockTransactionApplication(final BlockChange blockChange, final Transaction<? extends BlockSnapshot> transaction,
-        final EntityTickContext context) {
+    public void postBlockTransactionApplication(
+        final EntityTickContext context, final BlockChange blockChange,
+        final BlockTransactionReceipt transaction
+    ) {
         if (blockChange == BlockChange.BREAK) {
             final Entity tickingEntity = context.getSource(Entity.class).get();
-            final BlockPos blockPos = VecHelper.toBlockPos(transaction.original().position());
+            final BlockPos blockPos = VecHelper.toBlockPos(transaction.originalBlock().position());
             final List<HangingEntity> hangingEntities = ((ServerLevel) tickingEntity.world())
                 .getEntitiesOfClass(HangingEntity.class, new AABB(blockPos, blockPos).inflate(1.1D, 1.1D, 1.1D),
                     entityIn -> {

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/LocationBasedTickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/LocationBasedTickPhaseState.java
@@ -24,9 +24,11 @@
  */
 package org.spongepowered.common.event.tracking.phase.tick;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.Block;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.spongepowered.api.block.BlockSnapshot;
-import org.spongepowered.api.data.Transaction;
+import org.spongepowered.api.block.transaction.BlockTransactionReceipt;
 import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.world.LocatableBlock;
 import org.spongepowered.common.block.SpongeBlockSnapshot;
@@ -36,10 +38,6 @@ import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.world.BlockChange;
 
 import java.util.function.BiConsumer;
-
-import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.block.Block;
 
 abstract class LocationBasedTickPhaseState<T extends LocationBasedTickContext<T>> extends TickPhaseState<T> {
 
@@ -67,11 +65,13 @@ abstract class LocationBasedTickPhaseState<T extends LocationBasedTickContext<T>
     }
 
     @Override
-    public void postBlockTransactionApplication(final BlockChange blockChange,
-        final Transaction<? extends BlockSnapshot> snapshotTransaction, final T context) {
+    public void postBlockTransactionApplication(
+        final T context, final BlockChange blockChange,
+        final BlockTransactionReceipt receipt
+    ) {
         // If we do not have a notifier at this point then there is no need to attempt to retrieve one from the chunk
         context.applyNotifierIfAvailable(user -> {
-            final SpongeBlockSnapshot original = (SpongeBlockSnapshot) snapshotTransaction.original();
+            final SpongeBlockSnapshot original = (SpongeBlockSnapshot) receipt.originalBlock();
             final Block block = (Block) original.state().type();
             final BlockPos changedBlockPos = original.getBlockPos();
             original.getServerWorld().ifPresent(worldServer -> {

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/level/chunk/LevelChunkMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/level/chunk/LevelChunkMixin.java
@@ -61,6 +61,7 @@ import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.util.Constants;
 import org.spongepowered.common.util.DirectionUtil;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -71,8 +72,6 @@ import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
-import javax.annotation.Nullable;
 
 @Mixin(net.minecraft.world.level.chunk.LevelChunk.class)
 public abstract class LevelChunkMixin implements LevelChunkBridge, CacheKeyBridge {
@@ -164,7 +163,7 @@ public abstract class LevelChunkMixin implements LevelChunkBridge, CacheKeyBridg
         if (((WorldBridge) this.level).bridge$isFake()) {
             return;
         }
-        if (!PhaseTracker.getInstance().getCurrentState().tracksCreatorsAndNotifiers()) {
+        if (!PhaseTracker.getInstance().getPhaseContext().tracksCreatorsAndNotifiers()) {
             // Don't track chunk gen
             return;
         }

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/world/level/chunk/LevelChunkMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/world/level/chunk/LevelChunkMixin_Tracker.java
@@ -24,6 +24,17 @@
  */
 package org.spongepowered.common.mixin.tracker.world.level.chunk;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.TickList;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.LevelChunkSection;
+import net.minecraft.world.level.chunk.ProtoTickList;
+import net.minecraft.world.phys.AABB;
 import org.apache.logging.log4j.Level;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -38,10 +49,13 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.common.block.SpongeBlockSnapshot;
-import org.spongepowered.common.bridge.world.level.block.state.BlockStateBridge;
+import org.spongepowered.common.bridge.CreatorTrackedBridge;
 import org.spongepowered.common.bridge.world.WorldBridge;
+import org.spongepowered.common.bridge.world.level.block.state.BlockStateBridge;
 import org.spongepowered.common.bridge.world.level.chunk.ActiveChunkReferantBridge;
+import org.spongepowered.common.bridge.world.level.chunk.LevelChunkBridge;
 import org.spongepowered.common.bridge.world.level.chunk.TrackedLevelChunkBridge;
+import org.spongepowered.common.entity.PlayerTracker;
 import org.spongepowered.common.event.ShouldFire;
 import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.event.tracking.PhaseContext;
@@ -62,17 +76,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.TickList;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraft.world.level.chunk.LevelChunkSection;
-import net.minecraft.world.level.chunk.ProtoTickList;
-import net.minecraft.world.phys.AABB;
 
 
 @Mixin(LevelChunk.class)
@@ -238,9 +241,8 @@ public abstract class LevelChunkMixin_Tracker implements TrackedLevelChunkBridge
         ((ActiveChunkReferantBridge) tileEntityIn).bridge$setActiveChunk(this);
         // Make sure to set creator/notifier for TE if any chunk data exists
         // Failure to do this during chunk load will cause TE's to not have proper user tracking
-        // TODO - Reimplement player uuid tracking.
-//        ((CreatorTrackedBridge) tileEntityIn).tracked$setTrackedUUID(PlayerTracker.Type.CREATOR, ((ChunkBridge) this).bridge$getBlockCreatorUUID(pos).orElse(null));
-//        ((CreatorTrackedBridge) tileEntityIn).tracked$setTrackedUUID(PlayerTracker.Type.NOTIFIER, null);
+        ((CreatorTrackedBridge) tileEntityIn).tracked$setTrackedUUID(PlayerTracker.Type.CREATOR, ((LevelChunkBridge) this).bridge$getBlockCreatorUUID(pos).orElse(null));
+        ((CreatorTrackedBridge) tileEntityIn).tracked$setTrackedUUID(PlayerTracker.Type.NOTIFIER, null);
     }
 
     @Inject(method = "getEntities(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;Ljava/util/List;Ljava/util/function/Predicate;)V", at = @At("RETURN"))


### PR DESCRIPTION
This restores a vital hook to be able to associate ownership/creator
recognition from block changes processed in the world. There is a
subtle change to the signature being used due to the nature of needing
potential changes further to identify who is the creator of such block
changes.

Signed-off-by: Gabriel Harris-Rouquette <gabizou@me.com>