### PR TITLE
Minor fixes for SpongeVanishState

### DIFF
--- a/src/main/java/org/spongepowered/common/entity/effect/SpongeVanishState.java
+++ b/src/main/java/org/spongepowered/common/entity/effect/SpongeVanishState.java
@@ -29,7 +29,7 @@ import org.spongepowered.api.effect.VanishState;
 
 public final class SpongeVanishState implements VanishState {
     private static final VanishState VISIBLE = new SpongeVanishState(false, true, false, true, true, true);
-    private static final VanishState DEFAULT_VANISHED = new SpongeVanishState(true, false, false, false, false, false);
+    private static final VanishState DEFAULT_VANISHED = new SpongeVanishState(true, false, true, false, false, false);
 
     private final boolean vanished;
     private final boolean ignoresCollisions;

--- a/src/main/java/org/spongepowered/common/entity/effect/SpongeVanishState.java
+++ b/src/main/java/org/spongepowered/common/entity/effect/SpongeVanishState.java
@@ -128,7 +128,7 @@ public final class SpongeVanishState implements VanishState {
 
     @Override
     public boolean affectsMonsterSpawning() {
-        return false;
+        return this.affectsSpawning;
     }
 
     @Override
@@ -197,12 +197,20 @@ public final class SpongeVanishState implements VanishState {
 
     @Override
     public String toString() {
-        return "VanishedState{ignoresCollisions=" + this.ignoresCollisions + ", untargetable=" + this.untargetable + "}";
+        return "SpongeVanishState{" +
+                "vanished=" + this.vanished +
+                ", ignoresCollisions=" + this.ignoresCollisions +
+                ", untargetable=" + this.untargetable +
+                ", affectsSpawning=" + this.affectsSpawning +
+                ", createsSounds=" + this.createsSounds +
+                ", createsParticles=" + this.createsParticles +
+                '}';
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(true, this.ignoresCollisions, this.untargetable);
+        return Objects.hashCode(this.vanished, this.ignoresCollisions, this.untargetable,
+                this.affectsSpawning, this.createsSounds, this.createsParticles);
     }
 
     @Override
@@ -217,7 +225,10 @@ public final class SpongeVanishState implements VanishState {
         return
             this.invisible() == other.invisible()
                 && this.ignoresCollisions == other.ignoresCollisions()
-                && this.untargetable == other.untargetable();
+                && this.untargetable == other.untargetable()
+                && this.affectsSpawning == other.affectsMonsterSpawning()
+                && this.createsSounds == other.createsSounds()
+                && this.createsParticles == other.createsParticles();
     }
 
     public static final class SpongeVanishStateFactory implements Factory {


### PR DESCRIPTION
1. According to the javadoc the default VanishState should be untargetable.
2. toString, hashCode, equals and affectsMonsterSpawning were incomplete.