### PR TITLE
Don't continuously check command nodes for permissions when we have already done so once

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/commands/CommandsMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/commands/CommandsMixin.java
@@ -238,7 +238,9 @@ public abstract class CommandsMixin implements CommandsBridge {
             }
             // If empty, we have a node won't resolve (even if not complex), so we ignore it.
             return false;
-        } else if (!SpongeNodePermissionCache.canUse(
+        // If we have already processed this node and it appears in the suggestion node list, prevent a potentially costly
+        // canUse check as we know we can already use it.
+        } else if (!commandNodeToSuggestionNode.containsKey(commandNode) && !SpongeNodePermissionCache.canUse(
                 rootCommandNode instanceof RootCommandNode, this.impl$commandManager.getDispatcher(), commandNode, sourceButTyped)) {
             playerNodes.put(commandNode, Collections.emptyList());
             return false;


### PR DESCRIPTION
This should hopefully fix the problems with lockups on flags - due to their cyclic nature nodes that returned `false` for `canUse` failed were not being cached, so `canUse` potentially was being called many, _many_ times, possibly causing a server to stall out due to the number of pathways to flags, especially when many are involved.

We cache nodes that have had any canUse check now - so we don't have to permission check a given node more than once and should hopefully improve performance.

Not tested - can't do so at the moment (and I need test code).