### PR TITLE
Use implementation guava version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ val recommendedVersion: String by project
 val apiAdventureVersion: String by project
 val apiConfigurateVersion: String by project
 val apiGsonVersion: String by project
-val apiGuavaVersion: String by project
+val guavaVersion: String by project
 val apiPluginSpiVersion: String by project
 val asmVersion: String by project
 val log4jVersion: String by project
@@ -169,7 +169,7 @@ dependencies {
     launchConfig("org.spongepowered:plugin-spi:$apiPluginSpiVersion")
     launchConfig("org.spongepowered:mixin:$mixinVersion")
     launchConfig("org.checkerframework:checker-qual:$checkerVersion")
-    launchConfig("com.google.guava:guava:$apiGuavaVersion") {
+    launchConfig("com.google.guava:guava:$guavaVersion") {
         exclude(group = "com.google.code.findbugs", module = "jsr305") // We don't want to use jsr305, use checkerframework
         exclude(group = "org.checkerframework", module = "checker-qual") // We use our own version
         exclude(group = "com.google.j2objc", module = "j2objc-annotations")
@@ -183,7 +183,7 @@ dependencies {
     // Applaunch -- initialization that needs to occur without game access
     applaunchConfig("org.checkerframework:checker-qual:$checkerVersion")
     applaunchConfig("org.apache.logging.log4j:log4j-api:$log4jVersion")
-    applaunchConfig("com.google.guava:guava:$apiGuavaVersion")
+    applaunchConfig("com.google.guava:guava:$guavaVersion")
     applaunchConfig(platform("org.spongepowered:configurate-bom:$apiConfigurateVersion"))
     applaunchConfig("org.spongepowered:configurate-core") {
         exclude(group = "org.checkerframework", module = "checker-qual") // We use our own version

--- a/vanilla/build.gradle.kts
+++ b/vanilla/build.gradle.kts
@@ -238,7 +238,7 @@ dependencies {
     val apiAdventureVersion: String by project
     val apiConfigurateVersion: String by project
     val apiGsonVersion: String by project
-    val apiGuavaVersion: String by project
+    val guavaVersion: String by project
     val apiPluginSpiVersion: String by project
     val forgeAutoRenamingToolVersion: String by project
     val jlineVersion: String by project
@@ -322,7 +322,7 @@ dependencies {
     bootstrapLibraries("org.spongepowered:mixin:$mixinVersion")
     bootstrapLibraries("org.ow2.asm:asm-util:$asmVersion")
     bootstrapLibraries("org.ow2.asm:asm-tree:$asmVersion")
-    bootstrapLibraries("com.google.guava:guava:$apiGuavaVersion")
+    bootstrapLibraries("com.google.guava:guava:$guavaVersion")
 
     // Launch Dependencies - Needed to bootstrap the engine(s)
     // Not needing to be source-visible past the init phase


### PR DESCRIPTION
Stop using API guava version and use the version defined in the implementation gradle.properties