### PR TITLE
Hopper don't transfer if full and wrong destination for TransferInventoryEvent.Pre 

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/inventory/event/world/level/block/entity/HopperBlockEntityMixin_Inventory.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/inventory/event/world/level/block/entity/HopperBlockEntityMixin_Inventory.java
@@ -75,13 +75,13 @@ public abstract class HopperBlockEntityMixin_Inventory {
             at = @At(value = "INVOKE",
                      target = "Lnet/minecraft/world/level/block/entity/HopperBlockEntity;isFullContainer(Lnet/minecraft/world/Container;Lnet/minecraft/core/Direction;)Z"))
     private static boolean impl$throwTransferPreIfNotFull(
-        final Container var0, final Direction direction, final Level level, final BlockPos pos, final BlockState state, final Container container
+        final Container attachedContainer, final Direction direction, final Level level, final BlockPos pos, final BlockState state, final Container container
     ) {
-        final boolean result = HopperBlockEntityAccessor.invoker$isFullContainer(container, direction);
+        final boolean result = HopperBlockEntityAccessor.invoker$isFullContainer(attachedContainer, direction);
         if (result || !ShouldFire.TRANSFER_INVENTORY_EVENT_PRE) {
             return result;
         }
-        return InventoryEventFactory.callTransferPre(InventoryUtil.toInventory(container), InventoryUtil.toInventory(container)).isCancelled();
+        return InventoryEventFactory.callTransferPre(InventoryUtil.toInventory(container), InventoryUtil.toInventory(attachedContainer)).isCancelled();
     }
 
     // Capture Transactions


### PR DESCRIPTION
### Versions
SpongeAPI: 10.0.0-SNAPSHOT
Sponge: 1.19.4-10.0.0-SNAPSHOT
SpongeVanilla: 1.19.4-10.0.0-RC0

### The bug
A hopper didn't transfer its items if its 5 slots were filled with a full stack of items (example: 64 oak woods per slot).
Furthermore, the event **TransferInventoryEvent.Pre** had the same source and destination inventory.
This bug was reported by the issue #3883. 

### Description
Before transferring its items to the container in its direction, it checks that the container is not full. The check method `HopperBlockEntity#isFullContainer` was redirected to the mixin method `HopperBlockEntityMixin_Inventory#impl$throwTransferPreIfNotFull` to capture the transfer and create a `TransferInventoryEvent.Pre` event. The problem was that the check performed by `HopperBlockEntityAccessor.invoker$isFullContainer` was called with the hopper container and not the 'attached container' (the container in the hopper direction, such as a chest). In addition, the event  **TransferInventoryEvent.Pre** was created with the same source and destination container (the hopper).

### The fix
`HopperBlockEntityMixin_Inventory#impl$throwTransferPreIfNotFull` had two containers as arguments: the attached container and the hopper container. I just replaced the container argument of `HopperBlockEntityAccessor.invoker$isFullContainer` with the attached container. Its name was var0 but I renamed it to 'attachedContainer' like the method `HopperBlockEntity#getAttachedContainer`.

For the event, I just replaced the destination container with the attached container. 