### PR TITLE
[API-8] Fix removal of player capability on dimension change (Forge)

### DIFF
--- a/forge/src/mixins/java/org/spongepowered/forge/mixin/core/server/level/ServerLevelMixin_Forge.java
+++ b/forge/src/mixins/java/org/spongepowered/forge/mixin/core/server/level/ServerLevelMixin_Forge.java
@@ -22,34 +22,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.forge.mixin.core.world.entity;
+package org.spongepowered.forge.mixin.core.server.level;
 
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
-import net.minecraftforge.common.util.ITeleporter;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.common.bridge.world.entity.EntityBridge;
-import org.spongepowered.common.bridge.world.entity.PlatformEntityBridge;
-import org.spongepowered.common.world.portal.PortalLogic;
+import org.spongepowered.common.bridge.world.level.PlatformServerLevelBridge;
 
-@Mixin(Entity.class)
-public abstract class EntityMixin_Forge implements PlatformEntityBridge {
-
-    /**
-     * @author dualspiral - 8th August 2021, Minecraft 1.16.5
-     * @reason Redirects to our handling so we have common logic with Vanilla.
-     */
-    @Overwrite
-    @Nullable
-    public Entity changeDimension(final ServerLevel level, final ITeleporter teleporter) {
-        return ((EntityBridge) this).bridge$changeDimension(level, (PortalLogic) teleporter);
-    }
+@Mixin(ServerLevel.class)
+public abstract class ServerLevelMixin_Forge implements PlatformServerLevelBridge {
 
     @Override
-    public void bridge$revive() {
-        ((Entity) (Object) this).revive();
+    public void bridge$removeEntity(Entity entity, boolean keepData) {
+        if (entity instanceof net.minecraft.server.level.ServerPlayer) {
+            // Forge uses both removeEntity and removePlayer in ServerPlayer#changeDimension for some reason
+            ((ServerLevel) (Object) this).removePlayer((net.minecraft.server.level.ServerPlayer) entity, keepData);
+        } else {
+            ((ServerLevel) (Object) this).removeEntity(entity, keepData);
+        }
     }
 
 }

--- a/forge/src/mixins/resources/mixins.spongeforge.core.json
+++ b/forge/src/mixins/resources/mixins.spongeforge.core.json
@@ -31,6 +31,7 @@
         "network.FriendlyByteBufMixin_Forge",
         "server.BootstrapMixin_Forge",
         "server.MinecraftServerMixin_Forge",
+        "server.level.ServerLevelMixin_Forge",
         "server.level.ServerPlayerMixin_Forge",
         "server.network.ServerGamePacketListenerImplMixin_Forge",
         "world.entity.EntityMixin_Forge",

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java
@@ -136,6 +136,7 @@ import org.spongepowered.common.bridge.server.ServerScoreboardBridge;
 import org.spongepowered.common.bridge.server.level.ServerPlayerBridge;
 import org.spongepowered.common.bridge.world.BossEventBridge;
 import org.spongepowered.common.bridge.world.entity.player.PlayerBridge;
+import org.spongepowered.common.bridge.world.level.PlatformServerLevelBridge;
 import org.spongepowered.common.data.DataUtil;
 import org.spongepowered.common.data.type.SpongeSkinPart;
 import org.spongepowered.common.entity.EntityUtil;
@@ -501,11 +502,10 @@ public abstract class ServerPlayerMixin extends PlayerMixin implements SubjectBr
         }
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Override
     protected final Entity impl$performGameWinLogic() {
         this.shadow$unRide();
-        this.shadow$getLevel().removePlayerImmediately((net.minecraft.server.level.ServerPlayer) (Object) this);
+        ((PlatformServerLevelBridge) this.shadow$getLevel()).bridge$removeEntity((net.minecraft.server.level.ServerPlayer) (Object) this, true);
         if (!this.wonGame) {
             this.wonGame = true;
             this.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.WIN_GAME, this.seenCredits ? 0.0F : 1.0F));
@@ -524,8 +524,8 @@ public abstract class ServerPlayerMixin extends PlayerMixin implements SubjectBr
         this.connection.send(new ClientboundChangeDifficultyPacket(levelData.getDifficulty(), levelData.isDifficultyLocked()));
         final PlayerList playerlist = this.server.getPlayerList();
         playerlist.sendPlayerPermissionLevel((net.minecraft.server.level.ServerPlayer) (Object) this);
-        currentWorld.removePlayerImmediately((net.minecraft.server.level.ServerPlayer) (Object) this);
-        this.removed = false;
+        ((PlatformServerLevelBridge) currentWorld).bridge$removeEntity((net.minecraft.server.level.ServerPlayer) (Object) this, true);
+        this.bridge$revive();
     }
 
     @SuppressWarnings("ConstantConditions")


### PR DESCRIPTION
Fixes an issue where a `ServerPlayer` changing dimension would have its Capabilities invalidated due to `ServerWorld#removePlayerImmediately` being called with `keepData = false`. I'm not sure if this also happened for entities in general, but I've implemented `bridge$revive` for Forge just to make sure. It seems the groundwork for Forge compatibility has already been laid, but lacked an implementation.

Although this PR follows Forge's `changeDimesion` logic more closely, `ServerPlayerMixin#impl$prepareForPortalTeleport` will call `removePlayer` whereas Forge uses `removeEntity` for whatever reason. This shouldn't affect anything as prior to this change `removePlayerImmediately` was being called (which is the same as `removePlayer` with `keepData = false`).

I have only tested this with ProgressiveBosses because that's where I ran into the issue in the first place.