### PR TITLE
Don't call setPos after movement event when position hasn't changed

### DIFF
--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -391,15 +391,16 @@ public final class SpongeCommonEventFactory {
             frame.pushCause(entity);
             frame.addContext(EventContextKeys.MOVEMENT_TYPE, MovementTypes.NATURAL);
 
+            final Vector3d originalToPosition = ((Entity) entity).position();
             final @Nullable Vector3d finalPosition =
                     SpongeCommonEventFactory.callMoveEvent(
                             (Entity) entity,
                             new Vector3d(entity.xOld, entity.yOld, entity.zOld),
-                            new Vector3d(entity.getX(), entity.getY(), entity.getZ()));
+                            originalToPosition);
 
             if (finalPosition == null) {
                 entity.setPos(entity.xOld, entity.yOld, entity.zOld);
-            } else {
+            } else if (!finalPosition.equals(originalToPosition)) {
                 entity.setPos(finalPosition.x(), finalPosition.y(), finalPosition.z());
             }
         }


### PR DESCRIPTION
This fixes painting entities moving infinitely far away. However there is a deeper issue with hanging entities that I will try to answer in another PR.