### PR TITLE
Support changing the item of certain projectiles like Snowballs

### DIFF
--- a/src/main/java/org/spongepowered/common/data/provider/entity/EntityDataProviders.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/EntityDataProviders.java
@@ -107,6 +107,7 @@ public final class EntityDataProviders extends DataProviderRegistratorBuilder {
         SpellcastingIllagerData.register(this.registrator);
         SpiderData.register(this.registrator);
         TameableData.register(this.registrator);
+        ThrowableItemProjectileData.register(this.registrator);
         TNTData.register(this.registrator);
         TraderLlamaData.register(this.registrator);
         TropicalFishData.register(this.registrator);

--- a/src/main/java/org/spongepowered/common/data/provider/entity/PotionData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/PotionData.java
@@ -26,13 +26,10 @@ package org.spongepowered.common.data.provider.entity;
 
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.projectile.ThrownPotion;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.alchemy.PotionUtils;
 import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.effect.potion.PotionEffect;
 import org.spongepowered.common.data.provider.DataProviderRegistrator;
-import org.spongepowered.common.item.util.ItemStackUtil;
 import org.spongepowered.common.util.Constants;
 
 import java.util.stream.Collectors;
@@ -46,18 +43,6 @@ public final class PotionData {
     public static void register(final DataProviderRegistrator registrator) {
         registrator
                 .asMutable(ThrownPotion.class)
-                    .create(Keys.ITEM_STACK_SNAPSHOT)
-                        .get(h -> ItemStackUtil.snapshotOf(h.getItem()))
-                        .setAnd((h, v) -> {
-                            final ItemStack itemStack = ItemStackUtil.fromSnapshotToNative(v);
-                            if (itemStack.getItem() != Items.SPLASH_POTION && itemStack.getItem() != Items.LINGERING_POTION) {
-                                // Minecraft will throw a hissy fit if we do allow any other type of potion
-                                // so, we have to return false because the item stack is invalid.
-                                return false;
-                            }
-                            h.setItem(itemStack);
-                            return true;
-                        })
                     .create(Keys.POTION_EFFECTS)
                         .get(h -> PotionUtils.getMobEffects(h.getItem()).stream().map(PotionEffect.class::cast).collect(Collectors.toList()))
                         .set((h, v) -> {

--- a/src/main/java/org/spongepowered/common/data/provider/entity/ThrowableItemProjectileData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/ThrowableItemProjectileData.java
@@ -1,0 +1,27 @@
+package org.spongepowered.common.data.provider.entity;
+
+import net.minecraft.world.entity.projectile.ThrowableItemProjectile;
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.common.data.provider.DataProviderRegistrator;
+import org.spongepowered.common.item.util.ItemStackUtil;
+
+public class ThrowableItemProjectileData {
+
+    private ThrowableItemProjectileData() {
+    }
+
+    // @formatter:off
+    public static void register(final DataProviderRegistrator registrator) {
+        registrator
+                .asMutable(ThrowableItemProjectile.class)
+                    .create(Keys.ITEM_STACK_SNAPSHOT)
+                        .get(h -> ItemStackUtil.snapshotOf(h.getItem()))
+                        .setAnd((h, v) -> {
+                            h.setItem(ItemStackUtil.fromSnapshotToNative(v));
+
+                            return true;
+                        });
+    }
+    // @formatter:on
+
+}

--- a/src/main/java/org/spongepowered/common/data/provider/entity/ThrowableItemProjectileData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/ThrowableItemProjectileData.java
@@ -40,11 +40,7 @@ public class ThrowableItemProjectileData {
                 .asMutable(ThrowableItemProjectile.class)
                     .create(Keys.ITEM_STACK_SNAPSHOT)
                         .get(h -> ItemStackUtil.snapshotOf(h.getItem()))
-                        .setAnd((h, v) -> {
-                            h.setItem(ItemStackUtil.fromSnapshotToNative(v));
-
-                            return true;
-                        });
+                        .set((h, v) -> h.setItem(ItemStackUtil.fromSnapshotToNative(v)));
     }
     // @formatter:on
 

--- a/src/main/java/org/spongepowered/common/data/provider/entity/ThrowableItemProjectileData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/ThrowableItemProjectileData.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.common.data.provider.entity;
 
 import net.minecraft.world.entity.projectile.ThrowableItemProjectile;

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/projectile/ThrowableItemProjectileMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/projectile/ThrowableItemProjectileMixin_API.java
@@ -38,7 +38,7 @@ public abstract class ThrowableItemProjectileMixin_API extends ThrowableProjecti
     protected Set<Value.Immutable<?>> api$getVanillaValues() {
         final Set<Value.Immutable<?>> values = super.api$getVanillaValues();
 
-        this.getValue(Keys.ITEM_STACK_SNAPSHOT).map(Value::asImmutable).ifPresent(values::add);
+        values.add(this.requireValue(Keys.ITEM_STACK_SNAPSHOT).asImmutable());
 
         return values;
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/projectile/ThrowableItemProjectileMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/projectile/ThrowableItemProjectileMixin_API.java
@@ -25,9 +25,22 @@
 package org.spongepowered.common.mixin.api.minecraft.world.entity.projectile;
 
 import net.minecraft.world.entity.projectile.ThrowableItemProjectile;
+import org.spongepowered.api.data.Keys;
+import org.spongepowered.api.data.value.Value;
 import org.spongepowered.asm.mixin.Mixin;
+
+import java.util.Set;
 
 @Mixin(ThrowableItemProjectile.class)
 public abstract class ThrowableItemProjectileMixin_API extends ThrowableProjectileMixin_API {
+
+    @Override
+    protected Set<Value.Immutable<?>> api$getVanillaValues() {
+        final Set<Value.Immutable<?>> values = super.api$getVanillaValues();
+
+        this.getValue(Keys.ITEM_STACK_SNAPSHOT).map(Value::asImmutable).ifPresent(values::add);
+
+        return values;
+    }
 
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/projectile/ThrownPotionMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/projectile/ThrownPotionMixin_API.java
@@ -39,7 +39,6 @@ public abstract class ThrownPotionMixin_API extends ThrowableItemProjectileMixin
     protected Set<Value.Immutable<?>> api$getVanillaValues() {
         final Set<Value.Immutable<?>> values = super.api$getVanillaValues();
 
-        values.add(this.requireValue(Keys.ITEM_STACK_SNAPSHOT).asImmutable());
         values.add(this.requireValue(Keys.POTION_EFFECTS).asImmutable());
 
         return values;


### PR DESCRIPTION
Add support for changing the display item of `ThrowableItemProjectile`s like snowballs. 

This also removes the unnecessary requirement, that the display item of the thrown potion entity can only be splash or lingering potion. I assume this was necessary in the past, but it isn't anymore.