### PR TITLE
Convert arrays from NBT to JSON.

### DIFF
--- a/src/main/java/org/spongepowered/common/data/persistence/JsonDataFormat.java
+++ b/src/main/java/org/spongepowered/common/data/persistence/JsonDataFormat.java
@@ -51,6 +51,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -211,7 +212,29 @@ public final class JsonDataFormat extends SpongeCatalogType implements StringDat
         } else if (value instanceof String) {
             writer.value((String) value);
         } else if (value instanceof Iterable) {
-            writeArray(writer, (Iterable<?>) value);
+            writer.beginArray();
+            for (Object item : (Iterable<?>) value) {
+                write(writer, item);
+            }
+            writer.endArray();
+        } else if (value instanceof byte[]) {
+            writer.beginArray();
+            for (Object item : (byte[]) value) {
+                write(writer, item);
+            }
+            writer.endArray();
+        } else if (value instanceof int[]) {
+            writer.beginArray();
+            for (Object item : (int[]) value) {
+                write(writer, item);
+            }
+            writer.endArray();
+        } else if (value instanceof long[]) {
+            writer.beginArray();
+            for (Object item : (long[]) value) {
+                write(writer, item);
+            }
+            writer.endArray();
         } else if (value instanceof Map) {
             writeMap(writer, (Map<?, ?>) value);
         } else if (value instanceof DataSerializable) {
@@ -221,14 +244,6 @@ public final class JsonDataFormat extends SpongeCatalogType implements StringDat
         } else {
             throw new IllegalArgumentException("Unable to translate object to JSON: " + value);
         }
-    }
-
-    private static void writeArray(JsonWriter writer, Iterable<?> iterable) throws IOException {
-        writer.beginArray();
-        for (Object value : iterable) {
-            write(writer, value);
-        }
-        writer.endArray();
     }
 
     private static void writeMap(JsonWriter writer, Map<?, ?> map) throws IOException {

--- a/src/main/java/org/spongepowered/common/data/persistence/JsonDataFormat.java
+++ b/src/main/java/org/spongepowered/common/data/persistence/JsonDataFormat.java
@@ -51,7 +51,6 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -219,20 +218,20 @@ public final class JsonDataFormat extends SpongeCatalogType implements StringDat
             writer.endArray();
         } else if (value instanceof byte[]) {
             writer.beginArray();
-            for (Object item : (byte[]) value) {
-                write(writer, item);
+            for (byte item : (byte[]) value) {
+                writer.value(item);
             }
             writer.endArray();
         } else if (value instanceof int[]) {
             writer.beginArray();
-            for (Object item : (int[]) value) {
-                write(writer, item);
+            for (int item : (int[]) value) {
+                writer.value(item);
             }
             writer.endArray();
         } else if (value instanceof long[]) {
             writer.beginArray();
-            for (Object item : (long[]) value) {
-                write(writer, item);
+            for (long item : (long[]) value) {
+                writer.value(item);
             }
             writer.endArray();
         } else if (value instanceof Map) {

--- a/src/main/java/org/spongepowered/common/data/persistence/NbtTranslator.java
+++ b/src/main/java/org/spongepowered/common/data/persistence/NbtTranslator.java
@@ -188,7 +188,7 @@ public final class NbtTranslator implements DataTranslator<NBTTagCompound> {
         checkNotNull(view);
         checkNotNull(key);
         checkArgument(!key.isEmpty());
-        checkArgument(type > Constants.NBT.TAG_END && type <= Constants.NBT.TAG_INT_ARRAY);
+        checkArgument(type > Constants.NBT.TAG_END && type <= Constants.NBT.TAG_LONG_ARRAY);
         switch (type) {
             case Constants.NBT.TAG_BYTE:
                 if (key.contains(BOOLEAN_IDENTIFIER)) {


### PR DESCRIPTION
Arrays are not an Iterable instance like lists are.

Also accept long arrays when translating NBT.

This fixes plugins having errors when trying to convert NBT with int/long/byte arrays to JSON. Which usually happens with firework items (the Colors and FadeColors are int arrays).

However upon converting this JSON back to NBT, it will create lists of ints instead of int arrays etc.