### PR TITLE
Call LoadedGameEvent on Forge

### DIFF
--- a/forge/src/main/java/org/spongepowered/forge/SpongeForge.java
+++ b/forge/src/main/java/org/spongepowered/forge/SpongeForge.java
@@ -118,6 +118,8 @@ public final class SpongeForge {
     public void onServerStarted(final FMLServerStartedEvent event) {
         final Lifecycle lifecycle = Launch.instance().lifecycle();
         lifecycle.callStartedEngineEvent((Server) event.getServer());
+
+        lifecycle.callLoadedGameEvent();
     }
 
     @SubscribeEvent


### PR DESCRIPTION
This calls the lifecycle event `LoadedGameEvent` on SpongeForge. Fixes https://github.com/SpongePowered/Sponge/issues/3662.