### PR TITLE
Fix: Resources incorrectly listed for plugin packs

### DIFF
--- a/vanilla/src/main/java/org/spongepowered/vanilla/server/packs/PluginPackResources.java
+++ b/vanilla/src/main/java/org/spongepowered/vanilla/server/packs/PluginPackResources.java
@@ -25,7 +25,6 @@
 package org.spongepowered.vanilla.server.packs;
 
 import com.mojang.logging.LogUtils;
-import net.minecraft.ResourceLocationException;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.AbstractPackResources;
@@ -47,7 +46,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/vanilla/src/main/java/org/spongepowered/vanilla/server/packs/PluginPackResources.java
+++ b/vanilla/src/main/java/org/spongepowered/vanilla/server/packs/PluginPackResources.java
@@ -91,33 +91,16 @@ public final class PluginPackResources extends AbstractPackResources {
     public void listResources(final PackType type, final String namespace, final String path, final ResourceOutput out) {
         try {
             final Path root = this.typeRoot(type);
-            final Path namespaceDir = root.resolve(namespace).toAbsolutePath();
-            try (final Stream<Path> stream = Files.walk(namespaceDir)) {
+            final Path namespaceDir = root.resolve(namespace);
+            final Path resourcesDir = namespaceDir.resolve(path);
+            try (final Stream<Path> stream = Files.walk(resourcesDir)) {
                 stream.filter(Files::isRegularFile)
-                        .filter(s -> !s.getFileName().toString().endsWith(".mcmeta"))
+                        .filter(filePath -> !filePath.getFileName().toString().endsWith(".mcmeta"))
                         .map(namespaceDir::relativize)
-                        .map(Object::toString)
-// TODO filter needed?                   .filter(p -> filterValidPath(namespace, p, fileNameValidator))
-                        .map(s -> new ResourceLocation(namespace, s))
-                        .forEach(loc -> {
-                            out.accept(loc, this.getResource(type, loc));
-                        });
+                        .map(filePath -> new ResourceLocation(namespace, filePath.toString()))
+                        .forEach(loc -> out.accept(loc, this.getResource(type, loc)));
             }
         } catch (final IOException ignored) {
-        }
-    }
-
-    private boolean filterValidPath(final String namespace, final String path, final Predicate<ResourceLocation> fileNameValidator) {
-        try {
-            final ResourceLocation loc = ResourceLocation.tryBuild(namespace, path);
-            if (loc == null) {
-                // LOGGER.warn("Invalid path in datapack: {}:{}, ignoring", $$1, $$7);
-                return false;
-            }
-            return fileNameValidator.test(loc);
-        } catch (ResourceLocationException e) {
-            // LOGGER.error(var13.getMessage());
-            return false;
         }
     }
 


### PR DESCRIPTION
Fixes #4064

- Uses the `path` argument of `listResources` to filter valid resources
- Adds logging of invalid paths