### PR TITLE
Delay GoalType lookups until appropriate times

### DIFF
--- a/src/main/java/org/spongepowered/common/registry/provider/GoalTypeProvider.java
+++ b/src/main/java/org/spongepowered/common/registry/provider/GoalTypeProvider.java
@@ -24,12 +24,6 @@
  */
 package org.spongepowered.common.registry.provider;
 
-import org.spongepowered.api.entity.ai.goal.GoalType;
-import org.spongepowered.api.entity.ai.goal.GoalTypes;
-
-import java.util.IdentityHashMap;
-import java.util.Map;
-import java.util.Optional;
 import net.minecraft.world.entity.ai.goal.AvoidEntityGoal;
 import net.minecraft.world.entity.ai.goal.FloatGoal;
 import net.minecraft.world.entity.ai.goal.Goal;
@@ -40,29 +34,36 @@ import net.minecraft.world.entity.ai.goal.RandomStrollGoal;
 import net.minecraft.world.entity.ai.goal.RangedAttackGoal;
 import net.minecraft.world.entity.ai.goal.RunAroundLikeCrazyGoal;
 import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
+import org.spongepowered.api.entity.ai.goal.GoalType;
+import org.spongepowered.api.entity.ai.goal.GoalTypes;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 public final class GoalTypeProvider {
 
     public static final GoalTypeProvider INSTANCE = new GoalTypeProvider();
 
-    private final Map<Class<? extends Goal>, GoalType> mappings;
+    private final Map<Class<? extends Goal>, Supplier<GoalType>> mappings;
 
     GoalTypeProvider() {
         this.mappings = new IdentityHashMap<>();
 
-        this.mappings.put(AvoidEntityGoal.class, GoalTypes.AVOID_LIVING.get());
-        this.mappings.put(MeleeAttackGoal.class, GoalTypes.ATTACK_LIVING.get());
-        this.mappings.put(NearestAttackableTargetGoal.class, GoalTypes.FIND_NEAREST_ATTACKABLE.get());
-        this.mappings.put(LookAtPlayerGoal.class, GoalTypes.LOOK_AT.get());
-        this.mappings.put(RandomLookAroundGoal.class, GoalTypes.LOOK_RANDOMLY.get());
-        this.mappings.put(RandomStrollGoal.class, GoalTypes.RANDOM_WALKING.get());
-        this.mappings.put(RangedAttackGoal.class, GoalTypes.RANGED_ATTACK_AGAINST_AGENT.get());
-        this.mappings.put(RunAroundLikeCrazyGoal.class, GoalTypes.RUN_AROUND_LIKE_CRAZY.get());
-        this.mappings.put(FloatGoal.class, GoalTypes.SWIM.get());
+        this.mappings.put(AvoidEntityGoal.class, GoalTypes.AVOID_LIVING);
+        this.mappings.put(MeleeAttackGoal.class, GoalTypes.ATTACK_LIVING);
+        this.mappings.put(NearestAttackableTargetGoal.class, GoalTypes.FIND_NEAREST_ATTACKABLE);
+        this.mappings.put(LookAtPlayerGoal.class, GoalTypes.LOOK_AT);
+        this.mappings.put(RandomLookAroundGoal.class, GoalTypes.LOOK_RANDOMLY);
+        this.mappings.put(RandomStrollGoal.class, GoalTypes.RANDOM_WALKING);
+        this.mappings.put(RangedAttackGoal.class, GoalTypes.RANGED_ATTACK_AGAINST_AGENT);
+        this.mappings.put(RunAroundLikeCrazyGoal.class, GoalTypes.RUN_AROUND_LIKE_CRAZY);
+        this.mappings.put(FloatGoal.class, GoalTypes.SWIM);
 
     }
 
-    public Optional<GoalType> get(Class<? extends Goal> type) {
+    public Optional<Supplier<GoalType>> get(Class<? extends Goal> type) {
         return Optional.ofNullable(this.mappings.get(type));
     }
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/ai/goal/GoalMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/ai/goal/GoalMixin.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.mixin.core.world.entity.ai.goal;
 
 import com.google.common.base.MoreObjects;
+import net.minecraft.world.entity.ai.goal.Goal;
 import org.spongepowered.api.entity.ai.goal.GoalExecutor;
 import org.spongepowered.api.entity.ai.goal.GoalType;
 import org.spongepowered.asm.mixin.Mixin;
@@ -34,30 +35,29 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.bridge.world.entity.ai.GoalBridge;
 import org.spongepowered.common.registry.provider.GoalTypeProvider;
 
-import java.util.Optional;
-
 import javax.annotation.Nullable;
-import net.minecraft.world.entity.ai.goal.Goal;
+import java.util.Optional;
+import java.util.function.Supplier;
 
-@Mixin(net.minecraft.world.entity.ai.goal.Goal.class)
+@Mixin(Goal.class)
 public abstract class GoalMixin implements GoalBridge {
 
-    private GoalType impl$type;
+    private Supplier<GoalType> impl$type;
     private GoalExecutor<?> impl$owner;
 
     @Inject(method = "<init>", at = @At(value = "RETURN"))
     private void assignAITaskType(final CallbackInfo ci) {
-        this.impl$type = GoalTypeProvider.INSTANCE.get((Class<Goal>) (Object) this.getClass()).orElse(null);
+        this.impl$type = GoalTypeProvider.INSTANCE.get(((Goal) (Object) this).getClass()).orElse(null);
     }
 
     @Override
     public GoalType bridge$getType() {
-        return this.impl$type;
+        return this.impl$type.get();
     }
 
     @Override
     public void bridge$setType(final GoalType type) {
-        this.impl$type = type;
+        this.impl$type = () -> type;
     }
 
     @Override


### PR DESCRIPTION
This ought to fix #3630 which demonstrates an early registration/lookup of Goals during a mod's configuration lifecycle step. It's possible for these registrations to be "fixed" instead of adding a lazy evaluated access of types, but I figure this is sufficient without investigating further into the lifecycle of what is registered by the point in time vs what is not registered.

I'm sure @Zidane will have some opinions....