### PR TITLE
 Fix SpawnEntityEvent

### DIFF
--- a/src/main/java/org/spongepowered/common/entity/EntityUtil.java
+++ b/src/main/java/org/spongepowered/common/entity/EntityUtil.java
@@ -24,6 +24,22 @@
  */
 package org.spongepowered.common.entity;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.protocol.game.ClientboundChangeDifficultyPacket;
+import net.minecraft.network.protocol.game.ClientboundLevelEventPacket;
+import net.minecraft.network.protocol.game.ClientboundPlayerAbilitiesPacket;
+import net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.PlayerList;
+import net.minecraft.util.Mth;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.biome.BiomeManager;
+import net.minecraft.world.level.storage.LevelData;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.event.SpongeEventFactory;
@@ -42,28 +58,10 @@ import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.hooks.PlatformHooks;
 import org.spongepowered.math.vector.Vector3d;
 
-import net.minecraft.core.BlockPos;
-import net.minecraft.network.protocol.game.ClientboundChangeDifficultyPacket;
-import net.minecraft.network.protocol.game.ClientboundLevelEventPacket;
-import net.minecraft.network.protocol.game.ClientboundPlayerAbilitiesPacket;
-import net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.server.players.PlayerList;
-import net.minecraft.util.Mth;
-import net.minecraft.world.effect.MobEffectInstance;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.biome.BiomeManager;
-import net.minecraft.world.level.storage.LevelData;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
@@ -88,6 +86,18 @@ public final class EntityUtil {
             .findFirst();
 
     private EntityUtil() {
+    }
+
+    public static void despawnFilteredEntities(final Iterable<? extends Entity> originalEntities, final SpawnEntityEvent event) {
+        if (event.isCancelled()) {
+            for (Entity e : originalEntities)
+                ((ServerLevel) e.level).despawn(e);
+        } else {
+            for (Entity e : originalEntities) {
+                if (!event.entities().contains(e))
+                    ((ServerLevel) e.level).despawn(e);
+            }
+        }
     }
 
     public static void performPostChangePlayerWorldLogic(final ServerPlayer player, final ServerLevel fromWorld,

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/ClickCreativeMenuTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/ClickCreativeMenuTransaction.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.event.tracking.context.transaction.inventory;
 
-import com.google.common.collect.ImmutableList;
 import net.minecraft.network.protocol.game.ServerboundContainerClickPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
@@ -66,7 +65,7 @@ public class ClickCreativeMenuTransaction extends ContainerBasedTransaction {
 
     @Override
     Optional<ClickContainerEvent> createInventoryEvent(
-        final List<SlotTransaction> slotTransactions, final ImmutableList<Entity> entities,
+        final List<SlotTransaction> slotTransactions, final List<Entity> entities,
         final PhaseContext<@NonNull ?> context,
         final Cause cause
     ) {

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/ClickCreativeMenuTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/ClickCreativeMenuTransaction.java
@@ -32,7 +32,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.Cause;
+import org.spongepowered.api.event.EventContext;
+import org.spongepowered.api.event.EventContextKeys;
 import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.cause.entity.SpawnTypes;
 import org.spongepowered.api.event.item.inventory.container.ClickContainerEvent;
 import org.spongepowered.api.item.inventory.Container;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
@@ -81,7 +84,14 @@ public class ClickCreativeMenuTransaction extends ContainerBasedTransaction {
             return Optional.of(SpongeEventFactory.createClickContainerEventCreativeSet(cause, (Container) this.menu,
                         cursorTransaction, Optional.ofNullable(this.slot), slotTransactions));
         }
-        return Optional.of(SpongeEventFactory.createClickContainerEventCreativeDrop(cause, (Container) this.menu,
+
+        final Cause causeWithSpawnType = Cause.builder().from(cause).build(
+                EventContext.builder().from(cause.context()).add(
+                        EventContextKeys.SPAWN_TYPE,
+                        SpawnTypes.DROPPED_ITEM.get()
+                ).build());
+
+        return Optional.of(SpongeEventFactory.createClickContainerEventCreativeDrop(causeWithSpawnType, (Container) this.menu,
                 cursorTransaction, this.creativeStack, entities, Optional.ofNullable(this.slot), slotTransactions));
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/ClickMenuTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/ClickMenuTransaction.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.event.tracking.context.transaction.inventory;
 
-import com.google.common.collect.ImmutableList;
 import net.minecraft.network.protocol.game.ServerboundContainerClickPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
@@ -73,7 +72,7 @@ public class ClickMenuTransaction extends ContainerBasedTransaction {
 
     @Override
     Optional<ClickContainerEvent> createInventoryEvent(
-        final List<SlotTransaction> slotTransactions, final ImmutableList<Entity> entities,
+        final List<SlotTransaction> slotTransactions, final List<Entity> entities,
         final PhaseContext<@NonNull ?> context,
         final Cause cause
     ) {

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/ContainerBasedTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/ContainerBasedTransaction.java
@@ -27,7 +27,6 @@ package org.spongepowered.common.event.tracking.context.transaction.inventory;
 import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -53,6 +52,7 @@ import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
 import org.spongepowered.api.item.recipe.crafting.CraftingRecipe;
 import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.bridge.world.inventory.container.TrackedContainerBridge;
+import org.spongepowered.common.entity.EntityUtil;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.context.transaction.GameTransaction;
@@ -127,10 +127,10 @@ abstract class ContainerBasedTransaction extends MenuBasedTransaction<ClickConta
             //        }
         }
 
-        final ImmutableList<Entity> entities = containerBasedTransactions.stream()
+        final List<Entity> entities = containerBasedTransactions.stream()
             .map(ContainerBasedTransaction::getEntitiesSpawned)
             .flatMap(List::stream)
-            .collect(ImmutableList.toImmutableList());
+            .collect(Collectors.toList());
 
         final List<SlotTransaction> slotTransactions = containerBasedTransactions
             .stream()
@@ -198,7 +198,7 @@ abstract class ContainerBasedTransaction extends MenuBasedTransaction<ClickConta
 
     Optional<ClickContainerEvent> createInventoryEvent(
         final List<SlotTransaction> slotTransactions,
-        final ImmutableList<Entity> entities,
+        final List<Entity> entities,
         final PhaseContext<@NonNull ?> context,
         final Cause currentCause
     ) {
@@ -246,9 +246,9 @@ abstract class ContainerBasedTransaction extends MenuBasedTransaction<ClickConta
     protected void handleEventResults(final Player player, final ClickContainerEvent event) {
         PacketPhaseUtil.handleSlotRestore(player, this.menu, event.transactions(), event.isCancelled());
         PacketPhaseUtil.handleCursorRestore(player, event.cursorTransaction());
-        if (event.isCancelled() && event instanceof SpawnEntityEvent) {
-            ((SpawnEntityEvent) event).entities().forEach(e ->
-                    ((ServerLevel) e.world()).despawn((net.minecraft.world.entity.Entity) e));
+
+        if (this.entities != null && event instanceof SpawnEntityEvent) {
+            EntityUtil.despawnFilteredEntities(this.entities, (SpawnEntityEvent) event);
         }
 
         // If this is not a crafting event try to call crafting events

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/CraftingPreviewTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/CraftingPreviewTransaction.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.event.tracking.context.transaction.inventory;
 
-import com.google.common.collect.ImmutableList;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.CraftingContainer;
@@ -68,7 +67,7 @@ public class CraftingPreviewTransaction extends ContainerBasedTransaction {
     }
 
     @Override
-    Optional<ClickContainerEvent> createInventoryEvent(final List<SlotTransaction> slotTransactions, final ImmutableList<Entity> entities,
+    Optional<ClickContainerEvent> createInventoryEvent(final List<SlotTransaction> slotTransactions, final List<Entity> entities,
             final PhaseContext<@NonNull ?> context, final Cause currentCause) {
         if (slotTransactions.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/DropFromPlayerInventoryTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/DropFromPlayerInventoryTransaction.java
@@ -29,7 +29,10 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.Cause;
+import org.spongepowered.api.event.EventContext;
+import org.spongepowered.api.event.EventContextKeys;
 import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.cause.entity.SpawnTypes;
 import org.spongepowered.api.event.item.inventory.ChangeInventoryEvent;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.Slot;
@@ -60,10 +63,19 @@ public class DropFromPlayerInventoryTransaction extends InventoryBasedTransactio
             final List<Entity> entities, final PhaseContext<@NonNull ?> context,
             final Cause currentCause) {
         TrackingUtil.setCreatorReference(entities, this.player);
+
+        final Cause causeWithSpawnType = Cause.builder().from(currentCause).build(
+                EventContext.builder().from(currentCause.context()).add(
+                        EventContextKeys.SPAWN_TYPE,
+                        SpawnTypes.DROPPED_ITEM.get()
+                ).build());
+
         if (this.dropAll) {
-            return Optional.of(SpongeEventFactory.createChangeInventoryEventDropFull(currentCause, entities, this.inventory, this.slot, slotTransactions));
+            return Optional.of(SpongeEventFactory.createChangeInventoryEventDropFull(causeWithSpawnType,
+                    entities, this.inventory, this.slot, slotTransactions));
         }
-        return Optional.of(SpongeEventFactory.createChangeInventoryEventDropSingle(currentCause, entities, this.inventory, this.slot, slotTransactions));
+        return Optional.of(SpongeEventFactory.createChangeInventoryEventDropSingle(causeWithSpawnType,
+                entities, this.inventory, this.slot, slotTransactions));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/InventoryBasedTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/InventoryBasedTransaction.java
@@ -25,7 +25,6 @@
 package org.spongepowered.common.event.tracking.context.transaction.inventory;
 
 import com.google.common.collect.ImmutableList;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -39,6 +38,7 @@ import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.Slot;
 import org.spongepowered.api.item.inventory.transaction.SlotTransaction;
+import org.spongepowered.common.entity.EntityUtil;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.context.transaction.GameTransaction;
 import org.spongepowered.common.event.tracking.context.transaction.type.TransactionTypes;
@@ -96,10 +96,10 @@ abstract class InventoryBasedTransaction extends GameTransaction<ChangeInventory
             transaction.used = true;
         }
 
-        final ImmutableList<Entity> entities = containerBasedTransactions.stream()
+        final List<Entity> entities = containerBasedTransactions.stream()
                 .map(InventoryBasedTransaction::getEntitiesSpawned)
                 .flatMap(List::stream)
-                .collect(ImmutableList.toImmutableList());
+                .collect(Collectors.toList());
 
         // TODO on pickup grouping does not work?
         final Map<Slot, List<SlotTransaction>> collected = slotTransactions.stream().collect(Collectors.groupingBy(SlotTransaction::slot));
@@ -148,9 +148,9 @@ abstract class InventoryBasedTransaction extends GameTransaction<ChangeInventory
 
     protected void handleEventResults(final Player player, final ChangeInventoryEvent event) {
         PacketPhaseUtil.handleSlotRestore(player, null, event.transactions(), event.isCancelled());
-        if (event.isCancelled() && event instanceof SpawnEntityEvent) {
-            ((SpawnEntityEvent) event).entities().forEach(e ->
-                    ((ServerLevel) e.world()).despawn((net.minecraft.world.entity.Entity) e));
+
+        if (this.entities != null && event instanceof SpawnEntityEvent) {
+            EntityUtil.despawnFilteredEntities(this.entities, (SpawnEntityEvent) event);
         }
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/PlaceRecipeTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/PlaceRecipeTransaction.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.event.tracking.context.transaction.inventory;
 
-import com.google.common.collect.ImmutableList;
 import net.minecraft.network.protocol.game.ServerboundPlaceRecipePacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.crafting.Recipe;
@@ -66,7 +65,7 @@ public class PlaceRecipeTransaction extends ContainerBasedTransaction {
 
     @Override
     Optional<ClickContainerEvent> createInventoryEvent(
-        final List<SlotTransaction> slotTransactions, final ImmutableList<Entity> entities,
+        final List<SlotTransaction> slotTransactions, final List<Entity> entities,
         final PhaseContext<@NonNull ?> context,
         final Cause cause
     ) {

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/SelectTradeTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/SelectTradeTransaction.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.event.tracking.context.transaction.inventory;
 
-import com.google.common.collect.ImmutableList;
 import net.minecraft.network.protocol.game.ServerboundPlaceRecipePacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.inventory.MerchantMenu;
@@ -60,7 +59,7 @@ public class SelectTradeTransaction extends ContainerBasedTransaction {
 
     @Override
     Optional<ClickContainerEvent> createInventoryEvent(
-        final List<SlotTransaction> slotTransactions, final ImmutableList<Entity> entities,
+        final List<SlotTransaction> slotTransactions, final List<Entity> entities,
         final PhaseContext<@NonNull ?> context,
         final Cause cause
     ) {

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/world/SpawnEntityTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/world/SpawnEntityTransaction.java
@@ -158,9 +158,17 @@ public final class SpawnEntityTransaction extends WorldBasedTransaction<SpawnEnt
 
     @Override
     public boolean markCancelledTransactions(final SpawnEntityEvent event,
-        final ImmutableList<? extends GameTransaction<SpawnEntityEvent>> gameTransactions
-    ) {
-        return false;
+        final ImmutableList<? extends GameTransaction<SpawnEntityEvent>> gameTransactions) {
+        boolean cancelledAny = false;
+
+        for (final GameTransaction<SpawnEntityEvent> gameTransaction : gameTransactions) {
+            if (!event.entities().contains(((SpawnEntityTransaction) gameTransaction).entityToSpawn)) {
+                gameTransaction.markCancelled();
+                cancelledAny = true;
+            }
+        }
+
+        return cancelledAny;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/DropInventoryState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/DropInventoryState.java
@@ -40,6 +40,7 @@ import org.spongepowered.common.event.tracking.context.transaction.world.SpawnEn
 import org.spongepowered.common.item.util.ItemStackUtil;
 
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 public final class DropInventoryState extends BasicInventoryPacketState {
 
@@ -62,7 +63,7 @@ public final class DropInventoryState extends BasicInventoryPacketState {
     ) {
         return SpongeEventFactory.createDropItemEventDispense(currentCause, collect.stream()
             .map(Tuple::first).map(entity -> (Entity) entity)
-            .collect(ImmutableList.toImmutableList())
+            .collect(Collectors.toList())
         );
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/DropItemInsideWindowState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/DropItemInsideWindowState.java
@@ -28,7 +28,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.Cause;
+import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.api.event.EventContextKeys;
 import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.cause.entity.SpawnTypes;
 import org.spongepowered.api.event.item.inventory.container.ClickContainerEvent;
 import org.spongepowered.api.item.inventory.Container;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
@@ -39,11 +42,19 @@ import org.spongepowered.common.util.Constants;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 public final class DropItemInsideWindowState extends BasicInventoryPacketState {
 
     public DropItemInsideWindowState() {
         super(Constants.Networking.MODE_DROP | Constants.Networking.BUTTON_PRIMARY | Constants.Networking.BUTTON_SECONDARY | Constants.Networking.CLICK_INSIDE_WINDOW);
+    }
+
+    @Override
+    public BiConsumer<CauseStackManager.StackFrame, InventoryPacketContext> getFrameModifier() {
+        return super.getFrameModifier().andThen((frame, context) -> {
+            frame.addContext(EventContextKeys.SPAWN_TYPE, SpawnTypes.DROPPED_ITEM);
+        });
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/DropItemOutsideWindowState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/inventory/DropItemOutsideWindowState.java
@@ -29,7 +29,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.data.Transaction;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.event.Cause;
+import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.api.event.EventContextKeys;
 import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.cause.entity.SpawnTypes;
 import org.spongepowered.api.event.item.inventory.container.ClickContainerEvent;
 import org.spongepowered.api.item.inventory.Container;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
@@ -40,11 +43,20 @@ import org.spongepowered.common.util.Constants;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 public final class DropItemOutsideWindowState extends BasicInventoryPacketState {
 
     public DropItemOutsideWindowState(final int stateid) {
         super(stateid);
+    }
+
+
+    @Override
+    public BiConsumer<CauseStackManager.StackFrame, InventoryPacketContext> getFrameModifier() {
+        return super.getFrameModifier().andThen((frame, context) -> {
+            frame.addContext(EventContextKeys.SPAWN_TYPE, SpawnTypes.DROPPED_ITEM);
+        });
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/server/level/ServerLevelMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/server/level/ServerLevelMixin_Tracker.java
@@ -126,7 +126,7 @@ import org.spongepowered.common.world.SpongeBlockChangeFlag;
 import org.spongepowered.common.world.server.SpongeLocatableBlockBuilder;
 import org.spongepowered.common.world.volume.VolumeStreamUtils;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -819,20 +819,18 @@ public abstract class ServerLevelMixin_Tracker extends LevelMixin_Tracker implem
         }
 
         final Cause currentCause = tracker.currentCause();
+        final List<org.spongepowered.api.entity.Entity> entities = new ArrayList<>();
+        entities.add((org.spongepowered.api.entity.Entity) entityIn);
 
-        final SpawnEntityEvent.Pre pre = SpongeEventFactory.createSpawnEntityEventPre(
-            currentCause,
-            Collections.singletonList((org.spongepowered.api.entity.Entity) entityIn)
-        );
+        final SpawnEntityEvent.Pre pre = SpongeEventFactory.createSpawnEntityEventPre(currentCause, entities);
         Sponge.eventManager().post(pre);
-        if (pre.isCancelled()) {
+
+        if (pre.isCancelled() || entities.isEmpty()) {
             cir.setReturnValue(false);
         }
-
 
         if (current.allowsBulkEntityCaptures()) {
             current.getTransactor().logEntitySpawn(current, this, entityIn);
         }
-
     }
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/server/level/ServerLevelMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/server/level/ServerLevelMixin_Tracker.java
@@ -827,6 +827,7 @@ public abstract class ServerLevelMixin_Tracker extends LevelMixin_Tracker implem
 
         if (pre.isCancelled() || entities.isEmpty()) {
             cir.setReturnValue(false);
+            return;
         }
 
         if (current.allowsBulkEntityCaptures()) {

--- a/testplugins/src/main/java/org/spongepowered/test/entity/EntityTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/entity/EntityTest.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test.entity;
+
+import com.google.inject.Inject;
+import io.leangen.geantyref.TypeToken;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.spongepowered.api.command.Command;
+import org.spongepowered.api.command.Command.Parameterized;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.parameter.Parameter;
+import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.entity.SpawnEntityEvent;
+import org.spongepowered.api.event.lifecycle.RegisterCommandEvent;
+import org.spongepowered.api.registry.RegistryTypes;
+import org.spongepowered.plugin.PluginContainer;
+import org.spongepowered.plugin.builtin.jvm.Plugin;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Plugin("entitytest")
+public class EntityTest {
+
+    private final PluginContainer plugin;
+    private final Set<EntityType<@NonNull ?>> blockedSpawn = new HashSet<>();
+
+    @Inject
+    public EntityTest(final PluginContainer plugin) {
+        this.plugin = plugin;
+    }
+
+    @Listener
+    public void onRegisterCommand(final RegisterCommandEvent<Parameterized> event) {
+        final Parameter.Value<EntityType<@NonNull ?>> entityTypeParam =
+                Parameter.registryElement(new TypeToken<EntityType<@NonNull ?>>() {}, RegistryTypes.ENTITY_TYPE, "minecraft").key("entityType").build();
+        event.register(this.plugin, Command.builder()
+                .addChild(Command.builder()
+                        .addParameter(entityTypeParam)
+                        .executor(ctx -> {
+                            EntityType<@NonNull ?> type = ctx.requireOne(entityTypeParam);
+                            blockedSpawn.remove(type);
+                            ctx.sendMessage(Identity.nil(), Component.text("Entity type ").append(type).append(Component.text(" spawn is no longer blocked.")));
+                            return CommandResult.success();
+                        }).build(), "allow")
+                .addChild(Command.builder()
+                        .addParameter(entityTypeParam)
+                        .executor(ctx -> {
+                            EntityType<@NonNull ?> type = ctx.requireOne(entityTypeParam);
+                            blockedSpawn.add(type);
+                            ctx.sendMessage(Identity.nil(), Component.text("Entity type ").append(type).append(Component.text(" spawn is now blocked.")));
+                            return CommandResult.success();
+                        }).build(), "deny")
+                .addChild(Command.builder()
+                        .executor(ctx -> {
+                            ctx.sendMessage(Identity.nil(), Component.join(JoinConfiguration.builder()
+                                    .prefix(Component.text("Blocked entity types: ["))
+                                    .separator(Component.text(", "))
+                                    .suffix(Component.text("]."))
+                                    .build(), this.blockedSpawn));
+                            return CommandResult.success();
+                        }).build(), "list")
+                .build(), "spawnFilter");
+    }
+
+    @Listener
+    public void onSpawnEntity(final SpawnEntityEvent event) {
+        event.filterEntities(entity -> !this.blockedSpawn.contains(entity.type()));
+    }
+}

--- a/testplugins/src/main/resources/META-INF/sponge_plugins.json
+++ b/testplugins/src/main/resources/META-INF/sponge_plugins.json
@@ -80,6 +80,12 @@
             "description": "Testing data"
         },
         {
+            "id": "entitytest",
+            "name": "Entity Test",
+            "entrypoint": "org.spongepowered.test.entity.EntityTest",
+            "description": "Testing entities"
+        },
+        {
             "id": "humantest",
             "name": "Human Test",
             "entrypoint": "org.spongepowered.test.human.HumanTest",


### PR DESCRIPTION
API PR : [SpongeAPI#2401](https://github.com/SpongePowered/SpongeAPI/pull/2401)

Fixes:
- #3506.
- Some events were missing a `EventContextKeys.SPAWN_TYPE`.
- `SpawnEntityEvent` was fired after `SpawnEntityEvent.Pre` even after being cancelled.