### PR TITLE
Notify client when velocity is changed

### DIFF
--- a/src/main/java/org/spongepowered/common/data/provider/entity/EntityData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/EntityData.java
@@ -200,10 +200,16 @@ public final class EntityData {
                         .set((h, v) -> h.startRiding((Entity) v, true))
                     .create(Keys.VELOCITY)
                         .get(h -> VecHelper.toVector3d(h.getDeltaMovement()))
-                        .set((h, v) -> h.setDeltaMovement(VecHelper.toVanillaVector3d(v)))
+                        .set((h, v) -> {
+                            h.setDeltaMovement(VecHelper.toVanillaVector3d(v));
+                            h.hurtMarked = true;
+                        })
                     .create(Keys.SWIFTNESS)
                         .get(m -> m.getDeltaMovement().length())
-                        .set((m, v) -> m.setDeltaMovement(m.getDeltaMovement().normalize().scale(v)))
+                        .set((m, v) -> {
+                            m.setDeltaMovement(m.getDeltaMovement().normalize().scale(v));
+                            m.hurtMarked = true;
+                        })
                         .supports(m -> m.getDeltaMovement().lengthSqr() > 0)
                 .asMutable(EntityMaxAirBridge.class)
                     .create(Keys.MAX_AIR)


### PR DESCRIPTION
Offering `Keys.VELOCITY` or `Keys.SWIFTNESS` now sets the `hurtMarked` field to indicate that the velocity has changed. 
This field was named `velocityChanged` in mcp mapping : https://github.com/SpongePowered/Sponge/blob/stable-7/src/main/java/org/spongepowered/common/mixin/core/entity/EntityMixin.java#L543

Without this the velocity change is ignored.