### PR TITLE
Fix client crash with portals

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/EntityMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/EntityMixin.java
@@ -424,7 +424,7 @@ public abstract class EntityMixin implements EntityBridge, PlatformEntityBridge,
     @Inject(method = "setAsInsidePortal", at = @At(value = "FIELD", opcode = Opcodes.PUTFIELD, shift = At.Shift.AFTER,
             target = "Lnet/minecraft/world/entity/Entity;portalProcess:Lnet/minecraft/world/entity/PortalProcessor;"))
     public void impl$onCreatePortalProcessor(final Portal $$0, final BlockPos $$1, final CallbackInfo ci) {
-        if (this.shadow$level().isClientSide()) {
+        if (((LevelBridge) this.shadow$level()).bridge$isFake()) {
             return;
         }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/EntityMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/EntityMixin.java
@@ -424,6 +424,10 @@ public abstract class EntityMixin implements EntityBridge, PlatformEntityBridge,
     @Inject(method = "setAsInsidePortal", at = @At(value = "FIELD", opcode = Opcodes.PUTFIELD, shift = At.Shift.AFTER,
             target = "Lnet/minecraft/world/entity/Entity;portalProcess:Lnet/minecraft/world/entity/PortalProcessor;"))
     public void impl$onCreatePortalProcessor(final Portal $$0, final BlockPos $$1, final CallbackInfo ci) {
+        if (this.shadow$level().isClientSide()) {
+            return;
+        }
+
         try (final CauseStackManager.StackFrame frame = PhaseTracker.getCauseStackManager().pushCauseFrame()){
             var be = this.shadow$level().getBlockEntity(this.portalProcess.getEntryPosition());
             if (be != null) {


### PR DESCRIPTION
Fixes `java.lang.ClassCastException: class net.minecraft.client.multiplayer.ClientLevel cannot be cast to class net.minecraft.server.level.ServerLevel` when player tries to enter portal with Sponge on client (running it in ide).