### PR TITLE
Add another exploit patch for bad window clicks

### DIFF
--- a/src/main/java/org/spongepowered/common/config/category/ExploitCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/ExploitCategory.java
@@ -92,7 +92,7 @@ public class ExploitCategory extends ConfigCategory {
     private boolean checkUnknownSlotDuringWindowClicks = false;
 
     @Setting(value = "check-slot-ids-during-window-clicks",
-            comment = "If enabled, window click with slot ids that are higher then the inventory size will be canceled.")
+            comment = "If enabled, window clicks with slot ids that are higher then the inventory size will be canceled.")
     private boolean checkSlotID = false;
 
     @Setting(value = "check-slot-size-during-window-clicks",

--- a/src/main/java/org/spongepowered/common/config/category/ExploitCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/ExploitCategory.java
@@ -91,6 +91,10 @@ public class ExploitCategory extends ConfigCategory {
         comment = "If enabled, unknown slot clicks will trigger a log warning and disconnect of the offending player")
     private boolean checkUnknownSlotDuringWindowClicks = false;
 
+    @Setting(value = "check-slot-ids-during-window-clicks",
+            comment = "If enabled, window click with slot ids that are higher then the inventory size will be canceled.")
+    private boolean checkSlotID = false;
+
     @Setting(value = "check-slot-size-during-window-clicks",
         comment = "If enabled, slot clicks that have ItemStacks larger than a certain size will trigger a log warning and disconnect of the "
             + "offending player")
@@ -157,6 +161,10 @@ public class ExploitCategory extends ConfigCategory {
 
     public boolean checkUnknownSlotDuringWindowClicks() {
         return this.checkUnknownSlotDuringWindowClicks;
+    }
+
+    public boolean checkSlotID() {
+        return this.checkSlotID;
     }
 
     public boolean checkSlotSizeDuringWindowClicks() {

--- a/src/main/java/org/spongepowered/common/config/category/ExploitCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/ExploitCategory.java
@@ -92,7 +92,7 @@ public class ExploitCategory extends ConfigCategory {
     private boolean checkUnknownSlotDuringWindowClicks = false;
 
     @Setting(value = "check-slot-ids-during-window-clicks",
-            comment = "If enabled, window clicks with slot ids that are higher then the inventory size will be canceled.")
+            comment = "If enabled, window clicks with slot ids that are higher than the inventory size will will trigger a log warning and disconnect of the offending player.")
     private boolean checkSlotID = false;
 
     @Setting(value = "check-slot-size-during-window-clicks",

--- a/src/main/java/org/spongepowered/common/config/category/ExploitCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/ExploitCategory.java
@@ -87,10 +87,6 @@ public class ExploitCategory extends ConfigCategory {
             comment = "If 'limit-book-size' is enabled, controls the multiplier applied to each book page size")
     private double bookSizeTotalMultiplier = 0.98;
 
-    @Setting(value = "check-unknown-slots-during-window-clicks",
-        comment = "If enabled, unknown slot clicks will trigger a log warning and disconnect of the offending player")
-    private boolean checkUnknownSlotDuringWindowClicks = false;
-
     @Setting(value = "check-slot-ids-during-window-clicks",
             comment = "If enabled, window clicks with slot ids that are higher than the inventory size will will trigger a log warning and disconnect of the offending player.")
     private boolean checkSlotIDDuringWindowClicks = false;
@@ -159,10 +155,6 @@ public class ExploitCategory extends ConfigCategory {
         return this.bookSizeTotalMultiplier;
     }
 
-    public boolean checkUnknownSlotDuringWindowClicks() {
-        return this.checkUnknownSlotDuringWindowClicks;
-    }
-
     public boolean checkSlotIDDuringWindowClicks() {
         return this.checkSlotIDDuringWindowClicks;
     }
@@ -181,10 +173,6 @@ public class ExploitCategory extends ConfigCategory {
 
     public int getMaxSlotDataInteraction() {
         return this.maxSlotDataInteraction;
-    }
-
-    public boolean checkSlotOrSizeDuringWindowClicks() {
-        return this.checkSlotSizeDuringWindowClicks || this.checkUnknownSlotDuringWindowClicks;
     }
 
     public boolean isBlockHarmfulChatMessage() {

--- a/src/main/java/org/spongepowered/common/config/category/ExploitCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/ExploitCategory.java
@@ -93,7 +93,7 @@ public class ExploitCategory extends ConfigCategory {
 
     @Setting(value = "check-slot-ids-during-window-clicks",
             comment = "If enabled, window clicks with slot ids that are higher than the inventory size will will trigger a log warning and disconnect of the offending player.")
-    private boolean checkSlotID = false;
+    private boolean checkSlotIDDuringWindowClicks = false;
 
     @Setting(value = "check-slot-size-during-window-clicks",
         comment = "If enabled, slot clicks that have ItemStacks larger than a certain size will trigger a log warning and disconnect of the "
@@ -163,8 +163,8 @@ public class ExploitCategory extends ConfigCategory {
         return this.checkUnknownSlotDuringWindowClicks;
     }
 
-    public boolean checkSlotID() {
-        return this.checkSlotID;
+    public boolean checkSlotIDDuringWindowClicks() {
+        return this.checkSlotIDDuringWindowClicks;
     }
 
     public boolean checkSlotSizeDuringWindowClicks() {

--- a/src/main/java/org/spongepowered/common/mixin/exploit/NetHandlerPlayServerMixin_SlotIDFix.java
+++ b/src/main/java/org/spongepowered/common/mixin/exploit/NetHandlerPlayServerMixin_SlotIDFix.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.exploit;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.network.play.client.CPacketClickWindow;
+import net.minecraft.util.text.TextComponentString;
+import org.spongepowered.api.item.inventory.entity.PlayerInventory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.common.config.category.ExploitCategory;
+
+@Mixin(NetHandlerPlayServer.class)
+public abstract class NetHandlerPlayServerMixin_SlotIDFix {
+
+    // @formatter:off
+    @Shadow
+    public EntityPlayerMP player;
+    // @formatter:on
+
+    @Inject(method = "processClickWindow", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;markPlayerActive()V"), cancellable = true)
+    private void exploit$preventSlotAndSizeExploit(final CPacketClickWindow packet, final CallbackInfo ci) {
+        final ExploitCategory exploitsCategory = SpongeImpl.getGlobalConfigAdapter().getConfig().getExploits();
+        if (exploitsCategory.checkSlotID()) {
+            final int slotID = packet.getSlotId();
+            final int maxSlots = this.player.openContainer.getInventory().size();
+            if (slotID > maxSlots) {
+                this.player.connection.disconnect(new TextComponentString("Illegal slot id interaction detected!"));
+                SpongeImpl.getLogger().warn("Player '{}' is attempting to interact with a slot ID greater than their inventory size. Slot ID: {}, inventory size: {}!", this.player.getName(), slotID, maxSlots);
+                ci.cancel();
+
+            }
+        }
+
+    }
+}

--- a/src/main/java/org/spongepowered/common/mixin/exploit/NetHandlerPlayServerMixin_SlotIDFix.java
+++ b/src/main/java/org/spongepowered/common/mixin/exploit/NetHandlerPlayServerMixin_SlotIDFix.java
@@ -47,7 +47,7 @@ public abstract class NetHandlerPlayServerMixin_SlotIDFix {
     @Inject(method = "processClickWindow", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;markPlayerActive()V"), cancellable = true)
     private void exploit$preventSlotAndSizeExploit(final CPacketClickWindow packet, final CallbackInfo ci) {
         final ExploitCategory exploitsCategory = SpongeImpl.getGlobalConfigAdapter().getConfig().getExploits();
-        if (exploitsCategory.checkSlotID()) {
+        if (exploitsCategory.checkSlotIDDuringWindowClicks()) {
             final int slotID = packet.getSlotId();
             final int maxSlots = this.player.openContainer.getInventory().size();
             if (slotID > maxSlots) {

--- a/src/main/java/org/spongepowered/common/mixin/exploit/NetHandlerPlayServerMixin_SlotIDFix.java
+++ b/src/main/java/org/spongepowered/common/mixin/exploit/NetHandlerPlayServerMixin_SlotIDFix.java
@@ -28,7 +28,6 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.play.client.CPacketClickWindow;
 import net.minecraft.util.text.TextComponentString;
-import org.spongepowered.api.item.inventory.entity.PlayerInventory;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -55,9 +54,7 @@ public abstract class NetHandlerPlayServerMixin_SlotIDFix {
                 this.player.connection.disconnect(new TextComponentString("Illegal slot id interaction detected!"));
                 SpongeImpl.getLogger().warn("Player '{}' is attempting to interact with a slot ID greater than their inventory size. Slot ID: {}, inventory size: {}!", this.player.getName(), slotID, maxSlots);
                 ci.cancel();
-
             }
         }
-
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/exploit/NetHandlerPlayServerMixin_SlotSizeFix.java
+++ b/src/main/java/org/spongepowered/common/mixin/exploit/NetHandlerPlayServerMixin_SlotSizeFix.java
@@ -43,7 +43,7 @@ import org.spongepowered.common.bridge.inventory.ContainerBridge;
 import org.spongepowered.common.config.category.ExploitCategory;
 
 @Mixin(NetHandlerPlayServer.class)
-public abstract class NetHandlerPlayServerMixin_SlotAndSizeFix {
+public abstract class NetHandlerPlayServerMixin_SlotSizeFix {
 
     // @formatter:off
     @Shadow public EntityPlayerMP player;
@@ -52,17 +52,6 @@ public abstract class NetHandlerPlayServerMixin_SlotAndSizeFix {
     @Inject(method = "processClickWindow", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;markPlayerActive()V"), cancellable = true)
     private void exploit$preventSlotAndSizeExploit(final CPacketClickWindow packet, final CallbackInfo ci) {
         final ExploitCategory exploitsCategory = SpongeImpl.getGlobalConfigAdapter().getConfig().getExploits();
-        if (exploitsCategory.checkUnknownSlotDuringWindowClicks()) {
-            final Container container = this.player.inventoryContainer;
-            final Slot slot = ((ContainerBridge) container).bridge$getContainerSlot(packet.getSlotId());
-            if (slot == null) {
-                this.player.connection.disconnect(new TextComponentString("Illegal slot interaction detected!"));
-                SpongeImpl.getLogger().warn("Player '{}' is attempting an illegal slot interaction!", player.getName());
-                ci.cancel();
-                return;
-            }
-        }
-
         if (exploitsCategory.checkSlotSizeDuringWindowClicks()) {
             final ClickType clickType = packet.getClickType();
             if (clickType == ClickType.PICKUP || clickType == ClickType.PICKUP_ALL || clickType == ClickType.THROW) {
@@ -74,8 +63,8 @@ public abstract class NetHandlerPlayServerMixin_SlotAndSizeFix {
                     if (size > allowedSize) {
                         this.player.connection.disconnect(new TextComponentString("Illegal ItemStack data size!"));
                         SpongeImpl.getLogger()
-                            .warn("Player '{}' is attempting to send illegal ItemStack data sizes. Size sent: {}, size allowed: {}!",
-                                size, player.getName(), allowedSize);
+                                .warn("Player '{}' is attempting to send illegal ItemStack data sizes. Size sent: {}, size allowed: {}!",
+                                        size, player.getName(), allowedSize);
                         ci.cancel();
                     }
                 }

--- a/src/main/java/org/spongepowered/common/mixin/plugin/ExploitPlugin.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/ExploitPlugin.java
@@ -93,7 +93,7 @@ public class ExploitPlugin implements IMixinConfigPlugin {
         .put("PlayerVehiclesSyncPatch", ExploitCategory::playerSyncVehicle)
         .put("ItemNameOverflowPrevention", ExploitCategory::isPreventItemNameOverflow)
         .put("FilterInvalidEntities", ExploitCategory::chunkSaveFiltersEntities)
-        .put("SlotAndSizeFix", ExploitCategory::checkSlotOrSizeDuringWindowClicks)
+        .put("SlotSizeFix", ExploitCategory::checkSlotSizeDuringWindowClicks)
         .put("SlotIDFix", ExploitCategory::checkSlotIDDuringWindowClicks)
         .put("SpamSlotClicksFix", ExploitCategory::checkSlotClickCounts)
         .put("JNDIChatMessageBlock", ExploitCategory::isBlockHarmfulChatMessage)

--- a/src/main/java/org/spongepowered/common/mixin/plugin/ExploitPlugin.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/ExploitPlugin.java
@@ -94,6 +94,7 @@ public class ExploitPlugin implements IMixinConfigPlugin {
         .put("ItemNameOverflowPrevention", ExploitCategory::isPreventItemNameOverflow)
         .put("FilterInvalidEntities", ExploitCategory::chunkSaveFiltersEntities)
         .put("SlotAndSizeFix", ExploitCategory::checkSlotOrSizeDuringWindowClicks)
+        .put("SlotIDFix", ExploitCategory::checkSlotID)
         .put("SpamSlotClicksFix", ExploitCategory::checkSlotClickCounts)
         .put("JNDIChatMessageBlock", ExploitCategory::isBlockHarmfulChatMessage)
         .put("H2JNDIPatch", ExploitCategory::isBlockH2JndiExploit)

--- a/src/main/java/org/spongepowered/common/mixin/plugin/ExploitPlugin.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/ExploitPlugin.java
@@ -94,7 +94,7 @@ public class ExploitPlugin implements IMixinConfigPlugin {
         .put("ItemNameOverflowPrevention", ExploitCategory::isPreventItemNameOverflow)
         .put("FilterInvalidEntities", ExploitCategory::chunkSaveFiltersEntities)
         .put("SlotAndSizeFix", ExploitCategory::checkSlotOrSizeDuringWindowClicks)
-        .put("SlotIDFix", ExploitCategory::checkSlotID)
+        .put("SlotIDFix", ExploitCategory::checkSlotIDDuringWindowClicks)
         .put("SpamSlotClicksFix", ExploitCategory::checkSlotClickCounts)
         .put("JNDIChatMessageBlock", ExploitCategory::isBlockHarmfulChatMessage)
         .put("H2JNDIPatch", ExploitCategory::isBlockH2JndiExploit)

--- a/src/main/resources/mixins.common.exploit.json
+++ b/src/main/resources/mixins.common.exploit.json
@@ -13,7 +13,7 @@
     "JdbcUtilsMixin_H2JNDIPatch",
     "MinecraftServerMixin_JNDIChatMessageBlock",
     "NetHandlerPlayServerMixin_JNDIChatMessageBlock",
-    "NetHandlerPlayServerMixin_SlotAndSizeFix",
+    "NetHandlerPlayServerMixin_SlotSizeFix",
     "NetHandlerPlayServerMixin_SlotIDFix",
     "NetHandlerPlayServerMixin_SpamSlotClicksFix",
     "SPacketChatAccessor_JNDIChatMessageBlock",

--- a/src/main/resources/mixins.common.exploit.json
+++ b/src/main/resources/mixins.common.exploit.json
@@ -14,6 +14,7 @@
     "MinecraftServerMixin_JNDIChatMessageBlock",
     "NetHandlerPlayServerMixin_JNDIChatMessageBlock",
     "NetHandlerPlayServerMixin_SlotAndSizeFix",
+    "NetHandlerPlayServerMixin_SlotIDFix",
     "NetHandlerPlayServerMixin_SpamSlotClicksFix",
     "SPacketChatAccessor_JNDIChatMessageBlock",
     "SpongeImplHooksMixin_ItemNameOverflowPrevention"


### PR DESCRIPTION
(This is my first PR so excuse anything not done properly, and let me know if I need to modify anything.)

There is a commit that's suppose to patch this issue, however it breaks inventories. https://github.com/SpongePowered/Sponge/commit/dededb4dd67574d11c065bb94f0ede630afcde09

Issue relating to this (Only one I could find): #3280

Exploit spams [this](https://paste.gg/p/anonymous/e929fe355a104d7eb63c8af575ac6708) error and eventually lags the server to death.

My fix simply checks how many slots there are and if the packet slot ID is greater than that, it cancels it and disconnects the player.