### PR TITLE
Fix SpongeUserData returning the wrong identifier

### DIFF
--- a/src/main/java/org/spongepowered/common/entity/player/SpongeUserData.java
+++ b/src/main/java/org/spongepowered/common/entity/player/SpongeUserData.java
@@ -621,7 +621,7 @@ public final class SpongeUserData implements Identifiable, DataSerializable, Bed
 
     @Override
     public String identifier() {
-        return this.name();
+        return this.uniqueId().toString();
     }
 
 }


### PR DESCRIPTION
To align with [`ServerPlayerMixin_API#identifier()`](https://github.com/SpongePowered/Sponge/blob/api-8/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/level/ServerPlayerMixin_API.java#L214-L217), `SpongeUserData` should also return the UUID instead of the name.

This small PR fixes that :)