### PR TITLE
[API8] BlockStateProperties Registries

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeGame.java
+++ b/src/main/java/org/spongepowered/common/SpongeGame.java
@@ -28,12 +28,9 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import net.minecraft.tags.StaticTagHelper;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Client;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.Platform;
-import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.data.DataManager;
 import org.spongepowered.api.event.EventManager;
@@ -41,14 +38,10 @@ import org.spongepowered.api.network.channel.ChannelManager;
 import org.spongepowered.api.plugin.PluginManager;
 import org.spongepowered.api.registry.BuilderProvider;
 import org.spongepowered.api.registry.FactoryProvider;
-import org.spongepowered.api.registry.Registry;
-import org.spongepowered.api.registry.RegistryType;
 import org.spongepowered.api.service.ServiceProvider;
 import org.spongepowered.api.sql.SqlManager;
-import org.spongepowered.api.tag.Tag;
 import org.spongepowered.api.util.metric.MetricsConfigManager;
 import org.spongepowered.common.config.PluginConfigManager;
-import org.spongepowered.common.registry.InitialRegistryData;
 import org.spongepowered.common.registry.RegistryHolderLogic;
 import org.spongepowered.common.registry.SpongeRegistryHolder;
 import org.spongepowered.common.scheduler.AsyncScheduler;
@@ -57,10 +50,6 @@ import org.spongepowered.common.util.LocaleCache;
 
 import java.nio.file.Path;
 import java.util.Locale;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.BiConsumer;
