### PR TITLE
Cancelling ClickContainerEvent.Primary removes the item in the clicked slot

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/world/inventory/container/TrackedContainerBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/world/inventory/container/TrackedContainerBridge.java
@@ -28,5 +28,5 @@ public interface TrackedContainerBridge {
 
     boolean bridge$capturePossible();
 
-    void bridge$detectAndSendChanges(boolean captureOnly);
+    void bridge$detectAndSendChanges(boolean capture, boolean synchronize);
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -125,6 +125,7 @@ public final class PacketPhaseUtil {
         }
         final ItemStack cursor = ItemStackUtil.fromSnapshotToNative(cursorSnap);
         player.containerMenu.setCarried(cursor);
+        player.containerMenu.setRemoteCarried(cursor);
         if (player instanceof net.minecraft.server.level.ServerPlayer) {
             ((net.minecraft.server.level.ServerPlayer) player).connection.send(new ClientboundContainerSetSlotPacket(-1, player.containerMenu.getStateId(), -1, cursor));
         }

--- a/src/mixins/java/org/spongepowered/common/mixin/inventory/event/world/inventory/AbstractContainerMenuMixin_Inventory.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/inventory/event/world/inventory/AbstractContainerMenuMixin_Inventory.java
@@ -81,6 +81,8 @@ public abstract class AbstractContainerMenuMixin_Inventory implements TrackedCon
     @Shadow protected abstract void shadow$updateDataSlotListeners(int $$0, int $$1);
     @Shadow protected abstract void shadow$synchronizeDataSlotToRemote(int $$0, int $$1);
     @Shadow protected abstract void shadow$synchronizeCarriedToRemote();
+
+    @Shadow public abstract void shadow$sendAllDataToRemote();
     //@formatter:on
 
     private boolean impl$isClicking; // Menu Callbacks are only called when clicking in a container
@@ -168,6 +170,10 @@ public abstract class AbstractContainerMenuMixin_Inventory implements TrackedCon
             return;
         }
         this.bridge$detectAndSendChanges(false, false);
+        this.impl$broadcastDataSlots();
+        this.shadow$sendAllDataToRemote();
+        this.impl$captureSuccess = true; // Detect mod overrides
+        ci.cancel();
     }
 
     // broadcastChanges
@@ -230,17 +236,19 @@ public abstract class AbstractContainerMenuMixin_Inventory implements TrackedCon
                 for (final ContainerListener listener : this.containerListeners) {
                     listener.slotChanged(((AbstractContainerMenu) (Object) this), i, oldStack);
                 }
-                final ItemStack remoteStack = this.remoteSlots.get(i);
-                if (!ItemStack.matches(remoteStack, newStack)) {
-                    this.remoteSlots.set(i, newStack.copy());
-                    if (this.synchronizer != null) {
-                        this.synchronizer.sendSlotChange(((AbstractContainerMenu) (Object) this), i, newStack);
+                if(synchronize) {
+                    final ItemStack remoteStack = this.remoteSlots.get(i);
+                    if (!ItemStack.matches(remoteStack, newStack)) {
+                        this.remoteSlots.set(i, newStack.copy());
+                        if (this.synchronizer != null) {
+                            this.synchronizer.sendSlotChange(((AbstractContainerMenu) (Object) this), i, newStack);
+                        }
                     }
                 }
             }
         }
 
-        if(synchronize) {
+        if (synchronize) {
             this.shadow$synchronizeCarriedToRemote();
             this.impl$broadcastDataSlots();
         }

--- a/src/mixins/java/org/spongepowered/common/mixin/inventory/event/world/inventory/AbstractContainerMenuMixin_Inventory.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/inventory/event/world/inventory/AbstractContainerMenuMixin_Inventory.java
@@ -267,7 +267,7 @@ public abstract class AbstractContainerMenuMixin_Inventory implements TrackedCon
         }
     }
 
