### PR TITLE
Restore item after cancelling 'InteractBlockEvent.Secondary'

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/server/level/ServerPlayerGameModeMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/server/level/ServerPlayerGameModeMixin_Tracker.java
@@ -53,6 +53,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.common.bridge.server.level.ServerPlayerGameModeBridge;
 import org.spongepowered.common.bridge.world.inventory.container.ContainerBridge;
 import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.event.inventory.InventoryEventFactory;
@@ -100,11 +101,12 @@ public abstract class ServerPlayerGameModeMixin_Tracker {
         final Vector3d hitVec = Vector3d.from(blockRaytraceResultIn.getBlockPos().getX(), blockRaytraceResultIn.getBlockPos().getY(), blockRaytraceResultIn.getBlockPos().getZ());
         final org.spongepowered.api.util.Direction direction = DirectionFacingProvider.INSTANCE.getKey(blockRaytraceResultIn.getDirection()).get();
         final InteractBlockEvent.Secondary event = SpongeCommonEventFactory.callInteractBlockEventSecondary(playerIn, stackIn, hitVec, snapshot, direction, handIn);
+        final Tristate useItem = event.useItemResult();
+        final Tristate useBlock = event.useBlockResult();
+        ((ServerPlayerGameModeBridge) this).bridge$setInteractBlockRightClickCancelled(event.isCancelled() || useItem == Tristate.FALSE);
         if (event.isCancelled()) {
             return InteractionResult.FAIL;
         }
-        final Tristate useItem = event.useItemResult();
-        final Tristate useBlock = event.useBlockResult();
         // Sponge end
         if (this.gameModeForPlayer == GameType.SPECTATOR) {
             final MenuProvider inamedcontainerprovider = blockstate.getMenuProvider(worldIn, blockpos);

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/server/level/ServerPlayerGameModeMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/server/level/ServerPlayerGameModeMixin_Tracker.java
@@ -103,7 +103,7 @@ public abstract class ServerPlayerGameModeMixin_Tracker {
         final InteractBlockEvent.Secondary event = SpongeCommonEventFactory.callInteractBlockEventSecondary(playerIn, stackIn, hitVec, snapshot, direction, handIn);
         final Tristate useItem = event.useItemResult();
         final Tristate useBlock = event.useBlockResult();
-        ((ServerPlayerGameModeBridge) this).bridge$setInteractBlockRightClickCancelled(event.isCancelled() || useItem == Tristate.FALSE);
+        ((ServerPlayerGameModeBridge) this).bridge$setInteractBlockRightClickCancelled(event.isCancelled());
         if (event.isCancelled()) {
             return InteractionResult.FAIL;
         }
@@ -154,6 +154,7 @@ public abstract class ServerPlayerGameModeMixin_Tracker {
             if (!stackIn.isEmpty() && !playerIn.getCooldowns().isOnCooldown(stackIn.getItem())) {
                 // Sponge start
                 if (useItem == Tristate.FALSE) {
+                    ((ServerPlayerGameModeBridge) this).bridge$setInteractBlockRightClickCancelled(true);
                     return InteractionResult.PASS;
                 }
                 // Sponge end
@@ -179,6 +180,12 @@ public abstract class ServerPlayerGameModeMixin_Tracker {
 
                 return result;
             } else {
+                // Sponge start
+                if(useBlock == Tristate.FALSE && !flag1) {
+                    ((ServerPlayerGameModeBridge) this).bridge$setInteractBlockRightClickCancelled(true);
+                }
+                // Sponge end
+
                 return InteractionResult.PASS;
             }
         }

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/server/network/ServerGamePacketListenerImplMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/server/network/ServerGamePacketListenerImplMixin_Tracker.java
@@ -39,11 +39,9 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.bridge.world.entity.PlatformEntityBridge;
 import org.spongepowered.common.bridge.server.level.ServerPlayerGameModeBridge;
 import org.spongepowered.common.bridge.world.level.LevelBridge;
-import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.phase.packet.PacketContext;
 import org.spongepowered.common.event.tracking.phase.packet.PacketPhaseUtil;
@@ -80,21 +78,17 @@ public abstract class ServerGamePacketListenerImplMixin_Tracker {
         if (PhaseTracker.getInstance().getPhaseContext().isEmpty()) {
             return actionResult;
         }
+
         final PacketContext<?> context = ((PacketContext<?>) PhaseTracker.getInstance().getPhaseContext());
+        final ItemStack itemStack = ItemStackUtil.toNative(context.getItemUsed());
 
-        // If a plugin or mod has changed the item, avoid restoring
-        if (!context.getInteractItemChanged()) {
-            final ItemStack itemStack = ItemStackUtil.toNative(context.getItemUsed());
-
-            // Only do a restore if something actually changed. The client does an identity check ('==')
-            // to determine if it should continue using an itemstack. If we always resend the itemstack, we end up
-            // cancelling item usage (e.g. eating food) that occurs while targeting a block
-            final boolean isInteractionCancelled = ((ServerPlayerGameModeBridge) this.player.gameMode).bridge$isInteractBlockRightClickCancelled();
-            if (!ItemStack.matches(itemStack, this.player.getItemInHand(hand)) && isInteractionCancelled) {
-                PacketPhaseUtil.handlePlayerSlotRestore(this.player, itemStack, hand);
-            }
+        // Only do a restore if the items should stay the same. The client does an identity check ('==')
+        // to determine if it should continue using an itemstack.
+        final boolean isInteractionCancelled = ((ServerPlayerGameModeBridge) this.player.gameMode).bridge$isInteractBlockRightClickCancelled();
+        if (ItemStack.matches(itemStack, this.player.getItemInHand(hand)) && isInteractionCancelled) {
+            PacketPhaseUtil.handlePlayerSlotRestore(this.player, itemStack, hand);
         }
-        context.interactItemChanged(false);
+
         ((ServerPlayerGameModeBridge) this.player.gameMode).bridge$setInteractBlockRightClickCancelled(false);
         return actionResult;
     }


### PR DESCRIPTION
This restores the item in the player inventory if they cancelled the `InteractBlockEvent.Secondary` event or set `useItemResult` and or `useBlockResult` to false. Fixes https://github.com/SpongePowered/Sponge/issues/3727 .