### PR TITLE
Fix invocation of some client-only methods

### DIFF
--- a/src/accessors/java/org/spongepowered/common/accessor/server/packs/resources/ResourceAccessor.java
+++ b/src/accessors/java/org/spongepowered/common/accessor/server/packs/resources/ResourceAccessor.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.accessor.server.packs.resources;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.SimpleResource;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(SimpleResource.class)
+public interface ResourceAccessor {
+
+    @Accessor("location") ResourceLocation accessor$location();
+}

--- a/src/accessors/resources/mixins.sponge.accessors.json
+++ b/src/accessors/resources/mixins.sponge.accessors.json
@@ -50,6 +50,7 @@
         "server.level.TicketAccessor",
         "server.level.TicketTypeAccessor",
         "server.network.ServerLoginPacketListenerImplAccessor",
+        "server.packs.resources.ResourceAccessor",
         "server.players.GameProfileCache_GameProfileInfoAccessor",
         "server.players.IpBanListAccessor",
         "server.players.PlayerListAccessor",

--- a/src/main/java/org/spongepowered/common/resource/SpongeResource.java
+++ b/src/main/java/org/spongepowered/common/resource/SpongeResource.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.resource;
 import net.minecraft.server.packs.resources.Resource;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.resource.ResourcePath;
+import org.spongepowered.common.accessor.server.packs.resources.ResourceAccessor;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,7 +38,7 @@ public final class SpongeResource implements org.spongepowered.api.resource.Reso
     private InputStream stream;
 
     public SpongeResource(final Resource resource) {
-        this.path = new SpongeResourcePath((ResourceKey) (Object) resource.getLocation());
+        this.path = new SpongeResourcePath((ResourceKey) (Object) ((ResourceAccessor) resource).accessor$location());
         this.stream = resource.getInputStream();
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/players/PlayerListMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/players/PlayerListMixin.java
@@ -84,6 +84,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.SpongeServer;
+import org.spongepowered.common.accessor.network.protocol.game.ClientboundPlayerInfoPacketAccessor;
 import org.spongepowered.common.accessor.network.protocol.game.ClientboundRespawnPacketAccessor;
 import org.spongepowered.common.adventure.SpongeAdventure;
 import org.spongepowered.common.bridge.client.server.IntegratedPlayerListBridge;
@@ -436,10 +437,10 @@ public abstract class PlayerListMixin implements PlayerListBridge {
         )
     )
     private void impl$onlySendAddPlayerForUnvanishedPlayers(ServerGamePacketListenerImpl connection, Packet<?> packet) {
-        ClientboundPlayerInfoPacket pkt = (ClientboundPlayerInfoPacket) packet;
+        ClientboundPlayerInfoPacketAccessor playerInfoPacketAccessor = (ClientboundPlayerInfoPacketAccessor) packet;
 
         // size is always 1
-        VanishableBridge p = (VanishableBridge) this.playersByUUID.get(pkt.getEntries().get(0).getProfile().getId());
+        VanishableBridge p = (VanishableBridge) this.playersByUUID.get(playerInfoPacketAccessor.accessor$entries().get(0).getProfile().getId());
 
         // Effectively, don't notify new players of vanished players
         if (p.bridge$isVanished()) {


### PR DESCRIPTION
Fixed erroneous invocation of some client-only methods and switched to use accessors:

- `Resource#getLocation()`
- `ClientboundPlayerInfoPacket#entries()`