### PR TITLE
Edits to World Edit Accomodations PR

### DIFF
--- a/forge/src/launch/java/org/spongepowered/forge/launch/command/ForgeCommandManager.java
+++ b/forge/src/launch/java/org/spongepowered/forge/launch/command/ForgeCommandManager.java
@@ -59,8 +59,10 @@ public final class ForgeCommandManager extends SpongeCommandManager {
         final CommandRegistrar<?> registrar = mapping.registrar();
         final boolean isBrig = registrar instanceof BrigadierBasedRegistrar;
         final ParseResults<CommandSourceStack> parseResults;
+        final ParseResults<CommandSourceStack> forgeResults;
         if (isBrig) {
             parseResults = this.getDispatcher().parse(original, (CommandSourceStack) cause);
+            forgeResults = new ParseResults<>(parseResults.getContext(), new SpongeStringReader("/" + original), parseResults.getExceptions());
         } else {
             // We have a non Brig registrar, so we just create a dummy result for mods to inspect.
             final CommandContextBuilder<CommandSourceStack> contextBuilder = new CommandContextBuilder<>(
@@ -73,10 +75,11 @@ public final class ForgeCommandManager extends SpongeCommandManager {
                 contextBuilder.withArgument("parsed", new ParsedArgument<>(command.length(), original.length(), args));
             }
             parseResults = new ParseResults<>(contextBuilder, new SpongeStringReader(original), Collections.emptyMap());
+            forgeResults = new ParseResults<>(contextBuilder, new SpongeStringReader("/" + original), Collections.emptyMap());
         }
 
         // Relocated from Commands (injection short circuits it there)
-        final CommandEvent event = new CommandEvent(parseResults);
+        final CommandEvent event = new CommandEvent(forgeResults);
         if (MinecraftForge.EVENT_BUS.post(event)) {
             if (event.getException() != null) {
                 Throwables.throwIfUnchecked(event.getException());

--- a/forge/src/mixins/java/org/spongepowered/forge/mixin/core/minecraftforge/event/entity/player/PlayerInteractEvent_RightClickBlock_Forge.java
+++ b/forge/src/mixins/java/org/spongepowered/forge/mixin/core/minecraftforge/event/entity/player/PlayerInteractEvent_RightClickBlock_Forge.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.forge.mixin.core.minecraftforge.event.entity.player;
+
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.event.block.InteractBlockEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.forge.launch.bridge.event.ForgeEventBridge_Forge;
+
+@Mixin(value = PlayerInteractEvent.RightClickBlock.class)
+public abstract class PlayerInteractEvent_RightClickBlock_Forge implements ForgeEventBridge_Forge {
+
+    @Override
+    public void bridge$syncFrom(Event event) {
+        final InteractBlockEvent.Secondary spongeEvent = (InteractBlockEvent.Secondary) event;
+        ((net.minecraftforge.eventbus.api.Event) (Object) this).setCanceled(spongeEvent.isCancelled());
+    }
+
+    @Override
+    public void bridge$syncTo(Event event) {
+        final InteractBlockEvent.Secondary spongeEvent = (InteractBlockEvent.Secondary) event;
+        spongeEvent.setCancelled(((net.minecraftforge.eventbus.api.Event) (Object) this).isCanceled());
+    }
+}

--- a/forge/src/mixins/resources/mixins.spongeforge.core.json
+++ b/forge/src/mixins/resources/mixins.spongeforge.core.json
@@ -20,6 +20,7 @@
         "minecraftforge.event.ServerChatEventMixin_Forge",
         "minecraftforge.event.entity.EntityTravelToDimensionEventMixin_Forge",
         "minecraftforge.event.entity.player.PlayerEvent_PlayerChangedDimensionEventMixin_Forge",
+        "minecraftforge.event.entity.player.PlayerInteractEvent_RightClickBlock_Forge",
         "minecraftforge.event.world.BlockEvent_BreakEventMixin_Forge",
         "minecraftforge.event.world.BlockEventMixin_Forge",
         "minecraftforge.fml.BrandingControlMixin_Forge",

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/world/level/chunk/LevelChunkMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/world/level/chunk/LevelChunkMixin_Tracker.java
@@ -109,6 +109,7 @@ public abstract class LevelChunkMixin_Tracker implements TrackedLevelChunkBridge
                     .hr()
                     .add(new IllegalAccessException("It has been configured to log when Chunk.setBlock in a ServerWorld has been called, effectively bypassing Sponge's tracking."))
                     .log(PhaseTracker.LOGGER, Level.WARN);
+                LevelChunkMixin_Tracker.tracker$hasLoggedDirectAccess = true;
             }
         }
         if (disableDirectAccess) {


### PR DESCRIPTION
- Set the boolean value to true for the one time log direct access mixin
- Adds a bridge mixin to the PlayerInteractEvent.RightClickBlock so that it no longer exceptions when right clicking blocks with items
- Fixes forge CommandEvent behavior by passing in the command value with a forward slash as it normally receives in a standalone environment.