### PR TITLE
Fix WorldEdit-Forge commands

### DIFF
--- a/forge/src/launch/java/org/spongepowered/forge/launch/command/ForgeCommandManager.java
+++ b/forge/src/launch/java/org/spongepowered/forge/launch/command/ForgeCommandManager.java
@@ -28,6 +28,7 @@ import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.mojang.brigadier.ParseResults;
+import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.context.CommandContextBuilder;
 import com.mojang.brigadier.context.ParsedArgument;
 import net.minecraft.commands.CommandSourceStack;
@@ -38,7 +39,6 @@ import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.manager.CommandMapping;
 import org.spongepowered.api.command.registrar.CommandRegistrar;
-import org.spongepowered.common.command.brigadier.SpongeStringReader;
 import org.spongepowered.common.command.manager.SpongeCommandManager;
 import org.spongepowered.common.command.registrar.BrigadierBasedRegistrar;
 import org.spongepowered.common.command.sponge.SpongeCommand;
@@ -54,7 +54,7 @@ public final class ForgeCommandManager extends SpongeCommandManager {
 
     @Override
     protected CommandResult processCommand(final CommandCause cause, final CommandMapping mapping,
-            final String original, final String command, final String args)
+            final StringReader original, final String command, final String args)
             throws Throwable {
         final CommandRegistrar<?> registrar = mapping.registrar();
         final boolean isBrig = registrar instanceof BrigadierBasedRegistrar;
@@ -70,9 +70,9 @@ public final class ForgeCommandManager extends SpongeCommandManager {
                     0);
             contextBuilder.withCommand(ctx -> 1);
             if (!args.isEmpty()) {
-                contextBuilder.withArgument("parsed", new ParsedArgument<>(command.length(), original.length(), args));
+                contextBuilder.withArgument("parsed", new ParsedArgument<>(command.length(), original.getRemainingLength(), args));
             }
-            parseResults = new ParseResults<>(contextBuilder, new SpongeStringReader(original), Collections.emptyMap());
+            parseResults = new ParseResults<>(contextBuilder, original, Collections.emptyMap());
         }
 
         // Relocated from Commands (injection short circuits it there)
@@ -88,7 +88,7 @@ public final class ForgeCommandManager extends SpongeCommandManager {
         if (isBrig) {
             return CommandResult.builder().result(this.getDispatcher().execute(parseResults)).build();
         } else {
-            return mapping.registrar().process(cause, mapping, command, args);
+            return registrar.process(cause, mapping, command, args);
         }
     }
 

--- a/src/main/java/org/spongepowered/common/command/brigadier/dispatcher/SpongeCommandDispatcher.java
+++ b/src/main/java/org/spongepowered/common/command/brigadier/dispatcher/SpongeCommandDispatcher.java
@@ -123,7 +123,7 @@ public final class SpongeCommandDispatcher extends CommandDispatcher<CommandSour
             final CommandSourceStackBridge sourceBridge = (CommandSourceStackBridge) source;
             frame.addContext(EventContextKeys.COMMAND, input.getString());
             sourceBridge.bridge$updateFrameFromCommandSource(frame);
-            return this.commandManager.process(sourceBridge.bridge$withCurrentCause(), input.getRemaining()).result();
+            return this.commandManager.process(sourceBridge.bridge$withCurrentCause(), input).result();
         } catch (final CommandException e) {
             throw new net.minecraft.commands.CommandRuntimeException(SpongeAdventure.asVanilla(e.componentMessage()));
         }

--- a/vanilla/src/launch/java/org/spongepowered/vanilla/launch/command/VanillaCommandManager.java
+++ b/vanilla/src/launch/java/org/spongepowered/vanilla/launch/command/VanillaCommandManager.java
@@ -26,6 +26,7 @@ package org.spongepowered.vanilla.launch.command;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.mojang.brigadier.StringReader;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.command.CommandResult;
@@ -41,7 +42,7 @@ public final class VanillaCommandManager extends SpongeCommandManager {
     }
 
     @Override
-    protected CommandResult processCommand(final CommandCause cause, final CommandMapping mapping, final String original, final String command,
+    protected CommandResult processCommand(final CommandCause cause, final CommandMapping mapping, final StringReader original, final String command,
             final String args) throws Throwable {
         return mapping.registrar().process(cause, mapping, command, args);
     }


### PR DESCRIPTION
We were converting the `StringReader` (eg `/example` with cursor 1) to a `String` (`example`) and then again to a `StringReader` (`example` with cursor 0). That's why we were losing track of any potential command prefix such as `/` which is important for WorldEdit-Forge to work properly. 
Other PRs have attempted to always concat a `/` during the last step as a workaround. The problem is that for the console and for command blocks the `/` prefix is optional.
Now the original `StringReader` is passed to the Forge event.

Fixes the second point in #3811 