### PR TITLE
Implement SerializableDataHolder#rawData()

### DIFF
--- a/src/main/java/org/spongepowered/common/block/SpongeBlockSnapshot.java
+++ b/src/main/java/org/spongepowered/common/block/SpongeBlockSnapshot.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.common.block;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
@@ -261,13 +263,25 @@ public final class SpongeBlockSnapshot implements BlockSnapshot, SpongeImmutable
     }
 
     @Override
+    public DataContainer rawData() {
+        if (this.compound == null) {
+            return DataContainer.createNew(DataView.SafetyMode.NO_DATA_CLONED);
+        }
+        return NBTTranslator.INSTANCE.translate(this.compound);
+    }
+
+    @Override
     public BlockSnapshot withRawData(final DataView container) throws InvalidDataException {
-        return BuilderImpl.pooled().buildContent(container).orElseThrow(InvalidDataException::new);
+        checkNotNull(container, "Raw data cannot be null!");
+        final BuilderImpl builder = this.createBuilder();
+        builder.addUnsafeCompound(NBTTranslator.INSTANCE.translate(container));
+        return builder.build();
     }
 
     @Override
     public boolean validateRawData(final DataView container) {
-        return BuilderImpl.pooled().buildContent(container).isPresent();
+        checkNotNull(container, "Raw data cannot be null!");
+        return true;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/block/entity/SpongeBlockEntityArchetype.java
+++ b/src/main/java/org/spongepowered/common/block/entity/SpongeBlockEntityArchetype.java
@@ -80,11 +80,6 @@ public final class SpongeBlockEntityArchetype extends AbstractArchetype<BlockEnt
     }
 
     @Override
-    public DataContainer blockEntityData() {
-        return NBTTranslator.INSTANCE.translateFrom(this.compound);
-    }
-
-    @Override
     public Optional<BlockEntity> apply(final ServerLocation location) {
         final BlockState currentState = location.block();
         final Block currentBlock = ((net.minecraft.world.level.block.state.BlockState) currentState).getBlock();
@@ -131,7 +126,7 @@ public final class SpongeBlockEntityArchetype extends AbstractArchetype<BlockEnt
                 .set(Queries.CONTENT_VERSION, this.contentVersion())
                 .set(Constants.Sponge.BlockEntityArchetype.BLOCK_ENTITY_TYPE, this.type)
                 .set(Constants.Sponge.BlockEntityArchetype.BLOCK_STATE, this.blockState)
-                .set(Constants.Sponge.BlockEntityArchetype.BLOCK_ENTITY_DATA, this.blockEntityData())
+                .set(Constants.Sponge.BlockEntityArchetype.BLOCK_ENTITY_DATA, this.rawData())
                 ;
     }
 

--- a/src/main/java/org/spongepowered/common/block/entity/SpongeBlockEntityArchetypeBuilder.java
+++ b/src/main/java/org/spongepowered/common/block/entity/SpongeBlockEntityArchetypeBuilder.java
@@ -94,7 +94,7 @@ public final class SpongeBlockEntityArchetypeBuilder extends AbstractDataBuilder
     public BlockEntityArchetype.Builder from(final BlockEntityArchetype value) {
         this.type = value.blockEntityType();
         this.blockState = value.state();
-        this.data = value.blockEntityData();
+        this.data = value.rawData();
         return this;
     }
 

--- a/src/main/java/org/spongepowered/common/data/AbstractArchetype.java
+++ b/src/main/java/org/spongepowered/common/data/AbstractArchetype.java
@@ -29,6 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.nbt.CompoundTag;
+import org.spongepowered.api.data.persistence.DataContainer;
 import org.spongepowered.api.data.persistence.DataView;
 import org.spongepowered.api.data.persistence.InvalidDataException;
 import org.spongepowered.api.world.Archetype;
@@ -71,12 +72,16 @@ public abstract class AbstractArchetype<T, S extends LocatableSnapshot<S>, E> im
     }
 
     @Override
