### PR TITLE
Some viewer-related fixes

### DIFF
--- a/src/accessors/java/org/spongepowered/common/accessor/client/multiplayer/ClientLevelAccessor.java
+++ b/src/accessors/java/org/spongepowered/common/accessor/client/multiplayer/ClientLevelAccessor.java
@@ -25,13 +25,17 @@
 package org.spongepowered.common.accessor.client.multiplayer;
 
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.DimensionSpecialEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.entity.TransientEntitySectionManager;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(ClientLevel.class)
 public interface ClientLevelAccessor {
 
     @Accessor("entityStorage") TransientEntitySectionManager<Entity> accessor$getEntityStorage();
+
+    @Mutable @Accessor("effects") void accessor$effects(DimensionSpecialEffects effects);
 }

--- a/src/main/java/org/spongepowered/common/data/provider/item/stack/BookItemStackData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/item/stack/BookItemStackData.java
@@ -55,8 +55,7 @@ public final class BookItemStackData {
                             return LegacyComponentSerializer.legacySection().deserialize(content.author());
                         })
                         .set((h, v) -> {
-                            final WrittenBookContent content = h.get(DataComponents.WRITTEN_BOOK_CONTENT);
-                            // TODO handle missing data?
+                            final WrittenBookContent content = h.getOrDefault(DataComponents.WRITTEN_BOOK_CONTENT, WrittenBookContent.EMPTY);
                             final String author = LegacyComponentSerializer.legacySection().serialize(v);
                             h.set(DataComponents.WRITTEN_BOOK_CONTENT,
                                     new WrittenBookContent(content.title(), author, content.generation(), content.pages(), content.resolved()));
@@ -71,11 +70,10 @@ public final class BookItemStackData {
                             return content.generation();
                         })
                         .setAnd((h, v) -> {
-                            if (v < 0) {
+                            if (v < 0 || v > 3) {
                                 return false;
                             }
-                            final WrittenBookContent content = h.get(DataComponents.WRITTEN_BOOK_CONTENT);
-                            // TODO handle missing data?
+                            final WrittenBookContent content = h.getOrDefault(DataComponents.WRITTEN_BOOK_CONTENT, WrittenBookContent.EMPTY);
                             h.set(DataComponents.WRITTEN_BOOK_CONTENT,
                                     new WrittenBookContent(content.title(), content.author(), v, content.pages(), content.resolved()));
                             return true;
@@ -90,15 +88,13 @@ public final class BookItemStackData {
                             return content.pages().stream().map(Filterable::raw).map(SpongeAdventure::asAdventure).toList();
                         })
                         .set((h, v) -> {
-                            final WrittenBookContent content = h.get(DataComponents.WRITTEN_BOOK_CONTENT);
-                            // TODO handle missing data?
+                            final WrittenBookContent content = h.getOrDefault(DataComponents.WRITTEN_BOOK_CONTENT, WrittenBookContent.EMPTY);
                             var pages = v.stream().map(SpongeAdventure::asVanilla).map(Filterable::passThrough).toList();
                             h.set(DataComponents.WRITTEN_BOOK_CONTENT,
                                     new WrittenBookContent(content.title(), content.author(), content.generation(), pages, content.resolved()));
                         })
                         .delete(h -> {
-                            final WrittenBookContent content = h.get(DataComponents.WRITTEN_BOOK_CONTENT);
-                            // TODO handle missing data?
+                            final WrittenBookContent content = h.getOrDefault(DataComponents.WRITTEN_BOOK_CONTENT, WrittenBookContent.EMPTY);
                             h.set(DataComponents.WRITTEN_BOOK_CONTENT,
                                     new WrittenBookContent(content.title(), content.author(), content.generation(), Collections.emptyList(), content.resolved()));
                         })

--- a/src/main/java/org/spongepowered/common/network/packet/SpongePacketHandler.java
+++ b/src/main/java/org/spongepowered/common/network/packet/SpongePacketHandler.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.network.packet;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.DimensionSpecialEffects;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.entity.Entity;
@@ -37,8 +38,8 @@ import org.spongepowered.api.network.ClientConnectionState;
 import org.spongepowered.api.network.EngineConnectionStates;
 import org.spongepowered.api.network.channel.packet.PacketChannel;
 import org.spongepowered.common.SpongeCommon;
+import org.spongepowered.common.accessor.client.multiplayer.ClientLevelAccessor;
 import org.spongepowered.common.bridge.CreatorTrackedBridge;
-import org.spongepowered.common.bridge.world.level.LevelBridge;
 import org.spongepowered.common.bridge.world.level.chunk.LevelChunkBridge;
 import org.spongepowered.common.network.channel.SpongeChannelManager;
 
@@ -99,7 +100,7 @@ public final class SpongePacketHandler {
                     }
 
                     final DimensionType dimensionType = SpongeCommon.vanillaRegistry(Registries.DIMENSION_TYPE).get(packet.dimensionLogic);
-                    ((LevelBridge) world).bridge$adjustDimensionLogic(dimensionType);
+                    ((ClientLevelAccessor) world).accessor$effects(DimensionSpecialEffects.forType(dimensionType));
                 }
         );
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/client/multiplayer/ClientLevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/client/multiplayer/ClientLevelMixin.java
@@ -27,11 +27,10 @@ package org.spongepowered.common.mixin.core.client.multiplayer;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.world.level.dimension.DimensionType;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.common.bridge.world.level.LevelBridge;
 import org.spongepowered.common.mixin.core.world.level.LevelMixin;
 
 @Mixin(ClientLevel.class)
-public abstract class ClientLevelMixin extends LevelMixin implements LevelBridge {
+public abstract class ClientLevelMixin extends LevelMixin {
 
     @Override
     public void bridge$adjustDimensionLogic(final DimensionType dimensionType) {


### PR DESCRIPTION
Viewer#sendWorldType():
- DimensionType effects are contained in `ClientLevel#effects` so we need to modify it instead of modifying actual DimensionType
- Removed `implements LevelBridge` from `ClientLevelMixin` because `LevelMixin` already implements it

BookItemStackData:
- Don't know if we want to expose `WrittenBookContent` or keep current keys but for now I just made it working with current stuff

BookUtil:
- There is no more need to manually localize book content because it's done on client
- `bookSlot` was changed from `inventory.items.size() + inventory.selected` to `inventory.selected` and container id was changed from `0` to `-2` because the only reason it works now is that (picture) size of red area (`inventoryMenu` indexing) luckily equals to size of blue area (`inventory.items.size()`). `-2` stands for `Player#inventory` and first 9 items in it is hotbar
![image](https://github.com/SpongePowered/Sponge/assets/82652479/34e1ad49-6b22-47c0-b6c0-b9756a8266c5)