### PR TITLE
Move UnloadWorldEvent to be posted before world save

### DIFF
--- a/src/main/java/org/spongepowered/common/world/server/SpongeWorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/server/SpongeWorldManager.java
@@ -875,6 +875,8 @@ public abstract class SpongeWorldManager implements WorldManager {
 
         SpongeCommon.logger().info("Unloading world '{}' ({})", registryKey.location(), RegistryTypes.WORLD_TYPE.get().valueKey((WorldType) world.dimensionType()));
 
+        SpongeCommon.post(SpongeEventFactory.createUnloadWorldEvent(PhaseTracker.getCauseStackManager().currentCause(), (org.spongepowered.api.world.server.ServerWorld) world));
+
         final BlockPos spawnPoint = world.getSharedSpawnPos();
         world.getChunkSource().removeRegionTicket(SpongeWorldManager.SPAWN_CHUNKS, new ChunkPos(spawnPoint), 11, registryKey.location());
 
@@ -890,8 +892,6 @@ public abstract class SpongeWorldManager implements WorldManager {
         }
 
         this.worlds.remove(registryKey);
-
-        SpongeCommon.post(SpongeEventFactory.createUnloadWorldEvent(PhaseTracker.getCauseStackManager().currentCause(), (org.spongepowered.api.world.server.ServerWorld) world));
     }
 
     public void loadLevel() {


### PR DESCRIPTION
The ServerWorld ref would be nearly useless after the world has been unloaded.

For API-9, this event can be changed to use the Pre/Post style of events.