### PR TITLE
Handle a missing plugin container when registering mod commands

### DIFF
--- a/src/main/java/org/spongepowered/common/command/brigadier/dispatcher/SpongeNodePermissionCache.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/dispatcher/SpongeNodePermissionCache.java
@@ -97,8 +97,9 @@ public final class SpongeNodePermissionCache {
                 final String original = path.iterator().next();
                 pluginId = dispatcher.getCommandManager()
                         .commandMapping(original)
-                        .map(x -> x.plugin().metadata().id()).orElseGet(() -> {
-                            SpongeCommon.logger().error("Root command /{} does not have an associated plugin!", original);
+                        .flatMap(x -> x.plugin().map(y -> y.metadata().id())).orElseGet(() -> {
+                            SpongeCommon.logger().error("Root command /{} does not have an associated plugin! Using \"unknown\" in place of plugin "
+                                    + "ID for the permission.", original);
                             return "unknown";
                         });
                 permString = path.stream().map(x -> {

--- a/src/main/java/org/spongepowered/common/command/manager/SpongeCommandMapping.java
+++ b/src/main/java/org/spongepowered/common/command/manager/SpongeCommandMapping.java
@@ -32,18 +32,19 @@ import org.spongepowered.api.command.registrar.CommandRegistrar;
 import org.spongepowered.api.command.registrar.tree.CommandTreeNode;
 import org.spongepowered.plugin.PluginContainer;
 
+import java.util.Optional;
 import java.util.Set;
 
 public final class SpongeCommandMapping implements CommandMapping {
 
     private final String alias;
     private final Set<String> allAliases;
-    private final PluginContainer container;
+    private final @Nullable PluginContainer container;
     private final CommandRegistrar<?> registrar;
 
     public SpongeCommandMapping(final String alias,
                                 final Set<String> allAliases,
-                                final PluginContainer container,
+                                final @Nullable PluginContainer container,
                                 final CommandRegistrar<?> registrar) {
         this.alias = alias;
         this.allAliases = ImmutableSet.copyOf(allAliases);
@@ -62,8 +63,8 @@ public final class SpongeCommandMapping implements CommandMapping {
     }
 
     @Override
-    public @NonNull PluginContainer plugin() {
-        return this.container;
+    public @NonNull Optional<PluginContainer> plugin() {
+        return Optional.ofNullable(this.container);
     }
 
     @Override
@@ -74,10 +75,10 @@ public final class SpongeCommandMapping implements CommandMapping {
     @Override
     public String toString() {
         return "SpongeCommandMapping{" +
-                "alias='" + alias + '\'' +
-                ", allAliases=" + allAliases +
-                ", container=" + container +
-                ", registrar=" + registrar +
+                "alias='" + this.alias + '\'' +
+                ", allAliases=" + this.allAliases +
+                ", container=" + this.container +
+                ", registrar=" + this.registrar +
                 '}';
     }
 

--- a/src/main/java/org/spongepowered/common/command/registrar/BrigadierCommandRegistrar.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/BrigadierCommandRegistrar.java
@@ -35,6 +35,7 @@ import io.leangen.geantyref.TypeToken;
 import net.kyori.adventure.text.Component;
 import net.minecraft.commands.CommandSourceStack;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.command.CommandCompletion;
 import org.spongepowered.api.command.CommandResult;
@@ -88,12 +89,10 @@ public final class BrigadierCommandRegistrar implements BrigadierBasedRegistrar<
         return this.dispatcher;
     }
 
-    // For mods and others that use this. We get the plugin container from the CauseStack
-    // TODO: Make sure this is valid. For Forge, I suspect we'll have done this in a context of some sort.
+    // For mods and others that use this. We get the plugin container from the CauseStack, if we can.
     public LiteralCommandNode<CommandSourceStack> register(final LiteralArgumentBuilder<CommandSourceStack> command) {
-        // Get the plugin container
-        final PluginContainer container = PhaseTracker.getCauseStackManager().currentCause().first(PluginContainer.class)
-                .orElseThrow(() -> new IllegalStateException("Cannot register command without knowing its origin."));
+        // Get the plugin container - though we might not have it.
+        final @Nullable PluginContainer container = PhaseTracker.getCauseStackManager().currentCause().first(PluginContainer.class).orElse(null);
 
         return this.registerInternal(this,
                 container,
@@ -136,7 +135,7 @@ public final class BrigadierCommandRegistrar implements BrigadierBasedRegistrar<
 
     private Tuple<CommandMapping, LiteralCommandNode<CommandSourceStack>> registerInternal(
             final CommandRegistrar<?> registrar,
-            final PluginContainer container,
+            final @Nullable PluginContainer container,
             final LiteralCommandNode<CommandSourceStack> namespacedCommand,
             final String[] secondaryAliases,
             final boolean allowDuplicates) { // Brig technically allows them...

--- a/src/main/java/org/spongepowered/common/command/sponge/SpongeCommand.java
+++ b/src/main/java/org/spongepowered/common/command/sponge/SpongeCommand.java
@@ -28,6 +28,7 @@ import co.aikar.timings.Timings;
 import co.aikar.timings.sponge.SpongeTimingsFactory;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.LinearComponents;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.ClickEvent;
@@ -668,11 +669,11 @@ public class SpongeCommand {
         final CommandMapping mapping = context.requireOne(this.commandMappingKey);
         context.sendMessage(Identity.nil(), Component.text().append(
                 this.title("Aliases: "),
-                Component.join(Component.text(", "),
+                Component.join(JoinConfiguration.separator(Component.text(", ")),
                     mapping.allAliases().stream().map(x -> Component.text(x, NamedTextColor.YELLOW)).collect(Collectors.toList())),
                 Component.newline(),
                 this.title("Owned by: "),
-                this.hl(mapping.plugin().metadata().name().orElseGet(() -> mapping.plugin().metadata().id())))
+                this.hl(mapping.plugin().map(x -> x.metadata().name().orElseGet(() -> x.metadata().id())).orElse("unknown")))
                 .build());
         return CommandResult.success();
     }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2396) | **Sponge** | [Original Issue](https://github.com/SpongePowered/Sponge/issues/3540)

We prefix such commands with "unknown:" - we might want to do something different.

See the original issue: #3540