### PR TITLE
Remove invalid mixin reference

### DIFF
--- a/src/mixins/resources/mixins.sponge.core.json
+++ b/src/mixins/resources/mixins.sponge.core.json
@@ -241,7 +241,6 @@
         "world.level.dimension.DimensionTypeMixin",
         "world.level.dimension.LevelStemMixin",
         "world.level.entity.PersistentEntitySectionManagerMixin",
-        "world.level.gameevent.vibrations.VibrationListenerMixin",
         "world.level.levelgen.NoiseGeneratorSettingsMixin",
         "world.level.levelgen.WorldDimensionsMixin",
         "world.level.levelgen.WorldOptionsMixin",


### PR DESCRIPTION
The mixin was removed in https://github.com/SpongePowered/Sponge/commit/4712188a40039d45fc05d2208b3152246f5c7ebd 