### PR TITLE
Fix MoveEntityEvent and RotateEntityEvent for players

### DIFF
--- a/src/main/java/org/spongepowered/common/util/Constants.java
+++ b/src/main/java/org/spongepowered/common/util/Constants.java
@@ -506,7 +506,6 @@ public final class Constants {
         public static final int PACKET_BUTTON_SECONDARY_ID = 0;
         public static final int PACKET_BUTTON_MIDDLE_ID = 0;
         public static final InetSocketAddress LOCALHOST = InetSocketAddress.createUnresolved("127.0.0.1", 0);
-        public static final int MAGIC_TRIGGER_TELEPORT_CONFIRM_DIFF = 21;
     }
 
     public static final class Item {

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerGamePacketListenerImplMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerGamePacketListenerImplMixin.java
@@ -45,6 +45,7 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundBlockBreakAckPacket;
 import net.minecraft.network.protocol.game.ClientboundCommandSuggestionsPacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket;
+import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.network.protocol.game.ServerboundCommandSuggestionPacket;
 import net.minecraft.network.protocol.game.ServerboundInteractPacket;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
@@ -62,7 +63,6 @@ import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.block.entity.SignBlockEntity;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
-import org.objectweb.asm.Opcodes;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.block.entity.Sign;
@@ -95,12 +95,10 @@ import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.accessor.network.protocol.game.ServerboundMovePlayerPacketAccessor;
 import org.spongepowered.common.accessor.server.level.ServerPlayerGameModeAccessor;
-import org.spongepowered.common.accessor.world.entity.EntityAccessor;
 import org.spongepowered.common.adventure.SpongeAdventure;
 import org.spongepowered.common.bridge.network.ConnectionHolderBridge;
 import org.spongepowered.common.bridge.server.level.ServerPlayerBridge;
@@ -117,15 +115,16 @@ import org.spongepowered.common.event.tracking.phase.packet.PacketPhase;
 import org.spongepowered.common.hooks.PlatformHooks;
 import org.spongepowered.common.item.util.ItemStackUtil;
 import org.spongepowered.common.util.CommandUtil;
-import org.spongepowered.common.util.Constants;
 import org.spongepowered.common.util.VecHelper;
 import org.spongepowered.math.vector.Vector3d;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -136,18 +135,11 @@ public abstract class ServerGamePacketListenerImplMixin implements ServerGamePac
     @Shadow @Final public Connection connection;
     @Shadow public net.minecraft.server.level.ServerPlayer player;
     @Shadow @Final private MinecraftServer server;
-    @Shadow private Vec3 awaitingPositionFromClient;
-    @Shadow private double firstGoodX;
-    @Shadow private double firstGoodY;
-    @Shadow private double firstGoodZ;
     @Shadow private int receivedMovePacketCount;
     @Shadow private int knownMovePacketCount;
-    @Shadow private int tickCount;
-    @Shadow private int awaitingTeleportTime;
     @Shadow private int chatSpamTickCount;
 
-    @Shadow protected abstract boolean shadow$isSingleplayerOwner();
-    @Shadow public abstract void shadow$teleport(double x, double y, double z, float yaw, float pitch);
+    @Shadow public abstract void shadow$teleport(double x, double y, double z, float yaw, float pitch, Set<ClientboundPlayerPositionPacket.RelativeArgument> relativeArguments);
     @Shadow protected abstract void shadow$filterTextPacket(List<String> p_244537_1_, Consumer<List<String>> p_244537_2_);
     @Shadow public abstract void shadow$resetPosition();
     // @formatter:on
@@ -225,65 +217,26 @@ public abstract class ServerGamePacketListenerImplMixin implements ServerGamePac
         return PlatformHooks.INSTANCE.getGeneralHooks().getEntityReachDistanceSq(this.player, p_147340_1_.getTarget(this.player.level));
     }
 
