### PR TITLE
Resend player permission level after update Keys#SKIN_PROFILE_PROPERTY

### DIFF
--- a/src/main/java/org/spongepowered/common/data/provider/entity/ServerPlayerData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/ServerPlayerData.java
@@ -33,6 +33,7 @@ import net.minecraft.network.protocol.game.ClientboundRespawnPacket;
 import net.minecraft.network.protocol.game.ClientboundSetExperiencePacket;
 import net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.PlayerList;
 import net.minecraft.stats.Stat;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.level.GameType;
@@ -156,7 +157,9 @@ public final class ServerPlayerData {
             // resend remaining player data... (see ServerPlayer#changeDimension)
             h.connection.send(new ClientboundChangeDifficultyPacket(h.getLevel().getLevelData().getDifficulty(), h.getLevel().getLevelData().isDifficultyLocked()));
             h.connection.send(new ClientboundPlayerAbilitiesPacket(h.getAbilities()));
-            h.getServer().getPlayerList().sendAllPlayerInfo(h);
+            final PlayerList playerList = h.getServer().getPlayerList();
+            playerList.sendAllPlayerInfo(h);
+            playerList.sendPlayerPermissionLevel(h);
             for(MobEffectInstance $$6 : h.getActiveEffects()) {
                 h.connection.send(new ClientboundUpdateMobEffectPacket(h.getId(), $$6));
             }


### PR DESCRIPTION
Fixes a nasty bug that caused some client-side functions to stop working, such as fast switching to spectator mode (F3+N). The client was losing data about the permissions (`permissionLevel`) and thought that there were no permissions.
An example of the code that reproduces the bug:

```java
@Listener
private void onJoinPlayer(ServerSideConnectionEvent.Join event) {
    Objects.requireNonNull(event, "event");

    ServerPlayer player = event.player();
    Value<ProfileProperty> profileProperty = player.requireValue(Keys.SKIN_PROFILE_PROPERTY);

    player.offer(profileProperty);
}
```

After trying to write the same data, the permission level on the client is reset.