### PR TITLE
Improved sponge Humans skins

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -377,6 +377,12 @@ public final class DataRegistrar {
         DataUtil.registerDualProcessor(SkinData.class, SpongeSkinData.class, ImmutableSkinData.class,
                 ImmutableSpongeSkinData.class, new SkinDataProcessor());
 
+        DataUtil.registerDualProcessor(SkinTextureData.class, SpongeSkinTextureData.class, ImmutableSkinTextureData.class,
+                ImmutableSpongeSkinTextureData.class, new SkinTextureDataProcessor());
+
+        DataUtil.registerDualProcessor(SkinSignatureData.class, SpongeSkinSignatureData.class, ImmutableSkinSignatureData.class,
+                ImmutableSpongeSkinSignatureData.class, new SkinSignatureDataProcessor());
+
         DataUtil.registerDualProcessor(ExpOrbData.class, SpongeExpOrbData.class, ImmutableExpOrbData.class,
                 ImmutableSpongeExpOrbData.class, new ExpOrbDataProcessor());
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSkinSignatureData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSkinSignatureData.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSkinSignatureData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SkinSignatureData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSkinSignatureData;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+
+public class ImmutableSpongeSkinSignatureData extends AbstractImmutableSingleData<String, ImmutableSkinSignatureData, SkinSignatureData> implements ImmutableSkinSignatureData {
+
+    private final ImmutableSpongeValue<String> skinValue;
+
+    public ImmutableSpongeSkinSignatureData(String value) {
+        super(ImmutableSkinSignatureData.class, value, Keys.SKIN_SIGNATURE);
+        this.skinValue = new ImmutableSpongeValue<>(Keys.SKIN_SIGNATURE, value);
+    }
+
+    @Override
+    public SkinSignatureData asMutable() {
+        return new SpongeSkinSignatureData(this.value);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer()
+            .set(Keys.SKIN_SIGNATURE.getQuery(), this.value.toString());
+    }
+
+    @Override
+    public ImmutableValue<String> skinSignature() {
+        return this.skinValue;
+    }
+
+    @Override
+    protected ImmutableValue<?> getValueGetter() {
+        return skinSignature();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSkinTextureData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSkinTextureData.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSkinTextureData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SkinTextureData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSkinTextureData;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+
+public class ImmutableSpongeSkinTextureData extends AbstractImmutableSingleData<String, ImmutableSkinTextureData, SkinTextureData> implements ImmutableSkinTextureData {
+
+    private final ImmutableSpongeValue<String> skinValue;
+
+    public ImmutableSpongeSkinTextureData(String value) {
+        super(ImmutableSkinTextureData.class, value, Keys.SKIN_TEXTURE);
+        this.skinValue = new ImmutableSpongeValue<>(Keys.SKIN_TEXTURE, value);
+    }
+
+    @Override
+    public SkinTextureData asMutable() {
+        return new SpongeSkinTextureData(this.value);
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer()
+            .set(Keys.SKIN_TEXTURE.getQuery(), this.value.toString());
+    }
+
+    @Override
+    public ImmutableValue<String> skinTexture() {
+        return this.skinValue;
+    }
+
+    @Override
+    protected ImmutableValue<?> getValueGetter() {
+        return skinTexture();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSkinSignatureData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSkinSignatureData.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSkinSignatureData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SkinSignatureData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeSkinSignatureData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.util.Constants;
+
+public class SpongeSkinSignatureData extends AbstractSingleData<String, SkinSignatureData, ImmutableSkinSignatureData> implements SkinSignatureData {
+
+    public SpongeSkinSignatureData() {
+        super(SkinSignatureData.class, "", Keys.SKIN_SIGNATURE);
+    }
+
+    public SpongeSkinSignatureData(String Signature) {
+        super(SkinSignatureData.class, Signature, Keys.SKIN_SIGNATURE);
+    }
+
+    @Override
+    public SkinSignatureData copy() {
+        return new SpongeSkinSignatureData(getValue());
+    }
+
+    @Override
+    public ImmutableSkinSignatureData asImmutable() {
+        return new ImmutableSpongeSkinSignatureData(getValue());
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer()
+            .set(Constants.GameProfile.SKIN_SIGNATURE, getValue());
+    }
+
+    @Override
+    public Value<String> skinSignature() {
+        return new SpongeValue<>(Keys.SKIN_SIGNATURE, getValue());
+    }
+
+    @Override
+    protected Value<?> getValueGetter() {
+        return skinSignature();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSkinTextureData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSkinTextureData.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSkinTextureData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SkinTextureData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeSkinTextureData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.util.Constants;
+
+public class SpongeSkinTextureData extends AbstractSingleData<String, SkinTextureData, ImmutableSkinTextureData> implements SkinTextureData {
+
+    public SpongeSkinTextureData() {
+        super(SkinTextureData.class, "", Keys.SKIN_TEXTURE);
+    }
+
+    public SpongeSkinTextureData(String texture) {
+        super(SkinTextureData.class, texture, Keys.SKIN_TEXTURE);
+    }
+
+    @Override
+    public SkinTextureData copy() {
+        return new SpongeSkinTextureData(getValue());
+    }
+
+    @Override
+    public ImmutableSkinTextureData asImmutable() {
+        return new ImmutableSpongeSkinTextureData(getValue());
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer()
+            .set(Constants.GameProfile.SKIN_TEXTURE, getValue());
+    }
+
+    @Override
+    public Value<String> skinTexture() {
+        return new SpongeValue<>(Keys.SKIN_TEXTURE, getValue());
+    }
+
+    @Override
+    protected Value<?> getValueGetter() {
+        return skinTexture();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/SkinSignatureDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/SkinSignatureDataProcessor.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.data.entity;
+
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSkinSignatureData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SkinSignatureData;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSkinSignatureData;
+import org.spongepowered.common.data.processor.common.AbstractEntitySingleDataProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.entity.living.human.EntityHuman;
+
+import java.util.Optional;
+
+public class SkinSignatureDataProcessor extends
+        AbstractEntitySingleDataProcessor<EntityHuman, String, Value<String>, SkinSignatureData, ImmutableSkinSignatureData> {
+
+    public SkinSignatureDataProcessor() {
+        super(EntityHuman.class, Keys.SKIN_SIGNATURE);
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        if (!(container instanceof EntityHuman)) {
+            return DataTransactionResult.failNoData();
+        }
+        return ((EntityHuman) container).removeSkinSignature();
+    }
+
+    @Override
+    protected Value<String> constructValue(String actualValue) {
+        return new SpongeValue<>(Keys.SKIN_SIGNATURE, actualValue);
+    }
+
+    @Override
+    protected boolean set(EntityHuman entity, String value) {
+        return entity.setSkinSignature(value);
+    }
+
+    @Override
+    protected Optional<String> getVal(EntityHuman entity) {
+        return Optional.ofNullable(entity.getSkinSignature());
+    }
+
+    @Override
+    protected ImmutableValue<String> constructImmutableValue(String value) {
+        return new ImmutableSpongeValue<String>(Keys.SKIN_SIGNATURE, value);
+    }
+
+    @Override
+    protected SkinSignatureData createManipulator() {
+        return new SpongeSkinSignatureData();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/SkinTextureDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/SkinTextureDataProcessor.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.data.entity;
+
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSkinTextureData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SkinTextureData;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSkinTextureData;
+import org.spongepowered.common.data.processor.common.AbstractEntitySingleDataProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.entity.living.human.EntityHuman;
+
+import java.util.Optional;
+
+public class SkinTextureDataProcessor extends
+        AbstractEntitySingleDataProcessor<EntityHuman, String, Value<String>, SkinTextureData, ImmutableSkinTextureData> {
+
+    public SkinTextureDataProcessor() {
+        super(EntityHuman.class, Keys.SKIN_TEXTURE);
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        if (!(container instanceof EntityHuman)) {
+            return DataTransactionResult.failNoData();
+        }
+        return ((EntityHuman) container).removeSkinTexture();
+    }
+
+    @Override
+    protected Value<String> constructValue(String actualValue) {
+        return new SpongeValue<>(Keys.SKIN_TEXTURE, actualValue);
+    }
+
+    @Override
+    protected boolean set(EntityHuman entity, String value) {
+        return entity.setSkinTexture(value);
+    }
+
+    @Override
+    protected Optional<String> getVal(EntityHuman entity) {
+        return Optional.ofNullable(entity.getSkinTexture());
+    }
+
+    @Override
+    protected ImmutableValue<String> constructImmutableValue(String value) {
+        return new ImmutableSpongeValue<String>(Keys.SKIN_TEXTURE, value);
+    }
+
+    @Override
+    protected SkinTextureData createManipulator() {
+        return new SpongeSkinTextureData();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/data/KeyRegistryModule.java
@@ -403,6 +403,10 @@ public class KeyRegistryModule implements AdditionalCatalogRegistryModule<Key<?>
 
         this.register("skin_unique_id", Key.builder().type(TypeTokens.UUID_VALUE_TOKEN).id("skin_uuid").name("Skin UUID").query(of("SkinUUID")).build());
 
+        this.register("skin_texture", Key.builder().type(TypeTokens.STRING_VALUE_TOKEN).id("skin_texture").name("Skin Texture").query(of("SkinTexture")).build());
+
+        this.register("skin_signature", Key.builder().type(TypeTokens.STRING_VALUE_TOKEN).id("skin_signature").name("Skin Signature").query(of("SkinSignature")).build());
+
         this.register("moisture", Key.builder().type(TypeTokens.BOUNDED_INTEGER_VALUE_TOKEN).id("moisture").name("Moisture").query(of("Moisture")).build());
 
         this.register("angry", Key.builder().type(TypeTokens.BOOLEAN_VALUE_TOKEN).id("angry").name("Angry").query(of("Angry")).build());

--- a/src/main/java/org/spongepowered/common/util/Constants.java
+++ b/src/main/java/org/spongepowered/common/util/Constants.java
@@ -1093,6 +1093,8 @@ public final class Constants {
     public static final class GameProfile {
 
         public static final DataQuery SKIN_UUID = of("SkinUUID");
+        public static final DataQuery SKIN_TEXTURE = of("SkinTexture");
+        public static final DataQuery SKIN_SIGNATURE = of("SkinSignature");
         // RepresentedPlayerData
         public static final DataQuery GAME_PROFILE_ID = of("Id");
         public static final DataQuery GAME_PROFILE_NAME = of("Name");


### PR DESCRIPTION
Set the default value for human DataManager's PlayerModelFlagParameter to be 127 instead of 0.
Meaning that sponge human entities show their outer skin layers by default.

Also update human DataManager's to reflect a change in which hand is the main one.

And added new keys to set sponge human entities to have a specific skin texture (and signature),
instead of always using the latest from a specific player UUID.