### PR TITLE
Fix GS4 full queries always being overwritten by basic responses

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/rcon/thread/QueryThreadGs4Mixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/rcon/thread/QueryThreadGs4Mixin.java
@@ -65,6 +65,12 @@ public abstract class QueryThreadGs4Mixin {
 
     @Redirect(method = "processPacket", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/rcon/thread/QueryThreadGs4;sendTo([BLjava/net/DatagramPacket;)V"))
     public void impl$basicSendTo(QueryThreadGs4 query, byte[] param0, DatagramPacket datagramPacket) throws IOException {
+        if (datagramPacket.getLength() == 15) {
+            // We already generated the full query event and response in another mixin
+            this.shadow$sendTo(param0, datagramPacket);
+            return;
+        }
+
         final Cause currentCause = Sponge.server().causeStackManager().currentCause();
         final QueryServerEvent.Basic event = SpongeEventFactory.createQueryServerEventBasic(currentCause,
                 (InetSocketAddress) datagramPacket.getSocketAddress(),


### PR DESCRIPTION
This PR fixes all GS4 query requests to be wrongly answered with basic responses, instead of differentiating between the two query types (Basic and Full).

## Background
There are two types of GS4 query requests, apart from the initial handshake: The basic status query, and the full status query. The basic status query contains the most important pieces of information, similar to the Server List Ping, and is requested with a 11 byte long request.
The full status query contains all base details, plus a list of all players, active plugins and the current server map (vanilla server). This is expandable, as the full query response uses a K/V format for its fields in comparison to the basic one. This one is requested with a 15 byte long request.

## Detailed description of bug
Within the `net.minecraft.server.rcon.thread.QueryThreadGs4` class, after the validity of the request has been verified, it is decided whether to respond with a basic or full response. This check if done by checking the lenght of the request packet (11 vs 15 bytes).

Sponge has two mixins in that class:
- a replacement for the `QueryThreadGs4#buildRuleResponse` method, responsible for generating the full status response,
- and a redirect of the `QueryThreadGs4#sendTo` calls meant to finally send the generated response.

The first mixin makes sense, as we want to be able to modify the responses with event listeners in mods/plugins.
The second one however ignores the passed generated response and overwrites it with a newly generated basic response. This makes sense in the second if-branch, but not in the first one.

Pseudo code:
```java
if (15 == receivedPacket.getLength()) {
    // full status query
    this.sendTo(this.buildRuleResponse(receivedPacket));
} else {
    // basic status query
    /// <SNIP>
    // inline generate the basic response byte array
    /// </SNIP>
    this.sendTo(baseReponse);
}
```

## Suggested fix
Since the response bytes and event generation already work and exist, this PR simply checks for the request packet length in the `sendTo` method. If it is 15, we know that we already have our own "mixed-in" generated response ready.
Otherwise we continue with the basic response generation.

## Affected versions
As far as I can see, all current API implementations are affected (api 8, 9, 10).

*Sorry for the long wall of text, I hope this was understandable.*
Best regards,
MindSolve