### PR TITLE
Implement BlockEntityVolume methods for chunk

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/level/ServerLevelMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/level/ServerLevelMixin_API.java
@@ -263,7 +263,9 @@ public abstract class ServerLevelMixin_API extends LevelMixin_API<org.spongepowe
 
     @Override
     public void removeBlockEntity(final int x, final int y, final int z) {
-        this.shadow$removeBlockEntity(new BlockPos(x, y, z));
+        // *Just* removing the block entity is going to give is a glitchy state that should never happen.
+        // So just remove the whole block.
+        this.blockEntity(x, y, z).ifPresent(ignored -> this.removeBlock(x, y, z));
     }
 
     // UpdateableVolume

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/chunk/LevelChunkMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/chunk/LevelChunkMixin_API.java
@@ -291,12 +291,12 @@ public abstract class LevelChunkMixin_API implements WorldChunk {
 
     @Override
     public void addBlockEntity(int x, int y, int z, BlockEntity blockEntity) {
-        this.shadow$setBlockEntity(new BlockPos(x, y, z), (net.minecraft.world.level.block.entity.BlockEntity) blockEntity);
+        this.world().addBlockEntity(x, y, z, blockEntity);
     }
 
     @Override
     public void removeBlockEntity(int x, int y, int z) {
-        this.shadow$removeBlockEntity(new BlockPos(x, y, z));
+        this.world().removeBlockEntity(x, y, z);
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/chunk/LevelChunkMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/chunk/LevelChunkMixin_API.java
@@ -112,6 +112,9 @@ public abstract class LevelChunkMixin_API implements WorldChunk {
             net.minecraft.world.phys.AABB param1,
             List<net.minecraft.world.entity.Entity> param2,
             @org.jetbrains.annotations.Nullable Predicate<? super net.minecraft.world.entity.Entity> param3);
+    @Shadow public abstract Map<BlockPos, net.minecraft.world.level.block.entity.BlockEntity> shadow$getBlockEntities();
+    @Shadow public abstract void shadow$setBlockEntity(BlockPos param0, net.minecraft.world.level.block.entity.BlockEntity param1);
+    @Shadow public abstract void shadow$removeBlockEntity(BlockPos param0);
     //@formatter:on
 
     private @Nullable Vector3i api$blockMin;
@@ -240,6 +243,11 @@ public abstract class LevelChunkMixin_API implements WorldChunk {
     }
 
     @Override
+    public Collection<? extends BlockEntity> blockEntities() {
+        return (Collection) Collections.unmodifiableCollection(this.shadow$getBlockEntities().values());
+    }
+
+    @Override
     public VolumeStream<WorldChunk, BlockEntity> blockEntityStream(
         final Vector3i min, final Vector3i max, final StreamOptions options
     ) {
@@ -279,6 +287,16 @@ public abstract class LevelChunkMixin_API implements WorldChunk {
 
     private Stream<Map.Entry<BlockPos, net.minecraft.world.level.block.entity.BlockEntity>> impl$getBlockEntitiesStream(final ChunkAccess chunk) {
         return chunk instanceof LevelChunk ? ((LevelChunk) chunk).getBlockEntities().entrySet().stream() : Stream.empty();
+    }
+
+    @Override
+    public void addBlockEntity(int x, int y, int z, BlockEntity blockEntity) {
+        this.shadow$setBlockEntity(new BlockPos(x, y, z), (net.minecraft.world.level.block.entity.BlockEntity) blockEntity);
+    }
+
+    @Override
+    public void removeBlockEntity(int x, int y, int z) {
+        this.shadow$removeBlockEntity(new BlockPos(x, y, z));
     }
 
     @Override

--- a/testplugins/src/main/java/org/spongepowered/test/blockentity/BlockEntityVolumeTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/blockentity/BlockEntityVolumeTest.java
@@ -1,0 +1,87 @@
+package org.spongepowered.test.blockentity;
+
+import com.google.inject.Inject;
+import net.kyori.adventure.text.Component;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.api.block.entity.BlockEntity;
+import org.spongepowered.api.command.Command;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.exception.CommandException;
+import org.spongepowered.api.entity.living.player.server.ServerPlayer;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.lifecycle.RegisterCommandEvent;
+import org.spongepowered.api.world.chunk.WorldChunk;
+import org.spongepowered.math.vector.Vector3i;
+import org.spongepowered.plugin.PluginContainer;
+import org.spongepowered.plugin.builtin.jvm.Plugin;
+
+@Plugin("blockentityvolumetest")
+public class BlockEntityVolumeTest {
+
+    private final PluginContainer plugin;
+    private final Logger logger;
+
+    @Inject
+    public BlockEntityVolumeTest(final PluginContainer plugin, final Logger logger) {
+        this.plugin = plugin;
+        this.logger = logger;
+    }
+
+    @Listener
+    public void onRegisterCommands(final RegisterCommandEvent<Command.Parameterized> event) {
+        final Command.Parameterized countBlockEntitiesInChunk = Command.builder()
+                .executor(ctx -> {
+                    final ServerPlayer player = ctx.cause().first(ServerPlayer.class)
+                            .orElseThrow(() -> new CommandException(Component.text("You must be a player to execute this command")));
+                    final WorldChunk chunk = player.serverLocation().world().chunk(player.serverLocation().chunkPosition());
+                    final int count = chunk.blockEntities().size();
+
+                    player.sendMessage(Component.text("Counted " + count + " tile entities in this chunk"));
+                    return CommandResult.success();
+                })
+                .build();
+
+        event.register(this.plugin, countBlockEntitiesInChunk, "countBlockEntitiesInChunk");
+
+        final Command.Parameterized removeBlockEntity = Command.builder()
+                .executor(ctx -> {
+                    final ServerPlayer player = ctx.cause().first(ServerPlayer.class)
+                            .orElseThrow(() -> new CommandException(Component.text("You must be a player to execute this command")));
+                    WorldChunk chunk = player.serverLocation().world().chunk(player.serverLocation().chunkPosition());
+                    Vector3i pos = getBlockStandingOn(player);
+                    chunk.removeBlockEntity(pos);
+                    player.sendMessage(Component.text("Removed the BlockEntity you were standing on."));
+                    return CommandResult.success();
+                })
+                .build();
+
+        event.register(this.plugin, removeBlockEntity, "removeBlockEntity");
+
+
+        final Command.Parameterized testCopyPasteBlockEntity = Command.builder()
+                .executor(ctx -> {
+                    final ServerPlayer player = ctx.cause().first(ServerPlayer.class)
+                            .orElseThrow(() -> new CommandException(Component.text("You must be a player to execute this command")));
+                    final WorldChunk chunk = player.serverLocation().world().chunk(player.serverLocation().chunkPosition());
+                    final Vector3i pos = getBlockStandingOn(player);
+                    final BlockEntity blockEntity = chunk.blockEntity(pos)
+                            .orElseThrow(() -> new CommandException(Component.text("You must be standing on a block entity to execute this command")));
+
+                    chunk.addBlockEntity(pos.add(1, 0, 0), blockEntity);
+                    player.sendMessage(Component.text("You should observe the blockentity being copy/pasted you are standing on be pasted 1 block in the x direction (try this with a chest with items in)"));
+                    return CommandResult.success();
+                })
+               .build();
+
+        event.register(this.plugin, testCopyPasteBlockEntity, "testCopyPasteBlockEntity");
+    }
+
+    public Vector3i getBlockStandingOn(final ServerPlayer player) {
+        Vector3i pos = player.serverLocation().blockPosition();
+        // Chests make you sink into their block a bit, so this means you don't have to float awkwardly for the commands to work.
+        if (player.serverLocation().y() - player.serverLocation().blockY() < 0.3) {
+            pos = pos.sub(0, 1, 0);
+        }
+        return pos;
+    }
+}

--- a/testplugins/src/main/java/org/spongepowered/test/blockentity/BlockEntityVolumeTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/blockentity/BlockEntityVolumeTest.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.test.blockentity;
 
 import com.google.inject.Inject;

--- a/testplugins/src/main/resources/META-INF/sponge_plugins.json
+++ b/testplugins/src/main/resources/META-INF/sponge_plugins.json
@@ -249,6 +249,12 @@
             "name": "Key Listener Test",
             "entrypoint": "org.spongepowered.test.keys.KeyTest",
             "description": "Key Listener Testing"
+        },
+        {
+            "id": "blockentityvolumetest",
+            "name": "Block Entity Volume Test",
+            "entrypoint": "org.spongepowered.test.blockentity.BlockEntityVolumeTest",
+            "description": "Block Entity Volume testing for chunks."
         }
     ]
 }


### PR DESCRIPTION
Some block entity methods were not implemented for chunks.
I haven't been able to test this yet as it doesn't currently seem to build (CI seems to be failing at the moment too)
```
error: incompatible types: Key<Value<? extends EntityType<?>>> cannot be converted to Key<? extends Value<EntityType>>
                .create((Key<? extends Value<org.spongepowered.api.entity.EntityType>>) Keys.ENTITY_TYPE)
```