### PR TITLE
Add ServerWorld#saveAndFlush() method and fix memory leak related to block entities

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/level/ServerLevelMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/level/ServerLevelMixin_API.java
@@ -208,9 +208,16 @@ public abstract class ServerLevelMixin_API extends LevelMixin_API<org.spongepowe
     }
 
     @Override
-    public boolean save() throws IOException {
+    public boolean save() {
         ((ServerLevelBridge) this).bridge$setManualSave(true);
-        this.shadow$save(null, false, true);
+        this.shadow$save(null, false, false);
+        return true;
+    }
+
+    @Override
+    public boolean saveAndFlush() {
+        ((ServerLevelBridge) this).bridge$setManualSave(true);
+        this.shadow$save(null, true, false);
         return true;
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
@@ -441,6 +441,15 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerLevel
         this.impl$recentTickTimes[this.shadow$getServer().getTickCount() % 100] = postTickTime - this.impl$preTickTime;
     }
 
+    @Inject(method = "tick", at = @At("RETURN"))
+    private void impl$unloadBlockEntities(final BooleanSupplier param0, final CallbackInfo ci) {
+        if (!this.blockEntitiesToUnload.isEmpty()) {
+            this.tickableBlockEntities.removeAll(this.blockEntitiesToUnload);
+            this.blockEntityList.removeAll(this.blockEntitiesToUnload);
+            this.blockEntitiesToUnload.clear();
+        }
+    }
+
     private void impl$setWorldOnBorder() {
         ((WorldBorderBridge) this.shadow$getWorldBorder()).bridge$setAssociatedWorld(this.bridge$getKey());
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/level/LevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/level/LevelMixin.java
@@ -66,6 +66,7 @@ import org.spongepowered.common.util.Constants;
 import org.spongepowered.common.util.DataUtil;
 import org.spongepowered.math.vector.Vector3d;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 @Mixin(net.minecraft.world.level.Level.class)
@@ -77,6 +78,9 @@ public abstract class LevelMixin implements LevelBridge, LevelAccessor {
     @Shadow protected float rainLevel;
     @Shadow protected float oThunderLevel;
     @Shadow protected float thunderLevel;
+    @Shadow @Final public List<BlockEntity> blockEntityList;
+    @Shadow @Final public List<BlockEntity> tickableBlockEntities;
+    @Shadow @Final protected List<BlockEntity> blockEntitiesToUnload;
 
     @Shadow public abstract LevelData shadow$getLevelData();
     @Shadow public abstract void shadow$updateSkyBrightness();


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2429) |  **Sponge**

- Implemented `ServerWorld#saveAndFlush()` method and fixed boolean flags (`skipSave` was enabled, `ServerWorld#save()` method actually did nothing).
- Fixed memory leak related to inability to unload block entities when the world is inactive (no players and forced chunks). When the world is inactive, updating and unloading entities (including block entities) takes only 300 ticks (15 seconds). Next, three special arrays for block entities are inflated and hold a huge number of block entities in memory. Now it is guaranteed that every world tick there will be cleanup of block entity arrays.


`ServerLevel#tick()`:
```java
boolean inactive = !this.players.isEmpty() || !this.getForcedChunks().isEmpty();
if (inactive) {
    this.emptyTime = 0;
}
if (inactive || this.emptyTime++ < 300) {
    ...
    this.tickBlockEntities();
    ...
}
```
`Level#tickBlockEntities()`:
```java
public final List<BlockEntity> blockEntityList = Lists.newArrayList();
public final List<BlockEntity> tickableBlockEntities = Lists.newArrayList();
protected final List<BlockEntity> blockEntitiesToUnload = Lists.newArrayList();

public void tickBlockEntities() {
    ...
    if (!this.blockEntitiesToUnload.isEmpty()) {
        this.tickableBlockEntities.removeAll(this.blockEntitiesToUnload);
        this.blockEntityList.removeAll(this.blockEntitiesToUnload);
        this.blockEntitiesToUnload.clear();
    }
    ...
}
```