### PR TITLE
Fix error when using BiomeVolume#biome()

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/LevelReaderMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/LevelReaderMixin_API.java
@@ -169,7 +169,7 @@ public interface LevelReaderMixin_API<R extends Region<R>> extends Region<R> {
 
     @Override
     default Biome biome(final int x, final int y, final int z) {
-        return (Biome) (Object) this.shadow$getBiome(new BlockPos(x, y, z));
+        return (Biome) (Object) this.shadow$getBiome(new BlockPos(x, y, z)).value();
     }
 
     @Override


### PR DESCRIPTION
Using `BiomeVolume#biome()` causes an exception:
```
java.lang.ClassCastException: class net.minecraft.core.Holder$Reference cannot be cast to class org.spongepowered.api.world.biome.Biome (net.minecraft.core.Holder$Reference and org.spongepowered.api.world.biome.Biome are in unnamed module of loader cpw.mods.modlauncher.TransformingClassLoader @47a7a101)
	at net.minecraft.world.level.LevelReader.biome(LevelReader.java:672) ~[?:?]
	at org.spongepowered.api.world.volume.biome.BiomeVolume.biome(BiomeVolume.java:52) ~[BiomeVolume.class:1.18.2-9.0.0-RC0]
	at org.spongepowered.common.world.SpongeLocation.biome(SpongeLocation.java:228) ~[SpongeLocation.class:1.18.2-9.0.0-RC0]
	...
```

This PR fixes this :)