### PR TITLE
Fix damage implementation in builders

### DIFF
--- a/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeBlockDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeBlockDamageSourceBuilder.java
@@ -77,11 +77,11 @@ public final class SpongeBlockDamageSourceBuilder extends AbstractDamageSourceBu
         if (this.creative) {
             accessor.invoker$bypassInvul();
         }
-        if (this.exhaustion != null) {
-            accessor.accessor$exhaustion(this.exhaustion.floatValue());
-        }
         if (this.fire) {
             accessor.invoker$setIsFire();
+        }
+        if (this.exhaustion != null) {
+            accessor.accessor$exhaustion(this.exhaustion.floatValue());
         }
         return (BlockDamageSource) (Object) damageSource;
     }

--- a/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeCommonDamageSource.java
+++ b/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeCommonDamageSource.java
@@ -83,17 +83,4 @@ public abstract class SpongeCommonDamageSource extends DamageSource implements o
     public float getFoodExhaustion() {
         return (float) this.exhaustion();
     }
-
-
-    public void bridge$setDamageIsAbsolute() {
-        this.bypassMagic();
-    }
-    public void bridge$setDamageBypassesArmor() {
-        this.bypassArmor();
-    }
-
-
-    public void bridge$setHungerDamage(final float exhaustion) {
-        ((DamageSourceAccessor) this).accessor$exhaustion(exhaustion);
-    }
 }

--- a/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeCommonEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeCommonEntityDamageSource.java
@@ -60,13 +60,6 @@ public abstract class SpongeCommonEntityDamageSource extends EntityDamageSource 
         ((EntityDamageSourceAccessor) this).accessor$entity(entitySource);
     }
 
-    public void bridge$setDamageIsAbsolute() {
-        this.bypassMagic();
-    }
-    public void bridge$setDamageBypassesArmor() {
-        this.bypassArmor();
-    }
-
     @Override
     public Entity getEntity() {
         return (Entity) this.source();

--- a/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeCommonIndirectEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeCommonIndirectEntityDamageSource.java
@@ -65,15 +65,6 @@ public abstract class SpongeCommonIndirectEntityDamageSource extends net.minecra
         ((IndirectEntityDamageSourceAccessor) this).accessor$owner(entity);
     }
 
-
-    public void bridge$setDamageIsAbsolute() {
-        this.bypassMagic();
-    }
-    public void bridge$setDamageBypassesArmor() {
-        this.bypassArmor();
-    }
-
-
     @Override
     public Entity getEntity() {
         return (Entity) this.source();

--- a/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeDamageSourceBuilder.java
@@ -47,7 +47,7 @@ public class SpongeDamageSourceBuilder extends AbstractDamageSourceBuilder<Damag
                 && !this.creative
                 && !this.fire
                 && this.exhaustion == null
-                && this.damageType.equals(DamageTypes.DROWN)
+                && this.damageType.equals(DamageTypes.DROWN.get())
         ) {
             return (DamageSource) net.minecraft.world.damagesource.DamageSource.DROWN;
         }
@@ -165,11 +165,11 @@ public class SpongeDamageSourceBuilder extends AbstractDamageSourceBuilder<Damag
         if (this.explosion) {
             source.setExplosion();
         }
-        if (this.exhaustion != null) {
-            accessor.accessor$exhaustion(this.exhaustion.floatValue());
-        }
         if (this.fire) {
             accessor.invoker$setIsFire();
+        }
+        if (this.exhaustion != null) {
+            accessor.accessor$exhaustion(this.exhaustion.floatValue());
         }
         return (DamageSource) source;
     }

--- a/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeEntityDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeEntityDamageSourceBuilder.java
@@ -70,6 +70,9 @@ public class SpongeEntityDamageSourceBuilder extends AbstractDamageSourceBuilder
         if (this.explosion) {
             damageSource.setExplosion();
         }
+        if (this.fire) {
+            accessor.invoker$setIsFire();
+        }
         if (this.exhaustion != null) {
             accessor.accessor$exhaustion(this.exhaustion.floatValue());
         }

--- a/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeFallingBlockDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeFallingBlockDamageSourceBuilder.java
@@ -39,20 +39,15 @@ import org.spongepowered.common.util.MinecraftFallingBlockDamageSource;
 
 import java.lang.ref.WeakReference;
 
