### PR TITLE
Add movement threshold configuration

### DIFF
--- a/src/main/java/org/spongepowered/common/config/inheritable/MovementChecksCategory.java
+++ b/src/main/java/org/spongepowered/common/config/inheritable/MovementChecksCategory.java
@@ -31,6 +31,22 @@ import org.spongepowered.configurate.objectmapping.meta.Setting;
 @ConfigSerializable
 public final class MovementChecksCategory {
 
+    @Setting("moved-wrongly-threshold")
+    @Comment("Sets the threshold for whether the 'player moved wrongly!' check will be enforced")
+    public double movedWronglyThreshold = 0.0625;
+
+    @Setting("vehicle-moved-wrongly-threshold")
+    @Comment("Sets the threshold for whether the 'vehicle of player moved wrongly!' check will be enforced")
+    public double vehicleMovedWronglyThreshold = 0.0625;
+
+    @Setting("moved-too-quickly-threshold")
+    @Comment("Sets the threshold for whether the 'player moved too quickly!' check will be enforced")
+    public double movedTooQuicklyThreshold = 100.0;
+
+    @Setting("vehicle-moved-too-quickly-threshold")
+    @Comment("Sets the threshold for whether the 'vehicle of player moved too quickly!' check will be enforced")
+    public double vehicleMovedTooQuicklyThreshold = 100.0;
+
     @Setting("moved-wrongly")
     @Comment("Controls whether the 'player/entity moved wrongly!' check will be enforced")
     public boolean movedWrongly = true;

--- a/src/mixins/java/org/spongepowered/common/mixin/movementcheck/server/network/ServerGamePacketListenerImplMixin_MovementCheck.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/movementcheck/server/network/ServerGamePacketListenerImplMixin_MovementCheck.java
@@ -31,7 +31,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.common.config.SpongeGameConfigs;
 
@@ -40,53 +39,59 @@ public abstract class ServerGamePacketListenerImplMixin_MovementCheck {
 
     @Shadow public ServerPlayer player;
 
-    @Redirect(method = "handleMovePlayer",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;isChangingDimension()Z", ordinal = 0))
-    private boolean movementCheck$onPlayerMovedTooQuicklyCheck(final ServerPlayer player) {
-        if (SpongeGameConfigs.getForWorld(this.player.level).get().movementChecks.player.movedTooQuickly) {
-            return player.isChangingDimension();
+    @ModifyConstant(method = "handleMovePlayer", constant = @Constant(floatValue = 100.0F, ordinal = 0), slice =
+        @Slice(
+            from = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;isFallFlying()Z", ordinal = 0),
+            to = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerGamePacketListenerImpl;isSingleplayerOwner()Z", ordinal = 0)
+        )
+    )
+    private float movementCheck$onMovedTooQuickly(final float value) {
+        final double threshold = SpongeGameConfigs.getForWorld(this.player.level).get().movementChecks.movedTooQuicklyThreshold;
+        if (threshold > 0.0D && SpongeGameConfigs.getForWorld(this.player.level).get().movementChecks.player.movedTooQuickly) {
+            return (float) threshold;
         }
-        return true; // The 'moved too quickly' check only executes if isChangingDimension return false
+        return Float.NaN;
     }
 
-    @Redirect(method = "handleMovePlayer",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;isChangingDimension()Z", ordinal = 1))
-    private boolean movementCheck$onMovedWronglyCheck(final ServerPlayer player) {
-        if (SpongeGameConfigs.getForWorld(this.player.level).get().movementChecks.movedWrongly) {
-            return player.isChangingDimension();
+    @ModifyConstant(method = "handleMovePlayer", constant = @Constant(doubleValue = 0.0625D, ordinal = 0), slice =
+        @Slice(
+            from = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;isChangingDimension()Z", ordinal = 1),
+            to = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;isSleeping()Z", ordinal = 1)
+        )
+    )
+    private double movementCheck$onMovedWronglyCheck(final double value) {
+        final double threshold = SpongeGameConfigs.getForWorld(this.player.level).get().movementChecks.movedWronglyThreshold;
+        if (threshold > 0.0D && SpongeGameConfigs.getForWorld(this.player.level).get().movementChecks.movedWrongly) {
+            return threshold;
         }
-        return true; // The 'moved too quickly' check only executes if isChangingDimension return false
+        return Double.NaN;
     }
 
-    @ModifyConstant(method = "handleMoveVehicle", constant = @Constant(doubleValue = 100, ordinal = 0), slice =
+    @ModifyConstant(method = "handleMoveVehicle", constant = @Constant(doubleValue = 0.0625D, ordinal = 0), slice =
+        @Slice(
+            from = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V", ordinal = 0),
+            to = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;warn(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V")
+        )
+    )
+    private double movementCheck$onVehicleMovedWronglyCheck(final double value) {
+        final double threshold = SpongeGameConfigs.getForWorld(this.player.level).get().movementChecks.vehicleMovedWronglyThreshold;
+        if (threshold > 0.0D && SpongeGameConfigs.getForWorld(this.player.level).get().movementChecks.movedWrongly) {
+            return threshold;
+        }
+        return Double.NaN;
+    }
+
+    @ModifyConstant(method = "handleMoveVehicle", constant = @Constant(doubleValue = 100D, ordinal = 0), slice =
         @Slice(
             from = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;lengthSqr()D", ordinal = 0),
-            to = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerGamePacketListenerImpl;isSingleplayerOwner()Z", ordinal = 0))
+            to = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerGamePacketListenerImpl;isSingleplayerOwner()Z", ordinal = 0)
+        )
     )
-    private double movementCheck$onVehicleMovedTooQuicklyCheck(final double val) {
-        if (SpongeGameConfigs.getForWorld(this.player.level).get().movementChecks.player.vehicleMovedTooQuickly) {
-            return val;
+    private double movementCheck$onVehicleMovedTooQuicklyCheck(final double value) {
+        final double threshold = SpongeGameConfigs.getForWorld(this.player.level).get().movementChecks.vehicleMovedTooQuicklyThreshold;
+        if (threshold > 0.0D && SpongeGameConfigs.getForWorld(this.player.level).get().movementChecks.player.vehicleMovedTooQuickly) {
+            return threshold;
         }
-        return Double.NaN; // The 'vehicle moved too quickly' check only executes if the squared difference of the motion vectors lengths is greater than 100
-    }
-
-    @ModifyConstant(method = "handleMoveVehicle",
-        constant = @Constant(doubleValue = 0.0625D, ordinal = 0),
-        slice = @Slice(
-            from = @At(
-                value = "INVOKE",
-                target = "Lnet/minecraft/world/entity/Entity;move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
-                ordinal = 0),
-            to  = @At(
-                value = "INVOKE",
-                target = "Lorg/apache/logging/log4j/Logger;warn(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V",
-                ordinal = 0,
-                remap = false)
-    ))
-    private double movementCheck$onMovedWronglySecond(final double val) {
-        if (SpongeGameConfigs.getForWorld(this.player.level).get().movementChecks.movedWrongly) {
-            return val;
-        }
-        return Double.NaN; // The second 'moved wrongly' check only executes if the length of the movement vector is greater than 0.0625D
+        return Double.NaN;
     }
 }


### PR DESCRIPTION
Replaces the existing enable/disable movement checks with a customizable threshold. Using negative numbers will disable the movement checks still if desired.