### PR TITLE
Backport "Player moved wrongly" fix to API-8

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/server/network/ServerGamePacketListenerImplBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/server/network/ServerGamePacketListenerImplBridge.java
@@ -34,8 +34,6 @@ public interface ServerGamePacketListenerImplBridge {
 
     @Nullable ResourcePack bridge$popAcceptedResourcePack();
 
-    void bridge$captureCurrentPlayerPosition();
-
     void bridge$setLastMoveLocation(ServerLocation location);
 
     long bridge$getLastTryBlockPacketTimeStamp();

--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -401,9 +401,9 @@ public final class SpongeCommonEventFactory {
                             originalToPosition);
 
             if (finalPosition == null) {
-                entity.setPos(entity.xOld, entity.yOld, entity.zOld);
+                entity.moveTo(entity.xOld, entity.yOld, entity.zOld);
             } else if (!finalPosition.equals(originalToPosition)) {
-                entity.setPos(finalPosition.x(), finalPosition.y(), finalPosition.z());
+                entity.moveTo(finalPosition.x(), finalPosition.y(), finalPosition.z());
             }
         }
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java
@@ -134,7 +134,6 @@ import org.spongepowered.common.bridge.data.DataCompoundHolder;
 import org.spongepowered.common.bridge.permissions.SubjectBridge;
 import org.spongepowered.common.bridge.server.ServerScoreboardBridge;
 import org.spongepowered.common.bridge.server.level.ServerPlayerBridge;
-import org.spongepowered.common.bridge.server.network.ServerGamePacketListenerImplBridge;
 import org.spongepowered.common.bridge.world.BossEventBridge;
 import org.spongepowered.common.bridge.world.entity.player.PlayerBridge;
 import org.spongepowered.common.data.DataUtil;
@@ -878,15 +877,6 @@ public abstract class ServerPlayerMixin extends PlayerMixin implements SubjectBr
                 case OTHER_PROBLEM: // ignore
                     break;
             }
-        }
-    }
-
-    @Override
-    protected void impl$capturePlayerPosition(
-        final double x, final double y, final double z, final CallbackInfo ci
-    ) {
-        if (this.connection != null) {
-            ((ServerGamePacketListenerImplBridge) this.connection).bridge$captureCurrentPlayerPosition();
         }
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerGamePacketListenerImplMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerGamePacketListenerImplMixin.java
@@ -153,7 +153,6 @@ public abstract class ServerGamePacketListenerImplMixin implements ServerGamePac
 
     @Shadow public abstract void shadow$teleport(double x, double y, double z, float yaw, float pitch, Set<ClientboundPlayerPositionPacket.RelativeArgument> relativeArguments);
     @Shadow protected abstract void shadow$filterTextPacket(List<String> p_244537_1_, Consumer<List<String>> p_244537_2_);
-    @Shadow public abstract void shadow$resetPosition();
     // @formatter:on
 
     private int impl$ignorePackets;
@@ -549,11 +548,6 @@ public abstract class ServerGamePacketListenerImplMixin implements ServerGamePac
         }
 
         return 0;
-    }
-
-    @Override
-    public void bridge$captureCurrentPlayerPosition() {
-        this.shadow$resetPosition();
     }
 
     @Redirect(method = "handleChat(Ljava/lang/String;)V",

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/EntityMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/EntityMixin.java
@@ -927,12 +927,6 @@ public abstract class EntityMixin implements EntityBridge, PlatformEntityBridge,
 
     }
 
-
-    @Inject(method = "setPos", at = @At("HEAD"))
-    protected void impl$capturePlayerPosition(final double x, final double y, final double z, final CallbackInfo ci) {
-        // Overridden in ServerPlayer
-    }
-
     @Redirect(method = "move", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;collide(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;"))
     private Vec3 impl$onMoveCollide(final Entity entity, final Vec3 originalMove) {
         final Vec3 afterCollide = this.shadow$collide(originalMove);


### PR DESCRIPTION
Backports @Faithcaio's "moved wrongly" fix from API-10: https://github.com/SpongePowered/Sponge/compare/2c2cf414dabf3c5d1f53a8d9ccc840fa678e36b5...e218bf0fe20e7c360c5f31ffcb7ab53408fc9f16

Fixes super stuttery movement like this:

https://github.com/SpongePowered/Sponge/assets/13265322/10e5f5f2-4fab-4b85-86c4-64df57233b89

And fixes the completely broken elytra:

https://github.com/SpongePowered/Sponge/assets/13265322/ff10f196-70aa-4a31-9894-95bb39234960

This issue presently affects SpongeVanilla and SpongeForge on 1.16.5 and 1.18.2.