### PR TITLE
Fix minor issues with show_entity hover in messages

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/util/text/event/HoverEventMixin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/util/text/event/HoverEventMixin.java
@@ -71,7 +71,7 @@ public abstract class HoverEventMixin implements HoverEventBridge {
                         String name = nbt.getString("name");
                         EntityType type = null;
                         if (nbt.hasKey("type", Constants.NBT.TAG_STRING)) {
-                            type = SpongeImpl.getGame().getRegistry().getType(EntityType.class, name).orElse(null);
+                            type = SpongeImpl.getGame().getRegistry().getType(EntityType.class, nbt.getString("type")).orElse(null);
                         }
 
                         UUID uniqueId = UUID.fromString(nbt.getString("id"));

--- a/src/main/java/org/spongepowered/common/text/action/SpongeHoverAction.java
+++ b/src/main/java/org/spongepowered/common/text/action/SpongeHoverAction.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.text.action;
 import net.minecraft.entity.EntityList;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.event.HoverEvent;
@@ -66,7 +67,10 @@ public class SpongeHoverAction {
                 nbt.setString("id", entity.getUniqueId().toString());
 
                 if (entity.getType().isPresent()) {
-                    nbt.setString("type", EntityList.getKey(((SpongeEntityType) entity.getType().get()).entityClass).toString());
+                    ResourceLocation resource = EntityList.getKey(((SpongeEntityType) entity.getType().get()).entityClass);
+                    if (resource != null) {
+                        nbt.setString("type", resource.toString());
+                    }
                 }
 
                 nbt.setString("name", entity.getName());


### PR DESCRIPTION
The entity name was being used instead of the entity type, causing the type to not be shown to the user unless it happened to be the same as the entity name.

And in some cases such as an entity type (or name, before these changes) being "Player" it would cause an null pointer exception and not send the message at all.