### PR TITLE
Fix container click events involving player crafting slots

### DIFF
--- a/src/main/java/org/spongepowered/common/event/inventory/InventoryEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/inventory/InventoryEventFactory.java
@@ -235,7 +235,7 @@ public class InventoryEventFactory {
             return false;
         }
         // Custom cursor
-        PacketPhaseUtil.handleCursorRestore(player, event.cursorTransaction());
+        PacketPhaseUtil.handleCursorRestore(player, event.cursorTransaction(), event.isCancelled());
         return true;
     }
 
@@ -486,7 +486,7 @@ public class InventoryEventFactory {
         SpongeCommon.post(event);
 
         PacketPhaseUtil.handleSlotRestore(playerIn, container, event.transactions(), event.isCancelled());
-        PacketPhaseUtil.handleCursorRestore(playerIn, event.cursorTransaction());
+        PacketPhaseUtil.handleCursorRestore(playerIn, event.cursorTransaction(), event.isCancelled());
         return event;
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/CloseMenuTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/CloseMenuTransaction.java
@@ -97,7 +97,7 @@ public class CloseMenuTransaction extends MenuBasedTransaction<InteractContainer
             // If client closed container we need to reopen it
             this.reopen(this.player, this.menu);
         }
-        PacketPhaseUtil.handleCursorRestore(this.player, event.cursorTransaction());
+        PacketPhaseUtil.handleCursorRestore(this.player, event.cursorTransaction(), event.isCancelled());
         if (event instanceof ChangeInventoryEvent) {
             PacketPhaseUtil.handleSlotRestore(this.player, this.menu, ((ChangeInventoryEvent) event).transactions(), event.isCancelled());
         }
@@ -129,7 +129,7 @@ public class CloseMenuTransaction extends MenuBasedTransaction<InteractContainer
         this.player.containerMenu = this.player.inventoryMenu;
 
         // And restore cursor if needed
-        PacketPhaseUtil.handleCursorRestore(this.player, event.cursorTransaction());
+        PacketPhaseUtil.handleCursorRestore(this.player, event.cursorTransaction(), event.isCancelled());
         if (event instanceof ChangeInventoryEvent) {
             PacketPhaseUtil.handleSlotRestore(this.player, this.menu, ((ChangeInventoryEvent) event).transactions(), event.isCancelled());
         }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/ContainerBasedTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/ContainerBasedTransaction.java
@@ -143,7 +143,7 @@ abstract class ContainerBasedTransaction extends MenuBasedTransaction<ClickConta
         if (this.craftingInventory != null) { // Event with Preview transaction on crafting inventory?
             Slot slot = this.craftingInventory.result();
             @Nullable final SlotTransaction preview = this.findPreviewTransaction(this.craftingInventory.result(), slotTransactions);
-            final ItemStackSnapshot previewItem = ItemStackUtil.snapshotOf(this.craftingInventory.peek());
+            final ItemStackSnapshot previewItem = ItemStackUtil.snapshotOf(this.craftingInventory.result().peek());
             if (preview != null) {
                 slot = preview.slot();
                 // Check if preview transaction is correct
@@ -232,7 +232,7 @@ abstract class ContainerBasedTransaction extends MenuBasedTransaction<ClickConta
 
     protected void handleEventResults(final Player player, final ClickContainerEvent event) {
         PacketPhaseUtil.handleSlotRestore(player, this.menu, event.transactions(), event.isCancelled());
-        PacketPhaseUtil.handleCursorRestore(player, event.cursorTransaction());
+        PacketPhaseUtil.handleCursorRestore(player, event.cursorTransaction(), event.isCancelled());
 
         if (this.entities != null && event instanceof SpawnEntityEvent) {
             EntityUtil.despawnFilteredEntities(this.entities, (SpawnEntityEvent) event);

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/OpenMenuTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/OpenMenuTransaction.java
@@ -83,13 +83,13 @@ public class OpenMenuTransaction extends GameTransaction<InteractContainerEvent>
 
     @Override
     public void restore(final PhaseContext<@NonNull ?> context, final InteractContainerEvent event) {
-        PacketPhaseUtil.handleCursorRestore(this.player, event.cursorTransaction());
+        PacketPhaseUtil.handleCursorRestore(this.player, event.cursorTransaction(), event.isCancelled());
         this.player.closeContainer();
     }
 
     @Override
     public void postProcessEvent(final PhaseContext<@NonNull ?> context, final InteractContainerEvent event) {
-        PacketPhaseUtil.handleCursorRestore(this.player, event.cursorTransaction());
+        PacketPhaseUtil.handleCursorRestore(this.player, event.cursorTransaction(), event.isCancelled());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -114,9 +114,9 @@ public final class PacketPhaseUtil {
         }
     }
 
-    public static void handleCursorRestore(final Player player, final Transaction<ItemStackSnapshot> cursorTransaction) {
+    public static void handleCursorRestore(final Player player, final Transaction<ItemStackSnapshot> cursorTransaction, final boolean eventCancelled) {
         final ItemStackSnapshot cursorSnap;
-        if (!cursorTransaction.isValid()) {
+        if (eventCancelled || !cursorTransaction.isValid()) {
             cursorSnap = cursorTransaction.original();
         } else if (cursorTransaction.custom().isPresent()) {
             cursorSnap = cursorTransaction.finalReplacement();


### PR DESCRIPTION
Adding ingredients that do not have crafting recipe would result in transactions where the first ingredient would be seen as the output.

Cancelling event like `CraftItemEvent.Craft` would not take in to account whatever the event got cancelled and not just the cursor transaction.

Fixes #3803