### PR TITLE
Fix permission checking during ServerSideConnectionEvent.Login

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/service/permission/SubjectMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/service/permission/SubjectMixin.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.mixin.core.service.permission;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.service.permission.SubjectReference;
+import org.spongepowered.api.util.Tristate;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.common.bridge.permissions.SubjectBridge;
 import org.spongepowered.common.entity.player.SpongeUserData;
@@ -44,7 +45,7 @@ import net.minecraft.world.level.block.entity.CommandBlockEntity;
  * Mixin to provide a common implementation of subject that refers to the
  * installed permissions service for a subject.
  */
-@Mixin(value = {ServerPlayer.class, CommandBlockEntity.class, MinecartCommandBlock.class, RconConsoleSource.class, SpongeUserView.class, SpongeUserData.class})
+@Mixin(value = {ServerPlayer.class, CommandBlockEntity.class, MinecartCommandBlock.class, RconConsoleSource.class, SpongeUserView.class, SpongeUserData.class}, priority = 1001)
 public abstract class SubjectMixin implements SubjectBridge {
 
     @Nullable
@@ -72,5 +73,10 @@ public abstract class SubjectMixin implements SubjectBridge {
     public Subject bridge$resolve() {
         return this.bridge$resolveOptional()
             .orElseThrow(() -> new IllegalStateException("No subject reference present for user " + this));
+    }
+
+    @Override
+    public Tristate bridge$permDefault(final String permission) {
+        return Tristate.FALSE;
     }
 }


### PR DESCRIPTION
Fixes #3558.

### Explanation
[SubjectMixin](https://github.com/SpongePowered/Sponge/blob/5d0c1eeb169af323c55c3b88f924b58f13d899fe/src/mixins/java/org/spongepowered/common/mixin/core/service/permission/SubjectMixin.java) provides common implementations of [SubjectBridge](https://github.com/SpongePowered/Sponge/blob/5d0c1eeb169af323c55c3b88f924b58f13d899fe/src/main/java/org/spongepowered/common/bridge/permissions/SubjectBridge.java), but excludes `bridge$permDefault`, and leaves it to be implemented by the other mixins (such as in [ServerPlayerMixin](https://github.com/SpongePowered/Sponge/blob/5d0c1eeb169af323c55c3b88f924b58f13d899fe/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java#L204-L207)).

During [ServerSideConnectionEvent.Login](https://github.com/SpongePowered/SpongeAPI/blob/8727c7aa94d78a480778766c174fe0ad6e7104d4/src/main/java/org/spongepowered/api/event/network/ServerSideConnectionEvent.java#L139), `event.user()` provides a [SpongeUserView](https://github.com/SpongePowered/Sponge/blob/5d0c1eeb169af323c55c3b88f924b58f13d899fe/src/main/java/org/spongepowered/common/entity/player/SpongeUserView.java), which doesn't currently implement `bridge$permDefault` at runtime. I believe this PR should fix this in the simplest way by providing a common implementation, that other mixins such as ServerPlayerMixin are able to override.