-    private void impl$broadcastDataSlots(boolean synchronize) {
+    private void impl$broadcastDataSlots(final boolean synchronize) {
         for(int j = 0; j < this.dataSlots.size(); ++j) {
             final DataSlot dataSlot = this.dataSlots.get(j);
             if (dataSlot.checkAndClearUpdateFlag()) {

--- a/src/mixins/java/org/spongepowered/common/mixin/inventory/event/world/inventory/AbstractContainerMenuMixin_Inventory.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/inventory/event/world/inventory/AbstractContainerMenuMixin_Inventory.java
@@ -81,7 +81,6 @@ public abstract class AbstractContainerMenuMixin_Inventory implements TrackedCon
     @Shadow protected abstract void shadow$updateDataSlotListeners(int $$0, int $$1);
     @Shadow protected abstract void shadow$synchronizeDataSlotToRemote(int $$0, int $$1);
     @Shadow protected abstract void shadow$synchronizeCarriedToRemote();
-
     @Shadow public abstract void shadow$sendAllDataToRemote();
     //@formatter:on
 
@@ -170,7 +169,7 @@ public abstract class AbstractContainerMenuMixin_Inventory implements TrackedCon
             return;
         }
         this.bridge$detectAndSendChanges(false, false);
-        this.impl$broadcastDataSlots();
+        this.impl$broadcastDataSlots(false);
         this.shadow$sendAllDataToRemote();
         this.impl$captureSuccess = true; // Detect mod overrides
         ci.cancel();
@@ -236,7 +235,7 @@ public abstract class AbstractContainerMenuMixin_Inventory implements TrackedCon
                 for (final ContainerListener listener : this.containerListeners) {
                     listener.slotChanged(((AbstractContainerMenu) (Object) this), i, oldStack);
                 }
-                if(synchronize) {
+                if (synchronize) {
                     final ItemStack remoteStack = this.remoteSlots.get(i);
                     if (!ItemStack.matches(remoteStack, newStack)) {
                         this.remoteSlots.set(i, newStack.copy());
@@ -250,7 +249,7 @@ public abstract class AbstractContainerMenuMixin_Inventory implements TrackedCon
 
         if (synchronize) {
             this.shadow$synchronizeCarriedToRemote();
-            this.impl$broadcastDataSlots();
+            this.impl$broadcastDataSlots(true);
         }
     }
 
@@ -268,13 +267,15 @@ public abstract class AbstractContainerMenuMixin_Inventory implements TrackedCon
         }
     }
 
-    private void impl$broadcastDataSlots() {
+    private void impl$broadcastDataSlots(boolean synchronize) {
         for(int j = 0; j < this.dataSlots.size(); ++j) {
             final DataSlot dataSlot = this.dataSlots.get(j);
             if (dataSlot.checkAndClearUpdateFlag()) {
                 this.shadow$updateDataSlotListeners(j, dataSlot.get());
             }
-            this.shadow$synchronizeDataSlotToRemote(j, dataSlot.get());
+            if (synchronize) {
+                this.shadow$synchronizeDataSlotToRemote(j, dataSlot.get());
+            }
         }
     }
 

--- a/testplugins/src/main/java/org/spongepowered/test/interact/ClickContainerEventCancelledTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/interact/ClickContainerEventCancelledTest.java
@@ -1,0 +1,54 @@
+package org.spongepowered.test.interact;
+
+import com.google.inject.Inject;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.text.Component;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.parameter.CommandContext;
+import org.spongepowered.api.event.EventContextKeys;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.registry.RegistryTypes;
+import org.spongepowered.plugin.PluginContainer;
+import org.spongepowered.plugin.builtin.jvm.Plugin;
+import org.spongepowered.api.event.item.inventory.container.ClickContainerEvent.Primary;
+import org.spongepowered.test.LoadableModule;
+
+/**
+ *   @author CanardNocturne
+ */
+@Plugin("clickcontainereventcancelledtest")
+public class ClickContainerEventCancelledTest implements LoadableModule {
+
+    private final PluginContainer plugin;
+
+    @Inject
+    public ClickContainerEventCancelledTest(final PluginContainer plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void enable(final CommandContext ctx) {
+        Sponge.eventManager().registerListeners(this.plugin, new ClickContainerEventCancelledTest.ClickContainerListener());
+    }
+
+    public static class ClickContainerListener {
+        @Listener
+        private void onInteractItem(final ClickContainerEvent.Primary event) {
+            event.setCancelled(true);
+            Sponge.server().broadcastAudience().sendMessage(Identity.nil(), Component.text("/*************"));
+            Sponge.server().broadcastAudience().sendMessage(Identity.nil(), Component.text().append(Component.text("/* Event: ")).append(Component.text(event.getClass().getSimpleName())).build());
+            Sponge.server().broadcastAudience().sendMessage(Identity.nil(),
+                    Component.text().append(Component.text("/* Hand: "))
+                            .append(Component.text(event.context().get(EventContextKeys.USED_HAND).map(h -> RegistryTypes.HAND_TYPE.keyFor(Sponge.game(), h).formatted()).orElse("UNKNOWN")))
+                            .build()
+            );
+            Sponge.game().systemSubject().sendMessage(Identity.nil(), Component.text().append(Component.text("/ Cause: ")).append(Component.text(event.cause().all().toString())).build());
+            Sponge.game().systemSubject().sendMessage(Identity.nil(), Component.text().append(Component.text("/ Context: ")).append(Component.text(event.context().toString())).build());
+            Sponge.game().systemSubject().sendMessage(Identity.nil(),
+                    Component.text().append(Component.text("/ Cancelled: ")).append(Component.text(event.isCancelled())).build());
+        }
+    }
+
+
+
+}

--- a/testplugins/src/main/java/org/spongepowered/test/interact/ClickContainerEventCancelledTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/interact/ClickContainerEventCancelledTest.java
@@ -59,9 +59,9 @@ public class ClickContainerEventCancelledTest implements LoadableModule {
         @Listener
         private void onInteractItem(final ClickContainerEvent.Primary event) {
             event.setCancelled(true);
-            Sponge.server().broadcastAudience().sendMessage(Identity.nil(), Component.text("/*************"));
-            Sponge.server().broadcastAudience().sendMessage(Identity.nil(), Component.text().append(Component.text("/* Event: ")).append(Component.text(event.getClass().getSimpleName())).build());
-            Sponge.server().broadcastAudience().sendMessage(Identity.nil(),
+            Sponge.game().systemSubject().sendMessage(Identity.nil(), Component.text("/*************"));
+            Sponge.game().systemSubject().sendMessage(Identity.nil(), Component.text().append(Component.text("/* Event: ")).append(Component.text(event.getClass().getSimpleName())).build());
+            Sponge.game().systemSubject().sendMessage(Identity.nil(),
                     Component.text().append(Component.text("/* Hand: "))
                             .append(Component.text(event.context().get(EventContextKeys.USED_HAND).map(h -> RegistryTypes.HAND_TYPE.keyFor(Sponge.game(), h).formatted()).orElse("UNKNOWN")))
                             .build()

--- a/testplugins/src/main/java/org/spongepowered/test/interact/ClickContainerEventCancelledTest.java
+++ b/testplugins/src/main/java/org/spongepowered/test/interact/ClickContainerEventCancelledTest.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.test.interact;
 
 import com.google.inject.Inject;
@@ -7,10 +31,10 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.parameter.CommandContext;
 import org.spongepowered.api.event.EventContextKeys;
 import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.item.inventory.container.ClickContainerEvent;
 import org.spongepowered.api.registry.RegistryTypes;
 import org.spongepowered.plugin.PluginContainer;
 import org.spongepowered.plugin.builtin.jvm.Plugin;
-import org.spongepowered.api.event.item.inventory.container.ClickContainerEvent.Primary;
 import org.spongepowered.test.LoadableModule;
 
 /**

--- a/testplugins/src/main/resources/META-INF/sponge_plugins.json
+++ b/testplugins/src/main/resources/META-INF/sponge_plugins.json
@@ -285,6 +285,12 @@
             "name": "Display Entities Test",
             "entrypoint": "org.spongepowered.test.entity.DisplayEntityTest",
             "description": "Testing Display Entities"
+        },
+        {
+            "id": "clickcontainereventcancelledtest",
+            "name": "Click Container Event Cancelled Test",
+            "entrypoint": "org.spongepowered.test.interact.ClickContainerEventCancelledTest",
+            "description": "Testing Cancelling Click Container Primary Event"
         }
     ]
 }


### PR DESCRIPTION
This PR is aimed to fix the issue #3862 
Tested with SpongeAPI 10.0.0-SNAPSHOT and SpongeVanilla 1.19.4-10.0.0-RC0.

### The bug
When the `ClickContainerEvent.Primary` event is cancelled, the first click on an item is cancelled, but a second click causes the item to disappear. It's not a visual bug, leaving and then reconnecting to the server will not make the item to reappear.

### Why this bug happens
During the restore of the container after the first click, many packets are sent to the client to replace the item in the slot and remove the item in the cursor. At the end, the `stateId` of the container will be 4. But during the second click, the client will send a `stateId` of 3, leading to the execution of the method `AbstractContainerMenu.broadcastFullState` instead of `AbstractContainerMenu#broadcastChanges`, where the items in the container are set without transactions.

This difference of `stateId` is due to the fact that after the restoration, the `stateId` of the container is 3, but the tick system will detect an inconsistency between the "carried" item and the "remote carried" item. It will fix it and then send a packet with a `stateId` of 4 to tell to the client that the "carried" item has been updated. But it has already received the updated item through the cursor restore, so I think that it ignores the packet and so keep the `stateId` of the container to 3.

### The fix
The fix simply sets the "remote carried" and not only the "carried" item during the cursor restore to avoid the inconsistency. A test plugin has been made that cancels the event ClickContainerEvent.Primary to see the bug and that this PR fixes it.