### PR TITLE
Add Git details to jar manifests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,9 @@ val commonManifest = the<JavaPluginConvention>().manifest {
         "Implementation-Version" to spongeImpl.generateImplementationVersionString(apiVersion, minecraftVersion, recommendedVersion),
         "Implementation-Vendor" to "SpongePowered"
     )
+    // These two are included by most CI's
+    System.getenv()["GIT_COMMIT"]?.apply { attributes("Git-Commit" to this) }
+    System.getenv()["GIT_BRANCH"]?.apply { attributes("Git-Branch" to this) }
 }
 
 tasks {

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -231,6 +231,9 @@ val forgeManifest = java.manifest {
             "Implementation-Version" to spongeImpl.generatePlatformBuildVersionString(apiVersion, minecraftVersion, recommendedVersion, forgeVersion),
             "Implementation-Vendor" to "SpongePowered"
     )
+    // These two are included by most CI's
+    System.getenv()["GIT_COMMIT"]?.apply { attributes("Git-Commit" to this) }
+    System.getenv()["GIT_BRANCH"]?.apply { attributes("Git-Branch" to this) }
 }
 
 val mixinConfigs = spongeImpl.mixinConfigurations

--- a/vanilla/build.gradle.kts
+++ b/vanilla/build.gradle.kts
@@ -316,6 +316,9 @@ val vanillaManifest = the<JavaPluginConvention>().manifest {
             "Implementation-Version" to spongeImpl.generatePlatformBuildVersionString(apiVersion, minecraftVersion, recommendedVersion),
             "Implementation-Vendor" to "SpongePowered"
     )
+    // These two are included by most CI's
+    System.getenv()["GIT_COMMIT"]?.apply { attributes("Git-Commit" to this) }
+    System.getenv()["GIT_BRANCH"]?.apply { attributes("Git-Branch" to this) }
 }
 
 tasks {


### PR DESCRIPTION
Tagging for clarity whether this is the right move. Need to get the git information sooner than later so that we can properly generate changelings for the versions beyond the most current ones.