### PR TITLE
Fix forwarded profile being unused when using legacy forwarding

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/ipforward/server/network/ServerLoginPacketListenerImplMixin_IpForward.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/ipforward/server/network/ServerLoginPacketListenerImplMixin_IpForward.java
@@ -74,7 +74,7 @@ public abstract class ServerLoginPacketListenerImplMixin_IpForward {
             value = "FIELD",
             target = "Lnet/minecraft/server/network/ServerLoginPacketListenerImpl;gameProfile:Lcom/mojang/authlib/GameProfile;",
             opcode = Opcodes.PUTFIELD,
-            ordinal = 0,
+            ordinal = 1,
             shift = At.Shift.AFTER))
     private void bungee$initUuid(final CallbackInfo ci) {
         if (!this.server.usesAuthentication() && SpongeConfigs.getCommon().get().ipForwarding.mode == IpForwardingCategory.Mode.LEGACY) {


### PR DESCRIPTION
The ServerLoginPacketListenerImpl#handleHello method added a check if the current server is running in singleplayer and assigns the player profile to the "singleplayer profile" which is set in the minecraft server instance. The current mixin therefore only works if running in singleplayer. The simple fix is to move the mixin one down to the second assignment which is executed when the server runs in multiplayer:

```java
...
    GameProfile $$1 = this.server.getSingleplayerProfile();
    if ($$1 != null && $$0.name().equalsIgnoreCase($$1.getName())) {
      this.gameProfile = $$1; // current inject target
      this.state = ServerLoginPacketListenerImpl.State.READY_TO_ACCEPT;
    } else {
      this.gameProfile = new GameProfile((UUID)null, $$0.name());
...
```