### PR TITLE
Implement translations for item name and lore

### DIFF
--- a/src/main/java/org/spongepowered/common/util/Constants.java
+++ b/src/main/java/org/spongepowered/common/util/Constants.java
@@ -518,6 +518,9 @@ public final class Constants {
         public static final String ITEM_STORED_ENCHANTMENTS_LIST = "StoredEnchantments";
         public static final String ITEM_DISPLAY = "display";
         public static final String ITEM_LORE = "Lore";
+        public static final String ITEM_NAME = "Name";
+        public static final String ITEM_ORIGINAL_LORE = "SpongeOriginalLore";
+        public static final String ITEM_ORIGINAL_NAME = "SpongeOriginalName";
         public static final String ITEM_ENCHANTMENT_ID = "id";
         public static final String ITEM_ENCHANTMENT_LEVEL = "lvl";
         public static final String ITEM_BREAKABLE_BLOCKS = "CanDestroy";

--- a/testplugins/src/main/java/org/spongepowered/test/chat/ChatTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/chat/ChatTest.java
@@ -43,6 +43,7 @@ import org.spongepowered.api.adventure.ResolveOperations;
 import org.spongepowered.api.adventure.SpongeComponents;
 import org.spongepowered.api.command.Command;
 import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.exception.CommandException;
 import org.spongepowered.api.command.parameter.CommandContext;
 import org.spongepowered.api.command.parameter.Parameter;
 import org.spongepowered.api.data.Keys;
@@ -55,12 +56,15 @@ import org.spongepowered.api.event.lifecycle.ConstructPluginEvent;
 import org.spongepowered.api.event.lifecycle.RegisterCommandEvent;
 import org.spongepowered.api.event.message.PlayerChatEvent;
 import org.spongepowered.api.event.network.ServerSideConnectionEvent;
+import org.spongepowered.api.item.ItemTypes;
+import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.util.locale.Locales;
 import org.spongepowered.plugin.PluginContainer;
 import org.spongepowered.plugin.builtin.jvm.Plugin;
 import org.spongepowered.test.LoadableModule;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
@@ -123,6 +127,20 @@ public class ChatTest implements LoadableModule {
                                                                                Component.translatable("chattest.book.2")));
                           return CommandResult.success();
                       }).build(), "sendbook");
+
+        event.register(this.container, Command.builder()
+                .permission("chattest.giveitem")
+                .executor(ctx -> {
+                    final ServerPlayer player = ctx.cause().first(ServerPlayer.class)
+                            .orElseThrow(() -> new CommandException(Component.text("You must be a player to use this command!")));
+
+                    final ItemStack itemStack = ItemStack.builder().itemType(ItemTypes.PAPER)
+                            .add(Keys.CUSTOM_NAME, Component.translatable("chattest.item.name"))
+                            .add(Keys.LORE, Collections.singletonList(Component.translatable("chattest.item.lore"))).build();
+
+                    player.inventory().offer(itemStack);
+                    return CommandResult.success();
+                }).build(), "giveitem");
 
         final Parameter.Value<ServerPlayer> targetArg = Parameter.player().key("target").build();
         final Parameter.Value<Component> messageArg = Parameter.jsonText().key("message").build();

--- a/testplugins/src/main/resources/org/spongepowered/test/chat/messages.properties
+++ b/testplugins/src/main/resources/org/spongepowered/test/chat/messages.properties
@@ -3,3 +3,5 @@ chattest.response.chat=Message "{0}" sent by {1}
 chattest.book.1=First page of the book!
 chattest.book.2=Second page of the book!
 chattest.response=A test response!
+chattest.item.name=Item name
+chattest.item.lore=Item lore

--- a/testplugins/src/main/resources/org/spongepowered/test/chat/messages_en_UD.properties
+++ b/testplugins/src/main/resources/org/spongepowered/test/chat/messages_en_UD.properties
@@ -3,3 +3,5 @@ chattest.response.chat={1} ʎq ʇuǝs „{0}„ ǝƃɐssǝꟽ
 chattest.book.1=¡ʞooq ǝɥʇ ⅎo ǝƃɐd ʇsɹᴉᖵ
 chattest.book.2=¡ʞooq ǝɥʇ ⅎo ǝƃɐd puoɔǝS
 chattest.response=a test but upside down (but not, because i''m lazy)
+chattest.item.name=ǝɯɐu ɯǝʇI
+chattest.item.lore=ǝɹoʅ ɯǝʇI


### PR DESCRIPTION
Translate the components directly on item nbt tag right before sending to the client.
Undo the modifications when receiving an item from the client.
The nbt tag is not modified if there is nothing to translate.
