### PR TITLE
Fix IllegalArgumentException when set Keys.FLUID_LEVEL into liquid source

### DIFF
--- a/src/main/java/org/spongepowered/common/data/provider/block/state/FlowingFluidData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/block/state/FlowingFluidData.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.data.provider.block.state;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FlowingFluid;
+import net.minecraft.world.level.material.FluidState;
 import org.spongepowered.api.data.Keys;
 import org.spongepowered.common.data.provider.DataProviderRegistrator;
 import org.spongepowered.common.util.BoundedUtil;
@@ -42,7 +43,13 @@ public final class FlowingFluidData {
                 .asImmutable(BlockState.class)
                     .create(Keys.FLUID_LEVEL)
                         .get(h -> ((LiquidBlock) h.getBlock()).getFluidState(h).getAmount())
-                        .set((h, v) -> BoundedUtil.setInteger(((LiquidBlock) h.getBlock()).getFluidState(h), v, FlowingFluid.LEVEL).createLegacyBlock())
+                        .set((h, v) -> {
+                            final FluidState fluidState = ((LiquidBlock) h.getBlock()).getFluidState(h);
+                            if (fluidState.hasProperty(FlowingFluid.LEVEL)) {
+                                return BoundedUtil.setInteger(fluidState, v, FlowingFluid.LEVEL).createLegacyBlock();
+                            }
+                            return null;
+                        })
                         .supports(h -> h.getBlock() instanceof LiquidBlock);
     }
     // @formatter:on


### PR DESCRIPTION
I propose to ignore this data transaction, although it is possible to turn the liquid into flowing one and set level value.

Fixes exception:
```
java.lang.IllegalArgumentException: Cannot set property IntegerProperty{name=level, clazz=class java.lang.Integer, values=[1, 2, 3, 4, 5, 6, 7, 8]} as it does not exist in net.minecraft.world.level.material.WaterFluid$Source@37c5a3c7
        at net.minecraft.world.level.block.state.StateHolder.setValue(StateHolder.java:114)
        at org.spongepowered.common.util.BoundedUtil.setInteger(BoundedUtil.java:160)
        at org.spongepowered.common.data.provider.block.state.FlowingFluidData.lambda$register$1(FlowingFluidData.java:45)
        at org.spongepowered.common.data.provider.DataProviderRegistrator$ImmutableRegistrationBase$1.set(DataProviderRegistrator.java:507)
        at org.spongepowered.common.data.provider.GenericImmutableDataProviderBase.with(GenericImmutableDataProviderBase.java:138)
        at org.spongepowered.common.data.holder.SpongeImmutableDataHolder.with(SpongeImmutableDataHolder.java:58)
        ...
```
