### PR TITLE
Complete packet futures on disconnect

### DIFF
--- a/src/accessors/java/org/spongepowered/common/accessor/network/Connection_PacketHolderAccessor.java
+++ b/src/accessors/java/org/spongepowered/common/accessor/network/Connection_PacketHolderAccessor.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.accessor.network;
+
+import net.minecraft.network.PacketSendListener;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(targets = "net/minecraft/network/Connection$PacketHolder")
+public interface Connection_PacketHolderAccessor {
+    @Accessor("listener") PacketSendListener accessor$listener();
+}

--- a/src/accessors/resources/mixins.sponge.accessors.json
+++ b/src/accessors/resources/mixins.sponge.accessors.json
@@ -21,6 +21,7 @@
         "commands.arguments.selector.options.EntitySelectorOptions_OptionAccessor",
         "commands.arguments.selector.options.EntitySelectorOptionsAccessor",
         "entity.passive.AbstractChestedHorseEntityAccessor",
+        "network.Connection_PacketHolderAccessor",
         "network.ConnectionAccessor",
         "network.chat.HoverEvent_ItemStackInfoAccessor",
         "network.chat.StyleAccessor",

--- a/src/main/java/org/spongepowered/common/network/channel/PacketSender.java
+++ b/src/main/java/org/spongepowered/common/network/channel/PacketSender.java
@@ -61,7 +61,7 @@ public final class PacketSender {
 
     public static final class SpongePacketSendListener implements PacketSendListener {
         private final BlockableEventLoop<?> executor;
-        private final Consumer<Throwable> listener;
+        private final Consumer<@Nullable  Throwable> listener;
 
         public SpongePacketSendListener(final EngineConnectionSide<? extends EngineConnection> side, final Consumer<@Nullable Throwable> listener) {
             this.executor = (BlockableEventLoop<?>) (side == EngineConnectionSide.CLIENT ? Sponge.client() : Sponge.server());

--- a/src/main/java/org/spongepowered/common/network/channel/PacketSender.java
+++ b/src/main/java/org/spongepowered/common/network/channel/PacketSender.java
@@ -44,7 +44,7 @@ public final class PacketSender {
         PacketSender.sendTo(connection, packet, (Consumer) null);
     }
 
-    public static void sendTo(final EngineConnection connection, final Packet<?> packet, final @Nullable Consumer<Throwable> listener) {
+    public static void sendTo(final EngineConnection connection, final Packet<?> packet, final @Nullable Consumer<@Nullable Throwable> listener) {
         final Connection networkManager = ((ConnectionHolderBridge) connection).bridge$getConnection();
         networkManager.send(packet, listener == null ? null : new SpongePacketSendListener(connection.side(), listener));
     }
@@ -63,12 +63,12 @@ public final class PacketSender {
         private final BlockableEventLoop<?> executor;
         private final Consumer<Throwable> listener;
 
-        public SpongePacketSendListener(final EngineConnectionSide<? extends EngineConnection> side, final Consumer<Throwable> listener) {
+        public SpongePacketSendListener(final EngineConnectionSide<? extends EngineConnection> side, final Consumer<@Nullable Throwable> listener) {
             this.executor = (BlockableEventLoop<?>) (side == EngineConnectionSide.CLIENT ? Sponge.client() : Sponge.server());
             this.listener = listener;
         }
 
-        public void accept(final Throwable throwable) {
+        public void accept(final @Nullable Throwable throwable) {
             this.executor.execute(() -> this.listener.accept(throwable));
         }
     }

--- a/src/main/java/org/spongepowered/common/network/channel/SpongeChannelManager.java
+++ b/src/main/java/org/spongepowered/common/network/channel/SpongeChannelManager.java
@@ -165,9 +165,9 @@ public final class SpongeChannelManager implements ChannelManager {
 
         final ChannelBuf payload = this.bufferAllocator.buffer();
         final Packet<?> mcPacket = PacketUtil.createLoginPayloadRequest(Constants.Channels.SPONGE_CLIENT_TYPE, payload, transactionId);
-        PacketSender.sendTo(connection, mcPacket, sendFuture -> {
-            if (!sendFuture.isSuccess()) {
-                future.completeExceptionally(sendFuture.cause());
+        PacketSender.sendTo(connection, mcPacket, throwable -> {
+            if (throwable != null) {
+                future.completeExceptionally(throwable);
             }
         });
 
@@ -200,9 +200,9 @@ public final class SpongeChannelManager implements ChannelManager {
 
         final ChannelBuf payload = this.encodeChannelRegistry();
         final Packet<?> mcPacket = PacketUtil.createLoginPayloadRequest(Constants.Channels.SPONGE_CHANNEL_REGISTRY, payload, transactionId);
-        PacketSender.sendTo(connection, mcPacket, sendFuture -> {
-            if (!sendFuture.isSuccess()) {
-                future.completeExceptionally(sendFuture.cause());
+        PacketSender.sendTo(connection, mcPacket, throwable -> {
+            if (throwable != null) {
+                future.completeExceptionally(throwable);
             }
         });
 

--- a/src/main/java/org/spongepowered/common/network/channel/packet/SpongeBasicPacketChannel.java
+++ b/src/main/java/org/spongepowered/common/network/channel/packet/SpongeBasicPacketChannel.java
@@ -86,10 +86,10 @@ public final class SpongeBasicPacketChannel extends AbstractPacketChannel implem
             final int transactionId = transactionStore.nextId();
 
             final net.minecraft.network.protocol.Packet<?> mcPacket = PacketUtil.createLoginPayloadRequest(Constants.Channels.FML_LOGIN_WRAPPER_CHANNEL, payload, transactionId);
-            PacketSender.sendTo(connection, mcPacket, sendFuture -> {
-                if (!sendFuture.isSuccess()) {
+            PacketSender.sendTo(connection, mcPacket, throwable -> {
+                if (throwable != null) {
                     // Failed before it could reach the client
-                    SpongeBasicPacketChannel.this.handleException(connection, ChannelExceptionUtil.of(sendFuture.cause()), future);
+                    SpongeBasicPacketChannel.this.handleException(connection, ChannelExceptionUtil.of(throwable), future);
                 } else {
                     final TransactionData<P, R> transactionData = new TransactionData<>(request, binding, success, future);
                     transactionStore.put(transactionId, SpongeBasicPacketChannel.this, transactionData);

--- a/src/main/java/org/spongepowered/common/network/channel/packet/SpongePacketChannel.java
+++ b/src/main/java/org/spongepowered/common/network/channel/packet/SpongePacketChannel.java
@@ -135,9 +135,9 @@ public class SpongePacketChannel extends AbstractPacketChannel implements Packet
         }
 
         final net.minecraft.network.protocol.Packet<?> mcPacket = mcPacketSupplier.get();
-        PacketSender.sendTo(connection, mcPacket, sendFuture -> {
-            if (!sendFuture.isSuccess()) {
-                this.handleException(connection, sendFuture.cause(), future);
+        PacketSender.sendTo(connection, mcPacket, throwable -> {
+            if (throwable != null) {
+                this.handleException(connection, throwable, future);
                 // Failed before it could reach the client, so complete it
                 // and remove it from the store
                 if (response != null) {

--- a/src/main/java/org/spongepowered/common/network/channel/raw/SpongeRawLoginDataChannel.java
+++ b/src/main/java/org/spongepowered/common/network/channel/raw/SpongeRawLoginDataChannel.java
@@ -167,12 +167,12 @@ public class SpongeRawLoginDataChannel implements RawHandshakeDataChannel {
 
         final Packet<?> mcPacket = PacketUtil.createLoginPayloadRequest(this.parent.key(), buf, transactionId);
 
-        PacketSender.sendTo(connection, mcPacket, sendFuture -> {
-            if (sendFuture.isSuccess()) {
+        PacketSender.sendTo(connection, mcPacket, throwable -> {
+            if (throwable == null) {
                 transactionStore.put(transactionId, this.parent, resultConsumer);
             } else {
                 // The packet already failed before it could reach the client
-                future.completeExceptionally(sendFuture.cause());
+                future.completeExceptionally(throwable);
             }
         });
 

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java
@@ -33,6 +33,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.PacketSendListener;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.OutgoingChatMessage;
@@ -91,7 +92,6 @@ import org.spongepowered.api.event.entity.MoveEntityEvent;
 import org.spongepowered.api.event.entity.RotateEntityEvent;
 import org.spongepowered.api.event.entity.living.player.KickPlayerEvent;
 import org.spongepowered.api.event.entity.living.player.PlayerChangeClientSettingsEvent;
-import org.spongepowered.api.network.EngineConnection;
 import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.api.scoreboard.Scoreboard;
 import org.spongepowered.api.service.permission.PermissionService;
@@ -126,7 +126,6 @@ import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.hooks.PlatformHooks;
 import org.spongepowered.common.mixin.core.world.entity.player.PlayerMixin;
-import org.spongepowered.common.network.channel.PacketSender;
 import org.spongepowered.common.util.LocaleCache;
 import org.spongepowered.common.util.VecHelper;
 import org.spongepowered.common.world.border.PlayerOwnBorderListener;
@@ -617,16 +616,13 @@ public abstract class ServerPlayerMixin extends PlayerMixin implements SubjectBr
         if (flag) {
             final net.minecraft.network.chat.Component component = this.shadow$getCombatTracker().getDeathMessage();
             final ClientboundPlayerCombatKillPacket packet = new ClientboundPlayerCombatKillPacket(this.shadow$getCombatTracker(), component);
-            PacketSender.sendTo((EngineConnection) this.connection, packet, (p_212356_2_) -> {
-                if (!p_212356_2_.isSuccess()) {
-                    final int i = 256;
-                    final String s = component.getString(256);
-                    final net.minecraft.network.chat.Component itextcomponent1 = net.minecraft.network.chat.Component.translatable("death.attack.message_too_long", net.minecraft.network.chat.Component.literal(s).withStyle(ChatFormatting.YELLOW));
-                    final net.minecraft.network.chat.Component itextcomponent2 = net.minecraft.network.chat.Component.translatable("death.attack.even_more_magic", this.shadow$getDisplayName())
-                            .withStyle((p_212357_1_) -> p_212357_1_.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, itextcomponent1)));
-                    this.connection.send(new ClientboundPlayerCombatKillPacket(this.shadow$getCombatTracker(), itextcomponent2));
-                }
-            });
+            this.connection.send(packet, PacketSendListener.exceptionallySend(() -> {
+                final String s = component.getString(256);
+                final net.minecraft.network.chat.Component itextcomponent1 = net.minecraft.network.chat.Component.translatable("death.attack.message_too_long", net.minecraft.network.chat.Component.literal(s).withStyle(ChatFormatting.YELLOW));
+                final net.minecraft.network.chat.Component itextcomponent2 = net.minecraft.network.chat.Component.translatable("death.attack.even_more_magic", this.shadow$getDisplayName())
+                        .withStyle((p_212357_1_) -> p_212357_1_.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, itextcomponent1)));
+                return new ClientboundPlayerCombatKillPacket(this.shadow$getCombatTracker(), itextcomponent2);
+            }));
             final Team team = this.shadow$getTeam();
             if (team != null && team.getDeathMessageVisibility() != Team.Visibility.ALWAYS) {
                 if (team.getDeathMessageVisibility() == Team.Visibility.HIDE_FOR_OTHER_TEAMS) {


### PR DESCRIPTION
Not really sure about this and the exception we are throwing. Fixes that plugin message channel futures don't complete on disconnection or when the player has disconnected long time ago.