### PR TITLE
[api-10] Prevent invalid status responses with empty/dummy player UUIDs

### DIFF
--- a/src/main/java/org/spongepowered/common/network/status/SpongeStatusResponse.java
+++ b/src/main/java/org/spongepowered/common/network/status/SpongeStatusResponse.java
@@ -115,7 +115,12 @@ public final class SpongeStatusResponse implements ClientPingServerEvent.Respons
         }
 
         public ServerStatus.Players toVanilla() {
-            return new ServerStatus.Players(this.max, this.online, this.profiles.stream().map(SpongeGameProfile::toMcProfile).toList());
+            return new ServerStatus.Players(this.max, this.online, this.profiles.stream()
+                    // Make sure profiles are sent with non-null UUIDs and names because everything else
+                    // will make the response invalid on the client. Some plugins use empty UUIDs to create
+                    // custom lines in the player list that do not refer to a specific player.
+                    .map(SpongeGameProfile::toMcProfileNonNull)
+                    .toList());
         }
     }
 


### PR DESCRIPTION
Port of #3831 for api-10. The fix is still needed, the code just moved to a different place. (cc @ImMorpheus)