### PR TITLE
Fix multiple RespawnPlayerEvents issues

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/server/players/PlayerListBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/server/players/PlayerListBridge.java
@@ -26,17 +26,11 @@ package org.spongepowered.common.bridge.server.players;
 
 import com.mojang.authlib.GameProfile;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.world.level.Level;
 
 import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
 
 public interface PlayerListBridge {
-
-    void bridge$setNewDestinationDimension(ResourceKey<Level> dimension);
-
-    void bridge$setOriginalDestinationDimension(ResourceKey<Level> dimension);
 
     CompletableFuture<Component> bridge$canPlayerLogin(SocketAddress param0, GameProfile param1);
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/players/PlayerListMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/players/PlayerListMixin.java
@@ -39,7 +39,6 @@ import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundDisconnectPacket;
 import net.minecraft.network.protocol.game.ClientboundLoginPacket;
-import net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerScoreboard;
@@ -55,6 +54,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.border.BorderChangeListener;
 import net.minecraft.world.level.border.WorldBorder;
 import net.minecraft.world.level.dimension.DimensionType;
+import net.minecraft.world.phys.Vec3;
 import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.api.Sponge;
@@ -72,6 +72,7 @@ import org.spongepowered.api.service.ban.Ban;
 import org.spongepowered.api.service.permission.PermissionService;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.world.server.ServerLocation;
+import org.spongepowered.api.world.server.ServerWorld;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -85,15 +86,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.SpongeServer;
 import org.spongepowered.common.accessor.network.protocol.game.ClientboundPlayerInfoPacketAccessor;
-import org.spongepowered.common.accessor.network.protocol.game.ClientboundRespawnPacketAccessor;
 import org.spongepowered.common.adventure.SpongeAdventure;
 import org.spongepowered.common.bridge.client.server.IntegratedPlayerListBridge;
 import org.spongepowered.common.bridge.data.VanishableBridge;
 import org.spongepowered.common.bridge.network.ConnectionBridge;
-import org.spongepowered.common.bridge.server.level.ServerPlayerBridge;
 import org.spongepowered.common.bridge.server.ServerScoreboardBridge;
-import org.spongepowered.common.bridge.server.players.PlayerListBridge;
 import org.spongepowered.common.bridge.server.level.ServerLevelBridge;
+import org.spongepowered.common.bridge.server.level.ServerPlayerBridge;
+import org.spongepowered.common.bridge.server.players.PlayerListBridge;
 import org.spongepowered.common.bridge.world.level.storage.PrimaryLevelDataBridge;
 import org.spongepowered.common.entity.player.LoginPermissions;
 import org.spongepowered.common.entity.player.SpongeUserView;
@@ -110,7 +110,6 @@ import org.spongepowered.common.service.server.ban.SpongeUserBanList;
 import org.spongepowered.common.service.server.whitelist.SpongeUserWhiteList;
 import org.spongepowered.common.util.Constants;
 import org.spongepowered.common.util.NetworkUtil;
-import org.spongepowered.common.util.VecHelper;
 import org.spongepowered.math.vector.Vector3d;
 
 import java.net.InetAddress;
@@ -148,24 +147,13 @@ public abstract class PlayerListMixin implements PlayerListBridge {
     // @formatter:on
 
     private boolean impl$isGameMechanicRespawn = false;
-    ResourceKey<Level> impl$newDestination = null;
-    ResourceKey<Level> impl$originalDestination = null;
+    private ServerWorld impl$originalRespawnDestination = null;
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void impl$setSpongeLists(final CallbackInfo callbackInfo) {
         this.bans = new SpongeUserBanList(PlayerList.USERBANLIST_FILE);
         this.ipBans = new SpongeIPBanList(PlayerList.IPBANLIST_FILE);
         this.whitelist = new SpongeUserWhiteList(PlayerList.WHITELIST_FILE);
-    }
-
-    @Override
-    public void bridge$setOriginalDestinationDimension(final ResourceKey<Level> dimension) {
-        this.impl$originalDestination = dimension;
-    }
-
-    @Override
-    public void bridge$setNewDestinationDimension(final ResourceKey<Level> dimension) {
-        this.impl$newDestination = dimension;
     }
 
     @Override
@@ -521,56 +509,56 @@ public abstract class PlayerListMixin implements PlayerListBridge {
             to = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;isDemo()Z")
         )
     )
-    private boolean impl$flagIfRespawnLocationIsGameMechanic(final Optional<?> optional) {
-        this.impl$isGameMechanicRespawn = optional.isPresent();
-        return this.impl$isGameMechanicRespawn;
+    private boolean impl$flagIfRespawnPositionIsGameMechanic(final Optional<Vec3> respawnPosition) {
+        this.impl$isGameMechanicRespawn = respawnPosition.isPresent();
+        return false; // force call of MinecraftServer#overworld which is redirected into impl$callRespawnPlayerSelectWorld
     }
 
-    @Redirect(method = "respawn",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/server/network/ServerGamePacketListenerImpl;send(Lnet/minecraft/network/protocol/Packet;)V",
-            ordinal = 1
-        )
-    )
-    private void impl$callRespawnPlayerRecreateEvent(
-        final ServerGamePacketListenerImpl serverPlayNetHandler, final Packet<?> packetIn, final net.minecraft.server.level.ServerPlayer originalPlayer, final boolean keepAllPlayerData) {
-        final net.minecraft.server.level.ServerPlayer recreatedPlayer = serverPlayNetHandler.player;
+    @Redirect(method = "respawn", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;overworld()Lnet/minecraft/server/level/ServerLevel;"))
+    private ServerLevel impl$callRespawnPlayerSelectWorld(final MinecraftServer server, final net.minecraft.server.level.ServerPlayer player) {
+        final ServerLevel playerRespawnDestination = server.getLevel(player.getRespawnDimension());
+        this.impl$originalRespawnDestination =
+                (ServerWorld) (playerRespawnDestination != null && this.impl$isGameMechanicRespawn ? playerRespawnDestination : server.overworld());
 
-        final Vector3d originalPosition = VecHelper.toVector3d(originalPlayer.position());
-        final Vector3d destinationPosition = VecHelper.toVector3d(recreatedPlayer.position());
-        final org.spongepowered.api.world.server.ServerWorld originalWorld = (org.spongepowered.api.world.server.ServerWorld) originalPlayer.level;
-        final org.spongepowered.api.world.server.ServerWorld originalDestinationWorld = (org.spongepowered.api.world.server.ServerWorld) this.server.getLevel(this.impl$originalDestination == null ? Level.OVERWORLD : this.impl$originalDestination);
-        final org.spongepowered.api.world.server.ServerWorld destinationWorld = (org.spongepowered.api.world.server.ServerWorld) this.server.getLevel(this.impl$newDestination == null ? Level.OVERWORLD : this.impl$newDestination);
-
-        final RespawnPlayerEvent.Recreate event = SpongeEventFactory.createRespawnPlayerEventRecreate(PhaseTracker.getCauseStackManager().currentCause(), destinationPosition, originalWorld, originalPosition, destinationWorld, originalDestinationWorld, destinationPosition, (ServerPlayer) originalPlayer, (ServerPlayer) recreatedPlayer, this.impl$isGameMechanicRespawn, !keepAllPlayerData);
+        final RespawnPlayerEvent.SelectWorld event = SpongeEventFactory.createRespawnPlayerEventSelectWorld(PhaseTracker.getCauseStackManager().currentCause(),
+                        this.impl$originalRespawnDestination, (ServerWorld) player.getLevel(), this.impl$originalRespawnDestination, (ServerPlayer) player);
         SpongeCommon.post(event);
-        recreatedPlayer.setPos(event.destinationPosition().x(), event.destinationPosition().y(), event.destinationPosition().z());
-        this.impl$isGameMechanicRespawn = false;
-        this.impl$originalDestination = null;
-        this.impl$newDestination = null;
 
-        final ServerLevel targetWorld = (ServerLevel) event.destinationWorld();
-        ((ServerPlayerBridge) recreatedPlayer).bridge$sendChangeDimension(
-            targetWorld.dimensionType(),
-            ((ClientboundRespawnPacketAccessor) packetIn).accessor$dimension(),
-            ((ClientboundRespawnPacketAccessor) packetIn).accessor$seed(),
-            recreatedPlayer.gameMode.getGameModeForPlayer(),
-            recreatedPlayer.gameMode.getPreviousGameModeForPlayer(),
-            targetWorld.isDebug(),
-            targetWorld.isFlat(),
-            keepAllPlayerData
-        );
+        return (ServerLevel) event.destinationWorld();
+    }
+
+    @Redirect(method = "respawn", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;getX()D", ordinal = 1))
+    private double impl$callRespawnPlayerRecreateEvent(final net.minecraft.server.level.ServerPlayer newPlayer,
+            final net.minecraft.server.level.ServerPlayer player, final boolean keepAllPlayerData) {
+        final ServerPlayer originalPlayer = (ServerPlayer) player;
+        final ServerPlayer recreatedPlayer = (ServerPlayer) newPlayer;
+
+        final Vector3d originalPosition = originalPlayer.position();
+        final Vector3d destinationPosition = recreatedPlayer.position();
+        final ServerWorld originalWorld = originalPlayer.world();
+        final ServerWorld destinationWorld = recreatedPlayer.world();
+
+        final RespawnPlayerEvent.Recreate event = SpongeEventFactory.createRespawnPlayerEventRecreate(PhaseTracker.getCauseStackManager().currentCause(),
+                destinationPosition, originalWorld, originalPosition, destinationWorld, this.impl$originalRespawnDestination, destinationPosition,
+                originalPlayer, recreatedPlayer, this.impl$isGameMechanicRespawn, !keepAllPlayerData);
+        SpongeCommon.post(event);
+
+        this.impl$isGameMechanicRespawn = false;
+        newPlayer.setPos(event.destinationPosition().x(), event.destinationPosition().y(), event.destinationPosition().z());
+
+        return newPlayer.getX();
     }
 
     @Inject(method = "respawn", at = @At("RETURN"))
     private void impl$callRespawnPlayerPostEvent(final net.minecraft.server.level.ServerPlayer player, final boolean keepAllPlayerData, final CallbackInfoReturnable<net.minecraft.server.level.ServerPlayer> cir) {
-        final org.spongepowered.api.world.server.ServerWorld originalWorld = (org.spongepowered.api.world.server.ServerWorld) player.level;
-        final org.spongepowered.api.world.server.ServerWorld originalDestinationWorld = (org.spongepowered.api.world.server.ServerWorld) this.server.getLevel(this.impl$originalDestination == null ? Level.OVERWORLD : this.impl$originalDestination);
-        final org.spongepowered.api.world.server.ServerWorld destinationWorld = (org.spongepowered.api.world.server.ServerWorld) this.server.getLevel(this.impl$newDestination == null ? Level.OVERWORLD : this.impl$newDestination);
+        final ServerPlayer recreatedPlayer = (ServerPlayer) cir.getReturnValue();
+        final ServerWorld originalWorld = (ServerWorld) player.level;
 
-        final RespawnPlayerEvent.Post event = SpongeEventFactory.createRespawnPlayerEventPost(PhaseTracker.getCauseStackManager().currentCause(), destinationWorld, originalWorld, originalDestinationWorld, (ServerPlayer) cir.getReturnValue());
+        final RespawnPlayerEvent.Post event = SpongeEventFactory.createRespawnPlayerEventPost(PhaseTracker.getCauseStackManager().currentCause(),
+                recreatedPlayer.world(), originalWorld, this.impl$originalRespawnDestination, recreatedPlayer);
         SpongeCommon.post(event);
+
+        this.impl$originalRespawnDestination = null;
     }
 
     @Redirect(method = "sendLevelInfo", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;overworld()Lnet/minecraft/server/level/ServerLevel;"))


### PR DESCRIPTION
1. New player instance was not captured properly (`Recreate#entity()` and `Recreate#recreatedPlayer()` were returning the same object).
2. `Recreate#setDestinationPosition(Vector3d)` was ignored (consequence of 1. ). 
3. `SelectWorld#setDestinationWorld()` was ignored.
4. `Post#originalDestinationWorld()` and `Post#destinationWorld()` were returning incorrect values.
5. API `ServerPlayer#respawn()` was not firing `SelectWorld` but only `Recreate` and `Post` events.