### PR TITLE
Fix PluginPackResources#getResources error on some filesystems

### DIFF
--- a/vanilla/src/main/java/org/spongepowered/vanilla/server/packs/PluginPackResources.java
+++ b/vanilla/src/main/java/org/spongepowered/vanilla/server/packs/PluginPackResources.java
@@ -89,7 +89,7 @@ public final class PluginPackResources extends AbstractPackResources {
             final Predicate<String> fileNameValidator) {
         try {
             final Path root = this.typeRoot(type);
-            final Path namespaceDir = root.resolve(namespace);
+            final Path namespaceDir = root.resolve(namespace).toAbsolutePath();
             return Files.walk(namespaceDir, depth)
                     .filter(Files::isRegularFile)
                     .filter(s -> !s.getFileName().toString().endsWith(".mcmeta"))


### PR DESCRIPTION
The error happens when running gradle task `runJava8Server`. See https://pastebin.com/aycz6Z7j.
The path cannot be relativized if the directory is not absolute on some filesystems (eg: zip filesystems).