### PR TITLE
Mekanism workaround Fixes #3631

### DIFF
--- a/forge/src/mixins/java/org/spongepowered/forge/mixin/core/world/entity/item/ItemEntityMixin_Forge.java
+++ b/forge/src/mixins/java/org/spongepowered/forge/mixin/core/world/entity/item/ItemEntityMixin_Forge.java
@@ -42,8 +42,11 @@ public abstract class ItemEntityMixin_Forge {
     // @formatter:on
 
     @Inject(method = "<init>(Lnet/minecraft/world/entity/EntityType;Lnet/minecraft/world/level/Level;)V", at = @At("RETURN"))
-    private void forge$setLifespanFromConfig(EntityType<? extends ItemEntity> type, Level level, CallbackInfo ci) {
-        if (!level.isClientSide) {
+    private void forge$setLifespanFromConfig(final EntityType<? extends ItemEntity> type, final Level level,
+        final CallbackInfo ci
+    ) {
+        // Check the level is not null to avoid an NPE
+        if (level != null && !level.isClientSide) {
             this.lifespan = SpongeGameConfigs.getForWorld(level).get().entity.item.despawnRate;
         }
     }


### PR DESCRIPTION
Simple workaround for something trivial. I'd consider making some better changes down the line if this became a common practice, but crashing is suitable ot getting reports rather than letting null checks go around the codebase unecessarily.