### PR TITLE
Auth event called twice

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerLoginPacketListenerImplMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerLoginPacketListenerImplMixin.java
@@ -185,21 +185,23 @@ public abstract class ServerLoginPacketListenerImplMixin implements ServerLoginP
         return event.isCancelled();
     }
 
-    @Inject(method = "handleHello(Lnet/minecraft/network/protocol/login/ServerboundHelloPacket;)V",
-        at = @At(
-            value = "FIELD",
-            target = "Lnet/minecraft/server/network/ServerLoginPacketListenerImpl$State;KEY:Lnet/minecraft/server/network/ServerLoginPacketListenerImpl$State;",
-            opcode = Opcodes.GETSTATIC),
-        cancellable = true)
-    private void impl$fireAuthEventOffline(final CallbackInfo ci) {
+    @Inject(method = "startClientVerification(Lcom/mojang/authlib/GameProfile;)V", at = @At("HEAD"), cancellable = true)
+    private void impl$fireAuthEventOffline(final GameProfile gameProfile, final CallbackInfo ci) {
         // Move this check up here, so that the UUID isn't null when we fire the event
         // TODO broken
         /*if (!this.authenticatedProfile.isComplete()) {
             this.authenticatedProfile = this.shadow$createFakeProfile(this.authenticatedProfile);
         }*/
 
-        if (this.bridge$fireAuthEvent()) {
-            ci.cancel();
+        if(gameProfile.equals(createOfflineProfile(gameProfile.getName()))) {
+            if (this.bridge$fireAuthEvent()) {
+                ci.cancel();
+            }
         }
     }
+
+    @Shadow protected static GameProfile createOfflineProfile(String $$0) {
+        throw new UnsupportedOperationException("Shadowed createOfflineProfile");
+    }
+
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerLoginPacketListenerImplMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerLoginPacketListenerImplMixin.java
@@ -195,7 +195,6 @@ public abstract class ServerLoginPacketListenerImplMixin implements ServerLoginP
 
         if (this.bridge$fireAuthEvent()) {
             ci.cancel();
-            System.out.println("hello");
         }
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerLoginPacketListenerImplMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerLoginPacketListenerImplMixin.java
@@ -34,7 +34,6 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerLoginPacketListenerImpl;
 import net.minecraft.server.players.PlayerList;
-import org.objectweb.asm.Opcodes;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.Cause;
 import org.spongepowered.api.event.EventContext;

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerLoginPacketListenerImplMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/network/ServerLoginPacketListenerImplMixin.java
@@ -184,23 +184,19 @@ public abstract class ServerLoginPacketListenerImplMixin implements ServerLoginP
         return event.isCancelled();
     }
 
-    @Inject(method = "startClientVerification(Lcom/mojang/authlib/GameProfile;)V", at = @At("HEAD"), cancellable = true)
-    private void impl$fireAuthEventOffline(final GameProfile gameProfile, final CallbackInfo ci) {
+    @Inject(method = "handleHello(Lnet/minecraft/network/protocol/login/ServerboundHelloPacket;)V", at = @At(value = "INVOKE", target =
+            "startClientVerification(Lcom/mojang/authlib/GameProfile;)V", ordinal = 1), cancellable = true)
+    private void impl$fireAuthEventOffline(final CallbackInfo ci) {
         // Move this check up here, so that the UUID isn't null when we fire the event
         // TODO broken
         /*if (!this.authenticatedProfile.isComplete()) {
             this.authenticatedProfile = this.shadow$createFakeProfile(this.authenticatedProfile);
         }*/
 
-        if(gameProfile.equals(createOfflineProfile(gameProfile.getName()))) {
-            if (this.bridge$fireAuthEvent()) {
-                ci.cancel();
-            }
+        if (this.bridge$fireAuthEvent()) {
+            ci.cancel();
+            System.out.println("hello");
         }
-    }
-
-    @Shadow protected static GameProfile createOfflineProfile(String $$0) {
-        throw new UnsupportedOperationException("Shadowed createOfflineProfile");
     }
 
 }


### PR DESCRIPTION
## Version
Minecraft: 1.20.2
SpongeAPI: 11.0.0-SNAPSHOT
Sponge: 1.20.2-11.0.0-SNAPSHOT
SpongeVanilla: 1.20.2-11.0.0-RC0

## The bug
During the login of a player, the event `ServerSideConnectionEvent.Auth` was called twice.
Reported by #3907.

## Description
When a player logs in, the event `ServerSideConnectionEvent.Auth` is called for the first time by `ServerLoginPacketListenerImplMixin` and then by `ServerLoginPacketListenerImpl_1Mixin` if the server is on online mode, but and not called if it is on offline mode.
The reason for this is due to how the mixin `ServerLoginPacketListenerImpl#impl$fireAuthEventOffline` was injected: at the assignment of the field _state_ with the value KEY. In API-10 (1.19.4), this was done in singleplayer or if the server is in offline mode, but on API-11 (1.20.2), this is done if the server is on online mode. Later in the login process, the mixin `ServerLoginPacketListenerImpl_1Mixin` will trigger the event if the player was authenticated on an online server.

## The fix
As the name suggests, `fireAuthEventOffline` should only call the event when the server is in offline mode.
The fix changes the injection point to the method `startClientVerification` because it's called when the server is in offline mode. It then checks whether if the game profile given as argument is an "offline profile". This is done by comparing it with the result of a call to the method `createOfflineProfile` because the profile argument comes from that method (ie: `this.startClientVerification(createOfflineProfile(this.requestedUsername))`).

`startClientVerification` is also called in other cases: when it is on a singleplayer, but we were in the context of a server, and when the player is authenticated to the server, but the check skips the event trigger.  