### PR TITLE
Fix block entity memory leak (API 9)

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
@@ -541,7 +541,7 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerLevel
          * is without players.
          */
         if (this.emptyTime >= 300 && !this.blockEntityTickers.isEmpty()) {
-            blockEntityTickers.removeIf(TickingBlockEntity::isRemoved);
+            this.blockEntityTickers.removeIf(TickingBlockEntity::isRemoved);
         }
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerLevelMixin.java
@@ -47,6 +47,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.JukeboxBlockEntity;
+import net.minecraft.world.level.block.entity.TickingBlockEntity;
 import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.gameevent.GameEvent;
@@ -57,6 +58,7 @@ import net.minecraft.world.level.storage.PrimaryLevelData;
 import net.minecraft.world.level.storage.ServerLevelData;
 import net.minecraft.world.level.storage.WorldData;
 import net.minecraft.world.ticks.LevelTicks;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockSnapshot;
@@ -518,6 +520,29 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerLevel
             return;
         }
         manager.add(pos, type);
+    }
+
+    @Inject(
+        method = "tick",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/server/level/ServerLevel;emptyTime:I",
+            opcode = Opcodes.PUTFIELD,
+            shift = At.Shift.AFTER
+        )
+    )
+    private void impl$unloadBlockEntities(final BooleanSupplier param0, final CallbackInfo ci) {
+        /*
+         * This code fixes block entity memory leak when the level hasn't online players
+         * and forced chunks. For the first 300 ticks the level can still clean up removed
+         * block entities on its own (ticks are performed for block entities). After it
+         * this mixin code is responsible for the subsequent unloading of block entities.
+         * Such a memory leak occurs when a plugin writes a lot of blocks, but the level
+         * is without players.
+         */
+        if (this.emptyTime >= 300 && !this.blockEntityTickers.isEmpty()) {
+            blockEntityTickers.removeIf(TickingBlockEntity::isRemoved);
+        }
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/level/LevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/level/LevelMixin.java
@@ -40,6 +40,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.TickingBlockEntity;
 import net.minecraft.world.level.border.WorldBorder;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.dimension.DimensionType;
@@ -67,6 +68,7 @@ import org.spongepowered.common.util.Constants;
 import org.spongepowered.common.util.DataUtil;
 import org.spongepowered.math.vector.Vector3d;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 @Mixin(net.minecraft.world.level.Level.class)
@@ -78,6 +80,7 @@ public abstract class LevelMixin implements LevelBridge, LevelAccessor {
     @Shadow protected float rainLevel;
     @Shadow protected float oThunderLevel;
     @Shadow protected float thunderLevel;
+    @Shadow @Final protected List<TickingBlockEntity> blockEntityTickers;
 
     @Shadow public abstract LevelData shadow$getLevelData();
     @Shadow public abstract void shadow$updateSkyBrightness();


### PR DESCRIPTION
Adaptation of my early PR #3689 for api-8. In version 1.18.2, the associated code has changed slightly, leaving only one field with a collection of ticking block entities. The code is tested, the leak is gone.