### PR TITLE
Remove the internal usage of optional from Registry#value

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/core/RegistryMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/core/RegistryMixin_API.java
@@ -52,6 +52,7 @@ public abstract class RegistryMixin_API<T> implements Registry<T> {
     @Shadow public abstract net.minecraft.resources.ResourceKey<? extends net.minecraft.core.Registry<T>> shadow$key();
     @Shadow @Nullable public abstract ResourceLocation shadow$getKey(T p_177774_1_);
     @Shadow public abstract Optional<T> shadow$getOptional(@Nullable net.minecraft.resources.ResourceLocation param0);
+    @Shadow @Nullable public abstract T shadow$get(@Nullable ResourceLocation var1);
     // @formatter:on
 
 
@@ -91,8 +92,13 @@ public abstract class RegistryMixin_API<T> implements Registry<T> {
 
     @Override
     public <V extends T> V value(final ResourceKey key) {
-        return (V) this.shadow$getOptional((ResourceLocation) (Object) Objects.requireNonNull(key, "key"))
-            .orElseThrow(() -> new ValueNotFoundException(String.format("No value was found for key '%s'!", key)));
+        V value = (V) this.shadow$get((ResourceLocation) (Object) Objects.requireNonNull(key, "key"));
+        if (value != null)
+        {
+            return value;
+        }
+
+        throw new ValueNotFoundException(String.format("No value was found for key '%s'!", key));
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/core/RegistryMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/core/RegistryMixin_API.java
@@ -92,9 +92,8 @@ public abstract class RegistryMixin_API<T> implements Registry<T> {
 
     @Override
     public <V extends T> V value(final ResourceKey key) {
-        V value = (V) this.shadow$get((ResourceLocation) (Object) Objects.requireNonNull(key, "key"));
-        if (value != null)
-        {
+        final V value = (V) this.shadow$get((ResourceLocation) (Object) Objects.requireNonNull(key, "key"));
+        if (value != null) {
             return value;
         }
 


### PR DESCRIPTION
Removes the usage of Optional from the `Registry#value` in preference to just have a null check. This method can actually show up in profiler when hot methods end up calling `DefaultedRegistryReference#get` multiple times in a single tick.