### PR TITLE
Store in transit resourcepack for firing the ResourcePackStatusEvent

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/server/network/ServerGamePacketListenerImplBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/server/network/ServerGamePacketListenerImplBridge.java
@@ -34,8 +34,6 @@ public interface ServerGamePacketListenerImplBridge {
 
     @Nullable ResourcePack bridge$popAcceptedResourcePack();
 
-    void bridge$resendLatestResourcePackRequest();
-
     void bridge$captureCurrentPlayerPosition();
 
     void bridge$setLastMoveLocation(ServerLocation location);

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/ResourcePackState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/player/ResourcePackState.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.event.tracking.phase.packet.player;
 
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.entity.living.player.ResourcePackStatusEvent;
@@ -46,7 +47,7 @@ public final class ResourcePackState extends BasicPacketState {
         final ServerGamePacketListenerImplBridge mixinHandler = (ServerGamePacketListenerImplBridge) connection;
         final ServerboundResourcePackPacketAccessor resource = phaseContext.getPacket();
         final ResourcePackStatusEvent.ResourcePackStatus status;
-        ResourcePack pack;
+        @Nullable ResourcePack pack;
         switch (resource.accessor$action()) {
             case ACCEPTED:
                 pack = mixinHandler.bridge$popReceivedResourcePack(true);
@@ -67,11 +68,17 @@ public final class ResourcePackState extends BasicPacketState {
             default:
                 throw new AssertionError();
         }
+
         if (pack == null) {
             return;
         }
-        SpongeCommon.post(
-            SpongeEventFactory.createResourcePackStatusEvent(PhaseTracker.getCauseStackManager().currentCause(), pack, (ServerPlayer) player, status));
+
+        SpongeCommon.post(SpongeEventFactory.createResourcePackStatusEvent(
+                PhaseTracker.getCauseStackManager().currentCause(),
+                pack,
+                (ServerPlayer) player,
+                status
+        ));
     }
 
     @Override


### PR DESCRIPTION
Stores the resourcepack being sent to the player to use when receiving a response from the client to fire the ResourcePackStatusEvent. Fixes https://github.com/SpongePowered/Sponge/issues/3744 .