### PR TITLE
Fix removing leash holder

### DIFF
--- a/src/main/java/org/spongepowered/common/data/provider/entity/MobData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/MobData.java
@@ -48,7 +48,13 @@ public final class MobData {
                         .set((h, v) -> h.setLeftHanded(v.equals(HandPreferences.LEFT.get())))
                     .create(Keys.LEASH_HOLDER)
                         .get(h -> ((Entity) h.getLeashHolder()))
-                        .set((h, v) -> h.setLeashedTo((net.minecraft.world.entity.Entity) v, true))
+                        .set((h, v) -> {
+                            if (v == null) {
+                                h.dropLeash(true, false);
+                            } else {
+                                h.setLeashedTo((net.minecraft.world.entity.Entity) v, true);
+                            }
+                        })
                     .create(Keys.TARGET_ENTITY)
                         .get(h -> (Living) h.getTarget())
                         .setAnd((h, v) -> {


### PR DESCRIPTION
Removing a leash via `entity.offer(Keys.LEASH_HOLDER, null);` doesn't always notify the client. Moreover, the entities are left in an incorrect state (field `Entity#forcedLoading` must be set to `false`). This PR fixes this.