### PR TITLE
Fix missing null checks in DataProviderRegistrator

### DIFF
--- a/src/main/java/org/spongepowered/common/data/provider/DataProviderRegistrator.java
+++ b/src/main/java/org/spongepowered/common/data/provider/DataProviderRegistrator.java
@@ -338,6 +338,9 @@ public class DataProviderRegistrator {
 
                 @Override
                 protected Optional<E> getFrom(final H dataHolder) {
+                    if (registration.get == null) {
+                        return Optional.empty();
+                    }
                     if (this.isBooleanKey) {
                         return (Optional<E>) OptBool.of((Boolean) registration.get.apply(dataHolder));
                     }
@@ -487,6 +490,9 @@ public class DataProviderRegistrator {
 
                 @Override
                 protected Optional<E> getFrom(final H dataHolder) {
+                    if (registration.get == null) {
+                        return Optional.empty();
+                    }
                     if (this.isBooleanKey) {
                         return (Optional<E>) OptBool.of((Boolean) registration.get.apply(dataHolder));
                     }
@@ -495,6 +501,9 @@ public class DataProviderRegistrator {
 
                 @Override
                 protected Optional<H> set(final H dataHolder, final E value) {
+                    if (registration.set == null) {
+                        return Optional.empty();
+                    }
                     return Optional.ofNullable(registration.set.apply(dataHolder, value));
                 }
 


### PR DESCRIPTION
Fixes a `NullPointerException` when trying to write read-only keys. For example, when trying to merge data from one block state to another, an exception occurs when trying to merge in my case `Key.IS_PASSABLE`.

Example code:
```java
@Listener
public void onStartedServer(StartedEngineEvent<Server> event) {
    Objects.requireNonNull(event, "event");

    BlockState firstState = BlockTypes.OAK_LOG.get().defaultState().with(Keys.AXIS, Axis.Z).get();
    BlockState secondState = firstState.with(Keys.AXIS, Axis.Y).get();

    System.out.println(firstState);
    System.out.println(secondState);
    System.out.println(firstState.mergeWith(secondState)); // NPE
}
```
And exception:
```
java.lang.NullPointerException: null
	at org.spongepowered.common.data.provider.DataProviderRegistrator$ImmutableRegistrationBase$1.set(DataProviderRegistrator.java:501) ~[DataProviderRegistrator$ImmutableRegistrationBase$1.class:1.16.5-8.0.0-RC0]
	at org.spongepowered.common.data.provider.GenericImmutableDataProviderBase.with(GenericImmutableDataProviderBase.java:138) ~[GenericImmutableDataProviderBase.class:1.16.5-8.0.0-RC0]
	at org.spongepowered.common.data.holder.SpongeImmutableDataHolder.with(SpongeImmutableDataHolder.java:58) ~[SpongeImmutableDataHolder.class:1.16.5-8.0.0-RC0]
	at org.spongepowered.common.data.holder.SpongeImmutableDataHolder.mergeWith(SpongeImmutableDataHolder.java:72) ~[SpongeImmutableDataHolder.class:1.16.5-8.0.0-RC0]
	at org.spongepowered.api.data.DataHolder$Immutable.mergeWith(DataHolder.java:448) ~[DataHolder$Immutable.class:1.16.5-8.0.0-RC0]
	...
```