### PR TITLE
Replace printStackTrace() with a proper logger

### DIFF
--- a/src/main/java/org/spongepowered/common/advancement/SpongeFilteredTrigger.java
+++ b/src/main/java/org/spongepowered/common/advancement/SpongeFilteredTrigger.java
@@ -26,6 +26,8 @@ package org.spongepowered.common.advancement;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.spongepowered.api.advancement.criteria.trigger.FilteredTrigger;
 import org.spongepowered.api.advancement.criteria.trigger.FilteredTriggerConfiguration;
 import org.spongepowered.api.advancement.criteria.trigger.Trigger;
@@ -41,6 +43,7 @@ import net.minecraft.resources.ResourceLocation;
 @SuppressWarnings("rawtypes")
 public final class SpongeFilteredTrigger implements CriterionTriggerInstance, FilteredTrigger {
 
+    private static final Logger LOGGER = LogManager.getLogger();
     private final static Gson GSON = new Gson();
 
     private final SpongeCriterionTrigger triggerType;
@@ -74,7 +77,7 @@ public final class SpongeFilteredTrigger implements CriterionTriggerInstance, Fi
                 final String json = DataFormats.JSON.get().write(dataContainer);
                 return SpongeFilteredTrigger.GSON.fromJson(json, JsonObject.class);
             } catch (IOException e) {
-                e.printStackTrace();
+                SpongeFilteredTrigger.LOGGER.error("Failed to serialize trigger to json", e);
             }
         }
 

