### PR TITLE
Use bridge$blockEntitiesToUnload method to fix forge compatibility

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
@@ -452,13 +452,14 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerLevel
             shift = At.Shift.AFTER
         )
     )
+    @SuppressWarnings("SuspiciousMethodCalls")
     private void impl$unloadBlockEntities(final BooleanSupplier param0, final CallbackInfo ci) {
         // This code fixes block entity memory leak
         // https://github.com/SpongePowered/Sponge/pull/3689
-        if (this.emptyTime >= 300 && !this.blockEntitiesToUnload.isEmpty()) {
-            this.tickableBlockEntities.removeAll(this.blockEntitiesToUnload);
-            this.blockEntityList.removeAll(this.blockEntitiesToUnload);
-            this.blockEntitiesToUnload.clear();
+        if (this.emptyTime >= 300 && !this.bridge$blockEntitiesToUnload().isEmpty()) {
+            this.tickableBlockEntities.removeAll(this.bridge$blockEntitiesToUnload());
+            this.blockEntityList.removeAll(this.bridge$blockEntitiesToUnload());
+            this.bridge$blockEntitiesToUnload().clear();
         }
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/level/LevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/level/LevelMixin.java
@@ -80,7 +80,6 @@ public abstract class LevelMixin implements LevelBridge, LevelAccessor {
     @Shadow protected float thunderLevel;
     @Shadow @Final public List<BlockEntity> blockEntityList;
     @Shadow @Final public List<BlockEntity> tickableBlockEntities;
-    @Shadow @Final protected List<BlockEntity> blockEntitiesToUnload;
 
     @Shadow public abstract LevelData shadow$getLevelData();
     @Shadow public abstract void shadow$updateSkyBrightness();


### PR DESCRIPTION
This uses the bridge method instead of the shadow field, as Forge changes the `List` to a `Set`. Fixes https://github.com/SpongePowered/Sponge/issues/3752.