### PR TITLE
Fixes for Forge Worldedit

### DIFF
--- a/forge/src/launch/java/org/spongepowered/forge/launch/command/ForgeCommandManager.java
+++ b/forge/src/launch/java/org/spongepowered/forge/launch/command/ForgeCommandManager.java
@@ -28,6 +28,7 @@ import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.mojang.brigadier.ParseResults;
+import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.context.CommandContextBuilder;
 import com.mojang.brigadier.context.ParsedArgument;
 import net.minecraft.commands.CommandSourceStack;
@@ -59,8 +60,14 @@ public final class ForgeCommandManager extends SpongeCommandManager {
         final CommandRegistrar<?> registrar = mapping.registrar();
         final boolean isBrig = registrar instanceof BrigadierBasedRegistrar;
         final ParseResults<CommandSourceStack> parseResults;
+
+        // Some Forge mods expect `getOriginal()` will return exactly the original entered command
+        StringReader reader = new SpongeStringReader("/" + original);
+        // Skip the very first slash
+        reader.skip();
+
         if (isBrig) {
-            parseResults = this.getDispatcher().parse(original, (CommandSourceStack) cause);
+            parseResults = this.getDispatcher().parse(reader, (CommandSourceStack) cause);
         } else {
             // We have a non Brig registrar, so we just create a dummy result for mods to inspect.
             final CommandContextBuilder<CommandSourceStack> contextBuilder = new CommandContextBuilder<>(

--- a/forge/src/main/java/org/spongepowered/forge/hook/ForgeEventHooks.java
+++ b/forge/src/main/java/org/spongepowered/forge/hook/ForgeEventHooks.java
@@ -30,9 +30,13 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.AbstractMinecartContainer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.entity.player.CriticalHitEvent;
+import org.spongepowered.api.ResourceKey;
+import org.spongepowered.api.event.CauseStackManager;
+import org.spongepowered.api.event.EventContextKey;
 import org.spongepowered.api.event.entity.ChangeEntityWorldEvent;
 import org.spongepowered.common.hooks.EventHooks;
 
@@ -68,5 +72,17 @@ public final class ForgeEventHooks implements EventHooks {
             return new CriticalHitResult(true, hitResult.getDamageModifier() - 1.0F);
         }
         return new CriticalHitResult(false, v);
+    }
+
+    public static final EventContextKey<BlockHitResult> BLOCK_HIT_RESULT = EventContextKey.builder()
+            .key(ResourceKey.sponge("forge_block_hit_result"))
+            .type(BlockHitResult.class)
+            .build();
+
+    @Override
+    public void addHitVectorToInteractEvent(
+            final CauseStackManager.StackFrame frame, final BlockHitResult blockRaytraceResultIn
+    ) {
+        frame.addContext(ForgeEventHooks.BLOCK_HIT_RESULT, blockRaytraceResultIn);
     }
 }

--- a/forge/src/mixins/java/org/spongepowered/forge/mixin/core/api/event/block/InteractBlockEvent_SecondaryMixin_Forge.java
+++ b/forge/src/mixins/java/org/spongepowered/forge/mixin/core/api/event/block/InteractBlockEvent_SecondaryMixin_Forge.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.forge.mixin.core.api.event.block;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.Event;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.event.EventContextKeys;
+import org.spongepowered.api.event.block.InteractBlockEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.common.util.VecHelper;
+import org.spongepowered.forge.hook.ForgeEventHooks;
+import org.spongepowered.forge.launch.bridge.event.SpongeEventBridge_Forge;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+@Mixin(InteractBlockEvent.Secondary.class)
+public interface InteractBlockEvent_SecondaryMixin_Forge extends SpongeEventBridge_Forge {
+
+    @Override
+    default @Nullable Collection<? extends Event> bridge$createForgeEvents() {
+        final InteractBlockEvent.Secondary thisEvent = (InteractBlockEvent.Secondary) (Object) this;
+
+        final Optional<BlockHitResult> blockHitResult = thisEvent.context().get(ForgeEventHooks.BLOCK_HIT_RESULT);
+        if (!blockHitResult.isPresent()) {
+            return null;
+        }
+        final Optional<Player> playerOpt = thisEvent.cause().first(Player.class);
+        if (!playerOpt.isPresent()) {
+            return null;
+        }
+        final BlockHitResult hitResult = blockHitResult.get();
+        final BlockPos blockPos = VecHelper.toBlockPos(thisEvent.block().position());
+        final InteractionHand hand = (InteractionHand) (Object) thisEvent.context().require(EventContextKeys.USED_HAND);
+
+        final PlayerInteractEvent.RightClickBlock forgeEvent = new PlayerInteractEvent.RightClickBlock(
+                playerOpt.get(),
+                hand,
+                blockPos,
+                hitResult
+        );
+        return Collections.singleton(forgeEvent);
+    }
+}

--- a/forge/src/mixins/java/org/spongepowered/forge/mixin/core/minecraftforge/event/block/PlayerInteractEvent_RightClickBlockMixin_Forge.java
+++ b/forge/src/mixins/java/org/spongepowered/forge/mixin/core/minecraftforge/event/block/PlayerInteractEvent_RightClickBlockMixin_Forge.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.forge.mixin.core.minecraftforge.event.block;
+
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.event.block.InteractBlockEvent;
+import org.spongepowered.api.util.Tristate;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.forge.launch.bridge.event.ForgeEventBridge_Forge;
+
+@Mixin(value = PlayerInteractEvent.RightClickBlock.class, remap = false)
+public abstract class PlayerInteractEvent_RightClickBlockMixin_Forge implements ForgeEventBridge_Forge {
+
+    // @formatter:off
+    @Shadow
+    public abstract BlockHitResult shadow$getHitVec();
+    @Shadow
+    public abstract void shadow$setUseBlock(net.minecraftforge.eventbus.api.Event.Result e);
+    @Shadow public abstract net.minecraftforge.eventbus.api.Event.Result shadow$getUseBlock();
+    @Shadow
+    public abstract void shadow$setUseItem(net.minecraftforge.eventbus.api.Event.Result e);
+    @Shadow public abstract net.minecraftforge.eventbus.api.Event.Result shadow$getUseItem();
+    // @formatter:on
+
+    @Override
+    public void bridge$syncFrom(Event event) {
+        // spongeEvent.useBlockResult() // Do I need this?
+    }
+
+    @Override
+    public void bridge$syncTo(Event event) {
+        final InteractBlockEvent.Secondary spongeEvent = (InteractBlockEvent.Secondary) event;
+        spongeEvent.setCancelled(((net.minecraftforge.eventbus.api.Event) (Object) this).isCanceled());
+    }
+
+    @Override
+    public @Nullable Event bridge$createSpongeEvent() {
+//        final BlockSnapshot block, final Vector3d interactionPoint, final Direction targetSide
+        return null;
+    }
+
+    private static net.minecraftforge.eventbus.api.Event.Result tristateToResult(Tristate tristate) {
+        if (tristate == Tristate.TRUE) {
+            return net.minecraftforge.eventbus.api.Event.Result.ALLOW;
+        } else if (tristate == Tristate.UNDEFINED) {
+            return net.minecraftforge.eventbus.api.Event.Result.DEFAULT;
+        } else {
+            return net.minecraftforge.eventbus.api.Event.Result.DENY;
+        }
+    }
+
+    private static Tristate resultToTristate(net.minecraftforge.eventbus.api.Event.Result result) {
+        if (result == net.minecraftforge.eventbus.api.Event.Result.ALLOW) {
+            return Tristate.TRUE;
+        } else if (result == net.minecraftforge.eventbus.api.Event.Result.DEFAULT) {
+            return Tristate.UNDEFINED;
+        } else {
+            return Tristate.FALSE;
+        }
+    }
+}

--- a/forge/src/mixins/resources/mixins.spongeforge.core.json
+++ b/forge/src/mixins/resources/mixins.spongeforge.core.json
@@ -9,6 +9,7 @@
     "mixins": [
         "api.event.EventMixin_Forge",
         "api.event.block.ChangeBlockEvent_AllMixin_Forge",
+        "api.event.block.InteractBlockEvent_SecondaryMixin_Forge",
         "api.event.entity.ChangeEntityWorldEvent_PreMixin_Forge",
         "api.event.entity.ChangeEventWorldEvent_PostMixin_Forge",
         "api.event.message.PlayerChatEventMixin_Forge",
@@ -17,6 +18,7 @@
         "minecraftforge.core.ForgeRegistryMixin_Forge",
         "minecraftforge.core.NamespacedWrapperMixin_Forge",
         "minecraftforge.event.ServerChatEventMixin_Forge",
+        "minecraftforge.event.block.PlayerInteractEvent_RightClickBlockMixin_Forge",
         "minecraftforge.event.entity.EntityTravelToDimensionEventMixin_Forge",
         "minecraftforge.event.entity.player.PlayerEvent_PlayerChangedDimensionEventMixin_Forge",
         "minecraftforge.event.world.BlockEvent_BreakEventMixin_Forge",

--- a/src/applaunch/java/org/spongepowered/common/applaunch/config/common/PhaseTrackerCategory.java
+++ b/src/applaunch/java/org/spongepowered/common/applaunch/config/common/PhaseTrackerCategory.java
@@ -141,6 +141,27 @@ public final class PhaseTrackerCategory {
              + "https://github.com/Epoxide-Software/Enchanting-Plus/pull/135\n")
     public final Map<String, Boolean> autoFixNullSourceBlockProvidingBlockEntities = new HashMap<>();
 
+    @Setting("warn-on-direct-chunk-access")
+    @Comment("For use with mods or plugins that directly need access to Chunk code, usually\n"
+            + "bypassing Sponge's Tracking system. In circumstances, these mods are directly\n"
+            + "modifying the World without tracking involved for performance and functionality.\n"
+            + "With Sponge's tracking system, it's possible to avoid a majority of block changes\n"
+            + "being logged and events thrown, which can result in loss of plugin functionality\n"
+            + "depending on tracking all block changes.\n"
+            + "It has been accepted as a compromise to enable these mods to continue to function\n" +
+            "in hopes that by logging a warning will make the administrator aware of this compromise\n." +
+            "A warning will be emitted on the first occurrence after each game start.")
+    public boolean logDirectChunkAccess = true;
+
+    @Setting("allow-direct-chunk-access")
+    @Comment("In certain situations, an administrator may wish to disable mods capabilities\n" +
+            "in performing block changes directly with a Chunk, effectively bypassing sponge's\n" +
+            "ability to track said changes. When enabled with `warn-on-direct-chunk-access`, a\n" +
+            "warning will be emitted each time a block is attempted to be changed on a Chunk.\n" +
+            "When logging is disabled, the changes are blocked regardless. Behaviors of these\n" +
+            "mods are not guaranteed.")
+    public boolean allowDirectChunkAccess = true;
+
     private boolean isVanilla() {
         return AppLaunch.pluginPlatform().vanilla();
     }

--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -117,6 +117,7 @@ import org.spongepowered.common.entity.projectile.UnknownProjectileSource;
 import org.spongepowered.common.event.tracking.PhaseContext;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.phase.general.GeneralPhase;
+import org.spongepowered.common.hooks.PlatformHooks;
 import org.spongepowered.common.item.util.ItemStackUtil;
 import org.spongepowered.common.map.SpongeMapStorage;
 import org.spongepowered.common.registry.provider.DirectionFacingProvider;
@@ -344,10 +345,13 @@ public final class SpongeCommonEventFactory {
         }
     }
 
-    public static InteractBlockEvent.Secondary callInteractBlockEventSecondary(final net.minecraft.world.entity.player.Player player, final ItemStack heldItem, final Vector3d hitVec, final BlockSnapshot targetBlock, final Direction targetSide, final InteractionHand hand) {
+    public static InteractBlockEvent.Secondary callInteractBlockEventSecondary(final net.minecraft.world.entity.player.Player player, final ItemStack heldItem, final Vector3d hitVec, final BlockSnapshot targetBlock, final Direction targetSide, final InteractionHand hand, BlockHitResult blockRaytraceResultIn) {
         try (final CauseStackManager.StackFrame frame = PhaseTracker.getCauseStackManager().pushCauseFrame()) {
             SpongeCommonEventFactory.applyCommonInteractContext(player, heldItem, hand, targetBlock, null, frame);
-            final InteractBlockEvent.Secondary event = SpongeEventFactory.createInteractBlockEventSecondary(frame.currentCause(),
+            PlatformHooks.INSTANCE.getEventHooks().addHitVectorToInteractEvent(frame, blockRaytraceResultIn);
+            final Cause cause = frame.currentCause();
+            final InteractBlockEvent.Secondary event = SpongeEventFactory.createInteractBlockEventSecondary(
+                    cause,
                     Tristate.UNDEFINED, Tristate.UNDEFINED, Tristate.UNDEFINED, Tristate.UNDEFINED, targetBlock, hitVec,
                     targetSide);
             SpongeCommon.post(event);

--- a/src/main/java/org/spongepowered/common/hooks/EventHooks.java
+++ b/src/main/java/org/spongepowered/common/hooks/EventHooks.java
@@ -29,6 +29,8 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.BlockHitResult;
+import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.entity.ChangeEntityWorldEvent;
 import org.spongepowered.common.SpongeCommon;
@@ -49,6 +51,9 @@ public interface EventHooks {
     }
 
     default void callItemDestroyedEvent(final Player player, final ItemStack stack, final InteractionHand hand) {
+    }
+
+    default void addHitVectorToInteractEvent(CauseStackManager.StackFrame event, BlockHitResult blockRaytraceResultIn) {
     }
 
     final class CriticalHitResult {

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/server/level/ServerPlayerGameModeMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/server/level/ServerPlayerGameModeMixin_Tracker.java
@@ -100,7 +100,7 @@ public abstract class ServerPlayerGameModeMixin_Tracker {
         final BlockSnapshot snapshot = ((ServerWorld) (worldIn)).createSnapshot(VecHelper.toVector3i(blockpos));
         final Vector3d hitVec = Vector3d.from(blockRaytraceResultIn.getBlockPos().getX(), blockRaytraceResultIn.getBlockPos().getY(), blockRaytraceResultIn.getBlockPos().getZ());
         final org.spongepowered.api.util.Direction direction = DirectionFacingProvider.INSTANCE.getKey(blockRaytraceResultIn.getDirection()).get();
-        final InteractBlockEvent.Secondary event = SpongeCommonEventFactory.callInteractBlockEventSecondary(playerIn, stackIn, hitVec, snapshot, direction, handIn);
+        final InteractBlockEvent.Secondary event = SpongeCommonEventFactory.callInteractBlockEventSecondary(playerIn, stackIn, hitVec, snapshot, direction, handIn, blockRaytraceResultIn);
         final Tristate useItem = event.useItemResult();
         final Tristate useBlock = event.useBlockResult();
         ((ServerPlayerGameModeBridge) this).bridge$setInteractBlockRightClickCancelled(event.isCancelled());


### PR DESCRIPTION
I've taken the code from #3711 and reworked some of it, including the exact minutiae of the logging for direct block access here. I've also added `PlayerInteractEvent_RightClickBlockMixin_Forge`, which I'm very unsure of how much I need to sync, but it seems that many things work fine enough without syncing.

There's also a change in `ForgeCommandManager` to get WE to recognize the Forge `CommandEvent`s without the first character being cut off for no reason.