### PR TITLE
Add lifecycle state for stopped game, and hook in executors

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeServer.java
+++ b/src/main/java/org/spongepowered/common/SpongeServer.java
@@ -26,6 +26,7 @@ package org.spongepowered.common;
 
 import org.spongepowered.api.Server;
 import org.spongepowered.common.command.manager.SpongeCommandManager;
+import org.spongepowered.common.profile.SpongeGameProfileManager;
 import org.spongepowered.common.scheduler.ServerScheduler;
 import org.spongepowered.common.user.SpongeUserManager;
 import org.spongepowered.common.util.UsernameCache;
@@ -41,6 +42,8 @@ public interface SpongeServer extends SpongeEngine, Server {
     SpongeWorldManager worldManager();
 
     SpongePlayerDataManager getPlayerDataManager();
+
+    SpongeGameProfileManager gameProfileManagerIfPresent();
 
     UsernameCache getUsernameCache();
 

--- a/src/main/java/org/spongepowered/common/profile/UncachedGameProfileProvider.java
+++ b/src/main/java/org/spongepowered/common/profile/UncachedGameProfileProvider.java
@@ -88,8 +88,14 @@ public class UncachedGameProfileProvider implements GameProfileProvider {
 
     private CompletableFuture<@Nullable CachedProfile> requestProfile(final UUID uniqueId) {
         return this.submit(() -> {
-            final com.mojang.authlib.GameProfile mcProfile = SpongeCommon.server().getSessionService().fillProfileProperties(
+            final com.mojang.authlib.GameProfile mcProfile;
+
+            if (SpongeGameProfileManager.canLookup(uniqueId)) { // only attempt to resolve profiles for online mode clients
+                mcProfile = SpongeCommon.server().getSessionService().fillProfileProperties(
                     new com.mojang.authlib.GameProfile(uniqueId, ""), true);
+            } else {
+                mcProfile = null;
+            }
             if (mcProfile == null) {
                 return null;
             }

--- a/src/main/java/org/spongepowered/common/scheduler/AsyncScheduler.java
+++ b/src/main/java/org/spongepowered/common/scheduler/AsyncScheduler.java
@@ -189,9 +189,9 @@ public final class AsyncScheduler extends SpongeScheduler {
         this.executor.shutdown();
 
         try {
-            if (!this.executor.awaitTermination(10, TimeUnit.SECONDS)) {
+            if (!this.executor.awaitTermination(5, TimeUnit.SECONDS)) {
                 new PrettyPrinter()
-                        .add("Sponge async scheduler failed to shut down in 10 seconds! Tasks that may have been active:")
+                        .add("Sponge async scheduler failed to shut down in 5 seconds! Tasks that may have been active:")
                         .addWithIndices(tasks)
                         .add()
                         .add("We will now attempt immediate shutdown.")

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/MinecraftServerMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/MinecraftServerMixin_API.java
@@ -136,7 +136,7 @@ public abstract class MinecraftServerMixin_API extends ReentrantBlockableEventLo
     private UsernameCache api$usernameCache;
     private Audience api$broadcastAudience;
     private ServerScoreboard api$scoreboard;
-    private GameProfileManager api$profileManager;
+    private SpongeGameProfileManager api$profileManager;
     private MapStorage api$mapStorage;
     private RegistryHolder api$registryHolder;
     private SpongeUserManager api$userManager;
@@ -347,6 +347,11 @@ public abstract class MinecraftServerMixin_API extends ReentrantBlockableEventLo
             this.api$profileManager = new SpongeGameProfileManager(this);
         }
 
+        return this.api$profileManager;
+    }
+
+    @Override
+    public SpongeGameProfileManager gameProfileManagerIfPresent() {
         return this.api$profileManager;
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/core/client/MinecraftMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/client/MinecraftMixin.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.mixin.core.client;
 
-import com.mojang.datafixers.util.Function4;
 import com.mojang.serialization.DynamicOps;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.main.GameConfig;
@@ -46,7 +45,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.common.SpongeBootstrap;
 import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.bridge.client.MinecraftBridge;
@@ -57,7 +55,6 @@ import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.server.BootstrapProperties;
 
 import java.nio.file.Path;
-import java.util.function.Function;
 
 @Mixin(Minecraft.class)
 public abstract class MinecraftMixin implements MinecraftBridge, SpongeClient {
@@ -103,8 +100,8 @@ public abstract class MinecraftMixin implements MinecraftBridge, SpongeClient {
     }
 
     @Inject(method = "close", at = @At(value = "INVOKE", target = "Lnet/minecraft/Util;shutdownExecutors()V"))
-    private void impl$shutdownAsyncScheduler(final CallbackInfo ci) {
-        SpongeCommon.game().asyncScheduler().close();
+    private void impl$callStoppedGame(final CallbackInfo ci) {
+        SpongeBootstrap.lifecycle().callStoppedGameEvent();
     }
 
     @Redirect(method = "loadWorldData", at = @At(value = "INVOKE", target = "Lnet/minecraft/resources/RegistryReadOps;create(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/core/RegistryAccess$RegistryHolder;)Lnet/minecraft/resources/RegistryReadOps;"))

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/dedicated/DedicatedServerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/dedicated/DedicatedServerMixin.java
@@ -41,6 +41,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.SpongeBootstrap;
 import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.bridge.server.players.GameProfileCacheBridge;
 import org.spongepowered.common.mixin.core.server.MinecraftServerMixin;
@@ -66,8 +67,8 @@ public abstract class DedicatedServerMixin extends MinecraftServerMixin {
     }
 
     @Inject(method = "stopServer", at = @At("TAIL"))
-    private void impl$shutdownAsyncScheduler(final CallbackInfo ci) {
-        SpongeCommon.game().asyncScheduler().close();
+    private void impl$callStoppedGame(final CallbackInfo ci) {
+        SpongeBootstrap.lifecycle().callStoppedGameEvent();
     }
 
     @Override

--- a/testplugins/src/main/java/org/spongepowered/test/lifecycle/LifecycleTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/lifecycle/LifecycleTest.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test.lifecycle;
+
+import com.google.inject.Inject;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.command.parameter.CommandContext;
+import org.spongepowered.api.event.GenericEvent;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.lifecycle.LifecycleEvent;
+import org.spongepowered.plugin.PluginContainer;
+import org.spongepowered.plugin.jvm.Plugin;
+import org.spongepowered.test.LoadableModule;
+
+@Plugin("lifecycletest")
+public class LifecycleTest implements LoadableModule {
+
+    private static final boolean LOG_LIFECYCLE = Boolean.getBoolean("sponge.logLifecycle");
+
+    private final Game game;
+    private final PluginContainer container;
+    private final Logger logger;
+    private boolean registered;
+
+    @Inject
+    LifecycleTest(final Game game, final PluginContainer container, final Logger logger) {
+        this.game = game;
+        this.container = container;
+        this.logger = logger;
+
+        if (LifecycleTest.LOG_LIFECYCLE) {
+            game.eventManager().registerListeners(this.container, new Listeners());
+            this.registered = true;
+        }
+    }
+
+    @Override
+    public void enable(final CommandContext ctx) {
+        if (!this.registered) {
+            this.game.eventManager().registerListeners(this.container, new Listeners());
+            this.registered = true;
+            ctx.sendMessage(Identity.nil(), Component.text("Successfully registered lifecycle listener"));
+        } else {
+            ctx.sendMessage(Identity.nil(), Component.text("Listener already registered", NamedTextColor.RED));
+        }
+    }
+
+    @Override
+    public void disable(final CommandContext ctx) {
+        if (this.registered) {
+            this.game.eventManager().unregisterPluginListeners(this.container);
+            this.registered = false;
+            ctx.sendMessage(Identity.nil(), Component.text("Successfully unregistered lifecycle listener"));
+        } else {
+            ctx.sendMessage(Identity.nil(), Component.text("Listener not registered", NamedTextColor.RED));
+        }
+    }
+
+    public class Listeners {
+        @Listener
+        public void onLifecycle(final LifecycleEvent event) {
+            LifecycleTest.this.logger.info(":: Lifecycle {}", () -> {
+                final StringBuilder eventName = new StringBuilder(event.getClass().getSimpleName());
+                Class<?> enclosing = event.getClass().getEnclosingClass();
+                while (enclosing != null) {
+                    eventName.insert(0, '$');
+                    eventName.insert(0, enclosing.getSimpleName());
+                    enclosing = enclosing.getEnclosingClass();
+                }
+                if (event instanceof GenericEvent) {
+                    eventName.append('<')
+                        .append(((GenericEvent<?>) event).paramType().getType().getTypeName())
+                        .append('>');
+                }
+                return eventName;
+            });
+        }
+    }
+
+}

--- a/testplugins/src/main/resources/META-INF/plugins.json
+++ b/testplugins/src/main/resources/META-INF/plugins.json
@@ -612,6 +612,27 @@
                 "id": "spongeapi",
                 "version": "8.0.0"
             }]
+        },
+        {
+            "loader": "java_plain",
+            "id": "lifecycletest",
+            "name": "Lifecycle Test",
+            "version": "8.0.0",
+            "main-class": "org.spongepowered.test.lifecycle.LifecycleTest",
+            "description": "Lifecycle Testing",
+            "links": {
+                "homepage": "https://www.spongepowered.org",
+                "source": "https://www.spongepowered.org/source",
+                "issues": "https://www.spongepowered.org/issues"
+            },
+            "contributors": [{
+                "name": "SpongePowered",
+                "description": "Lead Developer"
+            }],
+            "dependencies": [{
+                "id": "spongeapi",
+                "version": "8.0.0"
+            }]
         }
     ]
 }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2379)

Fixes #3472 (though today's earlier user refactor likely means that the issue will no longer be triggered)

Implements the new `StoppedGameEvent`