### PR TITLE
Fix some errors related to volumes

### DIFF
--- a/src/main/java/org/spongepowered/common/world/volume/block/SpongeBlockVolumeFactory.java
+++ b/src/main/java/org/spongepowered/common/world/volume/block/SpongeBlockVolumeFactory.java
@@ -49,14 +49,14 @@ public class SpongeBlockVolumeFactory implements BlockVolumeFactory {
         final Vector3i min,
         final Vector3i max
     ) {
-        return new ArrayMutableBlockBuffer(palette, defaultState, min, max.sub(min));
+        return new ArrayMutableBlockBuffer(palette, defaultState, min, max.sub(min).add(Vector3i.ONE));
     }
 
     @Override
     public BlockVolume.Mutable copyFromRange(
         final BlockVolume.Streamable<@NonNull ?> existing, final Vector3i newMin, final Vector3i newMax
     ) {
-        final ArrayMutableBlockBuffer buffer = new ArrayMutableBlockBuffer(newMin, newMax.sub(newMin));
+        final ArrayMutableBlockBuffer buffer = new ArrayMutableBlockBuffer(newMin, newMax.sub(newMin).add(Vector3i.ONE));
         existing.blockStateStream(newMin, newMax, StreamOptions.lazily())
             .apply(VolumeCollectors.of(buffer, VolumePositionTranslators.identity(), VolumeApplicators.applyBlocks()));
         return buffer;
@@ -95,7 +95,7 @@ public class SpongeBlockVolumeFactory implements BlockVolumeFactory {
     @Override
     public BlockVolume.Immutable immutableOf(final BlockVolume.Streamable<@NonNull ?> existing, final Vector3i newMin, final Vector3i newMax
     ) {
-        final ArrayMutableBlockBuffer buffer = new ArrayMutableBlockBuffer(newMin, newMax.sub(newMin));
+        final ArrayMutableBlockBuffer buffer = new ArrayMutableBlockBuffer(newMin, newMax.sub(newMin).add(Vector3i.ONE));
         existing.blockStateStream(newMin, newMax, StreamOptions.lazily())
             .apply(VolumeCollectors.of(buffer, VolumePositionTranslators.identity(), VolumeApplicators.applyBlocks()));
         return this.createImmutableFromBufferData(buffer);

--- a/src/main/java/org/spongepowered/common/world/volume/buffer/archetype/blockentity/AbstractMutableBlockEntityArchetypeBuffer.java
+++ b/src/main/java/org/spongepowered/common/world/volume/buffer/archetype/blockentity/AbstractMutableBlockEntityArchetypeBuffer.java
@@ -98,22 +98,19 @@ public abstract class AbstractMutableBlockEntityArchetypeBuffer extends Abstract
         return this.blockBuffer.highestYAt(x, z);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public VolumeStream<BlockEntityArchetypeVolume.Mutable, BlockState> blockStateStream(final Vector3i min, final Vector3i max,
         final StreamOptions options) {
-        final Vector3i blockMin = this.min();
-        final Vector3i blockMax = this.max();
-        VolumeStreamUtils.validateStreamArgs(min, max, blockMin, blockMax, options);
+        VolumeStreamUtils.validateStreamArgs(min, max, this.min(), this.max(), options);
         final ArrayMutableBlockBuffer buffer;
         if (options.carbonCopy()) {
             buffer = this.blockBuffer.copy();
         } else {
             buffer = this.blockBuffer;
         }
-        final Stream<VolumeElement<BlockEntityArchetypeVolume.Mutable, BlockState>> stateStream = IntStream.range(blockMin.x(), blockMax.x() + 1)
-            .mapToObj(x -> IntStream.range(blockMin.z(), blockMax.z() + 1)
-                .mapToObj(z -> IntStream.range(blockMin.y(), blockMax.y() + 1)
+        final Stream<VolumeElement<BlockEntityArchetypeVolume.Mutable, BlockState>> stateStream = IntStream.range(min.x(), max.x() + 1)
+            .mapToObj(x -> IntStream.range(min.z(), max.z() + 1)
+                .mapToObj(z -> IntStream.range(min.y(), max.y() + 1)
                     .mapToObj(y -> VolumeElement.of((BlockEntityArchetypeVolume.Mutable) this, () -> buffer.block(x, y, z), new Vector3d(x, y, z)))
                 ).flatMap(Function.identity())
             ).flatMap(Function.identity());

--- a/src/main/java/org/spongepowered/common/world/volume/buffer/biome/ByteArrayImmutableBiomeBuffer.java
+++ b/src/main/java/org/spongepowered/common/world/volume/buffer/biome/ByteArrayImmutableBiomeBuffer.java
@@ -115,13 +115,11 @@ public final class ByteArrayImmutableBiomeBuffer extends AbstractBiomeBuffer imp
     @Override
     public VolumeStream<Immutable, Biome> biomeStream(final Vector3i min, final Vector3i max, final StreamOptions options
     ) {
-        final Vector3i blockMin = this.min();
-        final Vector3i blockMax = this.max();
-        VolumeStreamUtils.validateStreamArgs(min, max, blockMin, blockMax, options);
+        VolumeStreamUtils.validateStreamArgs(min, max, this.min(), this.max(), options);
 
-        final Stream<VolumeElement<Immutable, Biome>> stateStream = IntStream.range(blockMin.x(), blockMax.x() + 1)
-            .mapToObj(x -> IntStream.range(blockMin.z(), blockMax.z() + 1)
-                .mapToObj(z -> IntStream.range(blockMin.y(), blockMax.y() + 1)
+        final Stream<VolumeElement<Immutable, Biome>> stateStream = IntStream.range(min.x(), max.x() + 1)
+            .mapToObj(x -> IntStream.range(min.z(), max.z() + 1)
+                .mapToObj(z -> IntStream.range(min.y(), max.y() + 1)
                     .mapToObj(y -> VolumeElement.<Immutable, Biome>of(this, () -> {
                         final byte biomeId = this.biomes[this.getIndex(x, y, z)];
                         return this.palette.get(biomeId & 255, Sponge.server())

--- a/src/main/java/org/spongepowered/common/world/volume/buffer/biome/ObjectArrayMutableBiomeBuffer.java
+++ b/src/main/java/org/spongepowered/common/world/volume/buffer/biome/ObjectArrayMutableBiomeBuffer.java
@@ -143,18 +143,16 @@ public final class ObjectArrayMutableBiomeBuffer extends AbstractBiomeBuffer imp
         final Vector3i max,
         final StreamOptions options
     ) {
-        final Vector3i blockMin = this.min();
-        final Vector3i blockMax = this.max();
-        VolumeStreamUtils.validateStreamArgs(min, max, blockMin, blockMax, options);
+        VolumeStreamUtils.validateStreamArgs(min, max, this.min(), this.max(), options);
         final RegistryKey<Biome>[] buffer;
         if (options.carbonCopy()) {
             buffer = Arrays.copyOf(this.biomes, this.biomes.length);
         } else {
             buffer = this.biomes;
         }
-        final Stream<VolumeElement<ObjectArrayMutableBiomeBuffer, Biome>> stateStream = IntStream.range(blockMin.x(), blockMax.x() + 1)
-            .mapToObj(x -> IntStream.range(blockMin.z(), blockMax.z() + 1)
-                .mapToObj(z -> IntStream.range(blockMin.y(), blockMax.y() + 1)
+        final Stream<VolumeElement<ObjectArrayMutableBiomeBuffer, Biome>> stateStream = IntStream.range(min.x(), max.x() + 1)
+            .mapToObj(x -> IntStream.range(min.z(), max.z() + 1)
+                .mapToObj(z -> IntStream.range(min.y(), max.y() + 1)
                     .mapToObj(y -> VolumeElement.of(this, () ->  {
                         final RegistryKey<Biome> key = buffer[this.getIndex(x, y, z)];
                         final Biome biome = this.registry.value(key);

--- a/src/main/java/org/spongepowered/common/world/volume/buffer/block/ArrayImmutableBlockBuffer.java
+++ b/src/main/java/org/spongepowered/common/world/volume/buffer/block/ArrayImmutableBlockBuffer.java
@@ -138,9 +138,9 @@ public class ArrayImmutableBlockBuffer extends AbstractBlockBuffer implements Bl
     ) {
         VolumeStreamUtils.validateStreamArgs(min, max, this.min(), this.max(), options);
         // We don't need to copy since this is immutable.
-        final Stream<VolumeElement<Immutable, BlockState>> stateStream = IntStream.range(this.min().x(), this.max().x() + 1)
-            .mapToObj(x -> IntStream.range(this.min().z(), this.max().z() + 1)
-                .mapToObj(z -> IntStream.range(this.min().y(), this.max().y() + 1)
+        final Stream<VolumeElement<Immutable, BlockState>> stateStream = IntStream.range(min.x(), max.x() + 1)
+            .mapToObj(x -> IntStream.range(min.z(), max.z() + 1)
+                .mapToObj(z -> IntStream.range(min.y(), max.y() + 1)
                     .mapToObj(y -> VolumeElement.<Immutable, BlockState>of(this, () -> this.block(x, y, z), new Vector3d(x, y, z)))
                 ).flatMap(Function.identity())
             ).flatMap(Function.identity());

--- a/src/main/java/org/spongepowered/common/world/volume/buffer/block/ArrayMutableBlockBuffer.java
+++ b/src/main/java/org/spongepowered/common/world/volume/buffer/block/ArrayMutableBlockBuffer.java
@@ -191,18 +191,16 @@ public class ArrayMutableBlockBuffer extends AbstractBlockBuffer implements Bloc
 
     @Override
     public VolumeStream<BlockVolume.Mutable, BlockState> blockStateStream(final Vector3i min, final Vector3i max, final StreamOptions options) {
-        final Vector3i blockMin = this.min();
-        final Vector3i blockMax = this.max();
-        VolumeStreamUtils.validateStreamArgs(min, max, blockMin, blockMax, options);
+        VolumeStreamUtils.validateStreamArgs(min, max, this.min(), this.max(), options);
         final ArrayMutableBlockBuffer buffer;
         if (options.carbonCopy()) {
-            buffer = new ArrayMutableBlockBuffer(this.palette, this.data.copyOf(), this.start, this.size);
+            buffer = copy();
         } else {
             buffer = this;
         }
-        final Stream<VolumeElement<BlockVolume.Mutable, BlockState>> stateStream = IntStream.range(blockMin.x(), blockMax.x() + 1)
-            .mapToObj(x -> IntStream.range(blockMin.z(), blockMax.z() + 1)
-                .mapToObj(z -> IntStream.range(blockMin.y(), blockMax.y() + 1)
+        final Stream<VolumeElement<BlockVolume.Mutable, BlockState>> stateStream = IntStream.range(min.x(), max.x() + 1)
+            .mapToObj(x -> IntStream.range(min.z(), max.z() + 1)
+                .mapToObj(z -> IntStream.range(min.y(), max.y() + 1)
                     .mapToObj(y -> VolumeElement.of((BlockVolume.Mutable) this, () -> buffer.block(x, y, z), new Vector3d(x, y, z)))
                 ).flatMap(Function.identity())
             ).flatMap(Function.identity());

--- a/src/main/java/org/spongepowered/common/world/volume/buffer/blockentity/AbstractMutableBlockEntityBuffer.java
+++ b/src/main/java/org/spongepowered/common/world/volume/buffer/blockentity/AbstractMutableBlockEntityBuffer.java
@@ -93,22 +93,19 @@ public abstract class AbstractMutableBlockEntityBuffer extends AbstractBlockBuff
         return this.blockBuffer.highestYAt(x, z);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public VolumeStream<BlockEntityVolume.Mutable, BlockState> blockStateStream(final Vector3i min, final Vector3i max,
         final StreamOptions options) {
-        final Vector3i blockMin = this.min();
-        final Vector3i blockMax = this.max();
-        VolumeStreamUtils.validateStreamArgs(min, max, blockMin, blockMax, options);
+        VolumeStreamUtils.validateStreamArgs(min, max, this.min(), this.max(), options);
         final ArrayMutableBlockBuffer buffer;
         if (options.carbonCopy()) {
             buffer = this.blockBuffer.copy();
         } else {
             buffer = this.blockBuffer;
         }
-        final Stream<VolumeElement<BlockEntityVolume.Mutable, BlockState>> stateStream = IntStream.range(blockMin.x(), blockMax.x() + 1)
-            .mapToObj(x -> IntStream.range(blockMin.z(), blockMax.z() + 1)
-                .mapToObj(z -> IntStream.range(blockMin.y(), blockMax.y() + 1)
+        final Stream<VolumeElement<BlockEntityVolume.Mutable, BlockState>> stateStream = IntStream.range(min.x(), max.x() + 1)
+            .mapToObj(x -> IntStream.range(min.z(), max.z() + 1)
+                .mapToObj(z -> IntStream.range(min.y(), max.y() + 1)
                     .mapToObj(y -> VolumeElement.of((BlockEntityVolume.Mutable) this, () -> buffer.block(x, y, z), new Vector3d(x, y, z)))
                 ).flatMap(Function.identity())
             ).flatMap(Function.identity());


### PR DESCRIPTION
Going through the implementation of volumes, I noticed a few errors: 
- forgot to add one when calculating size
- blockStateStream/biomeStream using this.min()/this.max() instead of min/max arguments
- missing carbonCopy in blockStateStream