### PR TITLE
Bump Mixin compatibility level to Java 21

### DIFF
--- a/src/mixins/resources/mixins.sponge.parent.json
+++ b/src/mixins/resources/mixins.sponge.parent.json
@@ -1,7 +1,7 @@
 {
     "minVersion": "0.8",
     "target": "@env(DEFAULT)",
-    "compatibilityLevel": "JAVA_17",
+    "compatibilityLevel": "JAVA_21",
     "injectors": {
         "defaultRequire": 1
     }


### PR DESCRIPTION
Missed mixin in https://github.com/SpongePowered/Sponge/commit/f77cc3b100c6bd350d9a80050b8babd4cba28a9e