### PR TITLE
Fix item translations on Forge

### DIFF
--- a/forge/src/mixins/java/org/spongepowered/forge/mixin/core/network/FriendlyByteBufMixin_Forge.java
+++ b/forge/src/mixins/java/org/spongepowered/forge/mixin/core/network/FriendlyByteBufMixin_Forge.java
@@ -22,15 +22,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.bridge.network;
+package org.spongepowered.forge.mixin.core.network;
 
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.bridge.network.FriendlyByteBufBridge;
 
-import java.util.Locale;
+@Mixin(FriendlyByteBuf.class)
+public abstract class FriendlyByteBufMixin_Forge implements FriendlyByteBufBridge {
 
-public interface FriendlyByteBufBridge {
-
-    void bridge$setLocale(final Locale locale);
-
-    CompoundTag bridge$renderItemComponents(CompoundTag tag);
+    @Redirect(method = "writeItemStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/FriendlyByteBuf;writeNbt(Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/network/FriendlyByteBuf;"))
+    public FriendlyByteBuf renderItemComponents(final FriendlyByteBuf buf, final CompoundTag tag) {
+        return buf.writeNbt(bridge$renderItemComponents(tag));
+    }
 }

--- a/forge/src/mixins/resources/mixins.spongeforge.core.json
+++ b/forge/src/mixins/resources/mixins.spongeforge.core.json
@@ -26,6 +26,7 @@
         "minecraftforge.fml.ModContainerMixin_Forge",
         "minecraftforge.fml.NetworkHooksMixin_Forge",
         "minecraftforge.util.ITeleporterMixin_Forge",
+        "network.FriendlyByteBufMixin_Forge",
         "server.BootstrapMixin_Forge",
         "server.MinecraftServerMixin_Forge",
         "server.level.ServerPlayerMixin_Forge",

--- a/vanilla/src/mixins/java/org/spongepowered/vanilla/mixin/core/network/FriendlyByteBufMixin_Vanilla.java
+++ b/vanilla/src/mixins/java/org/spongepowered/vanilla/mixin/core/network/FriendlyByteBufMixin_Vanilla.java
@@ -22,15 +22,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.bridge.network;
+package org.spongepowered.vanilla.mixin.core.network;
 
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.bridge.network.FriendlyByteBufBridge;
 
-import java.util.Locale;
+@Mixin(FriendlyByteBuf.class)
+public abstract class FriendlyByteBufMixin_Vanilla implements FriendlyByteBufBridge {
 
-public interface FriendlyByteBufBridge {
-
-    void bridge$setLocale(final Locale locale);
-
-    CompoundTag bridge$renderItemComponents(CompoundTag tag);
+    @Redirect(method = "writeItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/FriendlyByteBuf;writeNbt(Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/network/FriendlyByteBuf;"))
+    public FriendlyByteBuf renderItemComponents(final FriendlyByteBuf buf, final CompoundTag tag) {
+        return buf.writeNbt(bridge$renderItemComponents(tag));
+    }
 }

--- a/vanilla/src/mixins/resources/mixins.spongevanilla.core.json
+++ b/vanilla/src/mixins/resources/mixins.spongevanilla.core.json
@@ -19,12 +19,14 @@
     "mixins": [
         "CrashReportMixin_Vanilla",
         "brigadier.exceptions.CommandSyntaxExceptionMixin_Vanilla",
+        "network.FriendlyByteBufMixin_Vanilla",
         "server.BootstrapMixin_Vanilla",
         "server.MinecraftServerMixin_Vanilla",
         "server.level.ServerPlayerMixin_Vanilla",
         "server.network.ServerGamePacketListenerImplMixin_Vanilla",
         "server.network.ServerLoginPacketListenerImpl_1Mixin_Vanilla",
         "server.network.ServerLoginPacketListenerImplMixin_Vanilla",
+        "server.packs.repository.PackRepositoryMixin_Vanilla",
         "world.entity.EntityMixin_Vanilla",
         "world.entity.LivingEntityMixin_Vanilla",
         "world.entity.ai.attributes.DefaultAttributesMixin",
@@ -32,10 +34,9 @@
         "world.entity.projectile.ThrownEnderpearlMixin_Vanilla",
         "world.entity.vehicle.BoatMixin_Vanilla",
         "world.level.LevelMixin_Vanilla",
-        "world.level.portal.PortalForcerMixin_Vanilla",
-        "world.level.storage.LevelStorageSourceMixin_Vanilla",
         "world.level.block.FireBlockMixin_Vanilla",
-        "server.packs.repository.PackRepositoryMixin_Vanilla"
+        "world.level.portal.PortalForcerMixin_Vanilla",
+        "world.level.storage.LevelStorageSourceMixin_Vanilla"
     ],
     "overwrites": {
         "conformVisibility": true


### PR DESCRIPTION
We must use different injection points for Forge and Vanilla but the behavior is the same.