### PR TITLE
Post ChangeDataHolderEvent.ValueChange for GameMode changes

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/LivingEntityMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/LivingEntityMixin.java
@@ -168,6 +168,7 @@ public abstract class LivingEntityMixin extends EntityMixin implements LivingEnt
     @Shadow public abstract float shadow$getMaxHealth();
     @Shadow public abstract AttributeMap shadow$getAttributes();
     @Shadow public abstract void shadow$clearSleepingPos();
+    @Shadow protected abstract void shadow$updateEffectVisibility();
     // @formatter:on
 
     @Nullable private ItemStack impl$activeItemStackCopy;


### PR DESCRIPTION
This may be possible without an `Overwrite`, but as far as I'm aware currently it would require more than 1 injection, and having to track state across injections can get hairy.