### PR TITLE
Custom Heads resetting to default after placing

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/level/block/entity/SkullBlockEntityMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/level/block/entity/SkullBlockEntityMixin.java
@@ -24,7 +24,9 @@
  */
 package org.spongepowered.common.mixin.core.world.level.block.entity;
 
+import com.google.common.collect.Iterables;
 import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.StringUtil;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -95,7 +97,12 @@ public abstract class SkullBlockEntityMixin extends BlockEntity implements Ticka
             return input;
         }
         future.thenAcceptAsync(profile -> {
-            this.owner = SpongeGameProfile.toMcProfile(profile);
+            final GameProfile mcProfile = SpongeGameProfile.toMcProfile(profile);
+            final Property textures = Iterables.getFirst(mcProfile.getProperties().get("textures"), null);
+            if(textures == null)
+                this.owner = input;
+            else
+                this.owner = mcProfile;
             this.impl$markDirtyAndUpdate();
         }, SpongeCommon.server());
         this.impl$currentProfileFuture = future;


### PR DESCRIPTION
### Version
SpongeAPI: 8.0.0
SpongeForge: 1.16.5-36.2.34-8.1.0-RC0

### The bug
Custom heads, retrieve through this kind of website: https://minecraft-heads.com/custom-heads are resetting to default after being placed in the world.
This bug was report by #3833.

### Description
After being placed in the world, Sponge gets the associated GameProfile of the SkullOwner by its UUID or its name to set the owner of the player's skull. But in the case of custom heads, the UUID is fake no name is associated, so Sponge gets a GameProfile without textures.
Minecraft on its side retrieves the GameProfile only by the name of the SkullOwner, which if it's not set, sets the owner to the GameProfile of the skull item which has textures.

### The fix
A check is made to only set the owner if the GameProfile retrieved has a texture, and use the skull item GameProfile otherwise. Suppressing the retrieval of GameProfile by UUID to have a behaviour similar to Minecraft can cause regressions if Plugins are using it. 