### PR TITLE
Fix many WorldManager issues

### DIFF
--- a/src/main/java/org/spongepowered/common/datapack/DataPackSerializer.java
+++ b/src/main/java/org/spongepowered/common/datapack/DataPackSerializer.java
@@ -24,8 +24,11 @@
  */
 package org.spongepowered.common.datapack;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import net.minecraft.SharedConstants;
 import org.apache.commons.io.FileUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -34,9 +37,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import net.minecraft.SharedConstants;
 
 public class DataPackSerializer<T extends DataPackSerializedObject> {
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
     protected final String name;
     protected final String typeDirectoryName;
@@ -91,8 +95,8 @@ public class DataPackSerializer<T extends DataPackSerializedObject> {
     public static void writeFile(final Path file, final JsonElement object) throws IOException {
         Files.deleteIfExists(file);
 
-        try (BufferedWriter bufferedwriter = Files.newBufferedWriter(file)) {
-            bufferedwriter.write(object.toString());
+        try (BufferedWriter writer = Files.newBufferedWriter(file)) {
+            DataPackSerializer.GSON.toJson(object, writer);
         }
     }
 

--- a/src/main/java/org/spongepowered/common/world/server/SpongeWorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/server/SpongeWorldManager.java
@@ -726,12 +726,12 @@ public abstract class SpongeWorldManager implements WorldManager {
 
         if (this.isVanillaWorld(key)) {
             final LevelStem stem = this.server.getWorldData().worldGenSettings().dimensions().get(SpongeWorldManager.createStemKey(key));
-            JsonElement template = SpongeWorldManager.stemToJson(stem);
+            final JsonElement template = SpongeWorldManager.stemToJson(stem);
 
             try {
                 this.writeTemplate(template, movedKey);
             } catch (final IOException e) {
-                FutureUtil.completedWithException(e);
+                return FutureUtil.completedWithException(e);
             }
         } else {
             final Path dimensionTemplate = this.getDataPackFile(key);
@@ -741,7 +741,7 @@ public abstract class SpongeWorldManager implements WorldManager {
                 Files.createDirectories(movedDimensionTemplate.getParent());
                 Files.move(dimensionTemplate, movedDimensionTemplate, StandardCopyOption.REPLACE_EXISTING);
             } catch (final IOException e) {
-                FutureUtil.completedWithException(e);
+                return FutureUtil.completedWithException(e);
             }
         }
 

--- a/src/main/java/org/spongepowered/common/world/server/SpongeWorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/server/SpongeWorldManager.java
@@ -720,6 +720,16 @@ public abstract class SpongeWorldManager implements WorldManager {
             loadedWorld.noSave = disableLevelSaving;
         }
 
+        final Path configFile = this.getConfigFile(key);
+        final Path copiedConfigFile = this.getConfigFile(copyKey);
+
+        try {
+            Files.createDirectories(copiedConfigFile.getParent());
+            Files.copy(configFile, copiedConfigFile, StandardCopyOption.REPLACE_EXISTING);
+        } catch (final IOException e) {
+            return FutureUtil.completedWithException(e);
+        }
+
         final Path dimensionTemplate = this.getDataPackFile(key);
         final Path copiedDimensionTemplate = this.getDataPackFile(copyKey);
 
@@ -789,7 +799,7 @@ public abstract class SpongeWorldManager implements WorldManager {
         final String moveDirectoryName = this.getDirectoryName(movedKey);
 
         final Path moveDirectory = isVanillaMoveWorld ? this.defaultWorldDirectory
-                .resolve(moveDirectoryName) : this.customWorldsDirectory.resolve(key.namespace()).resolve(key.value());
+                .resolve(moveDirectoryName) : this.customWorldsDirectory.resolve(movedKey.namespace()).resolve(movedKey.value());
 
         try {
             Files.createDirectories(moveDirectory);
@@ -798,25 +808,22 @@ public abstract class SpongeWorldManager implements WorldManager {
             return FutureUtil.completedWithException(e);
         }
 
-        final Path configFile = SpongeCommon.spongeConfigDirectory().resolve(Launch.instance().id()).resolve("worlds").resolve(key
-                .namespace()).resolve(key.value() + ".conf");
-
-        final Path copiedConfigFile = SpongeCommon.spongeConfigDirectory().resolve(Launch.instance().id()).resolve("worlds")
-                .resolve(movedKey.namespace()).resolve(movedKey.value() + ".conf");
+        final Path configFile = this.getConfigFile(key);
+        final Path movedConfigFile = this.getConfigFile(movedKey);
 
         try {
-            Files.createDirectories(copiedConfigFile.getParent());
-            Files.move(configFile, copiedConfigFile, StandardCopyOption.REPLACE_EXISTING);
+            Files.createDirectories(movedConfigFile.getParent());
+            Files.move(configFile, movedConfigFile, StandardCopyOption.REPLACE_EXISTING);
         } catch (final IOException e) {
             return FutureUtil.completedWithException(e);
         }
 
         final Path dimensionTemplate = this.getDataPackFile(key);
-        final Path copiedDimensionTemplate = this.getDataPackFile(movedKey);
+        final Path movedDimensionTemplate = this.getDataPackFile(movedKey);
 
         try {
-            Files.createDirectories(copiedDimensionTemplate.getParent());
-            Files.move(dimensionTemplate, copiedDimensionTemplate, StandardCopyOption.REPLACE_EXISTING);
+            Files.createDirectories(movedDimensionTemplate.getParent());
+            Files.move(dimensionTemplate, movedDimensionTemplate, StandardCopyOption.REPLACE_EXISTING);
         } catch (final IOException e) {
             FutureUtil.completedWithException(e);
         }
@@ -863,8 +870,7 @@ public abstract class SpongeWorldManager implements WorldManager {
             }
         }
 
-        final Path configFile = SpongeCommon.spongeConfigDirectory().resolve(Launch.instance().id()).resolve("worlds").resolve(key.namespace())
-            .resolve(key.value() + ".conf");
+        final Path configFile = getConfigFile(key);
 
         try {
             Files.deleteIfExists(configFile);
@@ -1255,6 +1261,11 @@ public abstract class SpongeWorldManager implements WorldManager {
 
     Path getDataPackFile(final ResourceKey key) {
         return this.getDimensionDataPackDirectory().resolve(key.namespace()).resolve("dimension").resolve(key.value() + ".json");
+    }
+
+    Path getConfigFile(final ResourceKey key) {
+        return SpongeCommon.spongeConfigDirectory().resolve(Launch.instance().id()).resolve("worlds").resolve(key.namespace())
+                .resolve(key.value() + ".conf");
     }
 
     private static final class SingleTemplateAccess implements RegistryReadOps.ResourceAccess {

--- a/src/main/java/org/spongepowered/common/world/server/SpongeWorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/server/SpongeWorldManager.java
@@ -1069,7 +1069,7 @@ public abstract class SpongeWorldManager implements WorldManager {
                     } else if (Level.END.equals(world.dimension())) {
                         ((PrimaryLevelData) world.getLevelData()).setSpawn(ServerLevel.END_SPAWN_POINT, 0);
                     }
-                } else {
+                } else if (levelData.worldGenSettings().generateBonusChest()) {
                     Features.BONUS_CHEST.place(world, world.getChunkSource().getGenerator(), world.random, new BlockPos(levelData.getXSpawn(),
                             levelData.getYSpawn(),levelData.getZSpawn()));
                 }

--- a/src/main/java/org/spongepowered/common/world/server/SpongeWorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/server/SpongeWorldManager.java
@@ -435,11 +435,10 @@ public abstract class SpongeWorldManager implements WorldManager {
                 registryKey, (DimensionType) worldType, chunkStatusListener, template.generator(), isDebugGeneration, seed, ImmutableList.of(), true);
         this.worlds.put(registryKey, world);
 
-        return SpongeCommon.asyncScheduler().submit(() -> this.prepareWorld(world, isDebugGeneration)).thenApply(w -> {
-            ((MinecraftServerAccessor) this.server).invoker$forceDifficulty();
-            return w;
-        }).thenCompose(w -> this.postWorldLoad(w, false))
-          .thenApply(w -> (org.spongepowered.api.world.server.ServerWorld) w);
+        this.prepareWorld(world, isDebugGeneration);
+        ((MinecraftServerAccessor) this.server).invoker$forceDifficulty();
+        this.postWorldLoad(world, false);
+        return CompletableFuture.completedFuture((org.spongepowered.api.world.server.ServerWorld) world);
     }
 
     @Override
@@ -1039,7 +1038,7 @@ public abstract class SpongeWorldManager implements WorldManager {
         ((SpongeServer) SpongeCommon.server()).getPlayerDataManager().load();
     }
 
-    private ServerLevel prepareWorld(final ServerLevel world, final boolean isDebugGeneration) {
+    private void prepareWorld(final ServerLevel world, final boolean isDebugGeneration) {
         final boolean isDefaultWorld = Level.OVERWORLD.equals(world.dimension());
         final PrimaryLevelData levelData = (PrimaryLevelData) world.getLevelData();
 
@@ -1097,8 +1096,6 @@ public abstract class SpongeWorldManager implements WorldManager {
         if (levelData.getCustomBossEvents() != null) {
             ((ServerLevelBridge) world).bridge$getBossBarManager().load(levelData.getCustomBossEvents());
         }
-
-        return world;
     }
 
     private CompletableFuture<ServerLevel> postWorldLoad(final ServerLevel world, final boolean blocking) {

--- a/src/main/java/org/spongepowered/common/world/server/SpongeWorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/server/SpongeWorldManager.java
@@ -561,11 +561,17 @@ public abstract class SpongeWorldManager implements WorldManager {
             }
         }
 
-        return this.loadTemplate(key).thenCompose(r -> {
-            r.ifPresent(template -> {
-                final LevelStem scratch = ((SpongeWorldTemplate) template).asDimension();
+        if (levelData == null) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        return this.loadTemplate(key).thenCompose(template -> {
+            if (template.isPresent()) {
+                final LevelStem scratch = ((SpongeWorldTemplate) template.get()).asDimension();
                 ((PrimaryLevelDataBridge) levelData).bridge$populateFromDimension(scratch);
-            });
+            } else {
+                ((ResourceKeyBridge) levelData).bridge$setKey(key);
+            }
 
             return CompletableFuture.completedFuture(Optional.of((ServerWorldProperties) levelData));
         });

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/level/ServerLevelMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/level/ServerLevelMixin_API.java
@@ -55,12 +55,9 @@ import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.api.fluid.FluidType;
-import org.spongepowered.api.registry.RegistryHolder;
-import org.spongepowered.api.registry.RegistryScope;
 import org.spongepowered.api.scheduler.ScheduledUpdateList;
 import org.spongepowered.api.util.Ticks;
 import org.spongepowered.api.world.BlockChangeFlag;
-import org.spongepowered.api.world.ChunkRegenerateFlag;
 import org.spongepowered.api.world.border.WorldBorder;
 import org.spongepowered.api.world.chunk.WorldChunk;
 import org.spongepowered.api.world.generation.ChunkGenerator;
@@ -79,15 +76,12 @@ import org.spongepowered.common.bridge.server.level.ServerLevelBridge;
 import org.spongepowered.common.bridge.world.level.border.WorldBorderBridge;
 import org.spongepowered.common.data.holder.SpongeLocationBaseDataHolder;
 import org.spongepowered.common.mixin.api.minecraft.world.level.LevelMixin_API;
-import org.spongepowered.common.util.MissingImplementationException;
 import org.spongepowered.common.util.VecHelper;
 import org.spongepowered.common.world.server.SpongeWorldTemplate;
 import org.spongepowered.common.world.storage.SpongeChunkLayout;
 import org.spongepowered.math.vector.Vector3d;
 import org.spongepowered.math.vector.Vector3i;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -96,6 +90,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 @Mixin(ServerLevel.class)
@@ -210,7 +207,7 @@ public abstract class ServerLevelMixin_API extends LevelMixin_API<org.spongepowe
     @Override
     public boolean save() throws IOException {
         ((ServerLevelBridge) this).bridge$setManualSave(true);
-        this.shadow$save(null, false, true);
+        this.shadow$save(null, false, false);
         return true;
     }
 


### PR DESCRIPTION
Affected API methods are : `World#save`, `WorldManager#loadProperties`, `WorldManager#loadWorld`, `WorldManager#copyWorld` and `WorldManager#moveWorld`. See the commit descriptions for more details.

I also added json indentation when writing templates so it's easier to edit as some server owners may want to edit generation settings.

~~One problem persists: renaming or copying from a vanilla world to a custom world does not work because custom worlds need a template and vanilla worlds don't have templates.~~

