### PR TITLE
Fix block entity memory leak

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
@@ -55,6 +55,7 @@ import net.minecraft.world.level.storage.ServerLevelData;
 import net.minecraft.world.level.storage.WorldData;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
@@ -442,8 +443,18 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerLevel
         this.impl$recentTickTimes[this.shadow$getServer().getTickCount() % 100] = postTickTime - this.impl$preTickTime;
     }
 
-    @Inject(method = "tick", at = @At("RETURN"))
+    @Inject(
+        method = "tick",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/server/level/ServerLevel;emptyTime:I",
+            opcode = Opcodes.PUTFIELD,
+            shift = At.Shift.AFTER
+        )
+    )
     private void impl$unloadBlockEntities(final BooleanSupplier param0, final CallbackInfo ci) {
+        // This code fixes block entity memory leak
+        // https://github.com/SpongePowered/Sponge/pull/3689
         if (this.emptyTime >= 300 && !this.blockEntitiesToUnload.isEmpty()) {
             this.tickableBlockEntities.removeAll(this.blockEntitiesToUnload);
             this.blockEntityList.removeAll(this.blockEntitiesToUnload);

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
@@ -441,6 +441,15 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerLevel
         this.impl$recentTickTimes[this.shadow$getServer().getTickCount() % 100] = postTickTime - this.impl$preTickTime;
     }
 
+    @Inject(method = "tick", at = @At("RETURN"))
+    private void impl$unloadBlockEntities(final BooleanSupplier param0, final CallbackInfo ci) {
+        if (!this.blockEntitiesToUnload.isEmpty()) {
+            this.tickableBlockEntities.removeAll(this.blockEntitiesToUnload);
+            this.blockEntityList.removeAll(this.blockEntitiesToUnload);
+            this.blockEntitiesToUnload.clear();
+        }
+    }
+
     private void impl$setWorldOnBorder() {
         ((WorldBorderBridge) this.shadow$getWorldBorder()).bridge$setAssociatedWorld(this.bridge$getKey());
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
@@ -128,6 +128,7 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerLevel
 
     // @formatter:off
     @Shadow @Final private ServerLevelData serverLevelData;
+    @Shadow private int emptyTime;
 
     @Shadow @Nonnull public abstract MinecraftServer shadow$getServer();
     @Shadow protected abstract void shadow$saveLevelData();
@@ -443,7 +444,7 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerLevel
 
     @Inject(method = "tick", at = @At("RETURN"))
     private void impl$unloadBlockEntities(final BooleanSupplier param0, final CallbackInfo ci) {
-        if (!this.blockEntitiesToUnload.isEmpty()) {
+        if (this.emptyTime >= 300 && !this.blockEntitiesToUnload.isEmpty()) {
             this.tickableBlockEntities.removeAll(this.blockEntitiesToUnload);
             this.blockEntityList.removeAll(this.blockEntitiesToUnload);
             this.blockEntitiesToUnload.clear();

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/level/LevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/level/LevelMixin.java
@@ -66,6 +66,7 @@ import org.spongepowered.common.util.Constants;
 import org.spongepowered.common.util.DataUtil;
 import org.spongepowered.math.vector.Vector3d;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 @Mixin(net.minecraft.world.level.Level.class)
@@ -77,6 +78,9 @@ public abstract class LevelMixin implements LevelBridge, LevelAccessor {
     @Shadow protected float rainLevel;
     @Shadow protected float oThunderLevel;
     @Shadow protected float thunderLevel;
+    @Shadow @Final public List<BlockEntity> blockEntityList;
+    @Shadow @Final public List<BlockEntity> tickableBlockEntities;
+    @Shadow @Final protected List<BlockEntity> blockEntitiesToUnload;
 
     @Shadow public abstract LevelData shadow$getLevelData();
     @Shadow public abstract void shadow$updateSkyBrightness();


### PR DESCRIPTION
Fixed memory leak related to inability to unload block entities when the world is inactive (no players and forced chunks). When the world is inactive, updating and unloading entities (including block entities) takes only 300 ticks (15 seconds). Next, three special arrays for block entities are inflated and hold a huge number of block entities in memory. Now it is guaranteed that every world tick there will be cleanup of block entity arrays.


`ServerLevel#tick()`:
```java
boolean active = !this.players.isEmpty() || !this.getForcedChunks().isEmpty();
if (active) {
    this.emptyTime = 0;
}
if (active || this.emptyTime++ < 300) {
    ...
    this.tickBlockEntities();
    ...
}
```
`Level#tickBlockEntities()`:
```java
public final List<BlockEntity> blockEntityList = Lists.newArrayList();
public final List<BlockEntity> tickableBlockEntities = Lists.newArrayList();
protected final List<BlockEntity> blockEntitiesToUnload = Lists.newArrayList();

public void tickBlockEntities() {
    ...
    if (!this.blockEntitiesToUnload.isEmpty()) {
        this.tickableBlockEntities.removeAll(this.blockEntitiesToUnload);
        this.blockEntityList.removeAll(this.blockEntitiesToUnload);
        this.blockEntitiesToUnload.clear();
    }
    ...
}
```