### PR TITLE
Fix GridInventory coordinates

### DIFF
--- a/src/main/java/org/spongepowered/common/inventory/lens/impl/comp/Inventory2DLens.java
+++ b/src/main/java/org/spongepowered/common/inventory/lens/impl/comp/Inventory2DLens.java
@@ -84,7 +84,7 @@ public class Inventory2DLens extends SlotBasedLens {
     }
 
     public SlotLens getSlot(Vector2i pos) {
-        return (SlotLens) this.spanningChildren.get(pos.y() + pos.x() * this.width);
+        return (SlotLens) this.spanningChildren.get(pos.x() + pos.y() * this.width);
     }
 
     @Override


### PR DESCRIPTION
Fix `GridInventory#set(x, y, stack)`, `#slot(x, y)` etc methods coordinates being inverted.

Test code : 
```java
ViewableInventory inv = ViewableInventory.builder().type(ContainerTypes.GENERIC_9X6).completeStructure().plugin(plugin).build();
GridInventory grid = inv.query(GridInventory.class).get();

for (int y = 0; y < 9; y++) {
    for (int x = 0; x < 9; x++) {
        grid.set(x, y, ItemStack.builder().itemType(ItemTypes.STONE).add(Keys.CUSTOM_NAME, Component.text("x=" + x + " y=" + y)).build());
    }
}
        
player.openInventory(inv);
```


Before fix : 

![before](https://user-images.githubusercontent.com/10995968/174494482-d037a5d9-bdd9-4779-85b7-67a7b45b528d.png)

After fix : 

![after](https://user-images.githubusercontent.com/10995968/174494492-d21f5c79-c5ad-4cd9-8094-52e79fbc721d.png)

