### PR TITLE
Additional handling for null pluginContainer needed for #3540

### DIFF
--- a/src/main/java/org/spongepowered/common/command/registrar/BrigadierCommandRegistrar.java
+++ b/src/main/java/org/spongepowered/common/command/registrar/BrigadierCommandRegistrar.java
@@ -245,9 +245,10 @@ public final class BrigadierCommandRegistrar implements BrigadierBasedRegistrar<
             // nope
             throw new IllegalArgumentException("The literal must not contain a colon or a space.");
         }
-
+        // Handle null plugin container for sponge-unaware mods (forge)
+        final String modid = (pluginContainer != null) ? pluginContainer.metadata().id() : "unknown";
         final LiteralArgumentBuilder<CommandSourceStack> replacementBuilder =
-                LiteralArgumentBuilder.<CommandSourceStack>literal(pluginContainer.metadata().id() + ":" + builder.getLiteral())
+                LiteralArgumentBuilder.<CommandSourceStack>literal(modid + ":" + builder.getLiteral())
                         .forward(builder.getRedirect(), builder.getRedirectModifier(), builder.isFork())
                         .executes(builder.getCommand())
                         .requires(builder.getRequirement());


### PR DESCRIPTION
This addresses an additional implication of the change needed for #3540 - that change allowed for pluginContainer to be null, but this did not include the needed handling for this value being null added by this change.

This fix has been confirmed good with Dynmap and with WorldEdit installed - it fixed the exceptions, and the dynmap commands functioned as expected.