### PR TITLE
some improvements in task scheduler

### DIFF
--- a/src/main/java/org/spongepowered/common/scheduler/SpongeScheduler.java
+++ b/src/main/java/org/spongepowered/common/scheduler/SpongeScheduler.java
@@ -62,7 +62,7 @@ public abstract class SpongeScheduler implements Scheduler {
     private final String tag;
 
     // The simple queue of all pending (and running) ScheduledTasks
-    protected final Map<UUID, SpongeScheduledTask> tasks = new ConcurrentHashMap<>();
+    private final Map<UUID, SpongeScheduledTask> tasks = new ConcurrentHashMap<>();
     private long sequenceNumber = 0L;
 
     SpongeScheduler(final String tag) {
@@ -107,9 +107,7 @@ public abstract class SpongeScheduler implements Scheduler {
     @Override
     public Optional<ScheduledTask> findTask(final UUID id) {
         Objects.requireNonNull(id, "id");
-        synchronized (this.tasks) {
-            return Optional.ofNullable(this.tasks.get(id));
-        }
+        return Optional.ofNullable(this.tasks.get(id));
     }
 
     @Override
@@ -130,9 +128,7 @@ public abstract class SpongeScheduler implements Scheduler {
 
     @Override
     public Set<ScheduledTask> tasks() {
-        synchronized (this.tasks) {
-            return Sets.newHashSet(this.tasks.values());
-        }
+        return Sets.newHashSet(this.tasks.values());
     }
 
     @Override


### PR DESCRIPTION
Removed the extra AtomicBoolean from the AsyncScheduler class, we do not need it, since we work with the stateChanged field always inside the lock

and set from in class SpongeScheduler added AtomicLong to sequenceNumber

Since the addition of tasks can occur from different threads, we must make a safe increment, from a structural point of view, nothing was broken, but the information was given incorrect

Then I made small optimizations in AsyncScheduler with timeout calculation, we don’t have to write it in the field, since we calculate the value again at each tick, I moved it to preTick at the same time removed the extra lock on this method (separate)

other changes: such as adding an extra method to avoid copying the map with tasks on every tick