### PR TITLE
Revert some unnecessary changes from merge commit

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeServer.java
+++ b/src/main/java/org/spongepowered/common/SpongeServer.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.common;
 
-import net.minecraft.core.BlockPos;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Server;
 import org.spongepowered.common.command.manager.SpongeCommandManager;
 import org.spongepowered.common.profile.SpongeGameProfileManager;
@@ -48,10 +46,6 @@ public interface SpongeServer extends SpongeEngine, Server {
     SpongeGameProfileManager gameProfileManagerIfPresent();
 
     UsernameCache getUsernameCache();
-
-    @Nullable Integer getBlockDestructionId(BlockPos pos);
-
-    int getOrCreateBlockDestructionId(BlockPos pos);
 
     SpongeUserManager userManager();
 

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/MinecraftServerMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/MinecraftServerMixin_API.java
@@ -34,7 +34,6 @@ import net.kyori.adventure.resource.ResourcePackRequest;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.minecraft.commands.Commands;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.server.MinecraftServer;
@@ -52,7 +51,6 @@ import net.minecraft.world.level.storage.LevelResource;
 import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.WorldData;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.Sponge;
@@ -479,16 +477,6 @@ public abstract class MinecraftServerMixin_API implements SpongeServer, SpongeRe
         }
 
         return this.api$usernameCache;
-    }
-
-    @Override
-    public @Nullable Integer getBlockDestructionId(BlockPos pos) {
-        return this.api$blockDestructionIdCache.get(pos).orElse(null);
-    }
-
-    @Override
-    public int getOrCreateBlockDestructionId(BlockPos pos) {
-        return this.api$blockDestructionIdCache.getOrCreate(pos);
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/level/ServerPlayerMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/level/ServerPlayerMixin_API.java
@@ -34,12 +34,10 @@ import net.kyori.adventure.resource.ResourcePackRequest;
 import net.kyori.adventure.text.Component;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementHolder;
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.MessageSignature;
 import net.minecraft.network.chat.PlayerChatMessage;
-import net.minecraft.network.protocol.game.ClientboundBlockDestructionPacket;
 import net.minecraft.network.protocol.game.ClientboundDeleteChatPacket;
 import net.minecraft.network.protocol.game.ClientboundInitializeBorderPacket;
 import net.minecraft.resources.ResourceLocation;
@@ -209,27 +207,6 @@ public abstract class ServerPlayerMixin_API extends PlayerMixin_API implements S
         final Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
         final Duration timeSinceFirstJoined = Duration.of(now.minusMillis(toTheMinute.toEpochMilli()).toEpochMilli(), ChronoUnit.MINUTES);
         return timeSinceFirstJoined.getSeconds() > 0;
-    }
-
-    @Override
-    public void sendBlockProgress(final int x, final int y, final int z, final double progress) {
-        if (progress < 0 || progress > 1) {
-            throw new IllegalArgumentException("Progress must be between 0 and 1");
-        }
-
-        final BlockPos pos = new BlockPos(x, y, z);
-        final int id = ((SpongeServer) this.server).getOrCreateBlockDestructionId(pos);
-        final int progressStage = progress == 1 ? 9 : (int) (progress * 10);
-        this.connection.send(new ClientboundBlockDestructionPacket(id, pos, progressStage));
-    }
-
-    @Override
-    public void resetBlockProgress(final int x, final int y, final int z) {
-        final BlockPos pos = new BlockPos(x, y, z);
-        final Integer id = ((SpongeServer) this.server).getBlockDestructionId(pos);
-        if (id != null) {
-            this.connection.send(new ClientboundBlockDestructionPacket(id, pos, -1));
-        }
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/LevelMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/LevelMixin_API.java
@@ -27,18 +27,15 @@ package org.spongepowered.common.mixin.api.minecraft.world.level;
 import net.kyori.adventure.sound.Sound;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerChunkCache;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.LightLayer;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ChunkSource;
 import net.minecraft.world.level.chunk.ImposterProtoChunk;
@@ -262,19 +259,6 @@ public abstract class LevelMixin_API<W extends World<W, L>, L extends Location<W
     @Override
     public void resetBlockProgress(final int x, final int y, final int z) {
         ViewerPacketUtil.resetBlockProgress(x, y, z, this.engine()).ifPresent(((ViewerBridge) this)::bridge$sendToViewer);
-    }
-
-    @Override
-    public void sendBlockChange(final int x, final int y, final int z, final org.spongepowered.api.block.BlockState state) {
-        Objects.requireNonNull(state, "state");
-
-        final ClientboundBlockUpdatePacket packet = new ClientboundBlockUpdatePacket(new BlockPos(x, y, z), (BlockState) state);
-
-        ((net.minecraft.world.level.Level) (Object) this).players()
-            .stream()
-            .filter(ServerPlayer.class::isInstance)
-            .map(ServerPlayer.class::cast)
-            .forEach(p -> p.connection.send(packet));
     }
 
     // Audience


### PR DESCRIPTION
Removes `Viewer` related methods that should not have been merged in [this commit](https://github.com/SpongePowered/Sponge/commit/2901a2b5e209fa94087d4f87b265b1ec5572c735) because they have already been removed in [this PR](https://github.com/SpongePowered/Sponge/pull/4054)