+    public DataContainer rawData() {
+        return NBTTranslator.INSTANCE.translate(this.compound);
+    }
+
+    @Override
     public void setRawData(final DataView container) throws InvalidDataException {
         checkNotNull(container, "Raw data cannot be null!");
-        final CompoundTag copy = NBTTranslator.INSTANCE.translate(container);
-        final boolean valid = this.getValidator().validate(copy);
-        if (valid) {
-            this.compound = copy;
+        final CompoundTag compoundTag = NBTTranslator.INSTANCE.translate(container);
+        if (this.getValidator().validate(compoundTag)) {
+            this.compound = compoundTag;
         } else {
             throw new InvalidDataException("Invalid data for " + this.getValidationType());
         }
@@ -84,6 +89,7 @@ public abstract class AbstractArchetype<T, S extends LocatableSnapshot<S>, E> im
 
     @Override
     public boolean validateRawData(final DataView container) {
+        checkNotNull(container, "Raw data cannot be null!");
         return this.getValidator().validate(container);
     }
 

--- a/src/main/java/org/spongepowered/common/data/provider/block/entity/MobSpawnerData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/block/entity/MobSpawnerData.java
@@ -116,7 +116,7 @@ public final class MobSpawnerData {
     }
 
     private static void setNextEntity(final SpawnerBlockEntity entity, final WeightedSerializableObject<EntityArchetype> value) {
-        final CompoundTag compound = NBTTranslator.INSTANCE.translate(value.get().entityData());
+        final CompoundTag compound = NBTTranslator.INSTANCE.translate(value.get().rawData());
         if (!compound.contains(Constants.Entity.ENTITY_TYPE_ID)) {
             final ResourceKey key = (ResourceKey) (Object) net.minecraft.world.entity.EntityType.getKey((net.minecraft.world.entity.EntityType<?>) value.get()
                     .type());
@@ -155,7 +155,7 @@ public final class MobSpawnerData {
             }
             final WeightedObject<EntityArchetype> object = (WeightedObject<EntityArchetype>) entry;
 
-            final CompoundTag compound = NBTTranslator.INSTANCE.translate(object.get().entityData());
+            final CompoundTag compound = NBTTranslator.INSTANCE.translate(object.get().rawData());
             if (!compound.contains(Constants.Entity.ENTITY_TYPE_ID)) {
                 final ResourceKey key = (ResourceKey) (Object) net.minecraft.world.entity.EntityType.getKey((net.minecraft.world.entity.EntityType<?>) object
                         .get().type());

--- a/src/main/java/org/spongepowered/common/entity/SpongeEntityArchetype.java
+++ b/src/main/java/org/spongepowered/common/entity/SpongeEntityArchetype.java
@@ -112,17 +112,12 @@ public final class SpongeEntityArchetype extends AbstractArchetype<EntityType, E
 
     @Override
     public DataContainer data$getDataContainer() {
-        return this.entityData();
+        return this.rawData();
     }
 
     @Override
     public void data$setDataContainer(final DataContainer container) {
         this.compound = NBTTranslator.INSTANCE.translate(Objects.requireNonNull(container, "DataContainer cannot be null!"));
-    }
-
-    @Override
-    public DataContainer entityData() {
-        return NBTTranslator.INSTANCE.translateFrom(this.compound);
     }
 
     @Override
@@ -210,7 +205,7 @@ public final class SpongeEntityArchetype extends AbstractArchetype<EntityType, E
         return DataContainer.createNew(DataView.SafetyMode.NO_DATA_CLONED)
                 .set(Queries.CONTENT_VERSION, this.contentVersion())
                 .set(Constants.Sponge.EntityArchetype.ENTITY_TYPE, this.type)
-                .set(Constants.Sponge.EntityArchetype.ENTITY_DATA, this.entityData());
+                .set(Constants.Sponge.EntityArchetype.ENTITY_DATA, this.rawData());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/entity/SpongeEntityArchetypeBuilder.java
+++ b/src/main/java/org/spongepowered/common/entity/SpongeEntityArchetypeBuilder.java
@@ -91,7 +91,7 @@ public class SpongeEntityArchetypeBuilder extends AbstractDataBuilder<EntityArch
     @Override
     public EntityArchetype.Builder from(final EntityArchetype value) {
         this.entityType = value.type();
-        this.compound = NBTTranslator.INSTANCE.translate(value.entityData());
+        this.compound = NBTTranslator.INSTANCE.translate(value.rawData());
         SpongeEntityArchetypeBuilder.stripCompound(this.compound);
         // TODO Copy over the pending manipulator data?
         this.manipulator = null;

--- a/src/main/java/org/spongepowered/common/entity/SpongeEntitySnapshot.java
+++ b/src/main/java/org/spongepowered/common/entity/SpongeEntitySnapshot.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.common.entity;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.base.MoreObjects;
 import net.minecraft.nbt.CompoundTag;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -156,14 +158,25 @@ public class SpongeEntitySnapshot implements EntitySnapshot, SpongeImmutableData
     }
 
     @Override
+    public DataContainer rawData() {
+        if (this.compound == null) {
+            return DataContainer.createNew(DataView.SafetyMode.NO_DATA_CLONED);
+        }
+        return NBTTranslator.INSTANCE.translate(this.compound);
+    }
+
+    @Override
     public boolean validateRawData(final DataView container) {
-        return new SpongeEntitySnapshotBuilder().buildContent(container).isPresent();
+        checkNotNull(container, "Raw data cannot be null!");
+        return true;
     }
 
     @Override
     public EntitySnapshot withRawData(final DataView container) throws InvalidDataException {
-        final Optional<EntitySnapshot> snap = new SpongeEntitySnapshotBuilder().buildContent(container);
-        return snap.orElseThrow(InvalidDataException::new);
+        checkNotNull(container, "Raw data cannot be null!");
+        final SpongeEntitySnapshotBuilder builder = this.createBuilder();
+        builder.unsafeCompound(NBTTranslator.INSTANCE.translate(container));
+        return builder.build();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/fluid/SpongeFluidStackSnapshot.java
+++ b/src/main/java/org/spongepowered/common/fluid/SpongeFluidStackSnapshot.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.common.fluid;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.ResourceKey;
@@ -122,12 +124,22 @@ public class SpongeFluidStackSnapshot implements FluidStackSnapshot, SpongeImmut
     }
 
     @Override
+    public DataContainer rawData() {
+        if (this.extraData == null) {
+            return DataContainer.createNew(DataView.SafetyMode.NO_DATA_CLONED);
+        }
+        return extraData.copy(DataView.SafetyMode.NO_DATA_CLONED);
+    }
+
+    @Override
     public boolean validateRawData(final DataView container) {
-        return container.contains(Queries.CONTENT_VERSION, Constants.Fluids.FLUID_TYPE, Constants.Fluids.FLUID_VOLUME);
+        checkNotNull(container, "Raw data cannot be null!");
+        return this.createStack().validateRawData(container);
     }
 
     @Override
     public @NonNull FluidStackSnapshot withRawData(final @NonNull DataView container) throws InvalidDataException {
+        checkNotNull(container, "Raw data cannot be null!");
         final FluidStack stack = this.createStack();
         stack.setRawData(container);
         return stack.createSnapshot();

--- a/src/main/java/org/spongepowered/common/item/SpongeItemStackSnapshot.java
+++ b/src/main/java/org/spongepowered/common/item/SpongeItemStackSnapshot.java
@@ -291,7 +291,16 @@ public class SpongeItemStackSnapshot implements ItemStackSnapshot {
     }
 
     @Override
+    public DataContainer rawData() {
+        if (this.compound == null) {
+            return DataContainer.createNew(DataView.SafetyMode.NO_DATA_CLONED);
+        }
+        return NBTTranslator.INSTANCE.translate(this.compound);
+    }
+
+    @Override
     public ItemStackSnapshot withRawData(DataView container) throws InvalidDataException {
+        checkNotNull(container, "Raw data cannot be null!");
         final ItemStack copy = this.privateStack.copy();
         copy.setRawData(container);
         return copy.createSnapshot();
@@ -316,8 +325,8 @@ public class SpongeItemStackSnapshot implements ItemStackSnapshot {
 
     @Override
     public boolean validateRawData(DataView container) {
-        final ItemStack copy = this.privateStack.copy();
-        return copy.validateRawData(container);
+        checkNotNull(container, "Raw data cannot be null!");
+        return this.privateStack.validateRawData(container);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/schematic/SchematicTranslator.java
+++ b/src/main/java/org/spongepowered/common/world/schematic/SchematicTranslator.java
@@ -466,7 +466,7 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
                 final DataContainer container = DataContainer.createNew(DataView.SafetyMode.NO_DATA_CLONED);
                 final Vector3i pos = entry.getKey();
                 final BlockEntityArchetype archetype = entry.getValue();
-                final DataContainer entityData = archetype.blockEntityData();
+                final DataContainer entityData = archetype.rawData();
                 final int[] apos = new int[]{pos.x() - xMin, pos.y() - yMin, pos.z() - zMin};
                 container.set(Constants.Sponge.Schematic.BLOCKENTITY_POS, apos);
                 container.set(Constants.Sponge.Schematic.BLOCKENTITY_DATA, entityData);
@@ -528,7 +528,7 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
                 requiredMods.add(key.namespace());
             }
             container.set(Constants.Sponge.Schematic.ENTITIES_ID, key.toString());
-            final DataContainer entityData = entry.archetype().entityData();
+            final DataContainer entityData = entry.archetype().rawData();
             container.set(Constants.Sponge.Schematic.BLOCKENTITY_DATA, entityData);
             return container;
         }).collect(Collectors.toList());

--- a/src/main/java/org/spongepowered/common/world/server/SpongeLocatableBlock.java
+++ b/src/main/java/org/spongepowered/common/world/server/SpongeLocatableBlock.java
@@ -157,7 +157,13 @@ public final class SpongeLocatableBlock implements LocatableBlock {
     }
 
     @Override
+    public DataContainer rawData() {
+        return this.blockState.rawData();
+    }
+
+    @Override
     public LocatableBlock withRawData(final DataView container) throws InvalidDataException {
+        checkNotNull(container, "Raw data cannot be null!");
         return LocatableBlock.builder().from(this).state(this.blockState.withRawData(container)).build();
     }
 
@@ -168,6 +174,7 @@ public final class SpongeLocatableBlock implements LocatableBlock {
 
     @Override
     public boolean validateRawData(final DataView container) {
+        checkNotNull(container, "Raw data cannot be null!");
         return this.blockState.validateRawData(container);
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/block/state/BlockStateMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/block/state/BlockStateMixin_API.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.common.mixin.api.minecraft.world.level.block.state;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import org.spongepowered.api.block.BlockSnapshot;
@@ -82,8 +84,14 @@ public abstract class BlockStateMixin_API extends BlockBehaviour_BlockStateBaseM
     }
 
     @Override
+    public DataContainer rawData() {
+        return DataContainer.createNew(DataView.SafetyMode.NO_DATA_CLONED); // BlockState has no extra data
+    }
+
+    @Override
     public boolean validateRawData(final DataView container) {
-        return container.contains(Constants.Block.BLOCK_STATE);
+        checkNotNull(container, "Raw data cannot be null!");
+        return true;
     }
 
     @Override
@@ -93,7 +101,8 @@ public abstract class BlockStateMixin_API extends BlockBehaviour_BlockStateBaseM
 
     @Override
     public BlockState withRawData(final DataView container) throws InvalidDataException {
-        throw new UnsupportedOperationException("Not implemented yet"); // TODO Data API
+        checkNotNull(container, "Raw data cannot be null!");
+        return this; // Ignore incoming container
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplateMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplateMixin_API.java
@@ -328,7 +328,7 @@ public abstract class StructureTemplateMixin_API implements Schematic, SpongeArc
     public void addEntity(final EntityArchetypeEntry entry) {
         final Vec3 pos = VecHelper.toVanillaVector3d(entry.position());
         final BlockPos blockPos = VecHelper.toBlockPos(entry.position()); // TODO special handling for paintings?
-        final CompoundTag data = NBTTranslator.INSTANCE.translate(entry.archetype().entityData());
+        final CompoundTag data = NBTTranslator.INSTANCE.translate(entry.archetype().rawData());
         final StructureTemplate.StructureEntityInfo info = new StructureTemplate.StructureEntityInfo(pos, blockPos, data);
         this.entityInfoList.add(info);
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/material/FluidStateMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/material/FluidStateMixin_API.java
@@ -24,8 +24,13 @@
  */
 package org.spongepowered.common.mixin.api.minecraft.world.level.material;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import net.minecraft.world.level.material.Fluid;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.data.persistence.DataContainer;
+import org.spongepowered.api.data.persistence.DataView;
+import org.spongepowered.api.data.persistence.InvalidDataException;
 import org.spongepowered.api.fluid.FluidState;
 import org.spongepowered.api.fluid.FluidType;
 import org.spongepowered.asm.mixin.Implements;
@@ -58,5 +63,22 @@ public abstract class FluidStateMixin_API implements FluidState {
     @Intrinsic
     public boolean fluidState$isEmpty() {
         return this.shadow$isEmpty();
+    }
+
+    @Override
+    public DataContainer rawData() {
+        return DataContainer.createNew(DataView.SafetyMode.NO_DATA_CLONED); // FluidState has no extra data
+    }
+
+    @Override
+    public boolean validateRawData(final DataView container) {
+        checkNotNull(container, "Raw data cannot be null!");
+        return true;
+    }
+
+    @Override
+    public FluidState withRawData(final DataView container) throws InvalidDataException {
+        checkNotNull(container, "Raw data cannot be null!");
+        return this; // Ignore incoming container
     }
 }

--- a/src/test/java/org/spongepowered/common/test/stub/block/StubState.java
+++ b/src/test/java/org/spongepowered/common/test/stub/block/StubState.java
@@ -100,6 +100,11 @@ public final class StubState implements BlockState, SpongeImmutableDataHolder<Bl
     }
 
     @Override
+    public DataContainer rawData() {
+        return null;
+    }
+
+    @Override
     public boolean validateRawData(final DataView container) {
         return false;
     }


### PR DESCRIPTION
[[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2463)|**Sponge**]

- Raw data is now usually an internal `CompoundTag` and has nothing to do with the `DataSerializable#toContainer()`/`DataBuilder#build(DataView)` methods.
- Implemented new method `SerializableDataHolder#rawData()`.