### PR TITLE
Api8/fix itemstack equalTo

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/item/ItemStackMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/item/ItemStackMixin_API.java
@@ -200,7 +200,7 @@ public abstract class ItemStackMixin_API implements SerializableDataHolder.Mutab
     }
 
     public boolean itemStack$equalTo(final ItemStack that) {
-        return net.minecraft.world.item.ItemStack.tagMatches(
+        return net.minecraft.world.item.ItemStack.matches(
                 (net.minecraft.world.item.ItemStack) (Object) this,
                 (net.minecraft.world.item.ItemStack) (Object) that
         );


### PR DESCRIPTION
At the moment it uses ItemStack.tagMatches but that only compares the nbt, meaning:
```java
ItemStack granite = ItemStack.of(ItemTypes.GRANITE);
ItemStack stone = ItemStack.of(ItemTypes.STONE);
ItemStack oak_plank = ItemStack.of(ItemTypes.OAK_PLANKS);
audience.sendMessage(Component.text("-- .equalTo --"));
audience.sendMessage(Component.text("Granite == Stone -> " + granite.equalTo(stone)));
audience.sendMessage(Component.text("Stone == Granite -> " + stone.equalTo(granite)));
audience.sendMessage(Component.text("Oak plank == Stone -> " + oak_plank.equalTo(stone)));
```
All yield true.
With this change, all are false, as well comparing the same item yielding true.