### PR TITLE
Disable lighting updates when using BlockChangeFlags#NONE

### DIFF
--- a/src/main/java/org/spongepowered/common/util/Constants.java
+++ b/src/main/java/org/spongepowered/common/util/Constants.java
@@ -998,6 +998,7 @@ public final class Constants {
             | Constants.BlockChangeFlags.DENY_NEIGHBOR_SHAPE_UPDATE
             | Constants.BlockChangeFlags.NEIGHBOR_DROPS
             | Constants.BlockChangeFlags.PATHFINDING_UPDATES
+            | Constants.BlockChangeFlags.LIGHTING_UPDATES
             ;
 
 

--- a/src/test/java/org/spongepowered/common/event/tracking/BlockChangeFlagManagerTest.java
+++ b/src/test/java/org/spongepowered/common/event/tracking/BlockChangeFlagManagerTest.java
@@ -86,7 +86,7 @@ class BlockChangeFlagManagerTest {
         assertFalse(none.updateNeighboringShapes());
         assertFalse(none.neighborDropsAllowed());
         assertFalse(none.movingBlocks());
-        assertTrue(none.updateLighting());
+        assertFalse(none.updateLighting());
         assertFalse(none.performBlockPhysics());
         assertFalse(none.notifyPathfinding());
     }


### PR DESCRIPTION
To disable lighting computation, native flag must be set to `1`. In the API this value should be inverted and represented as `false`.
This fixes unwanted light computation when bulk update blocks when using this flag, which implies that lighting computation is turned off.