### PR TITLE
Fix player ChangeInventoryEvent.Pickup.Pre (API 8 edition)

### DIFF
--- a/src/main/java/org/spongepowered/common/event/inventory/InventoryEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/inventory/InventoryEventFactory.java
@@ -88,8 +88,7 @@ import java.util.function.Supplier;
 
 public class InventoryEventFactory {
 
-
-    public static boolean callPlayerChangeInventoryPickupPreEvent(final Player player, final ItemEntity itemToPickup) {
+    public static boolean callPlayerInventoryPickupEvent(final Player player, final ItemEntity itemToPickup) {
         final ItemStack stack = itemToPickup.getItem();
         final ItemStackSnapshot snapshot = ItemStackUtil.snapshotOf(stack);
         final ChangeInventoryEvent.Pickup.Pre event =
@@ -103,8 +102,8 @@ public class InventoryEventFactory {
         if (event.custom().isPresent()) {
             final List<ItemStackSnapshot> list = event.custom().get();
             if (list.isEmpty()) {
-                itemToPickup.getItem().setCount(0);
-                return false;
+                stack.setCount(0);
+                return true;
             }
 
             final PhaseContext<@NonNull ?> context = PhaseTracker.SERVER.getPhaseContext();
@@ -124,12 +123,24 @@ public class InventoryEventFactory {
             if (!TrackingUtil.processBlockCaptures(context)) {
                 return false;
             }
-            itemToPickup.getItem().setCount(0);
+            stack.setCount(0);
+            return true;
+        } else {
+            final PhaseContext<@NonNull ?> context = PhaseTracker.SERVER.getPhaseContext();
+            final TransactionalCaptureSupplier transactor = context.getTransactor();
+            final boolean added;
+            try (final EffectTransactor ignored = transactor.logPlayerInventoryChangeWithEffect(player, PlayerInventoryTransaction.EventCreator.PICKUP)) {
+                added = player.inventory.add(stack);
+            }
+
+            if (!TrackingUtil.processBlockCaptures(context)) {
+                return false;
+            }
+            return added;
         }
-        return true;
     }
 
-    public static ItemStack callInventoryPickupEvent(final Container inventory, final ItemEntity item, final ItemStack stack) {
+    public static ItemStack callHopperInventoryPickupEvent(final Container inventory, final ItemEntity item, final ItemStack stack) {
         try (final CauseStackManager.StackFrame frame = PhaseTracker.getCauseStackManager().pushCauseFrame()) {
             frame.pushCause(inventory);
 

--- a/src/mixins/java/org/spongepowered/common/mixin/inventory/event/world/entity/item/ItemEntityMixin_Inventory.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/inventory/event/world/entity/item/ItemEntityMixin_Inventory.java
@@ -28,56 +28,18 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.event.inventory.InventoryEventFactory;
-import org.spongepowered.common.event.tracking.PhaseContext;
-import org.spongepowered.common.event.tracking.PhaseTracker;
-import org.spongepowered.common.event.tracking.TrackingUtil;
-import org.spongepowered.common.event.tracking.context.transaction.EffectTransactor;
-import org.spongepowered.common.event.tracking.context.transaction.TransactionalCaptureSupplier;
-import org.spongepowered.common.event.tracking.context.transaction.inventory.PlayerInventoryTransaction;
 
 @Mixin(ItemEntity.class)
 public abstract class ItemEntityMixin_Inventory {
 
-    @Shadow private int pickupDelay;
-
-    @Inject(
-        method = "playerTouch",
-        at = @At(
-            value = "INVOKE",
-            ordinal = 0,
-            target = "Lnet/minecraft/world/item/ItemStack;getItem()Lnet/minecraft/world/item/Item;"),
-        cancellable = true
-    )
-    private void spongeImpl$ThrowPickupEvent(final Player entityIn, final CallbackInfo ci) {
-        if (this.pickupDelay == 0) {
-            if (!InventoryEventFactory.callPlayerChangeInventoryPickupPreEvent(entityIn, (ItemEntity) (Object) this)) {
-                ci.cancel();
-            }
-        }
-    }
-
     @Redirect(method = "playerTouch", at = @At(value = "INVOKE",
             target = "Lnet/minecraft/world/entity/player/Inventory;add(Lnet/minecraft/world/item/ItemStack;)Z"))
     private boolean spongeImpl$throwPickupEventForAddItem(final Inventory inventory, final ItemStack itemStack, final Player player) {
-        final PhaseContext<@NonNull ?> context = PhaseTracker.SERVER.getPhaseContext();
-        final TransactionalCaptureSupplier transactor = context.getTransactor();
-        final boolean added;
-        try (final EffectTransactor ignored = transactor.logPlayerInventoryChangeWithEffect(player, PlayerInventoryTransaction.EventCreator.PICKUP)) {
-             added = inventory.add(itemStack);
-        }
-
-        if (!TrackingUtil.processBlockCaptures(context)) {
-            return false; // if PickupEvent was cancelled return false
-        }
-        return added;
+        return InventoryEventFactory.callPlayerInventoryPickupEvent(player, (ItemEntity) (Object) this);
     }
 
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/inventory/event/world/level/block/entity/HopperBlockEntityMixin_Inventory.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/inventory/event/world/level/block/entity/HopperBlockEntityMixin_Inventory.java
@@ -161,6 +161,6 @@ public abstract class HopperBlockEntityMixin_Inventory {
             at = @At(value = "INVOKE",
                     target = "Lnet/minecraft/world/level/block/entity/HopperBlockEntity;addItem(Lnet/minecraft/world/Container;Lnet/minecraft/world/Container;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/core/Direction;)Lnet/minecraft/world/item/ItemStack;"))
     private static ItemStack impl$onPutStackInInventoryAllSlots(final Container source, final Container destination, final ItemStack stack, final Direction direction, final Container d2, final ItemEntity entity) {
-        return InventoryEventFactory.callInventoryPickupEvent(destination, entity, stack);
+        return InventoryEventFactory.callHopperInventoryPickupEvent(destination, entity, stack);
     }
 }


### PR DESCRIPTION
Fixes pickup animation, statistic and sound when custom items are set.
Same as #3334 but for API 8.

I have also renamed `callInventoryPickupEvent` to `callHopperInventoryPickupEvent` for clarity.