### PR TITLE
WIP Allow overriding offerSingle and removeSingle

### DIFF
--- a/src/main/java/org/spongepowered/common/data/holder/SpongeMutableDataHolder.java
+++ b/src/main/java/org/spongepowered/common/data/holder/SpongeMutableDataHolder.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.data.value.MergeFunction;
 import org.spongepowered.api.data.value.Value;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.common.data.key.SpongeKey;
+import org.spongepowered.common.data.provider.GenericMutableDataProvider;
 import org.spongepowered.common.util.DataUtil;
 
 import java.util.Collection;
@@ -89,6 +90,9 @@ public interface SpongeMutableDataHolder extends SpongeDataHolder, DataHolder.Mu
         final SpongeKey<? extends CollectionValue<E, Collection<E>>, Collection<E>> key0 =
                 (SpongeKey<? extends CollectionValue<E, Collection<E>>, Collection<E>>) key;
         return this.impl$applyTransaction(key0, (p, m) -> {
+            if (p instanceof GenericMutableDataProvider) {
+                return ((GenericMutableDataProvider)p).offerSingle(m, element);
+            }
                     final Collection<E> collection = p.get(m)
                             .map(DataUtil::ensureMutable)
                             .orElseGet(key0.getDefaultValueSupplier());

--- a/src/main/java/org/spongepowered/common/data/provider/GenericMutableDataProviderBase.java
+++ b/src/main/java/org/spongepowered/common/data/provider/GenericMutableDataProviderBase.java
@@ -235,4 +235,8 @@ public abstract class GenericMutableDataProviderBase<H, V extends Value<E>, E> e
         }
         return this.deleteAndGetResult((H) dataHolder);
     }
+
+    public <TE> DataTransactionResult offerSingle(final DataHolder.Mutable dataHolder, final TE element) {
+        return DataTransactionResult.failNoData();
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/provider/entity/LivingData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/LivingData.java
@@ -156,7 +156,7 @@ public final class LivingData {
                     .create(Keys.MAX_HEALTH)
                         .get(h -> (double) h.getMaxHealth())
                         .set((h, v) -> h.getAttribute(Attributes.MAX_HEALTH).setBaseValue(v))
-                    .create(Keys.POTION_EFFECTS)
+                    .createCollection(Keys.POTION_EFFECTS)
                         .get(h -> {
                             final Collection<MobEffectInstance> effects = h.getActiveEffects();
                             return PotionEffectUtil.copyAsPotionEffects(effects);
@@ -166,6 +166,9 @@ public final class LivingData {
                             for (final PotionEffect effect : v) {
                                 h.addEffect(PotionEffectUtil.copyAsEffectInstance(effect));
                             }
+                        })
+                        .single((h, v) -> {
+                            h.addEffect(PotionEffectUtil.copyAsEffectInstance(v));
                         })
                     .create(Keys.SCALE)
                         .get(h -> (double) h.getScale())


### PR DESCRIPTION
This is a very rough draft just to show some outlines.

Tries to solve the problem that offerSingle retrieves the whole list, modifies it and then offers it back as a set. This works fine for most things but it gets a bit awkward for potion effects as they can contain attributes which are reset, for example absorption. This causes you to get new set of absorption hearts every time new potion effects are offered. This is also a performance improvement in a sense.

I tried to go the alternative route which was to compare if the same effects are offered but it feels a bit awkward and clumsy.

Some open questions are:
- Should we expose this in the API instead of doing `instanceof` checks?
- The generic mess.
- Is this worth it?