### PR TITLE
Add missing data conversion for BlockStateKeys

### DIFF
--- a/src/main/java/org/spongepowered/common/data/provider/block/state/BlockStateDataProvider.java
+++ b/src/main/java/org/spongepowered/common/data/provider/block/state/BlockStateDataProvider.java
@@ -140,12 +140,8 @@ public final class BlockStateDataProvider {
         registrator.asImmutable(BlockState.class)
                 .create(key)
                     .supports(bs -> bs.getOptionalValue(property).isPresent())
-                    .get(bs -> {
-                        return ((org.spongepowered.api.block.BlockState) bs).stateProperty((StateProperty<T>) property).orElse(null);
-                    })
-                    .set((bs, v) -> {
-                        return (BlockState) ((org.spongepowered.api.block.BlockState) bs).withStateProperty((StateProperty<T>) property, v).orElse(null);
-                    });
+                    .get(bs -> ((org.spongepowered.api.block.BlockState) bs).stateProperty((StateProperty<T>) property).orElse(null))
+                    .set((bs, v) -> (BlockState) ((org.spongepowered.api.block.BlockState) bs).withStateProperty((StateProperty<T>) property, v).orElse((org.spongepowered.api.block.BlockState) bs));
     }
     // @formatter:on
 

--- a/src/main/java/org/spongepowered/common/data/provider/block/state/BlockStateDataProvider.java
+++ b/src/main/java/org/spongepowered/common/data/provider/block/state/BlockStateDataProvider.java
@@ -30,6 +30,7 @@ import net.minecraft.world.level.block.state.properties.Property;
 import org.spongepowered.api.data.BlockStateKeys;
 import org.spongepowered.api.data.Key;
 import org.spongepowered.api.data.value.Value;
+import org.spongepowered.api.state.StateProperty;
 import org.spongepowered.common.data.provider.DataProviderRegistrator;
 
 public final class BlockStateDataProvider {
@@ -134,13 +135,17 @@ public final class BlockStateDataProvider {
     }
 
     // @formatter:off
-    private static <T, V extends Comparable<V>> void registerProperty(final DataProviderRegistrator registrator, final Key<Value<T>> key, final Property<V> property) {
+    private static <T extends Comparable<T>, V extends Comparable<V>> void registerProperty(final DataProviderRegistrator registrator, final Key<Value<T>> key, final Property<V> property) {
 
         registrator.asImmutable(BlockState.class)
                 .create(key)
                     .supports(bs -> bs.getOptionalValue(property).isPresent())
-                    .get(bs -> (T) bs.getOptionalValue(property).orElse(null))
-                    .set((bs, v) -> bs.setValue(property, (V) v));
+                    .get(bs -> {
+                        return ((org.spongepowered.api.block.BlockState) bs).stateProperty((StateProperty<T>) property).orElse(null);
+                    })
+                    .set((bs, v) -> {
+                        return (BlockState) ((org.spongepowered.api.block.BlockState) bs).withStateProperty((StateProperty<T>) property, v).orElse(null);
+                    });
     }
     // @formatter:on
 


### PR DESCRIPTION
Primitive types and mixins can cast freely, but types like `Direction` and `Axis` are not mixins and cannot cast on their own.