### PR TITLE
Fix RegisterRegistryEvent.GameScoped being fired too soon

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeLifecycle.java
+++ b/src/main/java/org/spongepowered/common/SpongeLifecycle.java
@@ -116,9 +116,6 @@ public final class SpongeLifecycle implements Lifecycle {
         holder.setRootMinecraftRegistry((Registry<Registry<?>>) BuiltInRegistries.REGISTRY);
 
         SpongeRegistries.registerEarlyGlobalRegistries(holder);
-
-        // Plugin registries
-        this.game.eventManager().post(new AbstractRegisterRegistryEvent.GameScopedImpl(Cause.of(EventContext.empty(), this.game), this.game));
     }
 
     @Override
@@ -139,6 +136,9 @@ public final class SpongeLifecycle implements Lifecycle {
             // WORLDGEN ->
             case DIMENSIONS -> {
                 SpongeRegistries.registerGlobalRegistriesDimensionLayer((SpongeRegistryHolder) this.game, registryAccess, this.featureFlags);
+
+                // Plugin registries
+                this.game.eventManager().post(new AbstractRegisterRegistryEvent.GameScopedImpl(Cause.of(EventContext.empty(), this.game), this.game));
 
                 // Freeze Sponge Root - Registries are now available
                 holder.registryHolder().freezeSpongeRootRegistry();


### PR DESCRIPTION
Forge constructs mods after bootstrapping registries. That's why we shouldn't fire events during `SpongeLifecycle#establishEarlyGlobalRegistries` and `SpongeLifecycle#finalizeEarlyGlobalRegistries`.

`RegisterRegistryValueEvent.BuiltIn` is fired in `SpongeLifecycle#finalizeEarlyGlobalRegistries`. I'm not sure how we could fix that because vanilla registries are frozen before mods are constructed.