-public final class SpongeFallingBlockDamgeSourceBuilder extends AbstractDamageSourceBuilder<FallingBlockDamageSource, FallingBlockDamageSource.Builder> implements FallingBlockDamageSource.Builder {
+public final class SpongeFallingBlockDamageSourceBuilder extends AbstractDamageSourceBuilder<FallingBlockDamageSource, FallingBlockDamageSource.Builder> implements FallingBlockDamageSource.Builder {
 
     protected WeakReference<Entity> reference = null;
 
     @Override
-    public SpongeFallingBlockDamgeSourceBuilder entity(final Entity entity) {
+    public SpongeFallingBlockDamageSourceBuilder entity(final Entity entity) {
         checkArgument(entity instanceof FallingBlock);
         this.reference = new WeakReference<>(entity);
         return this;
-    }
-
-    @Override
-    public FallingBlockDamageSource.Builder fire() {
-        return null;
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -81,6 +76,9 @@ public final class SpongeFallingBlockDamgeSourceBuilder extends AbstractDamageSo
         if (this.explosion) {
             damageSource.setExplosion();
         }
+        if (this.fire) {
+            accessor.invoker$setIsFire();
+        }
         if (this.exhaustion != null) {
             accessor.accessor$exhaustion(this.exhaustion.floatValue());
         }
@@ -95,7 +93,7 @@ public final class SpongeFallingBlockDamgeSourceBuilder extends AbstractDamageSo
     }
 
     @Override
-    public SpongeFallingBlockDamgeSourceBuilder reset() {
+    public SpongeFallingBlockDamageSourceBuilder reset() {
         super.reset();
         this.reference = null;
         return this;

--- a/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeIndirectEntityDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeIndirectEntityDamageSourceBuilder.java
@@ -79,6 +79,9 @@ public final class SpongeIndirectEntityDamageSourceBuilder extends AbstractDamag
         if (this.explosion) {
             damageSource.setExplosion();
         }
+        if (this.fire) {
+            accessor.invoker$setIsFire();
+        }
         if (this.exhaustion != null) {
             accessor.accessor$exhaustion(this.exhaustion.floatValue());
         }

--- a/src/main/java/org/spongepowered/common/registry/SpongeBuilderProvider.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeBuilderProvider.java
@@ -172,7 +172,7 @@ import org.spongepowered.common.event.cause.entity.damage.SpongeBlockDamageSourc
 import org.spongepowered.common.event.cause.entity.damage.SpongeDamageSourceBuilder;
 import org.spongepowered.common.event.cause.entity.damage.SpongeDamageType;
 import org.spongepowered.common.event.cause.entity.damage.SpongeEntityDamageSourceBuilder;
-import org.spongepowered.common.event.cause.entity.damage.SpongeFallingBlockDamgeSourceBuilder;
+import org.spongepowered.common.event.cause.entity.damage.SpongeFallingBlockDamageSourceBuilder;
 import org.spongepowered.common.event.cause.entity.damage.SpongeIndirectEntityDamageSourceBuilder;
 import org.spongepowered.common.fluid.SpongeFluidStackBuilder;
 import org.spongepowered.common.fluid.SpongeFluidStackSnapshotBuilder;
@@ -277,7 +277,7 @@ public final class SpongeBuilderProvider implements BuilderProvider {
                 .register(DamageSource.Builder.class, SpongeDamageSourceBuilder::new)
                 .register(EntityDamageSource.Builder.class, SpongeEntityDamageSourceBuilder::new)
                 .register(IndirectEntityDamageSource.Builder.class, SpongeIndirectEntityDamageSourceBuilder::new)
-                .register(FallingBlockDamageSource.Builder.class, SpongeFallingBlockDamgeSourceBuilder::new)
+                .register(FallingBlockDamageSource.Builder.class, SpongeFallingBlockDamageSourceBuilder::new)
                 .register(BlockDamageSource.Builder.class, SpongeBlockDamageSourceBuilder::new)
                 .register(Explosion.Builder.class, SpongeExplosionBuilder::new)
                 .register(BlockState.Builder.class, SpongeBlockStateBuilder::new)

--- a/src/mixins/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractDamageSourceMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractDamageSourceMixin_API.java
@@ -30,6 +30,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.accessor.world.damagesource.DamageSourceAccessor;
 import org.spongepowered.common.event.cause.entity.damage.SpongeCommonDamageSource;
 
 /*
@@ -48,12 +49,15 @@ public abstract class AbstractDamageSourceMixin_API implements DamageSource {
     @Inject(method = "<init>", at = @At("RETURN"))
     private void api$setUpBridges(final CallbackInfo callbackInfo) {
         final SpongeCommonDamageSource commonSource = (SpongeCommonDamageSource) (Object) this;
+        final DamageSourceAccessor accessor = (DamageSourceAccessor) commonSource;
+
         commonSource.setDamageType(this.type().name());
+
         if (this.isAbsolute()) {
-            commonSource.bridge$setDamageIsAbsolute();
+            accessor.invoker$bypassMagic();
         }
         if (this.isBypassingArmor()) {
-            commonSource.bridge$setDamageBypassesArmor();
+            accessor.invoker$bypassArmor();
         }
         if (this.isExplosive()) {
             commonSource.setExplosion();
@@ -65,11 +69,14 @@ public abstract class AbstractDamageSourceMixin_API implements DamageSource {
             commonSource.setScalesWithDifficulty();
         }
         if (this.doesAffectCreative()) {
-            commonSource.isBypassInvul();
+            accessor.invoker$bypassInvul();
         }
-        // Sets exhaustion last as to allow control if the builder specified a custom exhaustion value
+        if (this.isFire()) {
+            accessor.invoker$setIsFire();
+        }
 
-        commonSource.bridge$setHungerDamage((float) this.exhaustion());
+        // Sets exhaustion last as to allow control if the builder specified a custom exhaustion value
+        accessor.accessor$exhaustion((float) this.exhaustion());
     }
 
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractEntityDamageSourceMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractEntityDamageSourceMixin_API.java
@@ -31,6 +31,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.accessor.world.damagesource.DamageSourceAccessor;
 import org.spongepowered.common.event.cause.entity.damage.SpongeCommonEntityDamageSource;
 
 /*
@@ -49,13 +50,16 @@ public abstract class AbstractEntityDamageSourceMixin_API implements EntityDamag
     @Inject(method = "<init>", at = @At("RETURN"))
     private void impl$bridgeApiToImplConstruction(final CallbackInfo callbackInfo) {
         final SpongeCommonEntityDamageSource commonSource = (SpongeCommonEntityDamageSource) (Object) this;
+        final DamageSourceAccessor accessor = (DamageSourceAccessor) commonSource;
+
         commonSource.setDamageType(this.type().name());
         commonSource.setEntitySource((Entity) this.source());
+
         if (this.isAbsolute()) {
-            commonSource.bridge$setDamageIsAbsolute();
+            accessor.invoker$bypassMagic();
         }
         if (this.isBypassingArmor()) {
-            commonSource.bridge$setDamageBypassesArmor();
+            accessor.invoker$bypassArmor();
         }
         if (this.isExplosive()) {
             commonSource.setExplosion();
@@ -67,8 +71,13 @@ public abstract class AbstractEntityDamageSourceMixin_API implements EntityDamag
             commonSource.setScalesWithDifficulty();
         }
         if (this.doesAffectCreative()) {
-            commonSource.isBypassInvul();
+            accessor.invoker$bypassInvul();
         }
+        if (this.isFire()) {
+            accessor.invoker$setIsFire();
+        }
+
+        accessor.accessor$exhaustion((float) this.exhaustion());
     }
 
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSourceMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/event/cause/entity/damage/source/common/AbstractIndirectEntityDamageSourceMixin_API.java
@@ -31,6 +31,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.accessor.world.damagesource.DamageSourceAccessor;
 import org.spongepowered.common.event.cause.entity.damage.SpongeCommonIndirectEntityDamageSource;
 
 /*
@@ -48,28 +49,36 @@ public abstract class AbstractIndirectEntityDamageSourceMixin_API implements Ind
     @SuppressWarnings("ConstantConditions")
     @Inject(method = "<init>", at = @At("RETURN"))
     private void api$setUpBridges(final CallbackInfo callbackInfo) {
-        final SpongeCommonIndirectEntityDamageSource commonIndirect = (SpongeCommonIndirectEntityDamageSource) (Object) this;
-        commonIndirect.setDamageType(this.type().name());
-        commonIndirect.setEntitySource((Entity) this.source());
-        commonIndirect.setIndirectSource((Entity) this.indirectSource());
+        final SpongeCommonIndirectEntityDamageSource commonSource = (SpongeCommonIndirectEntityDamageSource) (Object) this;
+        final DamageSourceAccessor accessor = (DamageSourceAccessor) commonSource;
+
+        commonSource.setDamageType(this.type().name());
+        commonSource.setEntitySource((Entity) this.source());
+        commonSource.setIndirectSource((Entity) this.indirectSource());
+
         if (this.isAbsolute()) {
-            commonIndirect.bridge$setDamageIsAbsolute();
+            accessor.invoker$bypassMagic();
         }
         if (this.isBypassingArmor()) {
-            commonIndirect.bridge$setDamageBypassesArmor();
+            accessor.invoker$bypassArmor();
         }
         if (this.isExplosive()) {
-            commonIndirect.setExplosion();
+            commonSource.setExplosion();
         }
         if (this.isMagic()) {
-            commonIndirect.setMagic();
+            commonSource.setMagic();
         }
         if (this.isScaledByDifficulty()) {
-            commonIndirect.setScalesWithDifficulty();
+            commonSource.setScalesWithDifficulty();
         }
         if (this.doesAffectCreative()) {
-            commonIndirect.isBypassInvul();
+            accessor.invoker$bypassInvul();
         }
+        if (this.isFire()) {
+            accessor.invoker$setIsFire();
+        }
+
+        accessor.accessor$exhaustion((float) this.exhaustion());
     }
 
 }


### PR DESCRIPTION
**Sponge** | [SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2451)

isFire, doesAffectCreative and exhaustion were not properly implemented in most damage builders.