--- a/src/main/java/org/spongepowered/common/block/entity/SpongeBlockEntityArchetypeBuilder.java
+++ b/src/main/java/org/spongepowered/common/block/entity/SpongeBlockEntityArchetypeBuilder.java
@@ -102,7 +102,7 @@ public final class SpongeBlockEntityArchetypeBuilder extends AbstractDataBuilder
     public BlockEntityArchetype.Builder state(final BlockState state) {
         final net.minecraft.world.level.block.state.BlockState blockState = (net.minecraft.world.level.block.state.BlockState) state;
         if (!((BlockStateBridge) (blockState)).bridge$hasTileEntity()) {
-            SpongeBlockEntityArchetypeBuilder.LOGGER.warn("BlockState " + state + " does not provide TileEntities!", new IllegalArgumentException());
+            SpongeBlockEntityArchetypeBuilder.LOGGER.warn("BlockState {} does not provide BlockEntities!", state, new IllegalArgumentException());
         }
         if (this.blockState != state) {
             this.data = null;

--- a/src/main/java/org/spongepowered/common/block/entity/SpongeBlockEntityArchetypeBuilder.java
+++ b/src/main/java/org/spongepowered/common/block/entity/SpongeBlockEntityArchetypeBuilder.java
@@ -25,6 +25,8 @@
 package org.spongepowered.common.block.entity;
 
 import net.minecraft.nbt.CompoundTag;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.block.BlockState;
@@ -50,6 +52,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 
 public final class SpongeBlockEntityArchetypeBuilder extends AbstractDataBuilder<BlockEntityArchetype> implements BlockEntityArchetype.Builder {
 
+    private static final Logger LOGGER = LogManager.getLogger();
     private static final Deque<SpongeBlockEntityArchetypeBuilder> pool = new ConcurrentLinkedDeque<>();
 
     public static SpongeBlockEntityArchetypeBuilder unpooled() {
@@ -99,7 +102,7 @@ public final class SpongeBlockEntityArchetypeBuilder extends AbstractDataBuilder
     public BlockEntityArchetype.Builder state(final BlockState state) {
         final net.minecraft.world.level.block.state.BlockState blockState = (net.minecraft.world.level.block.state.BlockState) state;
         if (!((BlockStateBridge) (blockState)).bridge$hasTileEntity()) {
-            new IllegalArgumentException("BlockState: "+ state + " does not provide TileEntities!").printStackTrace();
+            SpongeBlockEntityArchetypeBuilder.LOGGER.warn("BlockState " + state + " does not provide TileEntities!", new IllegalArgumentException());
         }
         if (this.blockState != state) {
             this.data = null;

--- a/src/main/java/org/spongepowered/common/data/DataUpdaterDelegate.java
+++ b/src/main/java/org/spongepowered/common/data/DataUpdaterDelegate.java
@@ -62,10 +62,10 @@ public final class DataUpdaterDelegate implements DataContentUpdater {
             try {
                 updated = updater.update(updated);
             } catch (Exception e) {
-                DataUpdaterDelegate.LOGGER.error("There was error attempting to update some data for the content updater:"
-                                                 +  updater.getClass().getName() + "\nThe original data is being returned, possibly causing "
+                DataUpdaterDelegate.LOGGER.error("There was error attempting to update some data for the content updater: {}"
+                                                 + "\nThe original data is being returned, possibly causing "
                                                  + "issues later on, \nbut the original data should not be lost. Please notify the developer "
-                                                 + "of this exception with the stacktrace.", e);
+                                                 + "of this exception with the stacktrace.", updater.getClass().getName(), e);
                 return copied;
             }
         }

--- a/src/main/java/org/spongepowered/common/data/DataUpdaterDelegate.java
+++ b/src/main/java/org/spongepowered/common/data/DataUpdaterDelegate.java
@@ -25,10 +25,14 @@
 package org.spongepowered.common.data;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.spongepowered.api.data.persistence.DataContentUpdater;
 import org.spongepowered.api.data.persistence.DataView;
 
 public final class DataUpdaterDelegate implements DataContentUpdater {
+
+    private static final Logger LOGGER = LogManager.getLogger();
 
     private final ImmutableList<DataContentUpdater> updaters;
     private final int from;
@@ -58,11 +62,10 @@ public final class DataUpdaterDelegate implements DataContentUpdater {
             try {
                 updated = updater.update(updated);
             } catch (Exception e) {
-                Exception exception = new RuntimeException("There was error attempting to update some data for the content updater:"
-                                                           +  updater.getClass().getName() + "\nThe original data is being returned, possibly causing "
-                                                           + "issues later on, \nbut the original data should not be lost. Please notify the developer "
-                                                           + "of this exception with the stacktrace.", e);
-                exception.printStackTrace();
+                DataUpdaterDelegate.LOGGER.error("There was error attempting to update some data for the content updater:"
+                                                 +  updater.getClass().getName() + "\nThe original data is being returned, possibly causing "
+                                                 + "issues later on, \nbut the original data should not be lost. Please notify the developer "
+                                                 + "of this exception with the stacktrace.", e);
                 return copied;
             }
         }

--- a/src/main/java/org/spongepowered/common/data/SpongeDataManager.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeDataManager.java
@@ -200,10 +200,11 @@ public final class SpongeDataManager implements DataManager {
             }
         }
         if (version < fromVersion || version > toVersion) { // There wasn't a registered updater for the version being requested
-            SpongeCommon.logger().warn("The requested content version for: " + clazz.getSimpleName() + " was requested, "
-                                       + "\nhowever, the versions supplied: from " + fromVersion + " to " + toVersion + " is impossible"
-                                       + "\nas the latest version registered is: " + version + ". Please notify the developer of"
-                                       + "\nthe requested consumed DataSerializable of this error.");
+            SpongeCommon.logger().warn("The requested content version for: {} was requested, "
+                                       + "\nhowever, the versions supplied: from {} to {} is impossible"
+                                       + "\nas the latest version registered is: {}. Please notify the developer of"
+                                       + "\nthe requested consumed DataSerializable of this error.",
+                    clazz.getSimpleName(), fromVersion, toVersion, version);
             return Optional.empty();
         }
         return Optional.of(new DataUpdaterDelegate(builder.build(), fromVersion, toVersion));

--- a/src/main/java/org/spongepowered/common/data/SpongeDataManager.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeDataManager.java
@@ -199,12 +199,11 @@ public final class SpongeDataManager implements DataManager {
                 builder.add(updater);
             }
         }
-        if (version < toVersion || version > toVersion) { // There wasn't a registered updater for the version being requested
-            final Exception e = new IllegalStateException("The requested content version for: " + clazz.getSimpleName() + " was requested, "
-                                                    + "\nhowever, the versions supplied: from "+ fromVersion + " to " + toVersion + " is impossible"
-                                                    + "\nas the latest version registered is: " + version+". Please notify the developer of"
-                                                    + "\nthe requested consumed DataSerializable of this error.");
-            e.printStackTrace();
+        if (version < fromVersion || version > toVersion) { // There wasn't a registered updater for the version being requested
+            SpongeCommon.logger().warn("The requested content version for: " + clazz.getSimpleName() + " was requested, "
+                                       + "\nhowever, the versions supplied: from " + fromVersion + " to " + toVersion + " is impossible"
+                                       + "\nas the latest version registered is: " + version + ". Please notify the developer of"
+                                       + "\nthe requested consumed DataSerializable of this error.");
             return Optional.empty();
         }
         return Optional.of(new DataUpdaterDelegate(builder.build(), fromVersion, toVersion));

--- a/src/main/java/org/spongepowered/common/event/filter/FilterGenerator.java
+++ b/src/main/java/org/spongepowered/common/event/filter/FilterGenerator.java
@@ -41,6 +41,8 @@ import static org.objectweb.asm.Opcodes.RETURN;
 import static org.objectweb.asm.Opcodes.V1_6;
 
 import io.leangen.geantyref.AnnotationFormatException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
@@ -100,6 +102,8 @@ import java.util.function.Function;
 public class FilterGenerator {
 
     public static final boolean FILTER_DEBUG = Boolean.parseBoolean(System.getProperty("sponge.filter.debug", "false"));
+
+    private static final Logger LOGGER = LogManager.getLogger();
 
     public static FilterGenerator getInstance() {
         return Holder.INSTANCE;
@@ -260,8 +264,8 @@ public class FilterGenerator {
             }
             try (final FileOutputStream out = new FileOutputStream(outFile)) {
                 out.write(data);
-            } catch (final IOException ignored) {
-                ignored.printStackTrace();
+            } catch (final IOException e) {
+                FilterGenerator.LOGGER.error("Failed to write class to debug directory", e);
             }
         }
 

--- a/src/main/java/org/spongepowered/common/event/manager/ListenerChecker.java
+++ b/src/main/java/org/spongepowered/common/event/manager/ListenerChecker.java
@@ -27,8 +27,9 @@ package org.spongepowered.common.event.manager;
 import com.google.common.base.CaseFormat;
 import io.leangen.geantyref.GenericTypeReflector;
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.spongepowered.api.event.SpongeEventFactory;
-import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.configurate.util.Types;
 
 import java.lang.reflect.Field;
@@ -44,6 +45,7 @@ public final class ListenerChecker {
 
     private static final boolean ALL_TRUE = Boolean.parseBoolean(System.getProperty("sponge.shouldFireAll", "").toLowerCase());
     private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("sponge.debugShouldFire", "").toLowerCase());
+    private static final Logger LOGGER = LogManager.getLogger();
 
     private final Class<?> clazz;
     private Map<String, FieldData> fields = new HashMap<>();
@@ -66,12 +68,12 @@ public final class ListenerChecker {
                 this.fields.put(field.getName(), data);
                 if (ListenerChecker.ALL_TRUE) {
                     if (ListenerChecker.DEBUG) {
-                        System.err.println(String.format("Forcing field %s to true!", field.getName()));
+                        ListenerChecker.LOGGER.debug("Forcing field {} to true!", field.getName());
                     }
                     try {
                         field.set(null, true);
                     } catch (IllegalAccessException e) {
-                        e.printStackTrace();
+                        ListenerChecker.LOGGER.error("Error setting field {} to true", field.getName(), e);
                     }
                 }
             } else {
@@ -187,18 +189,18 @@ public final class ListenerChecker {
                 this.listenerCount--;
             }
             if (this.listenerCount < 0) {
-                SpongeCommon.logger().error(String.format("Decremented listener count to %s for field %s", this.listenerCount, this.field), new Exception("Dummy exception"));
+                ListenerChecker.LOGGER.error("Decremented listener count to {} for field {}", this.listenerCount, this.field, new Exception("Dummy exception"));
             }
             boolean val = this.listenerCount > 0;
 
             if (ListenerChecker.DEBUG) {
-                System.err.println(String.format("Updating field %s with value %s", this.field, val));
+                ListenerChecker.LOGGER.debug("Updating field {} with value {}", this.field, val);
             }
 
             try {
                 this.field.set(null, val);
             } catch (IllegalAccessException e) {
-                SpongeCommon.logger().error(String.format("Error setting field %s to %s", this.field, val), e);
+                ListenerChecker.LOGGER.error("Error setting field {} to {}", this.field, val, e);
             }
         }
     }

--- a/src/main/java/org/spongepowered/common/event/manager/ListenerClassVisitor.java
+++ b/src/main/java/org/spongepowered/common/event/manager/ListenerClassVisitor.java
@@ -26,6 +26,8 @@ package org.spongepowered.common.event.manager;
 
 import io.leangen.geantyref.AnnotationFormatException;
 import io.leangen.geantyref.TypeFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.objectweb.asm.AnnotationVisitor;
@@ -60,6 +62,8 @@ public class ListenerClassVisitor extends ClassVisitor {
     public static final String SPONGE_API_ANNOTATION_PREFIX = "org.spongepowered.api";
 
     public static final int ASM_VERSION = Opcodes.ASM9;
+
+    private static final Logger LOGGER = LogManager.getLogger();
 
     final List<DiscoveredMethod> foundListenerMethods = new LinkedList<>();
     final Class<?> declaringClass;
@@ -250,7 +254,7 @@ public class ListenerClassVisitor extends ClassVisitor {
             try {
                 this.annotation.put(name == null ? "value" : name, value);
             } catch (final ClassNotFoundException | AnnotationFormatException e) {
-                e.printStackTrace();
+                ListenerClassVisitor.LOGGER.error("Failed to visit annotation primitive value", e);
             }
         }
 
@@ -267,7 +271,7 @@ public class ListenerClassVisitor extends ClassVisitor {
                 final String className = Type.getType(descriptor).getClassName();
                 this.visit(name, Enum.valueOf((Class<? extends Enum>) this.annotation.discoveredMethod.classByLoader(className), value));
             } catch (final ClassNotFoundException e) {
-                e.printStackTrace();
+                ListenerClassVisitor.LOGGER.error("Failed to visit annotation enum value", e);
             }
         }
     }
@@ -565,7 +569,7 @@ public class ListenerClassVisitor extends ClassVisitor {
                     this.returnTypes.put(element.getName(), element.getReturnType());
                 }
             } catch (ClassNotFoundException e) {
-                e.printStackTrace();
+                ListenerClassVisitor.LOGGER.error("Failed to initialize return types", e);
             }
         }
     }

--- a/src/main/java/org/spongepowered/common/profile/SpongeGameProfileManager.java
+++ b/src/main/java/org/spongepowered/common/profile/SpongeGameProfileManager.java
@@ -180,13 +180,13 @@ public final class SpongeGameProfileManager implements GameProfileManager {
             try {
                 this.basicProfile(uniqueId).get();
             } catch (final InterruptedException | ExecutionException e) {
-                e.printStackTrace();
+                SpongeGameProfileManager.LOGGER.error("Failed to lookup profile {}", uniqueId, e);
             }
             if (SpongeGameProfileManager.canLookup(uniqueId)) { // only wait when it's possible that a lookup has actually occurred
                 try {
                     Thread.sleep(SpongeConfigs.getCommon().get().world.gameProfileQueryTaskInterval * 1000L);
                 } catch (final InterruptedException e) {
-                    e.printStackTrace();
+                    SpongeGameProfileManager.LOGGER.warn("The lookup service was interrupted while sleeping", e);
                 }
             }
         });
@@ -207,7 +207,7 @@ public final class SpongeGameProfileManager implements GameProfileManager {
                     .log(SpongeGameProfileManager.LOGGER, Level.WARN);
             }
         } catch (final InterruptedException e) {
-            SpongeGameProfileManager.LOGGER.error("The async scheduler was interrupted while awaiting shutdown!");
+            SpongeGameProfileManager.LOGGER.error("The lookup service was interrupted while awaiting shutdown", e);
         }
     }
 }

