### PR TITLE
Fix setting passengers performs mount logic

### DIFF
--- a/src/accessors/java/org/spongepowered/common/accessor/world/entity/EntityAccessor.java
+++ b/src/accessors/java/org/spongepowered/common/accessor/world/entity/EntityAccessor.java
@@ -91,8 +91,6 @@ public interface EntityAccessor {
 
     @Accessor("portalEntrancePos") void accessor$portalEntrancePos(final BlockPos portalEntrancePos);
 
-    @Accessor("passengers") List<Entity> accessor$passengers();
-
     @Invoker("setRot") void invoker$setRot(final float yRot, final float xRot);
 
     @Invoker("getEncodeId") @Nullable String invoker$getEncodeId();

--- a/src/main/java/org/spongepowered/common/data/provider/entity/EntityData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/EntityData.java
@@ -169,8 +169,8 @@ public final class EntityData {
                     .create(Keys.PASSENGERS)
                         .get(h -> h.getPassengers().stream().map(org.spongepowered.api.entity.Entity.class::cast).collect(Collectors.toList()))
                         .set((h, v) -> {
-                            ((EntityAccessor) h).accessor$passengers().clear();
-                            v.forEach(v1 -> ((EntityAccessor) h).accessor$passengers().add((Entity) v1));
+                            h.ejectPassengers();
+                            v.forEach(v1 -> ((Entity) v1).startRiding(h, true));
                         })
                     .create(Keys.REMAINING_AIR)
                         .get(h -> Math.max(0, h.getAirSupply()))


### PR DESCRIPTION
Modifying the underlying list is not enought and causes state updates to be missed.

The passengers vehicle field was not updated accordingly and they did not perform unmount logic if they were already riding another enity.

Fixes #3492
Fixes #3493