### PR TITLE
Fix issues with modded tile entities and lights

### DIFF
--- a/forge/src/mixins/java/org/spongepowered/forge/mixin/core/world/level/block/state/BlockStateMixin_Forge.java
+++ b/forge/src/mixins/java/org/spongepowered/forge/mixin/core/world/level/block/state/BlockStateMixin_Forge.java
@@ -22,46 +22,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.mixin.core.world.level.block.state;
+package org.spongepowered.forge.mixin.core.world.level.block.state;
 
-import com.google.common.collect.ImmutableMap;
-import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.Property;
+import net.minecraftforge.common.extensions.IForgeBlockState;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.common.bridge.world.level.block.state.BlockStateBridge;
 
-@Mixin(BlockState.class)
-public abstract class BlockStateMixin extends BlockBehaviour.BlockStateBase implements BlockStateBridge {
-
-    protected BlockStateMixin(Block block,
-        ImmutableMap<Property<?>, Comparable<?>> properties,
-        MapCodec<BlockState> codec
-    ) {
-        super(block, properties, codec);
-    }
-
+@Mixin(value = BlockState.class, priority = 1300)
+public abstract class BlockStateMixin_Forge implements BlockStateBridge {
 
     @Override
     public boolean bridge$hasTileEntity() {
-        return this.getBlock() instanceof EntityBlock;
+        return ((IForgeBlockState) this).hasTileEntity();
     }
 
     @Override
     public @Nullable BlockEntity bridge$createTileEntity(Level world) {
-        return ((EntityBlock) this.getBlock()).newBlockEntity(world);
+        return ((IForgeBlockState) this).createTileEntity(world);
     }
 
     @Override
     public int bridge$getLightValue(ServerLevel world, BlockPos pos) {
-        return this.getLightEmission();
+        return ((IForgeBlockState) this).getLightValue(world, pos);
     }
 }

--- a/forge/src/mixins/resources/mixins.spongeforge.core.json
+++ b/forge/src/mixins/resources/mixins.spongeforge.core.json
@@ -39,6 +39,7 @@
         "world.entity.vehicle.BoatMixin_Forge",
         "world.level.LevelMixin_Forge",
         "world.level.block.FireBlockMixin_Forge",
+        "world.level.block.state.BlockStateMixin_Forge",
         "world.level.storage.LevelStorageSourceMixin_Forge"
     ],
     "client": [

--- a/src/main/java/org/spongepowered/common/bridge/world/TrackedWorldBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/world/TrackedWorldBridge.java
@@ -27,7 +27,6 @@ package org.spongepowered.common.bridge.world;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -81,9 +80,7 @@ public interface TrackedWorldBridge {
 
     /**
      * Creates a {@link BlockSnapshot} but performs an additional {@link LevelChunk#getTileEntity(BlockPos, Chunk.CreateEntityType)}
-     * lookup if the providing {@link BlockState#getBlock()} {@code instanceof} is
-     * {@code true} for being an {@link EntityBlock} or
-     * {@link BlockStateBridge#bridge$hasTileEntity()}, and associates
+     * lookup if {@link BlockStateBridge#bridge$hasTileEntity()} is {@code true}, and associates
      * the resulting snapshot of said Tile with the snapshot. This is useful for in-progress
      * snapshot creation during transaction building for {@link TransactionalCaptureSupplier}.
      *

--- a/src/main/java/org/spongepowered/common/bridge/world/level/block/state/BlockStateBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/world/level/block/state/BlockStateBridge.java
@@ -34,7 +34,7 @@ public interface BlockStateBridge {
 
     boolean bridge$hasTileEntity();
 
-    @Nullable BlockEntity bridge$createNewTileEntity(Level world);
+    @Nullable BlockEntity bridge$createTileEntity(Level world);
 
     int bridge$getLightValue(ServerLevel world, BlockPos pos);
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/effect/RefreshOldTileEntityOnChunkChangeEffect.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/effect/RefreshOldTileEntityOnChunkChangeEffect.java
@@ -49,8 +49,8 @@ public final class RefreshOldTileEntityOnChunkChangeEffect implements Processing
     public EffectResult processSideEffect(final BlockPipeline pipeline, final PipelineCursor oldState, final BlockState newState,
         final SpongeBlockChangeFlag flag, final int limit
     ) {
-        final @Nullable BlockEntity existing = pipeline.getAffectedChunk().getBlockEntity(oldState.pos, LevelChunk.EntityCreationType.CHECK);
         if (((BlockStateBridge) oldState.state).bridge$hasTileEntity()) {
+            final @Nullable BlockEntity existing = pipeline.getAffectedChunk().getBlockEntity(oldState.pos, LevelChunk.EntityCreationType.CHECK);
             if (existing != null) {
                 existing.clearCache();
             }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/effect/UpdateLightSideEffect.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/effect/UpdateLightSideEffect.java
@@ -26,6 +26,7 @@ package org.spongepowered.common.event.tracking.context.transaction.effect;
 
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.common.bridge.world.level.block.state.BlockStateBridge;
 import org.spongepowered.common.event.tracking.context.transaction.pipeline.BlockPipeline;
 import org.spongepowered.common.event.tracking.context.transaction.pipeline.PipelineCursor;
 import org.spongepowered.common.world.SpongeBlockChangeFlag;
@@ -51,7 +52,6 @@ public final class UpdateLightSideEffect implements ProcessingSideEffect {
         if (!flag.updateLighting()) {
             return EffectResult.NULL_PASS;
         }
-        final int originalOpactiy = oldState.opacity;
         final ServerLevel serverWorld = pipeline.getServerWorld();
         final BlockState currentState = pipeline.getAffectedChunk().getBlockState(oldState.pos);
         // local variable notes:
@@ -68,8 +68,8 @@ public final class UpdateLightSideEffect implements ProcessingSideEffect {
         //         )
         //     ) {
         if (oldState.state != currentState
-            && (currentState.getLightBlock(serverWorld, oldState.pos) != originalOpactiy
-            || currentState.getLightEmission() != oldState.state.getLightEmission()
+            && (currentState.getLightBlock(serverWorld, oldState.pos) != oldState.opacity
+            || ((BlockStateBridge) currentState).bridge$getLightValue(serverWorld, oldState.pos) != oldState.light
             || currentState.useShapeForLightOcclusion()
             || oldState.state.useShapeForLightOcclusion()
         )) {

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/effect/UpdateOrCreateNewTileEntityPostPlacementEffect.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/effect/UpdateOrCreateNewTileEntityPostPlacementEffect.java
@@ -50,17 +50,18 @@ public final class UpdateOrCreateNewTileEntityPostPlacementEffect implements Pro
     public EffectResult processSideEffect(final BlockPipeline pipeline, final PipelineCursor oldState, final BlockState newState,
         final SpongeBlockChangeFlag flag, final int limit
     ) {
-        final ServerLevel serverWorld = pipeline.getServerWorld();
-        final LevelChunk chunk = pipeline.getAffectedChunk();
-        final @Nullable BlockEntity maybeNewTileEntity = chunk.getBlockEntity(oldState.pos, LevelChunk.EntityCreationType.CHECK);
         if (((BlockStateBridge) newState).bridge$hasTileEntity()) {
-            if (maybeNewTileEntity == null) {
-                // tileentity1 = ((ITileEntityProvider)block).createNewTileEntity(this.world); // Vanilla
-                // tileentity1 = state.createTileEntity(this.world); // Forge
+            final ServerLevel serverWorld = pipeline.getServerWorld();
+            final LevelChunk chunk = pipeline.getAffectedChunk();
+            final @Nullable BlockEntity existing = chunk.getBlockEntity(oldState.pos, LevelChunk.EntityCreationType.CHECK);
+
+            if (existing == null) {
+                // blockEntity = ((EntityBlock) block).newBlockEntity(this.level); // Vanilla
+                // blockEntity = state.createTileEntity(this.level); // Forge
                 // We cast to our bridge for easy access
-                serverWorld.setBlockEntity(oldState.pos, ((BlockStateBridge) newState).bridge$createNewTileEntity(serverWorld));
+                serverWorld.setBlockEntity(oldState.pos, ((BlockStateBridge) newState).bridge$createTileEntity(serverWorld));
             } else {
-                maybeNewTileEntity.clearCache();
+                existing.clearCache();
             }
         }
         return EffectResult.NULL_PASS;

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/pipeline/ChunkPipeline.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/pipeline/ChunkPipeline.java
@@ -33,6 +33,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.common.bridge.world.level.block.state.BlockStateBridge;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.context.transaction.EffectTransactor;
 import org.spongepowered.common.event.tracking.context.transaction.ResultingTransactionBySideEffect;
@@ -111,10 +112,11 @@ public final class ChunkPipeline implements BlockPipeline {
             return null;
         }
         final ServerLevel serverWorld = this.serverWorld.get();
+        final int oldLight = ((BlockStateBridge) currentState).bridge$getLightValue(serverWorld, pos);
         final int oldOpacity = currentState.getLightBlock(serverWorld, pos);
         final SpongeBlockChangeFlag flag = this.transaction.getBlockChangeFlag();
         final @Nullable BlockEntity existing = this.chunkSupplier.get().getBlockEntity(pos, LevelChunk.EntityCreationType.CHECK);
-        PipelineCursor formerState = new PipelineCursor(currentState, oldOpacity, pos, existing, (Entity) null, limit);
+        PipelineCursor formerState = new PipelineCursor(currentState, oldLight, oldOpacity, pos, existing, (Entity) null, limit);
 
         for (final ResultingTransactionBySideEffect effect : this.chunkEffects) {
             try (final EffectTransactor ignored = context.getTransactor().pushEffect(effect)) {
@@ -129,7 +131,7 @@ public final class ChunkPipeline implements BlockPipeline {
                     return result.resultingState;
                 }
                 if (formerState.drops.isEmpty() && !result.drops.isEmpty()) {
-                    formerState = new PipelineCursor(currentState, oldOpacity, pos, existing, null, result.drops, limit);
+                    formerState = new PipelineCursor(currentState, oldLight, oldOpacity, pos, existing, null, result.drops, limit);
                 }
             }
         }

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/pipeline/PipelineCursor.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/pipeline/PipelineCursor.java
@@ -37,6 +37,7 @@ import java.util.StringJoiner;
 
 public final class PipelineCursor {
     public final BlockState state;
+    public final int light;
     public final int opacity;
     public final BlockPos pos;
     public final @Nullable BlockEntity tileEntity;
@@ -44,11 +45,12 @@ public final class PipelineCursor {
     public final List<ItemStack> drops;
     public final int limit;
 
-    public PipelineCursor(final BlockState state, final int opacity, final BlockPos pos,
+    public PipelineCursor(final BlockState state, final int light, final int opacity, final BlockPos pos,
         final @Nullable BlockEntity tileEntity,
         final @Nullable Entity destroyer, final int limit
     ) {
         this.state = state;
+        this.light = light;
         this.opacity = opacity;
         this.pos = pos;
         this.tileEntity = tileEntity;
@@ -57,13 +59,14 @@ public final class PipelineCursor {
         this.limit = limit;
     }
 
-    public PipelineCursor(final BlockState state, final int opacity, final BlockPos pos,
+    public PipelineCursor(final BlockState state, final int light, final int opacity, final BlockPos pos,
         final @Nullable BlockEntity tileEntity,
         final @Nullable Entity destroyer,
         final List<ItemStack> drops,
         final int limit
     ) {
         this.state = state;
+        this.light = light;
         this.opacity = opacity;
         this.pos = pos;
         this.tileEntity = tileEntity;
@@ -74,12 +77,9 @@ public final class PipelineCursor {
 
     @Override
     public String toString() {
-        return new StringJoiner(
-            ", ",
-            PipelineCursor.class.getSimpleName() + "[",
-            "]"
-        )
+        return new StringJoiner(", ", PipelineCursor.class.getSimpleName() + "[", "]")
             .add("state=" + this.state)
+            .add("light=" + this.light)
             .add("opacity=" + this.opacity)
             .add("pos=" + this.pos)
             .add("tileEntity=" + this.tileEntity)

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/pipeline/TileEntityPipeline.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/pipeline/TileEntityPipeline.java
@@ -110,6 +110,7 @@ public final class TileEntityPipeline implements BlockPipeline {
                 if (result.resultingState != currentCursor.state) {
                     currentCursor = new PipelineCursor(
                         result.resultingState,
+                        currentCursor.light,
                         currentCursor.opacity,
                         currentCursor.pos,
                         currentCursor.tileEntity,

--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/pipeline/WorldPipeline.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/pipeline/WorldPipeline.java
@@ -33,6 +33,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.common.bridge.world.level.block.state.BlockStateBridge;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.context.transaction.EffectTransactor;
 import org.spongepowered.common.event.tracking.context.transaction.ResultingTransactionBySideEffect;
@@ -98,8 +99,9 @@ public final class WorldPipeline implements BlockPipeline {
         if (oldState == null) {
             return false;
         }
+        final int oldLight = ((BlockStateBridge) oldState).bridge$getLightValue(serverWorld, pos);
         final int oldOpacity = oldState.getLightBlock(serverWorld, pos);
-        PipelineCursor formerState = new PipelineCursor(oldState, oldOpacity, pos, existing, destroyer, limit);
+        PipelineCursor formerState = new PipelineCursor(oldState, oldLight, oldOpacity, pos, existing, destroyer, limit);
 
         for (final ResultingTransactionBySideEffect effect : this.worldEffects) {
             try (final EffectTransactor ignored = context.getTransactor().pushEffect(effect)) {
@@ -114,7 +116,7 @@ public final class WorldPipeline implements BlockPipeline {
                     return result.resultingState != null;
                 }
                 if (formerState.drops.isEmpty() && !result.drops.isEmpty()) {
-                    formerState = new PipelineCursor(oldState, oldOpacity, pos, existing, formerState.destroyer, result.drops, limit);
+                    formerState = new PipelineCursor(oldState, oldLight, oldOpacity, pos, existing, formerState.destroyer, result.drops, limit);
                 }
             }
         }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/block/state/BlockStateMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/block/state/BlockStateMixin_API.java
@@ -42,6 +42,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.common.block.BlockStateSerializerDeserializer;
 import org.spongepowered.common.block.SpongeBlockSnapshot;
 import org.spongepowered.common.bridge.data.SpongeDataHolderBridge;
+import org.spongepowered.common.bridge.world.level.block.state.BlockStateBridge;
 import org.spongepowered.common.util.Constants;
 
 import java.util.Arrays;
@@ -71,7 +72,7 @@ public abstract class BlockStateMixin_API extends BlockBehaviour_BlockStateBaseM
                 .blockState((net.minecraft.world.level.block.state.BlockState) (Object) this)
                 .position(location.blockPosition())
                 .world((ServerLevel) location.world());
-        if (this.shadow$getBlock().isEntityBlock() && location.block().type().equals(this.shadow$getBlock())) {
+        if (((BlockStateBridge) this).bridge$hasTileEntity() && location.block().type().equals(this.shadow$getBlock())) {
             final BlockEntity tileEntity = location.blockEntity()
                     .orElseThrow(() -> new IllegalStateException("Unable to retrieve a TileEntity for location: " + location));
             builder.add(((SpongeDataHolderBridge) tileEntity).bridge$getManipulator());

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/server/level/ServerLevelMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/server/level/ServerLevelMixin_Tracker.java
@@ -635,7 +635,8 @@ public abstract class ServerLevelMixin_Tracker extends LevelMixin_Tracker implem
                 .addEffect(RemoveTileEntityFromWorldEffect.getInstance())
                 .addEffect(RemoveTileEntityFromChunkEffect.getInstance())
                 .build();
-            pipeline.processEffects(current, new PipelineCursor(tileentity.getBlockState(), 0,immutable, tileentity, (Entity) null, Constants.World.DEFAULT_BLOCK_CHANGE_LIMIT));
+            pipeline.processEffects(current, new PipelineCursor(tileentity.getBlockState(), 0, 0, immutable, tileentity, (Entity) null,
+                    Constants.World.DEFAULT_BLOCK_CHANGE_LIMIT));
             return;
         }
         super.shadow$removeBlockEntity(immutable);
@@ -670,7 +671,7 @@ public abstract class ServerLevelMixin_Tracker extends LevelMixin_Tracker implem
                     .addEffect(AddTileEntityToTickableListEffect.getInstance())
                     .addEffect(TileOnLoadDuringAddToWorldEffect.getInstance())
                     .build();
-                return pipeline.processEffects(current, new PipelineCursor(tileEntity.getBlockState(), 0, immutable, tileEntity,
+                return pipeline.processEffects(current, new PipelineCursor(tileEntity.getBlockState(), 0, 0, immutable, tileEntity,
                     (Entity) null,
                     Constants.World.DEFAULT_BLOCK_CHANGE_LIMIT));
             }
@@ -707,7 +708,8 @@ public abstract class ServerLevelMixin_Tracker extends LevelMixin_Tracker implem
                     .addEffect(RemoveProposedTileEntitiesDuringSetIfWorldProcessingEffect.getInstance())
                     .addEffect(ReplaceTileEntityInWorldEffect.getInstance())
                     .build();
-                pipeline.processEffects(current, new PipelineCursor(proposed.getBlockState(), 0,immutable, proposed, (Entity) null, Constants.World.DEFAULT_BLOCK_CHANGE_LIMIT));
+                pipeline.processEffects(current, new PipelineCursor(proposed.getBlockState(), 0, 0, immutable, proposed, (Entity) null,
+                        Constants.World.DEFAULT_BLOCK_CHANGE_LIMIT));
                 return;
             }
         }


### PR DESCRIPTION
Forge adds specific methods to check whether a block has a tile entity or is emitting light. We need to use these methods instead of the vanilla ones to properly support modded blocks. Previously this was done correctly in API 7, but got lost in the update process.

This fixes issues with Create's gearbox and gearshit (#3835) and probably issues for many other mods as well.
