### PR TITLE
Add stream online players method

### DIFF
--- a/src/main/java/org/spongepowered/common/scheduler/ServerScheduler.java
+++ b/src/main/java/org/spongepowered/common/scheduler/ServerScheduler.java
@@ -41,12 +41,12 @@ public final class ServerScheduler extends SyncScheduler {
     public void tick() {
         super.tick();
 
-        for (final Player player : Sponge.server().onlinePlayers()) {
+        Sponge.server().streamOnlinePlayers().forEach(player -> {
             try (final EntityTickContext context = TickPhase.Tick.ENTITY.createPhaseContext(PhaseTracker.SERVER).source(player)) {
                 context.buildAndSwitch();
                 // Detect Changes on PlayerInventories marked as dirty.
                 ((PlayerInventoryBridge) ((net.minecraft.world.entity.player.Player) player).getInventory()).bridge$cleanupDirty();
             }
-        }
+        });
     }
 }

--- a/src/main/java/org/spongepowered/common/scheduler/ServerScheduler.java
+++ b/src/main/java/org/spongepowered/common/scheduler/ServerScheduler.java
@@ -25,7 +25,6 @@
 package org.spongepowered.common.scheduler;
 
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.common.bridge.world.entity.player.PlayerInventoryBridge;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.event.tracking.phase.tick.EntityTickContext;

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/advancements/CriterionTriggerMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/advancements/CriterionTriggerMixin_API.java
@@ -48,7 +48,7 @@ public interface CriterionTriggerMixin_API<C extends FilteredTriggerConfiguratio
 
     @Override
     default void trigger() {
-        this.trigger(Sponge.server().onlinePlayers());
+        Sponge.server().streamOnlinePlayers().forEach(this::trigger);
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/MinecraftServerMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/MinecraftServerMixin_API.java
@@ -105,6 +105,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 @SuppressWarnings("rawtypes")
 @Mixin(MinecraftServer.class)
@@ -288,6 +289,14 @@ public abstract class MinecraftServerMixin_API implements SpongeServer, SpongeRe
     }
 
     @Override
+    public Stream<ServerPlayer> streamOnlinePlayers() {
+        if (this.shadow$getPlayerList() == null || this.shadow$getPlayerList().getPlayers() == null) {
+            return Stream.empty();
+        }
+        return (Stream) this.shadow$getPlayerList().getPlayers().stream();
+    }
+
+    @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Collection<ServerPlayer> onlinePlayers() {
         if (this.shadow$getPlayerList() == null || this.shadow$getPlayerList().getPlayers() == null) {
@@ -355,9 +364,9 @@ public abstract class MinecraftServerMixin_API implements SpongeServer, SpongeRe
     @Override
     public void shutdown(final Component kickMessage) {
         Objects.requireNonNull(kickMessage, "kickMessage");
-        for (final ServerPlayer player : this.onlinePlayers()) {
+        this.streamOnlinePlayers().forEach(player -> {
             player.kick(kickMessage);
-        }
+        });
 
         this.shadow$halt(false);
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/scores/PlayerTeamMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/scores/PlayerTeamMixin.java
@@ -200,7 +200,7 @@ public abstract class PlayerTeamMixin implements PlayerTeamBridge {
 
     @Override
     public Audience bridge$getNonTeamChannel() {
-        return Audience.audience(Sponge.game().server().onlinePlayers().stream()
+        return Audience.audience(Sponge.game().server().streamOnlinePlayers()
                 .filter(player -> ((ServerPlayer) player).getTeam() != (Object) this)
                 .collect(Collectors.toSet()));
     }


### PR DESCRIPTION
`onlinePlayers` is creating a copy of the collection on each call.

This can get costly on large server, especially because the scheduler is calling that method on each tick.