--- a/src/main/java/org/spongepowered/common/service/SpongeServiceProvider.java
+++ b/src/main/java/org/spongepowered/common/service/SpongeServiceProvider.java
@@ -212,7 +212,10 @@ public abstract class SpongeServiceProvider implements ServiceProvider {
         try {
             ((SpongeEventManager) this.getGame().eventManager()).postToPlugin(event, container);
         } catch (final Exception ex) {
-            ex.printStackTrace();
+            SpongeCommon.logger().error("Failed to post ProvideServiceEvent for service {} to plugin {}.",
+                    service.getServiceClass().getSimpleName(),
+                    container.metadata().id(),
+                    ex);
         }
         if (event.getSuggestion() != null) {
             try {

--- a/src/main/java/org/spongepowered/common/world/server/WorldMigrator.java
+++ b/src/main/java/org/spongepowered/common/world/server/WorldMigrator.java
@@ -184,12 +184,12 @@ public final class WorldMigrator {
                                 FileUtils.deleteDirectory(invalidSaveDataFolder.toFile());
                             }
                         } catch (IOException e) {
-                            e.printStackTrace();
+                            SpongeCommon.logger().error("Failed to move invalid save folder from {} to {}", invalidSaveDataFolder, saveFolder, e);
                         }
                     }
                 });
             } catch (IOException e) {
-                e.printStackTrace();
+                SpongeCommon.logger().error("Failed to list world directories", e);
             }
         }
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/item/ItemStackMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/item/ItemStackMixin_API.java
@@ -36,6 +36,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.item.Item;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.api.ResourceKey;
@@ -50,6 +51,7 @@ import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.equipment.EquipmentType;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Interface.Remap;
@@ -71,6 +73,8 @@ import java.util.function.UnaryOperator;
 public abstract class ItemStackMixin_API implements SerializableDataHolder.Mutable, ComponentLike, HoverEventSource<HoverEvent.ShowItem> {       // conflict from overriding ValueContainer#copy() from DataHolder
 
     // @formatter:off
+    @Shadow @Final private static Logger LOGGER;
+
     @Shadow public abstract int shadow$getCount();
     @Shadow public abstract void shadow$setCount(int size); // Do not use field directly as Minecraft tracks the empty state
     @Shadow public abstract void shadow$setDamageValue(int meta);
@@ -190,7 +194,7 @@ public abstract class ItemStackMixin_API implements SerializableDataHolder.Mutab
         try {
             PlatformHooks.INSTANCE.getItemHooks().writeItemStackCapabilitiesToDataView(container, (net.minecraft.world.item.ItemStack) (Object) this);
         } catch (final Exception e) {
-            e.printStackTrace();
+            ItemStackMixin_API.LOGGER.error("Failed to write capabilities to data view", e);
         }
         return container;
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/MinecraftServerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/MinecraftServerMixin.java
@@ -140,7 +140,7 @@ public abstract class MinecraftServerMixin implements SpongeServer, MinecraftSer
             try {
                 this.impl$resourcePack = SpongeResourcePack.create(url, hash);
             } catch (final URISyntaxException e) {
-                e.printStackTrace();
+                MinecraftServerMixin.LOGGER.error("Invalid resource pack url", e);
             }
         }
     }

