### PR TITLE
Fire ValueChange event for entities when plugins offer data

### DIFF
--- a/src/accessors/java/org/spongepowered/common/accessor/world/entity/EntityAccessor.java
+++ b/src/accessors/java/org/spongepowered/common/accessor/world/entity/EntityAccessor.java
@@ -33,6 +33,7 @@ import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.entity.EntityInLevelCallback;
 import net.minecraft.world.level.portal.PortalInfo;
 import net.minecraft.world.phys.Vec3;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -93,6 +94,8 @@ public interface EntityAccessor {
     @Accessor("portalEntrancePos") void accessor$portalEntrancePos(final BlockPos portalEntrancePos);
 
     @Accessor("passengers") ImmutableList<Entity> accessor$passengers();
+
+    @Accessor("levelCallback") EntityInLevelCallback accessor$levelCallback();
 
     @Invoker("setRot") void invoker$setRot(final float yRot, final float xRot);
 


### PR DESCRIPTION
We now fire `ChangeDataHolderEvent.ValueChange` for entities when plugins offer data if the entity is spawned in the world. Limiting this to entities only should make this fairly more simpler and we can later expand on the support for more potential use cases.

Supporting this for item stacks is a bit problematic as it can be literally anywhere but they do have reference to a potential entity holder which we could use to check against whatever its worthwhile.

cc @gabizou api8/all-key-value-changes