### PR TITLE
Prevent invalid status responses with empty/dummy player UUIDs

### DIFF
--- a/src/main/java/org/spongepowered/common/profile/SpongeGameProfile.java
+++ b/src/main/java/org/spongepowered/common/profile/SpongeGameProfile.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.profile;
 
 import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -72,6 +73,10 @@ public final class SpongeGameProfile implements GameProfile {
 
     public static com.mojang.authlib.GameProfile toMcProfile(final GameProfile profile) {
         return ((SpongeGameProfile) profile).toMcProfile();
+    }
+
+    public static com.mojang.authlib.GameProfile toMcProfileNonNull(final GameProfile profile) {
+        return ((SpongeGameProfile) profile).toMcProfileNonNull();
     }
 
     public static GameProfile unsignedOf(final GameProfile profile) {
@@ -133,6 +138,17 @@ public final class SpongeGameProfile implements GameProfile {
     public com.mojang.authlib.GameProfile toMcProfile() {
         final UUID uniqueId = this.uniqueId.equals(SpongeGameProfile.EMPTY_UUID) ? null : this.uniqueId;
         final String name = this.name;
+        final com.mojang.authlib.GameProfile mcProfile = new com.mojang.authlib.GameProfile(uniqueId, name);
+        for (final SpongeProfileProperty property : this.properties) {
+            mcProfile.getProperties().put(property.name(), property.asProperty());
+        }
+        return mcProfile;
+    }
+
+    public com.mojang.authlib.GameProfile toMcProfileNonNull() {
+        // Make sure UUID and name are non-null
+        final UUID uniqueId = this.uniqueId;
+        final String name = Strings.nullToEmpty(this.name);
         final com.mojang.authlib.GameProfile mcProfile = new com.mojang.authlib.GameProfile(uniqueId, name);
         for (final SpongeProfileProperty property : this.properties) {
             mcProfile.getProperties().put(property.name(), property.asProperty());

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/network/protocol/status/ServerStatus_PlayersMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/network/protocol/status/ServerStatus_PlayersMixin_API.java
@@ -93,7 +93,10 @@ public abstract class ServerStatus_PlayersMixin_API implements ClientPingServerE
         // TODO: When serializing, Minecraft calls this method frequently (it doesn't store the result).
         // Maybe we should cache this until the list is modified or patch the serialization?
         return this.profiles.stream()
-                .map(SpongeGameProfile::toMcProfile)
+                // Make sure profiles are sent with non-null UUIDs and names because everything else
+                // will make the response invalid on the client. Some plugins use empty UUIDs to create
+                // custom lines in the player list that do not refer to a specific player.
+                .map(SpongeGameProfile::toMcProfileNonNull)
                 .toArray(GameProfile[]::new);
     }
 


### PR DESCRIPTION
Right now `SpongeGameProfile.toMcProfile()` converts all SpongeAPI `GameProfile`s with **empty** UUIDs (`= new UUID(0, 0)`) to authlib `GameProfile`s with a **null** UUID.

This is fine in most cases but problematic for the sample/player list in the status response. Empty UUIDs can be used there to create dummy entries, to display custom messages in the server list instead of the online players. (See e.g. https://github.com/Minecrell/ServerListPlus/wiki/Status-Configuration#player-hover-messages)

The Minecraft client completely rejects status responses that contain GameProfiles with null UUIDs and/or null names. This is why it is important that the empty UUID is not converted to a null UUID.

`[Client thread/ERROR]: Can't ping localhost: Internal Exception: io.netty.handler.codec.DecoderException: java.lang.IllegalArgumentException: Invalid UUID string: `

Prevent sending invalid responses to the client by making sure both UUID and name are non-null in the player samples of the status response.

This fixes a regression in API 8 when using the ServerListPlus plugin on Sponge. The problem was likely introduced in some `GameProfile` refactoring (API 7 worked fine).

There is similar code in Paper to avoid this problem: https://github.com/PaperMC/Paper/blob/ad3e1bc12104f1f8ea8bcf9248a606133bfc7780/patches/server/0182-Implement-extended-PaperServerListPingEvent.patch#L122-L128

I would appreciate if you could pick/merge this into all newer branches as well, not sure how Sponge development works nowadays :)