### PR TITLE
Support Java's System.Logger for plugin loggers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -183,6 +183,7 @@ dependencies {
     launchConfig("com.google.code.gson:gson:2.8.0")
     launchConfig("org.ow2.asm:asm-tree:$asmVersion")
     launchConfig("org.ow2.asm:asm-util:$asmVersion")
+    launchConfig("org.apache.logging.log4j:log4j-jpl:$log4jVersion")
 
     // Applaunch -- initialization that needs to occur without game access
     applaunchConfig("org.checkerframework:checker-qual:$checkerVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -163,7 +163,7 @@ dependencies {
     // ASM - required for generating event listeners
     implementation("org.ow2.asm:asm-util:$asmVersion")
     implementation("org.ow2.asm:asm-tree:$asmVersion")
-
+    
     // Implementation-only Adventure
     implementation(platform("net.kyori:adventure-bom:$apiAdventureVersion"))
     implementation("net.kyori:adventure-serializer-configurate4")
@@ -183,7 +183,6 @@ dependencies {
     launchConfig("com.google.code.gson:gson:2.8.0")
     launchConfig("org.ow2.asm:asm-tree:$asmVersion")
     launchConfig("org.ow2.asm:asm-util:$asmVersion")
-    launchConfig("org.apache.logging.log4j:log4j-jpl:$log4jVersion")
 
     // Applaunch -- initialization that needs to occur without game access
     applaunchConfig("org.checkerframework:checker-qual:$checkerVersion")
@@ -202,6 +201,7 @@ dependencies {
         exclude(group = "org.checkerframework", module = "checker-qual") // We use our own version
     }
     applaunchConfig("org.apache.logging.log4j:log4j-core:$log4jVersion")
+    applaunchConfig("org.apache.logging.log4j:log4j-jpl:$log4jVersion")
 
     mixinsConfig(sourceSets.named("main").map { it.output })
     mixinsConfig("org.spongepowered:timings:$timingsVersion")

--- a/src/main/java/org/spongepowered/common/inject/plugin/PluginModule.java
+++ b/src/main/java/org/spongepowered/common/inject/plugin/PluginModule.java
@@ -52,7 +52,9 @@ public final class PluginModule extends AbstractModule {
 
         this.bind(PluginContainer.class).toInstance(this.container);
         this.bind(Logger.class).toInstance(this.container.logger());
+        this.bind(System.Logger.class).toProvider(() -> System.getLogger(this.container.logger().getName())).in(Scopes.SINGLETON);
 
         this.install(new PluginConfigurationModule());
     }
+
 }

--- a/testplugins/src/main/java/org/spongepowered/test/logging/LoggingTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/logging/LoggingTest.java
@@ -1,0 +1,28 @@
+package org.spongepowered.test.logging;
+
+import com.google.inject.Inject;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.lifecycle.ConstructPluginEvent;
+import org.spongepowered.plugin.builtin.jvm.Plugin;
+
+@Plugin("logging-test")
+public class LoggingTest {
+
+    private final System.Logger platformLogger;
+
+    @Inject
+    LoggingTest(final System.Logger platformLogger) {
+        this.platformLogger = platformLogger;
+    }
+
+
+    @Listener
+    private void onConstructed(final ConstructPluginEvent event) {
+        this.platformLogger.log(
+            System.Logger.Level.INFO,
+            "Hello from {} on a platform logger",
+            event.plugin().metadata().id()
+        );
+    }
+
+}

--- a/testplugins/src/main/java/org/spongepowered/test/logging/LoggingTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/logging/LoggingTest.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.test.logging;
 
 import com.google.inject.Inject;

--- a/testplugins/src/main/resources/META-INF/sponge_plugins.json
+++ b/testplugins/src/main/resources/META-INF/sponge_plugins.json
@@ -237,6 +237,12 @@
             "name": "Vanish Test",
             "entrypoint": "org.spongepowered.test.vanish.VanishTest",
             "description": "Vanish Testing"
+        },
+        { 
+            "id": "logging-test",
+            "name": "Logging Test",
+            "entrypoint": "org.spongepowered.test.logging.LoggingTest",
+            "description": "Logging Testing"
         }
     ]
 }

--- a/vanilla/build.gradle.kts
+++ b/vanilla/build.gradle.kts
@@ -27,6 +27,7 @@ val vanillaLibrariesConfig = configurations.register("libraries")
 val vanillaAppLaunchConfig = configurations.register("applaunch") {
     extendsFrom(vanillaBootstrapLibrariesConfig.get())
     extendsFrom(configurations.minecraft.get())
+
 }
 val mlpatcherConfig = configurations.register("mlpatcher")
 val vanillaInstallerConfig = configurations.register("installer") {
@@ -300,6 +301,8 @@ dependencies {
     // and below library can be removed.
     // https://github.com/SpongePowered/Sponge/issues/3429
     bootstrapLibraries("org.fusesource.jansi:jansi:$jansiVersion")
+    // Must be on the base ClassLoader since ModLauncher has a dependency on log4j
+    bootstrapLibraries("org.apache.logging.log4j:log4j-jpl:$log4jVersion")
     
     bootstrapLibraries(platform("org.spongepowered:configurate-bom:$apiConfigurateVersion"))
     bootstrapLibraries("org.spongepowered:configurate-core") {


### PR DESCRIPTION
common: Support Java's System.Logger in addition to Log4J

This will never replace Log4J, but provides a universally available
    alternative for plugins with simple logging needs, or which use
    libraries that use the System.Logger facade.