### PR TITLE
Fix potential IndexOutOfBoundsException in TileEntityPipeline

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/pipeline/TileEntityPipeline.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/pipeline/TileEntityPipeline.java
@@ -66,7 +66,7 @@ public final class TileEntityPipeline implements BlockPipeline {
         final WeakReference<ServerLevel> worldRef = new WeakReference<>(world);
         final LevelChunk chunk = world.getChunkAt(pos);
         final WeakReference<LevelChunk> chunkRef = new WeakReference<>(chunk);
-        final WeakReference<LevelChunkSection> sectionRef = new WeakReference<>(chunk.getSections()[pos.getY() >> 4]);
+        final WeakReference<LevelChunkSection> sectionRef = new WeakReference<>(chunk.getSection(chunk.getSectionIndex(pos.getY())));
         final Supplier<ServerLevel> worldSupplier = () -> Objects.requireNonNull(worldRef.get(), "ServerWorld de-referenced");
         final Supplier<LevelChunk> chunkSupplier = () -> Objects.requireNonNull(chunkRef.get(), "Chunk de-referenced");
         final Supplier<LevelChunkSection> chunkSectionSupplier = () -> Objects.requireNonNull(sectionRef.get(), "ChunkSection de-referenced");


### PR DESCRIPTION
Since the `y` Level can now be `< 0`, the `TileEntityPipeline` can produce an `IndexOutOfBoundsException` and also generally chooses the wrong chunk-section.
This PR fixes this :)


<details>
  <summary>Stack-Trace of the IndexOutOfBoundsException</summary>
<br>

**Reproduce:**
Place Tile-Entity below y0. Break it.
  
```
[19:25:36] [Server thread/FATAL]: Error executing task on Server
java.lang.ArrayIndexOutOfBoundsException: Index -2 out of bounds for length 24
        at org.spongepowered.common.event.tracking.context.transaction.pipeline.TileEntityPipeline.kickOff(TileEntityPipeline.java:69) ~[TileEntityPipeline.class:1.18.1-9.0.0-RC0]
        at net.minecraft.server.level.ServerLevel.removeBlockEntity(ServerLevel.java:4339) ~[?:?]
        at net.minecraft.world.level.block.state.BlockBehaviour.onRemove(BlockBehaviour.java:158) ~[?:?]
        at net.minecraft.world.level.block.state.BlockBehaviour$BlockStateBase.onRemove(BlockBehaviour.java:913) ~[?:?]
        at org.spongepowered.common.event.tracking.context.transaction.effect.OldBlockOnReplaceEffect.processSideEffect(OldBlockOnReplaceEffect.java:59) ~[OldBlockOnReplaceEffect.class:1.18.1-9.0.0-RC0]
        at org.spongepowered.common.event.tracking.context.transaction.pipeline.ChunkPipeline.processChange(ChunkPipeline.java:121) ~[ChunkPipeline.class:1.18.1-9.0.0-RC0]
        at org.spongepowered.common.event.tracking.context.transaction.pipeline.WorldPipeline.processEffects(WorldPipeline.java:97) ~[WorldPipeline.class:1.18.1-9.0.0-RC0]
        at net.minecraft.server.level.ServerLevel.setBlock(ServerLevel.java:4222) ~[?:?]
        at net.minecraft.world.level.Level.setBlock(Level.java:198) ~[?:?]
        at net.minecraft.world.level.Level.removeBlock(Level.java:273) ~[?:?]
        at net.minecraft.server.level.ServerPlayerGameMode.destroyBlock(ServerPlayerGameMode.java:249) ~[?:?]
        at net.minecraft.server.level.ServerPlayerGameMode.destroyAndAck(ServerPlayerGameMode.java:221) ~[?:?]
        at net.minecraft.server.level.ServerPlayerGameMode.handleBlockBreakAction(ServerPlayerGameMode.java:154) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.redirect$zhe000$impl$callInteractBlockPrimaryEvent(ServerGamePacketListenerImpl.java:3560) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handlePlayerAction(ServerGamePacketListenerImpl.java:1019) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.handle(ServerboundPlayerActionPacket.java:34) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.handle(ServerboundPlayerActionPacket.java:8) ~[?:?]
        at org.spongepowered.common.event.tracking.phase.packet.PacketPhaseUtil.onProcessPacket(PacketPhaseUtil.java:263) ~[PacketPhaseUtil.class:1.18.1-9.0.0-RC0]
        at net.minecraft.network.protocol.PacketUtils.md77c3d5$lambda$tracker$redirectProcessPacket$0$0(PacketUtils.java:552) ~[?:?]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[?:?]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:151) ~[?:?]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:23) ~[?:?]
        at net.minecraft.server.MinecraftServer.redirect$zca000$tracker$wrapAndPerformContextSwitch(MinecraftServer.java:4852) ~[?:?]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:780) ~[?:?]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:162) ~[?:?]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:125) ~[?:?]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:762) ~[?:?]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:756) ~[?:?]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:134) ~[?:?]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:741) ~[?:?]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:688) ~[?:?]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:270) ~[?:?]
        at java.lang.Thread.run(Thread.java:831) [?:?]
 ```
 
 </details>