### PR TITLE
removed unnecessary read lock in SpongeScheduler

### DIFF
--- a/src/main/java/org/spongepowered/common/scheduler/SpongeScheduler.java
+++ b/src/main/java/org/spongepowered/common/scheduler/SpongeScheduler.java
@@ -62,7 +62,7 @@ public abstract class SpongeScheduler implements Scheduler {
     private final String tag;
 
     // The simple queue of all pending (and running) ScheduledTasks
-    protected final Map<UUID, SpongeScheduledTask> tasks = new ConcurrentHashMap<>();
+    private final Map<UUID, SpongeScheduledTask> tasks = new ConcurrentHashMap<>();
     private long sequenceNumber = 0L;
 
     SpongeScheduler(final String tag) {
@@ -107,9 +107,7 @@ public abstract class SpongeScheduler implements Scheduler {
     @Override
     public Optional<ScheduledTask> findTask(final UUID id) {
         Objects.requireNonNull(id, "id");
-        synchronized (this.tasks) {
-            return Optional.ofNullable(this.tasks.get(id));
-        }
+        return Optional.ofNullable(this.tasks.get(id));
     }
 
     @Override
@@ -130,9 +128,7 @@ public abstract class SpongeScheduler implements Scheduler {
 
     @Override
     public Set<ScheduledTask> tasks() {
-        synchronized (this.tasks) {
-            return Sets.newHashSet(this.tasks.values());
-        }
+        return Sets.newHashSet(this.tasks.values());
     }
 
     @Override


### PR DESCRIPTION
synchronization block (read-only) is not needed for ConcurrentHashMap

to all this, the lock there has no meaning on reads, without a write lock (it is not there)

a very unpleasant bug can also turn out, this is when the uuid of the prng tasks will match, then the previous task will simply be removed from the map) this is a very rare case, but in theory it can happen

might be worth looking at the existing api - java.util.concurrent.ScheduledExecutorService