### PR TITLE
Integrate LazyDFU into Sponge proper

### DIFF
--- a/src/applaunch/java/org/spongepowered/common/applaunch/config/common/OptimizationCategory.java
+++ b/src/applaunch/java/org/spongepowered/common/applaunch/config/common/OptimizationCategory.java
@@ -113,6 +113,18 @@ public final class OptimizationCategory {
         "are `persistent`. Does not drastically improve performance.")
     public boolean disableScheduledUpdatesForPersistentLeafBlocks = true;
 
+    @Setting("enable-lazydfu")
+    @Comment("By default, Vanilla 'warms-up' all migration rules for\n"
+            + "every Minecraft version when the game starts. This often\n"
+            + "causes a period of extremely high CPU usage when the game\n"
+            + "starts, often for no benefit since the typical pattern is\n"
+            + "that most chunks do not have to be migrated, or only have\n"
+            + "to be migrated from just a few versions. This option disables\n"
+            + "migration rules from being 'warmed-up' and instead forces them\n"
+            + "to be generated on demand. This is a very safe optimization and\n"
+            + "should usually remain enabled.")
+    public boolean enableLazyDFU = true;
+
     public OptimizationCategory() {
         // Enabled by default on SpongeVanilla, disabled by default on SpongeForge.
         // Because of how early this constructor gets called, we can't use SpongeImplHooks or even Game

--- a/src/main/java/org/spongepowered/common/util/LazyDataFixerBuilder.java
+++ b/src/main/java/org/spongepowered/common/util/LazyDataFixerBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.util;
+
+import com.mojang.datafixers.DataFixer;
+import com.mojang.datafixers.DataFixerBuilder;
+import java.util.concurrent.Executor;
+
+/**
+ * This version of {@code DataFixerBuilder} does not immediately initialize rules.
+ */
+public class LazyDataFixerBuilder extends DataFixerBuilder {
+
+    private static final Executor NO_OP_EXECUTOR = command -> {};
+
+    public LazyDataFixerBuilder(int dataVersion) {
+        super(dataVersion);
+    }
+
+    @Override
+    public DataFixer build(Executor executor) {
+        return super.build(NO_OP_EXECUTOR);
+    }
+}

--- a/src/mixins/java/org/spongepowered/common/mixin/optimization/general/DataFixersMixin_Optimization_LazyDFU.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/optimization/general/DataFixersMixin_Optimization_LazyDFU.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.optimization.general;
+
+import com.mojang.datafixers.DataFixerBuilder;
+import net.minecraft.util.datafix.DataFixers;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.util.LazyDataFixerBuilder;
+
+@Mixin(DataFixers.class)
+public abstract class DataFixersMixin_Optimization_LazyDFU {
+
+    // Replaces Mojang's default DataFixerBuilder with a version that doesn't prebake all version rules at server
+    // startup.
+    @Redirect(method = "createFixerUpper", at = @At(value = "NEW", target = "com/mojang/datafixers/DataFixerBuilder"))
+    private static DataFixerBuilder createFixerUpper$replaceBuilder(int dataVersion) {
+        return new LazyDataFixerBuilder(dataVersion);
+    }
+}

--- a/src/mixins/java/org/spongepowered/common/mixin/plugin/OptimizationPlugin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/plugin/OptimizationPlugin.java
@@ -53,6 +53,7 @@ public class OptimizationPlugin extends AbstractMixinConfigPlugin {
 
     // So that any additional optimizations can be added in succession.
     private static final Map<String, Function<OptimizationCategory, Boolean>> mixinEnabledMappings = ImmutableMap.<String, Function<OptimizationCategory, Boolean>> builder()
+            .put("org.spongepowered.common.mixin.optimization.general.DataFixersMixin_Optimization_LazyDFU", optimizationCategory -> optimizationCategory.enableLazyDFU)
             .put("org.spongepowered.common.mixin.optimization.entity.EntityMixin_Optimization_Collision", optimizationCategory -> optimizationCategory.useActiveChunksForCollisions)
             .put("org.spongepowered.common.mixin.optimization.world.entity.TamableAnimalMixin_Optimization_Owner", optimizationCategory -> optimizationCategory.cacheTameableOwners)
 // TODO investigate what is still relevant and add them back

--- a/src/mixins/resources/mixins.sponge.optimization.json
+++ b/src/mixins/resources/mixins.sponge.optimization.json
@@ -3,6 +3,7 @@
     "package": "org.spongepowered.common.mixin.optimization",
     "plugin": "org.spongepowered.common.mixin.plugin.OptimizationPlugin",
     "mixins": [
+        "general.DataFixersMixin_Optimization_LazyDFU",
         "entity.EntityMixin_Optimization_Collision",
         "world.entity.TamableAnimalMixin_Optimization_Owner"
     ]


### PR DESCRIPTION
This PR integrates the [LazyDFU](https://github.com/astei/lazydfu) mod into Sponge. This optimization was present in Paper itself from 1.13 until the Tuinity patches were merged in, and I made it into standalone mod for Fabric. Now it's well past time Sponge gets the benefits!

@Zidane wanted to ask me if they could integrate this mod, and I figured that I would not only say yes but also do the work myself too.