### PR TITLE
Remove manual update of bossbars locale

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/level/ServerPlayerMixin.java
@@ -39,7 +39,6 @@ import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.OutgoingChatMessage;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
-import net.minecraft.network.protocol.game.ClientboundBossEventPacket;
 import net.minecraft.network.protocol.game.ClientboundChangeDifficultyPacket;
 import net.minecraft.network.protocol.game.ClientboundGameEventPacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerAbilitiesPacket;
@@ -278,12 +277,6 @@ public abstract class ServerPlayerMixin extends PlayerMixin implements SubjectBr
         if (this.connection != null) {
             final Channel channel = ((ConnectionAccessor) ((ServerCommonPacketListenerImplAccessor) this.connection).accessor$connection()).accessor$channel();
             channel.attr(SpongeAdventure.CHANNEL_LOCALE).set(language);
-
-            SpongeAdventure.forEachBossBar(bar -> {
-                if (bar.getPlayers().contains(this)) {
-                    this.connection.send(ClientboundBossEventPacket.createUpdateNamePacket(bar));
-                }
-            });
 
             this.containerMenu.broadcastFullState();
         }


### PR DESCRIPTION
I'm not aware of how things worked before, but now client handle locale changing for all viewed bossbars on its own, so I think this can be removed