--- a/vanilla/src/applaunch/java/org/spongepowered/vanilla/applaunch/plugin/VanillaPluginPlatform.java
+++ b/vanilla/src/applaunch/java/org/spongepowered/vanilla/applaunch/plugin/VanillaPluginPlatform.java
@@ -198,7 +198,7 @@ public final class VanillaPluginPlatform implements PluginPlatform {
                         }
                         this.pluginCandidates.computeIfAbsent(languageService, k -> new LinkedList<>()).addAll(candidates);
                     } catch (final Exception ex) {
-                        ex.printStackTrace();
+                        this.standardEnvironment.logger().error("Failed to create plugin candidates", ex);
                     }
                 }
             }

--- a/vanilla/src/launch/java/org/spongepowered/vanilla/launch/plugin/VanillaPluginManager.java
+++ b/vanilla/src/launch/java/org/spongepowered/vanilla/launch/plugin/VanillaPluginManager.java
@@ -159,7 +159,7 @@ public final class VanillaPluginManager implements SpongePluginManager {
                     this.containerToResource.put(container, candidate.resource());
                 } catch (final InvalidPluginException e) {
                     failedInstances.put(candidate, "Failed to construct: see stacktrace(s) above this message for details.");
-                    e.printStackTrace();
+                    platform.logger().error("Failed to construct plugin {}", candidate.metadata().id(), e);
                 }
             }
         }

--- a/vanilla/src/mixins/java/org/spongepowered/vanilla/mixin/core/client/MinecraftMixin_Vanilla.java
+++ b/vanilla/src/mixins/java/org/spongepowered/vanilla/mixin/core/client/MinecraftMixin_Vanilla.java
@@ -34,6 +34,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.bridge.client.MinecraftBridge;
 import org.spongepowered.common.entity.player.ClientType;
 import org.spongepowered.common.launch.Launch;
@@ -73,7 +74,7 @@ public abstract class MinecraftMixin_Vanilla implements MinecraftBridge, Vanilla
         try (final InputStream stream = this.getClass().getClassLoader().getResourceAsStream("spongie_icon.png")) {
             WindowUtils.setWindowIcon(window.getWindow(), stream);
         } catch (final IOException e) {
-            e.printStackTrace();
+            SpongeCommon.logger().error("Failed to set window icon", e);
         }
     }
 }


### PR DESCRIPTION
I originally had an issue where my plugin failed to construct but I had no traces in the log files so I wanted to replace the printStackTrace() with a proper logger. I took the opportunity to do this in several places.