### PR TITLE
Enchantement ids were not retrieved correctly during deserialization

### DIFF
--- a/src/main/java/org/spongepowered/common/item/SpongeItemStack.java
+++ b/src/main/java/org/spongepowered/common/item/SpongeItemStack.java
@@ -356,10 +356,8 @@ public final class SpongeItemStack  {
             for (int i = 0; i < nbttaglist.size(); ++i)
             {
                 final CompoundTag nbttagcompound = nbttaglist.getCompound(i);
-                final String id = nbttagcompound.getString(Constants.Item.ITEM_ENCHANTMENT_ID);
                 final short lvl = nbttagcompound.getShort(Constants.Item.ITEM_ENCHANTMENT_LEVEL);
 
-                nbttagcompound.putString(Constants.Item.ITEM_ENCHANTMENT_ID, id);
                 nbttagcompound.putShort(Constants.Item.ITEM_ENCHANTMENT_LEVEL, lvl);
             }
         }

--- a/src/main/java/org/spongepowered/common/item/SpongeItemStack.java
+++ b/src/main/java/org/spongepowered/common/item/SpongeItemStack.java
@@ -356,10 +356,10 @@ public final class SpongeItemStack  {
             for (int i = 0; i < nbttaglist.size(); ++i)
             {
                 final CompoundTag nbttagcompound = nbttaglist.getCompound(i);
-                final short id = nbttagcompound.getShort(Constants.Item.ITEM_ENCHANTMENT_ID);
+                final String id = nbttagcompound.getString(Constants.Item.ITEM_ENCHANTMENT_ID);
                 final short lvl = nbttagcompound.getShort(Constants.Item.ITEM_ENCHANTMENT_LEVEL);
 
-                nbttagcompound.putShort(Constants.Item.ITEM_ENCHANTMENT_ID, id);
+                nbttagcompound.putString(Constants.Item.ITEM_ENCHANTMENT_ID, id);
                 nbttagcompound.putShort(Constants.Item.ITEM_ENCHANTMENT_LEVEL, lvl);
             }
         }


### PR DESCRIPTION
### Version
Minecraft: 1.19.4
SpongeAPI: 10.1.0-SNAPSHOT
Sponge: 1.19.4-10.1.0-SNAPSHOT
SpongeVanilla: 1.19.4-10.0.0-RC0

### The bug
The deserialization of an enchanted item in a config file produces an item without its enchantments.  
Reported by #3904.

### Description
During the deserilization of an enchanted item, it will first create a `CompoundTag` from `UnsafeData` and then fix the enchantment data. The problem is that the enchantment ids in the `CompoundTag` are String which represent the resource location of an enchantment but they were retrieved as short. As a result, the modified `CompoundTag` contained enchantment ids with "0s" as value.
After that, if the enchantments were retrieved from the itemstack, the Optional was empty because it couldn't retrieved the enchantment type from the incorrect value "0s".

### The fix
The fix is to retrieve and set as a string the enchantment id in the nbt and not as a short. 