-    /**
-     * Effectively, hooking into the following code block:
-     * <pre>
-     *       if (isMovePlayerPacketInvalid(packetIn)) {
-     *          this.disconnect(new TranslationTextComponent("multiplayer.disconnect.invalid_player_movement"));
-     *       } else {
-     *          ServerWorld serverworld = this.server.world(this.player.dimension);
-     *          if (!this.player.queuedEndExit) { // <---- Here is where we're injecting
-     *             if (this.networkTickCount == 0) {
-     *                this.captureCurrentPosition();
-     *             }
-     * </pre>
-     * we can effectively short circuit the method to handle movement code where
-     * returning {@code true} will escape the packet being processed further entirely and
-     * {@code false} will allow the remaining processing of the method run.
-     *
-     * @param packetIn The movement packet
-     */
     @Inject(method = "handleMovePlayer",
-            at = @At(
-                    value = "FIELD",
-                    opcode = Opcodes.GETFIELD,
-                    target = "Lnet/minecraft/server/network/ServerGamePacketListenerImpl;awaitingPositionFromClient:Lnet/minecraft/world/phys/Vec3;"
-            ),
-            slice = @Slice(
-                    from = @At(
-                            value = "FIELD",
-                            target = "Lnet/minecraft/server/level/ServerPlayer;wonGame:Z"
-                    ),
-                    to = @At(
-                            value = "FIELD",
-                            target = "Lnet/minecraft/server/network/ServerGamePacketListenerImpl;tickCount:I",
-                            ordinal = 1
-                    )
-            ),
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;isPassenger()Z"),
             cancellable = true
     )
     private void impl$callMoveEntityEvent(final ServerboundMovePlayerPacket packetIn, final CallbackInfo ci) {
-
-        // If the movement is modified we pretend that the player has queuedEndExit = true
-        // so that vanilla wont process that packet further
-
         final ServerboundMovePlayerPacketAccessor packetInAccessor = (ServerboundMovePlayerPacketAccessor) packetIn;
 
-        // During login, minecraft sends a packet containing neither the 'moving' or 'rotating' flag set - but only once.
-        // We don't fire an event to avoid confusing plugins.
-        if (!packetInAccessor.accessor$hasPos() && !packetInAccessor.accessor$hasRot()) {
-            return;
-        }
-
-        final boolean goodMovementPacket = this.receivedMovePacketCount - this.knownMovePacketCount <= 5;
+        // receivedMovePacketCount will be incremented later
+        final boolean goodMovementPacket = (this.receivedMovePacketCount + 1) - this.knownMovePacketCount <= 5;
         final boolean fireMoveEvent = goodMovementPacket && packetInAccessor.accessor$hasPos() && ShouldFire.MOVE_ENTITY_EVENT;
         final boolean fireRotationEvent = goodMovementPacket && packetInAccessor.accessor$hasRot() && ShouldFire.ROTATE_ENTITY_EVENT;
 
-        final ServerPlayer player = (ServerPlayer) this.player;
-        final Vector3d fromRotation = new Vector3d(this.player.yRot, this.player.xRot, 0);
+        // During login, minecraft sends a packet containing neither the 'moving' or 'rotating' flag set - but only once.
+        // We don't fire an event to avoid confusing plugins.
+        if (!fireMoveEvent && !fireRotationEvent) {
+            return;
+        }
 
-        // Use the position of the last movement with an event or the current player position if never called
-        // We need this because we ignore very small position changes as to not spam as many move events.
+        final ServerPlayer player = (ServerPlayer) this.player;
+        final Vector3d fromRotation = player.rotation();
         final Vector3d fromPosition = player.position();
 
         Vector3d toPosition = new Vector3d(packetIn.getX(this.player.getX()),
@@ -294,12 +247,13 @@ public abstract class ServerGamePacketListenerImplMixin implements ServerGamePac
         final boolean significantRotation = fromRotation.distanceSquared(toRotation) > (.15f * .15f);
 
         final Vector3d originalToPosition = toPosition;
+        final Vector3d originalToRotation = toRotation;
+
         boolean cancelMovement = false;
-        boolean cancelRotation = false;
         // Call move & rotate event as needed...
         if (fireMoveEvent) {
             PhaseTracker.getCauseStackManager().addContext(EventContextKeys.MOVEMENT_TYPE, MovementTypes.NATURAL);
-            final MoveEntityEvent event = SpongeEventFactory.createMoveEntityEvent(PhaseTracker.getCauseStackManager().currentCause(), (ServerPlayer) this.player, fromPosition,
+            final MoveEntityEvent event = SpongeEventFactory.createMoveEntityEvent(PhaseTracker.getCauseStackManager().currentCause(), player, fromPosition,
                     toPosition, toPosition);
             if (SpongeCommon.post(event)) {
                 cancelMovement = true;
@@ -310,10 +264,9 @@ public abstract class ServerGamePacketListenerImplMixin implements ServerGamePac
         }
 
         if (significantRotation && fireRotationEvent) {
-            final RotateEntityEvent event = SpongeEventFactory.createRotateEntityEvent(PhaseTracker.getCauseStackManager().currentCause(), (ServerPlayer) this.player, fromRotation,
+            final RotateEntityEvent event = SpongeEventFactory.createRotateEntityEvent(PhaseTracker.getCauseStackManager().currentCause(), player, fromRotation,
                     toRotation);
             if (SpongeCommon.post(event)) {
-                cancelRotation = true;
                 toRotation = fromRotation;
             } else {
                 toRotation = event.toRotation();
@@ -323,46 +276,30 @@ public abstract class ServerGamePacketListenerImplMixin implements ServerGamePac
         // At this point, we cancel out and let the "confirmed teleport" code run through to update the
         // player position and update the player's relation in the chunk manager.
         if (cancelMovement) {
-            if (fromPosition.distanceSquared(toPosition) > 0) {
-                // Set the location, as if the player was teleporting
-                this.awaitingTeleportTime = this.tickCount;
-                this.shadow$teleport(fromPosition.x(), fromPosition.y(), fromPosition.z(), (float) toRotation.x(), (float) toRotation.y());
-            } else {
-                // If this is only rotation do not teleport back
-                this.player.absMoveTo(fromPosition.x(), fromPosition.y(), fromPosition.z(), (float) toRotation.x(), (float) toRotation.y());
-            }
+            // This will both cancel the movement and notify the client about the new rotation if any.
+            // The position is absolute so the momentum will be reset by the client.
+            // The rotation is relative so the head movement is still smooth.
+            // The client thinks its current rotation is originalToRotation so the new rotation is relative to that.
+            this.player.absMoveTo(fromPosition.x(), fromPosition.y(), fromPosition.z(),
+                    (float) originalToRotation.x(), (float) originalToRotation.y());
+            this.shadow$teleport(fromPosition.x(), fromPosition.y(), fromPosition.z(),
+                    (float) toRotation.x(), (float) toRotation.y(),
+                    EnumSet.of(ClientboundPlayerPositionPacket.RelativeArgument.X_ROT, ClientboundPlayerPositionPacket.RelativeArgument.Y_ROT));
             ci.cancel();
             return;
         }
 
-        // TODO handle cancelRotation or rotation change
-
         // Handle event results
-        if (!toPosition.equals(originalToPosition)) {
-            // Check if we have to say it's a "teleport" vs a standard move
-            final double d4 = packetIn.getX(this.player.getX());
-            final double d5 = packetIn.getY(this.player.getY());
-            final double d6 = packetIn.getZ(this.player.getZ());
-            final double d7 = d4 - this.firstGoodX;
-            final double d8 = d5 - this.firstGoodY;
-            final double d9 = d6 - this.firstGoodZ;
-            final double d10 = this.player.getDeltaMovement().lengthSqr();
-            final double d11 = d7 * d7 + d8 * d8 + d9 * d9;
-            final float f2 = this.player.isFallFlying() ? 300.0F : 100.0F;
-            final int i = this.receivedMovePacketCount - this.knownMovePacketCount;
-            if (d11 - d10 > (double)(f2 * (float)i) && !this.shadow$isSingleplayerOwner()) {
-                // At this point, we need to set the target position so the teleport code forces it
-                this.awaitingPositionFromClient = VecHelper.toVanillaVector3d(toPosition);
-                ((EntityAccessor) this.player).invoker$setRot((float) toRotation.x(), (float) toRotation.y());
-                // And reset the position update so the force set is done.
-                this.awaitingTeleportTime = this.tickCount - Constants.Networking.MAGIC_TRIGGER_TELEPORT_CONFIRM_DIFF;
-            } else {
-                // otherwise, set the data back onto the packet
-                packetInAccessor.accessor$hasPos(true);
-                packetInAccessor.accessor$x(toPosition.x());
-                packetInAccessor.accessor$y(toPosition.y());
-                packetInAccessor.accessor$z(toPosition.z());
-            }
+        if (!toPosition.equals(originalToPosition) || !toRotation.equals(originalToRotation)) {
+            // Notify the client about the new position and new rotation.
+            // Both are relatives so the client will keep its momentum.
+            // The client thinks its current position is originalToPosition so the new position is relative to that.
+            this.player.absMoveTo(originalToPosition.x(), originalToPosition.y(), originalToPosition.z(),
+                    (float) originalToRotation.x(), (float) originalToRotation.y());
+            this.shadow$teleport(toPosition.x(), toPosition.y(), toPosition.z(),
+                    (float) toRotation.x(), (float) toRotation.y(),
+                    EnumSet.allOf(ClientboundPlayerPositionPacket.RelativeArgument.class));
+            ci.cancel();
         }
     }
 

--- a/testplugins/src/main/java/org/spongepowered/test/movement/MovementTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/movement/MovementTest.java
@@ -121,14 +121,14 @@ public final class MovementTest implements LoadableModule {
 
     private CommandResult toggleMovement(CommandContext context) {
         this.cancelMovement = !this.cancelMovement;
-        final Component newState = Component.text(this.cancelMovement ? "OFF" : "ON", this.cancelMovement ? NamedTextColor.RED : NamedTextColor.GREEN);
+        final Component newState = Component.text(this.cancelMovement ? "ON" : "OFF", this.cancelMovement ? NamedTextColor.GREEN : NamedTextColor.RED);
         context.sendMessage(Identity.nil(), Component.text("Cancel Player All Movement : ").append(newState));
         return CommandResult.success();
     }
 
     private CommandResult toggleUnnatural(CommandContext context) {
         this.cancelUnnaturalMovement = !this.cancelUnnaturalMovement;
-        final Component newState = Component.text(this.cancelUnnaturalMovement ? "OFF" : "ON", this.cancelUnnaturalMovement ? NamedTextColor.RED : NamedTextColor.GREEN);
+        final Component newState = Component.text(this.cancelUnnaturalMovement ? "ON" : "OFF", this.cancelUnnaturalMovement ? NamedTextColor.GREEN : NamedTextColor.RED);
         context.sendMessage(Identity.nil(), Component.text("Cancel Player Unnatural Movement : ").append(newState));
         return CommandResult.success();
     }


### PR DESCRIPTION
- Do not fire the events if the `awaitingPositionFromClient` is not null because the packet will be ignored and the previous position will be resent without change. To achieve this, the injection point has been moved.
- Custom `toPosition` and `toRotation` were ignored by the client. The client is now notified about the changes.
- Cancellation is now implemented for `RotateEntityEvent`.