### PR TITLE
Fix chunk unloading causing dangling neighbors

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ChunkMapMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ChunkMapMixin.java
@@ -124,10 +124,9 @@ public abstract class ChunkMapMixin implements ChunkMapBridge {
         level.unload(chunk);
 
         for (final Direction dir : Constants.Chunk.CARDINAL_DIRECTIONS) {
-            final Vector3i neighborPos = chunkPos.add(dir.asBlockOffset());
-            final ChunkAccess neighbor = this.level.getChunk(neighborPos.x(), neighborPos.z(), ChunkStatus.EMPTY, false);
-            if (neighbor instanceof LevelChunk) {
-                final int index = DirectionUtil.directionToIndex(dir);
+            final int index = DirectionUtil.directionToIndex(dir);
+            final LevelChunk neighbor = ((LevelChunkBridge) chunk).bridge$getNeighborChunk(index);
+            if (neighbor != null) {
                 final int oppositeIndex = DirectionUtil.directionToIndex(dir.opposite());
                 ((LevelChunkBridge) chunk).bridge$setNeighborChunk(index, null);
                 ((LevelChunkBridge) neighbor).bridge$setNeighborChunk(oppositeIndex, null);


### PR DESCRIPTION
When chunks were unloaded we tried to clear out the neighboring reference but it turns out we actually never end up hitting this path.  The neighboring chunk is considered absent at this point (but still loaded in memory) so we end up receiving null chunk upon requesting for it. Instead use the chunk reference we have stored to clear out the neighbors.

To reproduce this bug you just need to fly around your world and the memory eventually keeps rising without ever clearing out. From here you can take a heap dump and inspect the nearest GC roots of LevelChunk. You should notice that ChunkHolder's are keeping more than one reference alive through the neighbors array. After applying this patch this is no longer the case and all ChunkHolder's are holding to only one reference.