-import java.util.stream.Stream;
 
 @Singleton
 public final class SpongeGame implements Game, SpongeRegistryHolder {
@@ -223,21 +212,7 @@ public final class SpongeGame implements Game, SpongeRegistryHolder {
     }
 
     @Override
-    public <T> Registry<T> registry(final RegistryType<T> type) {
-        return this.registryHolder().registry(Objects.requireNonNull(type, "type"));
-    }
-
-    @Override
-    public <T> Optional<Registry<T>> findRegistry(final RegistryType<T> type) {
-        return this.registryHolder().findRegistry(Objects.requireNonNull(type, "type"));
-    }
-
-    @Override
-    public Stream<Registry<?>> streamRegistries(final ResourceKey root) {
-        return this.registryHolder().streamRegistries(Objects.requireNonNull(root, "root"));
-    }
-
-    private RegistryHolderLogic registryHolder() {
+    public RegistryHolderLogic registryHolder() {
         if (this.registryHolder == null) {
             this.registryHolder = new RegistryHolderLogic();
         }
@@ -250,21 +225,5 @@ public final class SpongeGame implements Game, SpongeRegistryHolder {
         return MoreObjects.toStringHelper(this)
                 .add("platform", this.platform)
                 .toString();
-    }
-
-    @Override
-    public void setRootMinecraftRegistry(final net.minecraft.core.Registry<net.minecraft.core.Registry<?>> registry) {
-        this.registryHolder().setRootMinecraftRegistry(registry);
-    }
-
-    @Override
-    public <T> Registry<T> createRegistry(final RegistryType<T> type, @Nullable final InitialRegistryData<T> defaultValues, final boolean isDynamic,
-        @Nullable final BiConsumer<net.minecraft.resources.ResourceKey<T>, T> callback) {
-        return this.registryHolder().createRegistry(type, defaultValues, isDynamic, callback);
-    }
-
-    @Override
-    public <T> void wrapTagHelperAsRegistry(final RegistryType<Tag<T>> type, final StaticTagHelper<T> helper) {
-        this.registryHolder().wrapTagHelperAsRegistry(type, helper);
     }
 }

--- a/src/main/java/org/spongepowered/common/registry/SpongeMappedRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeMappedRegistry.java
@@ -1,0 +1,173 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.registry;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+import com.mojang.serialization.Lifecycle;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenCustomHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectList;
+import net.minecraft.Util;
+import net.minecraft.core.Registry;
+import net.minecraft.core.WritableRegistry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+/**
+ * Based on {@link net.minecraft.core.MappedRegistry} but supports non-unique inverse mappings
+ */
+public final class SpongeMappedRegistry<T> extends WritableRegistry<T> {
+
+    protected static final Logger LOGGER = LogManager.getLogger();
+    private final ObjectList<T> byId = new ObjectArrayList<>(256);
+    private final Object2IntMap<T> toId = Util.make(new Object2IntOpenCustomHashMap<>(Util.identityStrategy()), ($$0x) -> $$0x.defaultReturnValue(-1));
+    private final Map<ResourceLocation, T> storage = new HashMap<>();
+    private final IdentityHashMap<T, ResourceLocation> inverseStorage = Maps.newIdentityHashMap();
+    private final Map<ResourceKey<T>, T> keyStorage = new HashMap<>();
+    private final IdentityHashMap<T, ResourceKey<T>> inverseKeyStorage = Maps.newIdentityHashMap();
+    private final Map<T, Lifecycle> lifecycles = Maps.newIdentityHashMap();
+    private Lifecycle elementsLifecycle;
+    private int nextId;
+
+    public SpongeMappedRegistry(ResourceKey<? extends Registry<T>> $$0, Lifecycle $$1) {
+        super($$0, $$1);
+        this.elementsLifecycle = $$1;
+    }
+
+    public <V extends T> V registerMapping(int $$0, ResourceKey<T> $$1, V $$2, Lifecycle $$3) {
+        Validate.notNull($$1);
+        Validate.notNull((T)$$2);
+        this.byId.size(Math.max(this.byId.size(), $$0 + 1));
+        this.byId.set($$0, $$2);
+        this.toId.put((T)$$2, $$0);
+
+        this.storage.put($$1.location(), $$2);
+        this.inverseStorage.put($$2, $$1.location());
+        this.keyStorage.put($$1, (T)$$2);
+        this.inverseKeyStorage.put($$2, $$1);
+        this.lifecycles.put((T)$$2, $$3);
+        this.elementsLifecycle = this.elementsLifecycle.add($$3);
+        if (this.nextId <= $$0) {
+            this.nextId = $$0 + 1;
+        }
+
+        return $$2;
+    }
+
+
+    public <V extends T> V register(ResourceKey<T> $$0, V $$1, Lifecycle $$2) {
+        return this.registerMapping(this.nextId, $$0, $$1, $$2);
+    }
+
+    public <V extends T> V registerOrOverride(OptionalInt $$0, ResourceKey<T> $$1, V $$2, Lifecycle $$3) {
+        Validate.notNull($$1);
+        Validate.notNull((T)$$2);
+        T $$4 = this.keyStorage.get($$1);
+        int $$5;
+        if ($$4 == null) {
+            $$5 = $$0.isPresent() ? $$0.getAsInt() : this.nextId;
+        } else {
+            $$5 = this.toId.getInt($$4);
+            if ($$0.isPresent() && $$0.getAsInt() != $$5) {
+                throw new IllegalStateException("ID mismatch");
+            }
+
+            this.toId.removeInt($$4);
+            this.lifecycles.remove($$4);
+        }
+
+        return this.registerMapping($$5, $$1, $$2, $$3);
+    }
+
+    @Nullable
+    public ResourceLocation getKey(T $$0) {
+        return this.inverseStorage.get($$0);
+    }
+
+    public Optional<ResourceKey<T>> getResourceKey(T $$0) {
+        return Optional.ofNullable(this.inverseKeyStorage.get($$0));
+    }
+
+    public int getId(@Nullable T $$0) {
+        return this.toId.getInt($$0);
+    }
+
+    @Nullable
+    public T get(@Nullable ResourceKey<T> $$0) {
+        return this.keyStorage.get($$0);
+    }
+
+    @Nullable
+    public T byId(int $$0) {
+        return (T)($$0 >= 0 && $$0 < this.byId.size() ? this.byId.get($$0) : null);
+    }
+
+    public Lifecycle lifecycle(T $$0) {
+        return this.lifecycles.get($$0);
+    }
+
+    public Lifecycle elementsLifecycle() {
+        return this.elementsLifecycle;
+    }
+
+    public Iterator<T> iterator() {
+        return Iterators.filter(this.byId.iterator(), Objects::nonNull);
+    }
+
+    @Nullable
+    public T get(@Nullable ResourceLocation $$0) {
+        return this.storage.get($$0);
+    }
+
+    public Set<ResourceLocation> keySet() {
+        return Collections.unmodifiableSet(this.storage.keySet());
+    }
+
+    public Set<Map.Entry<ResourceKey<T>, T>> entrySet() {
+        return Collections.unmodifiableMap(this.keyStorage).entrySet();
+    }
+
+    public boolean containsKey(ResourceLocation $$0) {
+        return this.storage.containsKey($$0);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/registry/SpongeRegistries.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeRegistries.java
@@ -99,6 +99,9 @@ public final class SpongeRegistries {
         holder.wrapTagHelperAsRegistry(RegistryTypes.ITEM_TYPE_TAGS, (StaticTagHelper<ItemType>) (Object) ItemTagsAccessor.accessor$HELPER());
         holder.wrapTagHelperAsRegistry(RegistryTypes.ENTITY_TYPE_TAGS, (StaticTagHelper<EntityType<?>>) (Object) EntityTypeTagsAccessor.accessor$HELPER());
         holder.wrapTagHelperAsRegistry(RegistryTypes.FLUID_TYPE_TAGS, (StaticTagHelper<FluidType>) (Object) FluidTagsAccessor.accessor$HELPER());
+        holder.createIdentityRegistry(RegistryTypes.BOOLEAN_STATE_PROPERTY, SpongeRegistryLoaders.booleanStateProperties());
+        holder.createIdentityRegistry(RegistryTypes.INTEGER_STATE_PROPERTY, SpongeRegistryLoaders.integerStateProperties());
+        holder.createIdentityRegistry(RegistryTypes.ENUM_STATE_PROPERTY, SpongeRegistryLoaders.enumStateProperties());
     }
 
     public static void registerServerRegistries(final RegistryHolder holder) {

--- a/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeRegistryLoaders.java
@@ -54,9 +54,13 @@ import net.minecraft.commands.synchronization.brigadier.DoubleArgumentSerializer
 import net.minecraft.commands.synchronization.brigadier.FloatArgumentSerializer;
 import net.minecraft.commands.synchronization.brigadier.IntegerArgumentSerializer;
 import net.minecraft.commands.synchronization.brigadier.LongArgumentSerializer;
+import net.minecraft.core.Registry;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.RecordItem;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.material.MaterialColor;
 import net.minecraft.world.level.saveddata.maps.MapDecoration;
 import net.minecraft.world.phys.Vec2;
@@ -157,6 +161,8 @@ import org.spongepowered.api.map.decoration.orientation.MapDecorationOrientation
 import org.spongepowered.api.map.decoration.orientation.MapDecorationOrientations;
 import org.spongepowered.api.placeholder.PlaceholderParser;
 import org.spongepowered.api.placeholder.PlaceholderParsers;
+import org.spongepowered.api.registry.RegistryKey;
+import org.spongepowered.api.registry.RegistryType;
 import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.scoreboard.displayslot.DisplaySlot;
 import org.spongepowered.api.scoreboard.displayslot.DisplaySlots;
@@ -165,6 +171,9 @@ import org.spongepowered.api.service.ban.BanType;
 import org.spongepowered.api.service.ban.BanTypes;
 import org.spongepowered.api.service.economy.account.AccountDeletionResultType;
 import org.spongepowered.api.service.economy.account.AccountDeletionResultTypes;
+import org.spongepowered.api.state.BooleanStateProperty;
+import org.spongepowered.api.state.EnumStateProperty;
+import org.spongepowered.api.state.IntegerStateProperty;
 import org.spongepowered.api.tag.TagType;
 import org.spongepowered.api.tag.TagTypes;
 import org.spongepowered.api.util.Color;
@@ -248,6 +257,7 @@ import org.spongepowered.common.data.type.SpongeParrotType;
 import org.spongepowered.common.data.type.SpongeRabbitType;
 import org.spongepowered.common.data.type.SpongeSkinPart;
 import org.spongepowered.common.economy.SpongeAccountDeletionResultType;
+import org.spongepowered.common.economy.SpongeTransactionType;
 import org.spongepowered.common.effect.particle.SpongeParticleOption;
 import org.spongepowered.common.effect.record.SpongeMusicDisc;
 import org.spongepowered.common.entity.ai.SpongeGoalExecutorType;
@@ -288,7 +298,6 @@ import org.spongepowered.common.map.decoration.orientation.SpongeMapDecorationOr
 import org.spongepowered.common.placeholder.SpongePlaceholderParserBuilder;
 import org.spongepowered.common.scoreboard.SpongeDisplaySlot;
 import org.spongepowered.common.scoreboard.SpongeDisplaySlotFactory;
-import org.spongepowered.common.economy.SpongeTransactionType;
 import org.spongepowered.common.tag.SpongeTagType;
 import org.spongepowered.common.util.SpongeOrientation;
 import org.spongepowered.common.util.VecHelper;
@@ -309,50 +318,15 @@ import org.spongepowered.math.vector.Vector2d;
 import org.spongepowered.math.vector.Vector3d;
 import org.spongepowered.math.vector.Vector3i;
 
-import com.mojang.brigadier.arguments.ArgumentType;
-import com.mojang.brigadier.arguments.BoolArgumentType;
-import com.mojang.brigadier.arguments.DoubleArgumentType;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
-import com.mojang.brigadier.arguments.LongArgumentType;
-import com.mojang.brigadier.arguments.StringArgumentType;
-import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
-import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.arguments.ComponentArgument;
-import net.minecraft.commands.arguments.CompoundTagArgument;
-import net.minecraft.commands.arguments.DimensionArgument;
-import net.minecraft.commands.arguments.EntityArgument;
-import net.minecraft.commands.arguments.GameProfileArgument;
-import net.minecraft.commands.arguments.ResourceLocationArgument;
-import net.minecraft.commands.arguments.ScoreHolderArgument;
-import net.minecraft.commands.arguments.UuidArgument;
-import net.minecraft.commands.arguments.blocks.BlockStateArgument;
-import net.minecraft.commands.arguments.coordinates.RotationArgument;
-import net.minecraft.commands.arguments.coordinates.Vec2Argument;
-import net.minecraft.commands.arguments.coordinates.Vec3Argument;
-import net.minecraft.commands.arguments.item.ItemArgument;
-import net.minecraft.commands.arguments.selector.EntitySelectorParser;
-import net.minecraft.commands.synchronization.SuggestionProviders;
-import net.minecraft.commands.synchronization.brigadier.DoubleArgumentSerializer;
-import net.minecraft.commands.synchronization.brigadier.FloatArgumentSerializer;
-import net.minecraft.commands.synchronization.brigadier.IntegerArgumentSerializer;
-import net.minecraft.commands.synchronization.brigadier.LongArgumentSerializer;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.world.item.Items;
-import net.minecraft.world.item.RecordItem;
-import net.minecraft.world.level.material.MaterialColor;
-import net.minecraft.world.level.saveddata.maps.MapDecoration;
-import net.minecraft.world.phys.Vec2;
-import org.checkerframework.checker.nullness.qual.NonNull;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Comparator;
-import java.util.List;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("unchecked")
@@ -1161,6 +1135,56 @@ public final class SpongeRegistryLoaders {
             l.add(TagTypes.ENTITY_TYPE, k -> new SpongeTagType<@NonNull EntityType<?>>("entity_types", RegistryTypes.ENTITY_TYPE, RegistryTypes.ENTITY_TYPE_TAGS));
             l.add(TagTypes.FLUID_TYPE, k -> new SpongeTagType<@NonNull FluidType>("fluids", RegistryTypes.FLUID_TYPE, RegistryTypes.FLUID_TYPE_TAGS));
             l.add(TagTypes.ITEM_TYPE, k -> new SpongeTagType<@NonNull ItemType>("items", RegistryTypes.ITEM_TYPE, RegistryTypes.ITEM_TYPE_TAGS));
+        });
+    }
+
+    private static final Pattern ILLEGAL_FIELD_CHARACTERS = Pattern.compile("[./-]");
+
+    private static String sanitizedKey(String key) {
+        return SpongeRegistryLoaders.ILLEGAL_FIELD_CHARACTERS.matcher(key).replaceAll("_").toLowerCase(Locale.ROOT);
+    }
+
+    private static <T> Map<String, T> stateProperties(Class<T> clazz) {
+        Map<String, T> propertyMap = new HashMap<>();
+        Registry.BLOCK.forEach(block -> block.defaultBlockState().getProperties().forEach(prop -> {
+            if (clazz.isInstance(prop)) {
+                final String key = Registry.BLOCK.getKey(block).getPath() + "_" + prop.getName();
+                propertyMap.put(SpongeRegistryLoaders.sanitizedKey(key), clazz.cast(prop));
+            }
+        }));
+        return propertyMap;
+    }
+
+    public static RegistryLoader<BooleanStateProperty> booleanStateProperties() {
+        return RegistryLoader.of(l -> {
+            final Map<String, BooleanProperty> props = SpongeRegistryLoaders.stateProperties(BooleanProperty.class);
+            final Map<String, BooleanProperty> finalProps = new HashMap<>();
+            props.forEach((key, value) -> finalProps.put(key, BooleanProperty.create(value.getName()))); // Create clones for API States
+            props.values().stream().distinct().forEach(property -> finalProps.put(sanitizedKey(property.getName()), property)); // Add real keys of properties
+            finalProps.forEach((key, value) -> l.add(RegistryKey.of(RegistryTypes.BOOLEAN_STATE_PROPERTY, ResourceKey.sponge(key)), k -> (BooleanStateProperty) value));
+        });
+    }
+
+    public static RegistryLoader<IntegerStateProperty> integerStateProperties() {
+        return RegistryLoader.of(l -> {
+            final Map<String, IntegerProperty> props = SpongeRegistryLoaders.stateProperties(IntegerProperty.class);
+            final Map<String, IntegerProperty> finalProps = new HashMap<>();
+            props.forEach((key, value) -> finalProps.put(key, IntegerProperty.create(value.getName(),
+                    value.getPossibleValues().stream().min(Integer::compare).get(),
+                    value.getPossibleValues().stream().max(Integer::compare).get()))); // Create clones for API States
+            props.values().stream().distinct().forEach(property -> finalProps.put(sanitizedKey(property.getName()), property)); // Add real keys of properties
+            finalProps.forEach((key, value) -> l.add(RegistryKey.of(RegistryTypes.INTEGER_STATE_PROPERTY, ResourceKey.sponge(key)), k -> (IntegerStateProperty) value));
+        });
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static RegistryLoader<EnumStateProperty<?>> enumStateProperties() {
+        return RegistryLoader.of(l -> {
+            final Map<String, EnumProperty> props = SpongeRegistryLoaders.stateProperties(EnumProperty.class);
+            final Map<String, EnumProperty> finalProps = new HashMap<>();
+            props.forEach((key, value) -> finalProps.put(key, EnumProperty.create(value.getName(), value.getValueClass(), value.getPossibleValues()))); // Create clones for API States
+            props.values().stream().distinct().forEach(property -> finalProps.put(sanitizedKey(property.getName()), property)); // Add real keys of properties
+            finalProps.forEach((key, value) -> l.add(RegistryKey.of(RegistryTypes.ENUM_STATE_PROPERTY, ResourceKey.sponge(key)), k -> (EnumStateProperty<?>) value));
         });
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/client/MinecraftMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/client/MinecraftMixin_API.java
@@ -29,19 +29,13 @@ import net.minecraft.client.Options;
 import net.minecraft.client.server.IntegratedServer;
 import net.minecraft.network.Connection;
 import net.minecraft.server.packs.repository.PackRepository;
-import net.minecraft.tags.StaticTagHelper;
-import net.minecraft.util.thread.ReentrantBlockableEventLoop;
 import org.spongepowered.api.Game;
-import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.client.LocalServer;
 import org.spongepowered.api.entity.living.player.client.LocalPlayer;
 import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.network.ClientSideConnection;
-import org.spongepowered.api.registry.Registry;
-import org.spongepowered.api.registry.RegistryType;
 import org.spongepowered.api.resource.ResourceManager;
-import org.spongepowered.api.tag.Tag;
 import org.spongepowered.api.world.client.ClientWorld;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -49,17 +43,13 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.bridge.client.MinecraftBridge;
 import org.spongepowered.common.client.SpongeClient;
 import org.spongepowered.common.event.tracking.PhaseTracker;
-import org.spongepowered.common.registry.InitialRegistryData;
 import org.spongepowered.common.registry.RegistryHolderLogic;
 import org.spongepowered.common.registry.SpongeRegistryHolder;
 import org.spongepowered.common.scheduler.ClientScheduler;
 import org.spongepowered.common.util.LocaleCache;
 
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.function.BiConsumer;
-import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -146,35 +136,7 @@ public abstract class MinecraftMixin_API implements SpongeClient, SpongeRegistry
     }
 
     @Override
-    public <T> Registry<T> registry(final RegistryType<T> type) {
-        return this.api$registryHolder.registry(Objects.requireNonNull(type, "type"));
+    public RegistryHolderLogic registryHolder() {
+        return this.api$registryHolder;
     }
-
-    @Override
-    public <T> Optional<Registry<T>> findRegistry(final RegistryType<T> type) {
-        return this.api$registryHolder.findRegistry(Objects.requireNonNull(type, "type"));
-    }
-
-    @Override
-    public Stream<Registry<?>> streamRegistries(final ResourceKey root) {
-        return this.api$registryHolder.streamRegistries(Objects.requireNonNull(root, "root"));
-    }
-
-    @Override
-    public void setRootMinecraftRegistry(final net.minecraft.core.Registry<net.minecraft.core.Registry<?>> registry) {
-        this.api$registryHolder.setRootMinecraftRegistry(registry);
-    }
-
-    @Override
-    public <T> Registry<T> createRegistry(final RegistryType<T> type, @org.checkerframework.checker.nullness.qual.Nullable
-    final InitialRegistryData<T> defaultValues, final boolean isDynamic,
-        @org.checkerframework.checker.nullness.qual.Nullable final BiConsumer<net.minecraft.resources.ResourceKey<T>, T> callback) {
-        return this.api$registryHolder.createRegistry(type, defaultValues, isDynamic, callback);
-    }
-
-    @Override
-    public <T> void wrapTagHelperAsRegistry(final RegistryType<Tag<T>> type, final StaticTagHelper<T> helper) {
-        this.api$registryHolder.wrapTagHelperAsRegistry(type, helper);
-    }
-
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/MinecraftServerMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/MinecraftServerMixin_API.java
@@ -45,15 +45,12 @@ import net.minecraft.server.level.progress.ChunkProgressListenerFactory;
 import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.server.players.GameProfileCache;
 import net.minecraft.server.players.PlayerList;
-import net.minecraft.tags.StaticTagHelper;
 import net.minecraft.util.Mth;
 import net.minecraft.util.thread.ReentrantBlockableEventLoop;
 import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.WorldData;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Game;
-import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
@@ -62,13 +59,10 @@ import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.item.recipe.RecipeManager;
 import org.spongepowered.api.map.MapStorage;
 import org.spongepowered.api.profile.GameProfileManager;
-import org.spongepowered.api.registry.Registry;
-import org.spongepowered.api.registry.RegistryType;
 import org.spongepowered.api.resource.ResourceManager;
 import org.spongepowered.api.resourcepack.ResourcePack;
 import org.spongepowered.api.scoreboard.Scoreboard;
 import org.spongepowered.api.service.ServiceProvider;
-import org.spongepowered.api.tag.Tag;
 import org.spongepowered.api.util.Ticks;
 import org.spongepowered.api.world.difficulty.Difficulty;
 import org.spongepowered.api.world.storage.ChunkLayout;
@@ -92,7 +86,6 @@ import org.spongepowered.common.command.manager.SpongeCommandManager;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.map.SpongeMapStorage;
 import org.spongepowered.common.profile.SpongeGameProfileManager;
-import org.spongepowered.common.registry.InitialRegistryData;
 import org.spongepowered.common.registry.RegistryHolderLogic;
 import org.spongepowered.common.registry.SpongeRegistryHolder;
 import org.spongepowered.common.scheduler.ServerScheduler;
@@ -110,8 +103,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.BiConsumer;
-import java.util.stream.Stream;
 
 @Mixin(MinecraftServer.class)
 @Implements(value = @Interface(iface = Server.class, prefix = "server$", remap = Remap.NONE))
@@ -464,33 +455,7 @@ public abstract class MinecraftServerMixin_API extends ReentrantBlockableEventLo
     }
 
     @Override
-    public <T> Registry<T> registry(final RegistryType<T> type) {
-        return this.api$registryHolder.registry(Objects.requireNonNull(type, "type"));
-    }
-
-    @Override
-    public <T> Optional<Registry<T>> findRegistry(final RegistryType<T> type) {
-        return this.api$registryHolder.findRegistry(Objects.requireNonNull(type, "type"));
-    }
-
-    @Override
-    public Stream<Registry<?>> streamRegistries(final ResourceKey root) {
-        return this.api$registryHolder.streamRegistries(Objects.requireNonNull(root, "root"));
-    }
-
-    @Override
-    public void setRootMinecraftRegistry(final net.minecraft.core.Registry<net.minecraft.core.Registry<?>> registry) {
-        this.api$registryHolder.setRootMinecraftRegistry(registry);
-    }
-
-    @Override
-    public <T> Registry<T> createRegistry(final RegistryType<T> type, @Nullable final InitialRegistryData<T> defaultValues, final boolean isDynamic,
-        @Nullable final BiConsumer<net.minecraft.resources.ResourceKey<T>, T> callback) {
-        return this.api$registryHolder.createRegistry(type, defaultValues, isDynamic, callback);
-    }
-
-    @Override
-    public <T> void wrapTagHelperAsRegistry(final RegistryType<Tag<T>> type, final StaticTagHelper<T> helper) {
-        this.api$registryHolder.wrapTagHelperAsRegistry(type, helper);
+    public RegistryHolderLogic registryHolder() {
+        return this.api$registryHolder;
     }
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/LevelMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/LevelMixin_API.java
@@ -36,7 +36,6 @@ import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.tags.StaticTagHelper;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
@@ -57,15 +56,12 @@ import org.spongepowered.api.effect.sound.music.MusicDisc;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.registry.RegistryHolder;
-import org.spongepowered.api.registry.RegistryType;
 import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.tag.Tag;
 import org.spongepowered.api.util.AABB;
 import org.spongepowered.api.world.HeightTypes;
 import org.spongepowered.api.world.Location;
-import org.spongepowered.api.world.WorldLike;
 import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.WorldLike;
 import org.spongepowered.api.world.biome.Biome;
 import org.spongepowered.api.world.chunk.WorldChunk;
 import org.spongepowered.api.world.volume.archetype.ArchetypeVolume;
@@ -85,7 +81,6 @@ import org.spongepowered.common.bridge.world.level.LevelBridge;
 import org.spongepowered.common.effect.particle.SpongeParticleHelper;
 import org.spongepowered.common.effect.record.SpongeMusicDisc;
 import org.spongepowered.common.entity.living.human.HumanEntity;
-import org.spongepowered.common.registry.InitialRegistryData;
 import org.spongepowered.common.registry.RegistryHolderLogic;
 import org.spongepowered.common.registry.SpongeRegistryHolder;
 import org.spongepowered.common.util.Constants;
@@ -105,7 +100,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
-import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -194,37 +188,7 @@ public abstract class LevelMixin_API<W extends World<W, L>, L extends Location<W
     }
 
     @Override
-    public <T> org.spongepowered.api.registry.Registry<T> registry(final RegistryType<T> type) {
-        return this.api$registryHolder().registry(Objects.requireNonNull(type, "type"));
-    }
-
-    @Override
-    public <T> Optional<org.spongepowered.api.registry.Registry<T>> findRegistry(final RegistryType<T> type) {
-        return this.api$registryHolder().findRegistry(Objects.requireNonNull(type, "type"));
-    }
-
-    @Override
-    public Stream<org.spongepowered.api.registry.Registry<?>> streamRegistries(final org.spongepowered.api.ResourceKey root) {
-        return this.api$registryHolder().streamRegistries(Objects.requireNonNull(root, "root"));
-    }
-
-    @Override
-    public void setRootMinecraftRegistry(final net.minecraft.core.Registry<net.minecraft.core.Registry<?>> registry) {
-        this.api$registryHolder().setRootMinecraftRegistry(registry);
-    }
-
-    @Override
-    public <T> org.spongepowered.api.registry.Registry<T> createRegistry(final RegistryType<T> type, @Nullable final InitialRegistryData<T> defaultValues, final boolean isDynamic,
-        @Nullable final BiConsumer<ResourceKey<T>, T> callback) {
-        return this.api$registryHolder().createRegistry(type, defaultValues, isDynamic, callback);
-    }
-
-    @Override
-    public <T> void wrapTagHelperAsRegistry(final RegistryType<Tag<T>> type, final StaticTagHelper<T> helper) {
-        this.api$registryHolder().wrapTagHelperAsRegistry(type, helper);
-    }
-
-    private RegistryHolderLogic api$registryHolder() {
+    public RegistryHolderLogic registryHolder() {
         if (this.api$registryHolder == null) {
             this.api$registryHolder = new RegistryHolderLogic(((LevelAccessor) this).registryAccess());
         }

--- a/testplugins/src/main/java/org/spongepowered/test/blockstate/BlockStateTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/blockstate/BlockStateTest.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.test.blockstate;
+
+import com.google.inject.Inject;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.spongepowered.api.ResourceKey;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.command.parameter.CommandContext;
+import org.spongepowered.api.data.type.HandTypes;
+import org.spongepowered.api.entity.living.player.server.ServerPlayer;
+import org.spongepowered.api.event.EventContextKeys;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.block.InteractBlockEvent;
+import org.spongepowered.api.event.filter.cause.First;
+import org.spongepowered.api.registry.RegistryTypes;
+import org.spongepowered.api.state.BooleanStateProperties;
+import org.spongepowered.api.state.BooleanStateProperty;
+import org.spongepowered.api.state.StateProperty;
+import org.spongepowered.plugin.PluginContainer;
+import org.spongepowered.plugin.builtin.jvm.Plugin;
+import org.spongepowered.test.LoadableModule;
+
+import java.util.Map;
+
+@Plugin("blockstate-test")
+public class BlockStateTest implements LoadableModule {
+
+    private final PluginContainer plugin;
+
+    @Inject
+    public BlockStateTest(final PluginContainer plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void enable(final CommandContext ctx) {
+        Sponge.eventManager().registerListeners(this.plugin, new BlockStateTestListener());
+    }
+
+    public static class BlockStateTestListener {
+
+        @Listener
+        public void onSpawnEntity(final InteractBlockEvent.Secondary event, @First ServerPlayer player) {
+            if (event.context().get(EventContextKeys.USED_HAND).map(hand -> hand == HandTypes.MAIN_HAND.get()).orElse(false)) {
+                final BlockState state = event.block().state();
+                player.sendMessage(Component.text("Interacted Block has the following block state properties:").color(NamedTextColor.GREEN));
+                state.statePropertyMap().forEach((prop, value) -> player.sendMessage(Component.text(prop.name()+ ": " + value.toString())));
+                for (Map.Entry<StateProperty<?>, ?> entry : state.statePropertyMap().entrySet()) {
+                    if (entry.getKey().equals(BooleanStateProperties.GRASS_BLOCK_SNOWY.get())) {
+                        final ResourceKey key = RegistryTypes.BOOLEAN_STATE_PROPERTY.get().valueKey((BooleanStateProperty) entry.getKey());
+                        player.sendMessage(Component.text(key.toString()));
+                        event.block().location().get().setBlock(state.withStateProperty(BooleanStateProperties.GRASS_BLOCK_SNOWY, !(Boolean) entry.getValue()).get());
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/testplugins/src/main/resources/META-INF/sponge_plugins.json
+++ b/testplugins/src/main/resources/META-INF/sponge_plugins.json
@@ -239,6 +239,12 @@
             "description": "Vanish Testing"
         },
         {
+            "id": "blockstate-test",
+            "name": "BlockState Test",
+            "entrypoint": "org.spongepowered.test.blockstate.BlockStateTest",
+            "description": "BlockState Testing"
+        },
+        {
             "id": "key-test",
             "name": "Key Listener Test",
             "entrypoint": "org.spongepowered.test.keys.KeyTest",


### PR DESCRIPTION
Provides registries for BlockStateProperties. 

We might want to change them not to be in a registry for API9.
The properties used by vanilla are always the same instance. API properties are now clones of those.

Move duplicate code up into SpongeRegistryHolder.

fixes #3611