### PR TITLE
Fix multiple missing slot transaction tracking + backport from 1.19

### DIFF
--- a/forge/src/mixins/java/org/spongepowered/forge/mixin/core/minecraftforge/fml/NetworkHooksMixin_Forge.java
+++ b/forge/src/mixins/java/org/spongepowered/forge/mixin/core/minecraftforge/fml/NetworkHooksMixin_Forge.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.forge.mixin.core.minecraftforge.fml;
+
+import net.minecraft.world.MenuProvider;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraftforge.fml.network.NetworkHooks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.event.tracking.PhaseTracker;
+import org.spongepowered.common.event.tracking.context.transaction.EffectTransactor;
+
+@Mixin(NetworkHooks.class)
+public abstract class NetworkHooksMixin_Forge {
+
+    @Redirect(
+        method = "openGui(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/world/MenuProvider;Ljava/util/function/Consumer;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/MenuProvider;createMenu(ILnet/minecraft/world/entity/player/Inventory;Lnet/minecraft/world/entity/player/Player;)Lnet/minecraft/world/inventory/AbstractContainerMenu;"
+        )
+    )
+    private static AbstractContainerMenu forge$openGuiCreateMenu(final MenuProvider instance, final int i, final Inventory inventory, final Player player) {
+        try (final EffectTransactor ignored = PhaseTracker.SERVER.getPhaseContext()
+            .getTransactor()
+            .logOpenInventory(player)
+        ) {
+            return instance.createMenu(i, inventory, player);
+        }
+    }
+}

--- a/forge/src/mixins/resources/mixins.spongeforge.core.json
+++ b/forge/src/mixins/resources/mixins.spongeforge.core.json
@@ -24,6 +24,7 @@
         "minecraftforge.fml.BrandingControlMixin_Forge",
         "minecraftforge.fml.FMLModContainerMixin_Forge",
         "minecraftforge.fml.ModContainerMixin_Forge",
+        "minecraftforge.fml.NetworkHooksMixin_Forge",
         "minecraftforge.util.ITeleporterMixin_Forge",
         "server.BootstrapMixin_Forge",
         "server.MinecraftServerMixin_Forge",

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/TransactionSink.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/TransactionSink.java
@@ -88,6 +88,7 @@ import org.spongepowered.common.event.tracking.context.transaction.inventory.Shi
 import org.spongepowered.common.event.tracking.context.transaction.world.EntityPerformingDropsTransaction;
 import org.spongepowered.common.event.tracking.context.transaction.world.SpawnEntityTransaction;
 import org.spongepowered.common.event.tracking.phase.general.CommandPhaseContext;
+import org.spongepowered.common.event.tracking.phase.plugin.EventListenerPhaseContext;
 import org.spongepowered.common.event.tracking.phase.tick.EntityTickContext;
 import org.spongepowered.common.inventory.adapter.InventoryAdapter;
 import org.spongepowered.common.item.util.ItemStackUtil;
@@ -277,6 +278,7 @@ interface TransactionSink {
      */
     /*
      Non-Javadoc: Known areas where we are keeping transactions recorded:
+     - events - during EventListenerPhaseContext
      - commands - during CommandPhaseContext see below
      - place/use ServerPlayerGameModeMixin_Tracker#useItemOn
      - Dispenser equip PlayerEntityMixin_Inventory#setItemSlot
@@ -296,8 +298,12 @@ interface TransactionSink {
         final PhaseContext<@NonNull ?> phaseContext, final SlotTransaction newTransaction,
         final AbstractContainerMenu abstractContainerMenu
     ) {
-        // Inventory change during command
+        // Inventory change during event or command
         if (abstractContainerMenu instanceof InventoryMenu) {
+            if (phaseContext instanceof EventListenerPhaseContext) {
+                this.logPlayerInventoryChange(((InventoryMenuAccessor) abstractContainerMenu).accessor$owner(),
+                    PlayerInventoryTransaction.EventCreator.STANDARD);
+            }
             if (phaseContext instanceof CommandPhaseContext) {
                 this.logPlayerInventoryChange(((InventoryMenuAccessor) abstractContainerMenu).accessor$owner(),
                     PlayerInventoryTransaction.EventCreator.STANDARD);

--- a/src/mixins/java/org/spongepowered/common/mixin/inventory/event/server/network/ServerGamePacketListenerImplMixin_Inventory.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/inventory/event/server/network/ServerGamePacketListenerImplMixin_Inventory.java
@@ -114,11 +114,11 @@ public class ServerGamePacketListenerImplMixin_Inventory {
             final Level param1, final ItemStack param2, final InteractionHand param3) {
         final PhaseContext<@NonNull ?> context = PhaseTracker.SERVER.getPhaseContext();
         final TransactionalCaptureSupplier transactor = context.getTransactor();
-        final InteractionResult result = serverPlayerGameMode.useItem(param0, param1, param2, param3);
         try (EffectTransactor ignored = transactor.logPlayerInventoryChangeWithEffect(this.player, PlayerInventoryTransaction.EventCreator.STANDARD)) {
+            final InteractionResult result = serverPlayerGameMode.useItem(param0, param1, param2, param3);
             this.player.inventoryMenu.broadcastChanges(); // capture
+            return result;
         }
-        return result;
         // TrackingUtil.processBlockCaptures called by UseItemPacketState
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/server/players/PlayerListMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/server/players/PlayerListMixin_Tracker.java
@@ -55,7 +55,16 @@ public class PlayerListMixin_Tracker {
 
     @Redirect(method = "placeNewPlayer",
               at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;initMenu()V"))
-    private void tracker$onInitMenu(final ServerPlayer player) {
+    private void tracker$onPlaceNewPlayerInitMenu(final ServerPlayer player) {
+        try (final PhaseContext<?> context = BlockPhase.State.RESTORING_BLOCKS.createPhaseContext(PhaseTracker.SERVER).source(player);) {
+            context.buildAndSwitch();
+            player.initMenu();
+        }
+    }
+
+    @Redirect(method = "respawn",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;initMenu()V"))
+    private void tracker$onRespawnInitMenu(final ServerPlayer player) {
         try (final PhaseContext<?> context = BlockPhase.State.RESTORING_BLOCKS.createPhaseContext(PhaseTracker.SERVER).source(player);) {
             context.buildAndSwitch();
             player.initMenu();


### PR DESCRIPTION
Fixes the reported cases in https://github.com/SpongePowered/Sponge/issues/3680.

Backports https://github.com/SpongePowered/Sponge/commit/6ebd3ea977f6c24ae44f5e11edca9d0e32051801. 

Includes:
- Captures player inventory transactions during an event (i.e mod adds an item to the players inventory on the forge left click event). i.e in the Storage Drawers mod where the player will interact with the block to take an item out of it (without using a GUI).
- Captures slot transactions during a command correctly, using the example provided here https://github.com/SpongePowered/Sponge/issues/3680#issuecomment-1220822916.
- Captures inventory open and slot transactions during an open gui, this fixes cases where a mod will add items to the container as it is opening. i.e in the Storage Drawers mod where the player will shift + interact to open the GUI.
- Fixes the slot transaction tracking to include what happens during the call to `useItem`. i.e interacting with an empty map to create a map.