### PR TITLE
Fix LevelMixin_API#setBiome

### DIFF
--- a/src/main/java/org/spongepowered/common/world/volume/VolumeStreamUtils.java
+++ b/src/main/java/org/spongepowered/common/world/volume/VolumeStreamUtils.java
@@ -160,17 +160,17 @@ public final class VolumeStreamUtils {
         return VolumeStreamUtils.getElementByPosition(VolumeStreamUtils.chunkSectionBlockStateGetter(), min, max);
     }
 
-    public static boolean setBiomeOnNativeChunk(final int x, final int y, final int z, final
-        org.spongepowered.api.world.biome.Biome biome, final Supplier<@Nullable ChunkBiomeContainerAccessor> accessor,
+    public static boolean setBiomeOnNativeChunk(final int x, final int y, final int z,
+        final org.spongepowered.api.world.biome.Biome biome, final Supplier<@Nullable ChunkBiomeContainerAccessor> accessor,
         final Runnable finalizer
-        ) {
+    ) {
         @Nullable final ChunkBiomeContainerAccessor chunkBiomeContainerAccessor = accessor.get();
         if (chunkBiomeContainerAccessor == null) {
             return false;
         }
-        final int maskedX = x & ChunkBiomeContainer.HORIZONTAL_MASK;
-        final int maskedY = Mth.clamp(y, 0, ChunkBiomeContainer.VERTICAL_MASK);
-        final int maskedZ = z & ChunkBiomeContainer.HORIZONTAL_MASK;
+        final int maskedX = (x >> 2) & ChunkBiomeContainer.HORIZONTAL_MASK;
+        final int maskedY = Mth.clamp((y >> 2), 0, ChunkBiomeContainer.VERTICAL_MASK);
+        final int maskedZ = (z >> 2) & ChunkBiomeContainer.HORIZONTAL_MASK;
         final int WIDTH_BITS = ChunkBiomeContainerAccessor.accessor$WIDTH_BITS();
         final int posKey = maskedY << WIDTH_BITS + WIDTH_BITS | maskedZ << WIDTH_BITS | maskedX;
         final Biome[] biomes = chunkBiomeContainerAccessor.accessor$biomes();

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/LevelMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/LevelMixin_API.java
@@ -453,7 +453,7 @@ public abstract class LevelMixin_API<W extends World<W, L>, L extends Location<W
     @SuppressWarnings("rawtypes")
     @Override
     public boolean setBiome(final int x, final int y, final int z, final Biome biome) {
-        if (!((Level) (Object) this).hasChunk(x << 4, z << 4)) {
+        if (!((Level) (Object) this).hasChunk(x >> 4, z >> 4)) {
             return false;
         }
         final LevelChunk levelChunk = this.shadow$getChunkAt(new BlockPos(x, y, z));


### PR DESCRIPTION
This fixes the position to quad position conversion used for `setBiome` and fixes the `hasChunk` condition due to an incorrect bitshift. Tested `//setbiome` with WorldEdit and it worked. Fixes https://github.com/SpongePowered/Sponge/issues/3691 .