### PR TITLE
Click on merchants can kick players

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/network/FriendlyByteBufMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/network/FriendlyByteBufMixin.java
@@ -24,11 +24,13 @@
  */
 package org.spongepowered.common.mixin.core.network;
 
+import com.google.gson.JsonSyntaxException;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.util.locale.Locales;
 import org.spongepowered.asm.mixin.Mixin;
@@ -86,7 +88,7 @@ public abstract class FriendlyByteBufMixin implements FriendlyByteBufBridge {
 
             for (int i = 0; i < renderedLines.length; i++) {
                 final String lineStr = lore.getString(i);
-                final Component line = Component.Serializer.fromJson(lineStr);
+                final Component line = this.getComponentFromJson(lineStr);
                 final Component renderedLine = NativeComponentRenderer.apply(line, locale);
 
                 renderedLines[i] = renderedLine;
@@ -139,4 +141,13 @@ public abstract class FriendlyByteBufMixin implements FriendlyByteBufBridge {
     public void bridge$setLocale(final Locale locale) {
         this.impl$locale = locale;
     }
+
+    public Component getComponentFromJson(String json) {
+        try {
+            return Component.Serializer.fromJson(json);
+        } catch (JsonSyntaxException e) {
+            return new TextComponent(json);
+        }
+    }
+
 }


### PR DESCRIPTION
### Version
Sponge: 8.0.0
SpongeForge: 1.16.5-36.2.5-8.1.0-RC1352-universal

### The bug
When a player clicks on a merchant, an error can be thrown and the player kicked off the server.
This bug typically happens when clicking on a TCG Trader from Pixelmon mod.
This bug was reported by #3871 and #3828.

### Description
When the packet _ClientboundMerchantOffersPacket_ is sent, the itemstacks and its NBTs are written into the byte buf. Sponge manipulates the NBTs to do server-side translation and for this, it needs to deserialize the name of the item and its lore.
The lines of the lore of the itemstacks sold by the TCG traders are a simple string and not a JSON in a string, so the deserialization throws an _JsonParseException_ which kicks the player.

### The fix
The fix is to support simple strings as lore lines. The are several ways to do it, and the solution of this PR is to use a  _TextComponent_ if the deserialization fails.

An another solution would be to use `fromJsonLenient` instead of `fromJson` but I don't know if this can cause "corrupted" merchant because of JSON deserializable with SpongeForge but not with Minecraft.

