### PR TITLE
Implement Entity#setPosition and clean up some related logic

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/server/level/ServerPlayerBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/server/level/ServerPlayerBridge.java
@@ -29,6 +29,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundRespawnPacket;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.Entity;
@@ -43,6 +44,7 @@ import org.spongepowered.api.scoreboard.Scoreboard;
 import org.spongepowered.common.bridge.network.ConnectionBridge;
 import org.spongepowered.common.entity.player.ClientType;
 import org.spongepowered.common.world.border.PlayerOwnBorderListener;
+import org.spongepowered.math.vector.Vector3d;
 
 import java.util.Locale;
 import java.util.Set;
@@ -107,7 +109,5 @@ public interface ServerPlayerBridge extends ServerPlayerEntityHealthScaleBridge 
     }
 
     boolean bridge$kick(final Component message);
-
-    Entity bridge$performGameWinLogic();
 
 }

--- a/src/main/java/org/spongepowered/common/bridge/world/entity/EntityBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/world/entity/EntityBridge.java
@@ -52,8 +52,6 @@ public interface EntityBridge {
 
     @Nullable BlockPos bridge$getLastCollidedBlockPos();
 
-    void bridge$setTransform(Transform transform);
-
     void bridge$setFireImmuneTicks(int ticks);
 
     default void bridge$clearWrappedCaptureList() {
@@ -80,26 +78,7 @@ public interface EntityBridge {
 
     boolean bridge$dismountRidingEntity(DismountType type);
 
-    Optional<BlockUtil.FoundRectangle> bridge$determineExitPortal(ServerLevel targetWorld, BlockPos targetPosition, boolean targetIsNether,
-            boolean shouldFireEvent);
-
     Entity bridge$changeDimension(ServerLevel targetWorld, PlatformTeleporter teleporter);
-
-    default void bridge$setPlayerChangingDimensions() {
-    }
-
-    default void bridge$playerPrepareForPortalTeleport(final ServerLevel currentWorld, final ServerLevel targetWorld) {
-    }
-
-    default void bridge$validateEntityAfterTeleport(final Entity e, final PlatformTeleporter teleporter) {
-    }
-
-    Entity bridge$portalRepositioning(final boolean createEndPlatform,
-            final ServerLevel serverworld,
-            final ServerLevel targetWorld,
-            final PortalInfo portalinfo);
-
-    void bridge$postPortalForceChangeTasks(Entity entity, ServerLevel targetWorld, boolean isVanilla);
 
     ChangeEntityWorldEvent.Reposition bridge$fireRepositionEvent(org.spongepowered.api.world.server.ServerWorld originalDestinationWorld,
             org.spongepowered.api.world.server.ServerWorld targetWorld,

--- a/src/main/java/org/spongepowered/common/bridge/world/entity/EntityBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/world/entity/EntityBridge.java
@@ -60,6 +60,8 @@ public interface EntityBridge {
 
     }
 
+    boolean bridge$setPosition(Vector3d position);
+
     boolean bridge$setLocation(ServerLocation location);
 
     /**

--- a/src/main/java/org/spongepowered/common/bridge/world/level/PlatformServerLevelBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/world/level/PlatformServerLevelBridge.java
@@ -29,7 +29,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 
 public interface PlatformServerLevelBridge {
-    default void bridge$removeEntity(Entity entity, boolean keepData) {
+    default void bridge$removeEntity(final Entity entity, final boolean keepData) {
         if (entity instanceof ServerPlayer) {
             ((ServerLevel) this).removePlayerImmediately((ServerPlayer) entity);
         } else {

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/EntityMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/EntityMixin_API.java
@@ -72,6 +72,7 @@ import org.spongepowered.math.vector.Vector3d;
 import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -97,7 +98,6 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
     @Shadow public abstract double shadow$getZ();
     @Shadow public abstract net.minecraft.world.level.Level shadow$getCommandSenderWorld();
     @Shadow @Nullable public abstract MinecraftServer shadow$getServer();
-    @Shadow public abstract void shadow$setPos(double x, double y, double z);
     @Shadow public abstract void shadow$remove();
     @Shadow public abstract UUID shadow$getUUID();
     @Shadow public abstract void shadow$setRemainingFireTicks(int ticks);
@@ -122,6 +122,11 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
     }
 
     @Override
+    public boolean setPosition(final Vector3d position) {
+        return ((EntityBridge) this).bridge$setPosition(Objects.requireNonNull(position, "The position was null!"));
+    }
+
+    @Override
     public World<?, ?> world() {
         return (World<?, ?>) this.level;
     }
@@ -132,13 +137,12 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
     }
 
     @Override
-    public boolean setLocation(ServerLocation location) {
-        Preconditions.checkNotNull(location, "The location was null!");
-        return ((EntityBridge) this).bridge$setLocation(location);
+    public boolean setLocation(final ServerLocation location) {
+        return ((EntityBridge) this).bridge$setLocation(Objects.requireNonNull(location, "The location was null!"));
     }
 
     @Override
-    public boolean setLocationAndRotation(ServerLocation location, Vector3d rotation) {
+    public boolean setLocationAndRotation(final ServerLocation location, final Vector3d rotation) {
         if (this.setLocation(location)) {
             this.setRotation(rotation);
             return true;
@@ -168,7 +172,7 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
         }
         Preconditions.checkNotNull(transform, "The transform cannot be null!");
         final Vector3d position = transform.position();
-        this.shadow$setPos(position.x(), position.y(), position.z());
+        ((EntityBridge) this).bridge$setPosition(transform.position());
         this.setRotation(transform.rotation());
         this.setScale(transform.scale());
         if (!((LevelBridge) this.shadow$getCommandSenderWorld()).bridge$isFake()) {

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/EntityMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/EntityMixin_API.java
@@ -87,7 +87,7 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
     @Shadow public float yRot;
     @Shadow public float xRot;
     @Shadow public boolean removed;
-    @Final @Shadow protected Random random;
+    @Shadow @Final protected Random random;
     @Shadow public int tickCount;
     @Shadow protected UUID uuid;
     @Shadow @Final private net.minecraft.world.entity.EntityType<?> type;
@@ -170,22 +170,23 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
         if (!PhaseTracker.SERVER.onSidedThread()) {
             return false;
         }
-        Preconditions.checkNotNull(transform, "The transform cannot be null!");
-        final Vector3d position = transform.position();
-        ((EntityBridge) this).bridge$setPosition(transform.position());
-        this.setRotation(transform.rotation());
-        this.setScale(transform.scale());
-        if (!((LevelBridge) this.shadow$getCommandSenderWorld()).bridge$isFake()) {
-            ((ServerLevel) this.shadow$getCommandSenderWorld()).updateChunkPos((Entity) (Object) this);
+        Objects.requireNonNull(transform, "The transform cannot be null!");
+        if (((EntityBridge) this).bridge$setPosition(transform.position())) {
+            this.setRotation(transform.rotation());
+            this.setScale(transform.scale());
+            if (!((LevelBridge) this.shadow$getCommandSenderWorld()).bridge$isFake()) {
+                ((ServerLevel) this.shadow$getCommandSenderWorld()).updateChunkPos((Entity) (Object) this);
+            }
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     @Override
     public boolean transferToWorld(final org.spongepowered.api.world.server.ServerWorld world, final Vector3d position) {
-        Preconditions.checkNotNull(world, "World was null!");
-        Preconditions.checkNotNull(position, "Position was null!");
+        Objects.requireNonNull(world, "World was null!");
+        Objects.requireNonNull(position, "Position was null!");
         return this.setLocation(ServerLocation.of(world, position));
     }
 
@@ -194,16 +195,16 @@ public abstract class EntityMixin_API implements org.spongepowered.api.entity.En
         return new Vector3d(this.xRot, this.yRot, 0);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings("ConstantConditions")
     @Override
     public void setRotation(final Vector3d rotation) {
-        Preconditions.checkNotNull(rotation, "Rotation was null!");
+        Objects.requireNonNull(rotation, "Rotation was null!");
         if (this.isRemoved()) {
             return;
         }
-        if (((Entity) (Object) this) instanceof ServerPlayer && ((ServerPlayer) (Entity) (Object) this).connection != null) {
+        if (((Entity) (Object) this) instanceof ServerPlayer && ((ServerPlayer) (Object) this).connection != null) {
             // Force an update, this also set the rotation in this entity
-            ((ServerPlayer) (Entity) (Object) this).connection.teleport(this.position().x(), this.position().y(),
+            ((ServerPlayer) (Object) this).connection.teleport(this.position().x(), this.position().y(),
                     this.position().z(), (float) rotation.y(), (float) rotation.x(), EnumSet.noneOf(ClientboundPlayerPositionPacket.RelativeArgument.class));
         } else {
             if (!this.shadow$getCommandSenderWorld().isClientSide) { // We can't set the rotation update on client worlds.

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/EntityMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/EntityMixin.java
@@ -168,6 +168,7 @@ public abstract class EntityMixin implements EntityBridge, PlatformEntityBridge,
     @Shadow public abstract EntityType<?> shadow$getType();
     @Shadow public abstract boolean shadow$isInWater();
     @Shadow public abstract boolean shadow$isPassenger();
+    @Shadow public abstract void shadow$teleportToWithTicket(double x, double y, double z);
     @Shadow public abstract void shadow$teleportTo(double x, double y, double z);
     @Shadow public abstract void shadow$doEnchantDamageEffects(LivingEntity entityLivingBaseIn, Entity entityIn);
     @Shadow public abstract CommandSourceStack shadow$createCommandSourceStack();
@@ -238,6 +239,32 @@ public abstract class EntityMixin implements EntityBridge, PlatformEntityBridge,
     }
 
     @Override
+    public boolean bridge$setPosition(final Vector3d position) {
+        if (this.removed) {
+            return false;
+        }
+
+        try (final CauseStackManager.StackFrame frame = PhaseTracker.getCauseStackManager().pushCauseFrame()) {
+            frame.pushCause(SpongeCommon.activePlugin());
+            frame.addContext(EventContextKeys.MOVEMENT_TYPE, MovementTypes.PLUGIN);
+
+            final net.minecraft.world.phys.Vec3 originalPosition = this.shadow$position();
+            Vector3d destinationPosition = position;
+            if (ShouldFire.MOVE_ENTITY_EVENT) {
+                final MoveEntityEvent event = SpongeEventFactory.createMoveEntityEvent(frame.currentCause(),
+                    (org.spongepowered.api.entity.Entity) this, VecHelper.toVector3d(this.shadow$position()), position, position);
+                if (SpongeCommon.post(event)) {
+                    return false;
+                }
+                destinationPosition = event.destinationPosition();
+            }
+            this.shadow$teleportToWithTicket(destinationPosition.x(), destinationPosition.y(), destinationPosition.z());
+        }
+
+        return true;
+    }
+
+    @Override
     public boolean bridge$setLocation(final ServerLocation location) {
         if (this.removed || ((LevelBridge) location.world()).bridge$isFake()) {
             return false;
@@ -250,6 +277,7 @@ public abstract class EntityMixin implements EntityBridge, PlatformEntityBridge,
             final net.minecraft.world.phys.Vec3 originalPosition = this.shadow$position();
 
             net.minecraft.server.level.ServerLevel destinationWorld = (net.minecraft.server.level.ServerLevel) location.world();
+            Vector3d destinationPosition;
 
             if (this.shadow$getCommandSenderWorld() != destinationWorld) {
                 final ChangeEntityWorldEvent.Pre event = SpongeEventFactory.createChangeEntityWorldEventPre(frame.currentCause(),
@@ -262,19 +290,27 @@ public abstract class EntityMixin implements EntityBridge, PlatformEntityBridge,
                 final ChangeEntityWorldEvent.Reposition repositionEvent =
                         SpongeEventFactory.createChangeEntityWorldEventReposition(frame.currentCause(),
                                 (org.spongepowered.api.entity.Entity) this, (ServerWorld) this.shadow$getCommandSenderWorld(),
-                                VecHelper.toVector3d(this.shadow$position()), location.position(), event.originalDestinationWorld(),
+                                VecHelper.toVector3d(originalPosition), location.position(), event.originalDestinationWorld(),
                                 location.position(), event.destinationWorld());
 
                 if (SpongeCommon.post(repositionEvent)) {
                     return false;
                 }
 
-                destinationWorld = (net.minecraft.server.level.ServerLevel) event.destinationWorld();
+                ((Entity) (Object) this).unRide();
 
-                this.shadow$setPos(repositionEvent.destinationPosition().x(),
-                        repositionEvent.destinationPosition().y(), repositionEvent.destinationPosition().z());
+                destinationWorld = (net.minecraft.server.level.ServerLevel) event.destinationWorld();
+                destinationPosition = repositionEvent.destinationPosition();
+
+                final net.minecraft.server.level.ServerLevel originalWorld = (net.minecraft.server.level.ServerLevel) this.shadow$getCommandSenderWorld();
+                ((PlatformServerLevelBridge) this.shadow$getCommandSenderWorld()).bridge$removeEntity((Entity) (Object) this, true);
+                this.bridge$revive();
+                this.shadow$setLevel(destinationWorld);
+                destinationWorld.addFromAnotherDimension((Entity) (Object) this);
+
+                originalWorld.resetEmptyTime();
+                destinationWorld.resetEmptyTime();
             } else {
-                final Vector3d destination;
                 if (ShouldFire.MOVE_ENTITY_EVENT) {
                     final MoveEntityEvent event = SpongeEventFactory.createMoveEntityEvent(frame.currentCause(),
                             (org.spongepowered.api.entity.Entity) this, VecHelper.toVector3d(this.shadow$position()),
@@ -282,32 +318,14 @@ public abstract class EntityMixin implements EntityBridge, PlatformEntityBridge,
                     if (SpongeCommon.post(event)) {
                         return false;
                     }
-                    destination = event.destinationPosition();
+                    destinationPosition = event.destinationPosition();
                 } else {
-                    destination = location.position();
+                    destinationPosition = location.position();
                 }
-                this.shadow$setPos(destination.x(), destination.y(), destination.z());
+
+                ((Entity) (Object) this).unRide();
             }
-
-            if (!destinationWorld.getChunkSource().hasChunk((int) this.shadow$getX() >> 4, (int) this.shadow$getZ() >> 4)) {
-                // Roll back the position
-                this.shadow$setPos(originalPosition.x, originalPosition.y, originalPosition.z);
-                return false;
-            }
-
-            ((Entity) (Object) this).unRide();
-
-            final net.minecraft.server.level.ServerLevel originalWorld = (net.minecraft.server.level.ServerLevel) this.shadow$getCommandSenderWorld();
-            ((PlatformServerLevelBridge) this.shadow$getCommandSenderWorld()).bridge$removeEntity((Entity) (Object) this, true);
-            this.bridge$revive();
-            this.shadow$setLevel(destinationWorld);
-            destinationWorld.addFromAnotherDimension((Entity) (Object) this);
-
-            originalWorld.resetEmptyTime();
-            destinationWorld.resetEmptyTime();
-
-            final ChunkPos chunkPos = new ChunkPos((int) this.shadow$getX() >> 4, (int) this.shadow$getZ() >> 4);
-            destinationWorld.getChunkSource().addRegionTicket(TicketType.POST_TELEPORT, chunkPos, 1, ((Entity) (Object) this).getId());
+            this.shadow$teleportToWithTicket(destinationPosition.x(), destinationPosition.y(), destinationPosition.z());
         }
 
         return true;

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/projectile/ThrownEnderpearlMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/projectile/ThrownEnderpearlMixin.java
@@ -94,9 +94,7 @@ public abstract class ThrownEnderpearlMixin extends ThrowableProjectileMixin {
 
     @Override
     @Nullable
-    public Entity bridge$changeDimension(final ServerLevel dimensionIn, final PlatformTeleporter teleporter) {
-        final Entity entity = super.bridge$changeDimension(dimensionIn, teleporter);
-
+    public Entity impl$postProcessChangeDimension(final Entity entity) {
         if (entity instanceof ThrownEnderpearl) {
             // We actually teleported so...
             this.shadow$setOwner(null);

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/vehicle/AbstractMinecartContainerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/vehicle/AbstractMinecartContainerMixin.java
@@ -24,32 +24,29 @@
  */
 package org.spongepowered.common.mixin.core.world.entity.vehicle;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.common.world.portal.PlatformTeleporter;
-
-import javax.annotation.Nullable;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.vehicle.AbstractMinecartContainer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import javax.annotation.Nullable;
 
 @Mixin(AbstractMinecartContainer.class)
 public abstract class AbstractMinecartContainerMixin extends AbstractMinecartMixin {
 
+    // @formatter:off
     @Shadow private boolean dropEquipment;
+    // @formatter:on
 
     /**
      * @author Zidane - June 2019 - 1.12.2
      * @author i509VCB - Feb 2020 - 1.14.4
-     * @author dualspiral - 21 December 2020 - 1.16.4
+     * @author dualspiral - 24th July 2021 - 1.16.5
      * @reason Only have this Minecart not drop contents if we actually changed dimension
      */
     @Override
     @Nullable
-    public Entity bridge$changeDimension(final ServerLevel world, final PlatformTeleporter platformTeleporter) {
-        final Entity entity = super.bridge$changeDimension(world, platformTeleporter);
-
+    protected @org.checkerframework.checker.nullness.qual.Nullable Entity impl$postProcessChangeDimension(final Entity entity) {
         if (entity instanceof AbstractMinecartContainer) {
             // We actually teleported so...
             this.dropEquipment = false;

--- a/testplugins/src/main/java/org/spongepowered/test/movement/MovementTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/movement/MovementTest.java
@@ -37,7 +37,9 @@ import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.command.Command;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.parameter.CommandContext;
+import org.spongepowered.api.command.parameter.CommonParameters;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.entity.MoveEntityEvent;
 import org.spongepowered.api.event.entity.RotateEntityEvent;
@@ -96,9 +98,41 @@ public final class MovementTest implements LoadableModule {
             })
             .build(), "toggleTeleportOnMove"
         );
+        event.register(this.plugin, Command.builder()
+            .addParameter(CommonParameters.POSITION)
+            .executor(context -> {
+                if (context.cause().root() instanceof ServerPlayer) {
+                    final ServerPlayer serverPlayer = (ServerPlayer) context.cause().root();
+                    final boolean success = serverPlayer.setPosition(context.requireOne(CommonParameters.POSITION));
+                    if (success) {
+                        context.sendMessage(Identity.nil(), Component.text("Successfully changed position"));
+                        return CommandResult.success();
+                    } else {
+                        return CommandResult.error(Component.text("Could not change position."));
+                    }
+                } else {
+                    return CommandResult.error(Component.text("You must be a player to set your position."));
+                }
+            }).build(), "setpos");
+        event.register(this.plugin, Command.builder()
+            .addParameter(CommonParameters.LOCATION_ONLINE_ONLY)
+            .executor(context -> {
+                if (context.cause().root() instanceof ServerPlayer) {
+                    final ServerPlayer serverPlayer = (ServerPlayer) context.cause().root();
+                    final boolean success = serverPlayer.setLocation(context.requireOne(CommonParameters.LOCATION_ONLINE_ONLY));
+                    if (success) {
+                        context.sendMessage(Identity.nil(), Component.text("Successfully changed location"));
+                        return CommandResult.success();
+                    } else {
+                        return CommandResult.error(Component.text("Could not change location."));
+                    }
+                } else {
+                    return CommandResult.error(Component.text("You must be a player to set your location."));
+                }
+            }).build(), "setlocation");
     }
 
-    public class RotationEventListener {
+    public final class RotationEventListener {
         @Listener
         public void onEntitySpawn(final RotateEntityEvent event) {
             if (!MovementTest.this.printRotationEvents) {
@@ -116,7 +150,7 @@ public final class MovementTest implements LoadableModule {
         }
     }
 
-    public class MoveEntityTeleportListener {
+    public final class MoveEntityTeleportListener {
         @Listener
         public void onEntitySpawn(final MoveEntityEvent event, final @Root Player player) {
             if (!MovementTest.this.teleportOnMove) {
@@ -157,6 +191,8 @@ public final class MovementTest implements LoadableModule {
             final Logger pluginLogger = MovementTest.this.plugin.logger();
             pluginLogger.log(Level.INFO, MovementTest.marker, "/*************");
             pluginLogger.log(Level.INFO, MovementTest.marker, "/* MoveEntityEvent");
+            pluginLogger.log(Level.INFO, MovementTest.marker, "/");
+            pluginLogger.log(Level.INFO, MovementTest.marker, "/* Event Impl: " + post.getClass().getSimpleName());
             pluginLogger.log(Level.INFO, MovementTest.marker, "/");
             pluginLogger.log(Level.INFO, MovementTest.marker, "/ Cause:");
             for (final Object o : post.cause()) {


### PR DESCRIPTION
Superscedes https://github.com/SpongePowered/Sponge/pull/3442

With many thanks to @Lignium for starting this. The further changes attempts to unify some of the move event handling and reduce duplication. Some cleanup has occurred too, converting methods that didn't actually need to be bridge methods to `impl$` methods.

I want to test it once more tomorrow before I merge.