### PR TITLE
fix: Issues related to fireworks and fused explosives

### DIFF
--- a/src/main/java/org/spongepowered/common/bridge/explosives/FusedExplosiveBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/explosives/FusedExplosiveBridge.java
@@ -36,8 +36,6 @@ public interface FusedExplosiveBridge {
 
     boolean bridge$isPrimed();
 
-    boolean bridge$setPrimed(boolean primed);
-
     int bridge$getFuseDuration();
 
     void bridge$setFuseDuration(int fuseTicks);

--- a/src/main/java/org/spongepowered/common/bridge/explosives/FusedExplosiveBridge.java
+++ b/src/main/java/org/spongepowered/common/bridge/explosives/FusedExplosiveBridge.java
@@ -34,6 +34,10 @@ import org.spongepowered.common.event.tracking.PhaseTracker;
 
 public interface FusedExplosiveBridge {
 
+    boolean bridge$isPrimed();
+
+    boolean bridge$setPrimed(boolean primed);
+
     int bridge$getFuseDuration();
 
     void bridge$setFuseDuration(int fuseTicks);

--- a/src/main/java/org/spongepowered/common/data/provider/entity/FireworkRocketData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/FireworkRocketData.java
@@ -24,17 +24,13 @@
  */
 package org.spongepowered.common.data.provider.entity;
 
-import com.google.common.collect.ImmutableList;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.entity.projectile.FireworkRocketEntity;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.component.Fireworks;
 import org.spongepowered.api.data.Keys;
-import org.spongepowered.common.accessor.world.entity.EntityAccessor;
-import org.spongepowered.common.accessor.world.entity.projectile.FireworkRocketEntityAccessor;
 import org.spongepowered.common.data.provider.DataProviderRegistrator;
 import org.spongepowered.common.util.FireworkUtil;
 import org.spongepowered.common.util.SpongeTicks;
+
+import java.util.OptionalInt;
 
 public final class FireworkRocketData {
 
@@ -47,27 +43,22 @@ public final class FireworkRocketData {
                 .asMutable(FireworkRocketEntity.class)
                     .create(Keys.FIREWORK_EFFECTS)
                         .get(h -> FireworkUtil.getFireworkEffects(h).orElse(null))
-                        .set(FireworkUtil::setFireworkEffects)
-                        .resetOnDelete(ImmutableList.of())
+                        .setAnd(FireworkUtil::setFireworkEffects)
+                        .deleteAnd(FireworkUtil::removeFireworkEffects)
                     .create(Keys.FIREWORK_FLIGHT_MODIFIER)
                         .get(h -> {
-                            final ItemStack item = FireworkUtil.getItem(h);
-                            final Fireworks fireworks = item.get(DataComponents.FIREWORKS);
-                            if (fireworks == null) {
+                            final OptionalInt modifier = FireworkUtil.getFlightModifier(h);
+                            if (modifier.isEmpty()) {
                                 return null;
                             }
-                            return new SpongeTicks(fireworks.flightDuration());
+                            return new SpongeTicks(modifier.getAsInt());
                         })
                         .setAnd((h, v) -> {
                             final int ticks = SpongeTicks.toSaturatedIntOrInfinite(v);
                             if (v.isInfinite() || ticks < 0 || ticks > Byte.MAX_VALUE) {
                                 return false;
                             }
-                            final ItemStack item = FireworkUtil.getItem(h);
-                            final Fireworks fireworks = item.get(DataComponents.FIREWORKS);
-                            item.set(DataComponents.FIREWORKS, new Fireworks((int) v.ticks(), fireworks.explosions()));
-                            ((FireworkRocketEntityAccessor) h).accessor$lifetime(10 * ticks + ((EntityAccessor) h).accessor$random().nextInt(6) + ((EntityAccessor) h).accessor$random().nextInt(7));
-                            return true;
+                            return FireworkUtil.setFlightModifier(h, ticks);
                         });
     }
     // @formatter:on

--- a/src/main/java/org/spongepowered/common/data/provider/entity/FusedExplosiveData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/FusedExplosiveData.java
@@ -41,7 +41,6 @@ public final class FusedExplosiveData {
                 .asMutable(FusedExplosive.class)
                     .create(Keys.IS_PRIMED)
                         .get(h -> ((FusedExplosiveBridge) h).bridge$isPrimed())
-                        .setAnd((h, v) -> ((FusedExplosiveBridge) h).bridge$setPrimed(v))
                     .create(Keys.FUSE_DURATION)
                         .get(h -> new SpongeTicks(((FusedExplosiveBridge) h).bridge$getFuseDuration()))
                         .setAnd((h, v) -> {

--- a/src/main/java/org/spongepowered/common/data/provider/entity/FusedExplosiveData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/FusedExplosiveData.java
@@ -39,11 +39,14 @@ public final class FusedExplosiveData {
     public static void register(final DataProviderRegistrator registrator) {
         registrator
                 .asMutable(FusedExplosive.class)
+                    .create(Keys.IS_PRIMED)
+                        .get(h -> ((FusedExplosiveBridge) h).bridge$isPrimed())
+                        .setAnd((h, v) -> ((FusedExplosiveBridge) h).bridge$setPrimed(v))
                     .create(Keys.FUSE_DURATION)
                         .get(h -> new SpongeTicks(((FusedExplosiveBridge) h).bridge$getFuseDuration()))
                         .setAnd((h, v) -> {
                             final int ticks = SpongeTicks.toSaturatedIntOrInfinite(v);
-                            if (!v.isInfinite() || ticks < 0) {
+                            if (v.isInfinite() || ticks < 0) {
                                 return false;
                             }
                             ((FusedExplosiveBridge) h).bridge$setFuseDuration(ticks);
@@ -56,8 +59,7 @@ public final class FusedExplosiveData {
                             if (v.isInfinite() || ticks < 0) {
                                 return false;
                             }
-                            // TODO isPrimed on bridge?
-                            if (h.primed().get()) {
+                            if (((FusedExplosiveBridge) h).bridge$isPrimed()) {
                                 ((FusedExplosiveBridge) h).bridge$setFuseTicksRemaining(ticks);
                             }
                             return true;

--- a/src/main/java/org/spongepowered/common/data/provider/entity/TNTData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/TNTData.java
@@ -44,8 +44,6 @@ public final class TNTData {
                     .create(Keys.DETONATOR)
                         .get(h -> (Living) h.getOwner())
                         .set((h, v) -> ((PrimedTntAccessor) h).accessor$owner((LivingEntity) v))
-                    .create(Keys.IS_PRIMED)
-                        .get(h -> !h.isRemoved() && h.getFuse() > 0)
                     .create(Keys.BLOCK_STATE)
                         .get(h -> (BlockState) h.getBlockState())
                         .set((h, v) -> h.setBlockState((net.minecraft.world.level.block.state.BlockState) v));

--- a/src/main/java/org/spongepowered/common/util/FireworkUtil.java
+++ b/src/main/java/org/spongepowered/common/util/FireworkUtil.java
@@ -44,7 +44,7 @@ import java.util.function.Function;
 
 public final class FireworkUtil {
     public static boolean setFireworkEffects(final FireworkRocketEntity firework, final List<? extends FireworkEffect> effects) {
-        return updateFireworkRocketItem(firework, item -> setFireworkEffects(item, effects));
+        return FireworkUtil.updateFireworkRocketItem(firework, item -> FireworkUtil.setFireworkEffects(item, effects));
     }
 
     public static boolean setFireworkEffects(final ItemStack item, final List<? extends FireworkEffect> effects) {
@@ -69,7 +69,7 @@ public final class FireworkUtil {
     }
 
     public static Optional<List<FireworkEffect>> getFireworkEffects(final FireworkRocketEntity firework) {
-        return getFireworkEffects(getItem(firework));
+        return FireworkUtil.getFireworkEffects(FireworkUtil.getItem(firework));
     }
 
     public static Optional<List<FireworkEffect>> getFireworkEffects(final ItemStack item) {
@@ -94,7 +94,7 @@ public final class FireworkUtil {
     }
 
     public static boolean removeFireworkEffects(final FireworkRocketEntity firework) {
-        return updateFireworkRocketItem(firework, FireworkUtil::removeFireworkEffects);
+        return FireworkUtil.updateFireworkRocketItem(firework, FireworkUtil::removeFireworkEffects);
     }
 
     public static boolean removeFireworkEffects(final ItemStack item) {
@@ -117,7 +117,7 @@ public final class FireworkUtil {
     }
 
     public static boolean setFlightModifier(final FireworkRocketEntity firework, final int modifier) {
-        if (updateFireworkRocketItem(firework, item -> setFlightModifier(item, modifier))) {
+        if (FireworkUtil.updateFireworkRocketItem(firework, item -> FireworkUtil.setFlightModifier(item, modifier))) {
             int lifetime = 10 * modifier + ((EntityAccessor) firework).accessor$random().nextInt(6) + ((EntityAccessor) firework).accessor$random().nextInt(7);
             ((FireworkRocketEntityAccessor) firework).accessor$lifetime(lifetime);
             return true;
@@ -138,7 +138,7 @@ public final class FireworkUtil {
     }
 
     public static OptionalInt getFlightModifier(final FireworkRocketEntity firework) {
-        return getFlightModifier(getItem(firework));
+        return FireworkUtil.getFlightModifier(FireworkUtil.getItem(firework));
     }
 
     public static OptionalInt getFlightModifier(final ItemStack item) {
@@ -150,7 +150,7 @@ public final class FireworkUtil {
     }
 
     public static boolean updateFireworkRocketItem(final FireworkRocketEntity firework, final Function<ItemStack, Boolean> function) {
-        final ItemStack item = getItem(firework).copy();
+        final ItemStack item = FireworkUtil.getItem(firework).copy();
         if (function.apply(item)) {
             firework.getEntityData().set(FireworkRocketEntityAccessor.accessor$DATA_ID_FIREWORKS_ITEM(), item);
             return true;

--- a/src/main/java/org/spongepowered/common/util/FireworkUtil.java
+++ b/src/main/java/org/spongepowered/common/util/FireworkUtil.java
@@ -32,37 +32,47 @@ import net.minecraft.world.item.component.FireworkExplosion;
 import net.minecraft.world.item.component.Fireworks;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.ItemTypes;
+import org.spongepowered.common.accessor.world.entity.EntityAccessor;
 import org.spongepowered.common.accessor.world.entity.projectile.FireworkRocketEntityAccessor;
 import org.spongepowered.common.item.SpongeItemStack;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.Function;
 
 public final class FireworkUtil {
+    public static boolean setFireworkEffects(final FireworkRocketEntity firework, final List<? extends FireworkEffect> effects) {
+        return updateFireworkRocketItem(firework, item -> setFireworkEffects(item, effects));
+    }
 
-    public static boolean setFireworkEffects(final Object object, final List<? extends FireworkEffect> effects) {
+    public static boolean setFireworkEffects(final ItemStack item, final List<? extends FireworkEffect> effects) {
         if (effects.isEmpty()) {
-            return FireworkUtil.removeFireworkEffects(object);
+            return FireworkUtil.removeFireworkEffects(item);
         }
-        final ItemStack item = FireworkUtil.getItem(object);
+
         if (item.isEmpty()) {
             return false;
         }
 
         if (item.getItem() == Items.FIREWORK_STAR) {
-            item.set(DataComponents.FIREWORK_EXPLOSION, (FireworkExplosion) (Object) effects.get(0));
+            item.set(DataComponents.FIREWORK_EXPLOSION, (FireworkExplosion) (Object) effects.getFirst());
             return true;
         } else if (item.getItem() == Items.FIREWORK_ROCKET) {
             final List<FireworkExplosion> mcEffects = effects.stream().map(FireworkExplosion.class::cast).toList();
             item.update(DataComponents.FIREWORKS, new Fireworks(1, Collections.emptyList()), p -> new Fireworks(p.flightDuration(), mcEffects));
             return true;
         }
+
         return false;
     }
 
-    public static Optional<List<FireworkEffect>> getFireworkEffects(final Object object) {
-        final ItemStack item = FireworkUtil.getItem(object);
+    public static Optional<List<FireworkEffect>> getFireworkEffects(final FireworkRocketEntity firework) {
+        return getFireworkEffects(getItem(firework));
+    }
+
+    public static Optional<List<FireworkEffect>> getFireworkEffects(final ItemStack item) {
         if (item.isEmpty()) {
             return Optional.empty();
         }
@@ -83,8 +93,11 @@ public final class FireworkUtil {
         return Optional.of(List.of((FireworkEffect) (Object) fireworkExplosion));
     }
 
-    public static boolean removeFireworkEffects(final Object object) {
-        final ItemStack item = FireworkUtil.getItem(object);
+    public static boolean removeFireworkEffects(final FireworkRocketEntity firework) {
+        return updateFireworkRocketItem(firework, FireworkUtil::removeFireworkEffects);
+    }
+
+    public static boolean removeFireworkEffects(final ItemStack item) {
         if (item.isEmpty()) {
             return false;
         }
@@ -103,6 +116,48 @@ public final class FireworkUtil {
         return false;
     }
 
+    public static boolean setFlightModifier(final FireworkRocketEntity firework, final int modifier) {
+        if (updateFireworkRocketItem(firework, item -> setFlightModifier(item, modifier))) {
+            int lifetime = 10 * modifier + ((EntityAccessor) firework).accessor$random().nextInt(6) + ((EntityAccessor) firework).accessor$random().nextInt(7);
+            ((FireworkRocketEntityAccessor) firework).accessor$lifetime(lifetime);
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean setFlightModifier(final ItemStack item, final int modifier) {
+        if (item.isEmpty()) {
+            return false;
+        }
+
+        if (item.getItem() == Items.FIREWORK_ROCKET) {
+            item.update(DataComponents.FIREWORKS, new Fireworks(1, Collections.emptyList()), p -> new Fireworks(modifier, p.explosions()));
+            return true;
+        }
+        return false;
+    }
+
+    public static OptionalInt getFlightModifier(final FireworkRocketEntity firework) {
+        return getFlightModifier(getItem(firework));
+    }
+
+    public static OptionalInt getFlightModifier(final ItemStack item) {
+        final Fireworks fireworks = item.get(DataComponents.FIREWORKS);
+        if (fireworks == null) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.of(fireworks.flightDuration());
+    }
+
+    public static boolean updateFireworkRocketItem(final FireworkRocketEntity firework, final Function<ItemStack, Boolean> function) {
+        final ItemStack item = getItem(firework);
+        if (function.apply(item)) {
+            firework.getEntityData().set(FireworkRocketEntityAccessor.accessor$DATA_ID_FIREWORKS_ITEM(), item);
+            return true;
+        }
+        return false;
+    }
+
     public static ItemStack getItem(final FireworkRocketEntity firework) {
         ItemStack item = firework.getEntityData().get(FireworkRocketEntityAccessor.accessor$DATA_ID_FIREWORKS_ITEM());
         if (item.isEmpty()) {
@@ -110,16 +165,6 @@ public final class FireworkUtil {
             firework.getEntityData().set(FireworkRocketEntityAccessor.accessor$DATA_ID_FIREWORKS_ITEM(), item);
         }
         return item;
-    }
-
-    private static ItemStack getItem(final Object object) {
-        if (object instanceof ItemStack) {
-            return (ItemStack) object;
-        }
-        if (object instanceof FireworkRocketEntity) {
-            return FireworkUtil.getItem((FireworkRocketEntity) object);
-        }
-        return ItemStack.EMPTY;
     }
 
     private FireworkUtil() {

--- a/src/main/java/org/spongepowered/common/util/FireworkUtil.java
+++ b/src/main/java/org/spongepowered/common/util/FireworkUtil.java
@@ -117,12 +117,9 @@ public final class FireworkUtil {
     }
 
     public static boolean setFlightModifier(final FireworkRocketEntity firework, final int modifier) {
-        if (FireworkUtil.updateFireworkRocketItem(firework, item -> FireworkUtil.setFlightModifier(item, modifier))) {
-            int lifetime = 10 * modifier + ((EntityAccessor) firework).accessor$random().nextInt(6) + ((EntityAccessor) firework).accessor$random().nextInt(7);
-            ((FireworkRocketEntityAccessor) firework).accessor$lifetime(lifetime);
-            return true;
-        }
-        return false;
+        int lifetime = 10 * modifier + ((EntityAccessor) firework).accessor$random().nextInt(6) + ((EntityAccessor) firework).accessor$random().nextInt(7);
+        ((FireworkRocketEntityAccessor) firework).accessor$lifetime(lifetime);
+        return true;
     }
 
     public static boolean setFlightModifier(final ItemStack item, final int modifier) {

--- a/src/main/java/org/spongepowered/common/util/FireworkUtil.java
+++ b/src/main/java/org/spongepowered/common/util/FireworkUtil.java
@@ -150,7 +150,7 @@ public final class FireworkUtil {
     }
 
     public static boolean updateFireworkRocketItem(final FireworkRocketEntity firework, final Function<ItemStack, Boolean> function) {
-        final ItemStack item = getItem(firework);
+        final ItemStack item = getItem(firework).copy();
         if (function.apply(item)) {
             firework.getEntityData().set(FireworkRocketEntityAccessor.accessor$DATA_ID_FIREWORKS_ITEM(), item);
             return true;
@@ -161,8 +161,7 @@ public final class FireworkUtil {
     public static ItemStack getItem(final FireworkRocketEntity firework) {
         ItemStack item = firework.getEntityData().get(FireworkRocketEntityAccessor.accessor$DATA_ID_FIREWORKS_ITEM());
         if (item.isEmpty()) {
-            item = (ItemStack) (Object) new SpongeItemStack.BuilderImpl().itemType(ItemTypes.FIREWORK_ROCKET).build();
-            firework.getEntityData().set(FireworkRocketEntityAccessor.accessor$DATA_ID_FIREWORKS_ITEM(), item);
+            return (ItemStack) (Object) new SpongeItemStack.BuilderImpl().itemType(ItemTypes.FIREWORK_ROCKET).build();
         }
         return item;
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/item/PrimedTntMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/item/PrimedTntMixin_API.java
@@ -43,8 +43,8 @@ public abstract class PrimedTntMixin_API extends EntityMixin_API implements Prim
 
     @Override
     public void detonate() {
-        this.shadow$discard();
         this.shadow$explode();
+        this.shadow$discard();
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/monster/CreeperMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/monster/CreeperMixin_API.java
@@ -49,6 +49,7 @@ public abstract class CreeperMixin_API extends MonsterMixin_API implements Creep
         final Set<Value.Immutable<?>> values = super.api$getVanillaValues();
 
         values.add(this.requireValue(Keys.FUSE_DURATION).asImmutable());
+        values.add(this.requireValue(Keys.IS_PRIMED).asImmutable());
         values.add(this.requireValue(Keys.IS_CHARGED).asImmutable());
         values.add(this.requireValue(Keys.TICKS_REMAINING).asImmutable());
 

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/monster/CreeperMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/monster/CreeperMixin_API.java
@@ -36,13 +36,12 @@ import java.util.Set;
 public abstract class CreeperMixin_API extends MonsterMixin_API implements Creeper {
 
     // @formatter:off
-    @Shadow protected abstract void shadow$explodeCreeper();
+    @Shadow public void shadow$ignite() { } // explode
     // @formatter:on
-
 
     @Override
     public void detonate() {
-        this.shadow$explodeCreeper();
+        this.shadow$ignite();
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/monster/CreeperMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/monster/CreeperMixin_API.java
@@ -36,12 +36,13 @@ import java.util.Set;
 public abstract class CreeperMixin_API extends MonsterMixin_API implements Creeper {
 
     // @formatter:off
-    @Shadow public void shadow$ignite() { } // explode
+    @Shadow protected abstract void shadow$explodeCreeper();
     // @formatter:on
+
 
     @Override
     public void detonate() {
-        this.shadow$ignite();
+        this.shadow$explodeCreeper();
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/projectile/FireworkRocketEntityMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/projectile/FireworkRocketEntityMixin_API.java
@@ -37,14 +37,11 @@ import java.util.Set;
 public abstract class FireworkRocketEntityMixin_API extends ProjectileMixin_API implements FireworkRocket {
 
     // @formatter:off
-    @Shadow private int life;
-    @Shadow private int lifetime;
     @Shadow protected abstract void shadow$explode();
     // @formatter:on
 
     @Override
     public void detonate() {
-        this.life = this.lifetime + 1;
         this.shadow$explode();
     }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/projectile/FireworkRocketEntityMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/projectile/FireworkRocketEntityMixin_API.java
@@ -53,6 +53,7 @@ public abstract class FireworkRocketEntityMixin_API extends ProjectileMixin_API 
         final Set<Value.Immutable<?>> values = super.api$getVanillaValues();
 
         values.add(this.requireValue(Keys.FUSE_DURATION).asImmutable());
+        values.add(this.requireValue(Keys.IS_PRIMED).asImmutable());
         values.add(this.requireValue(Keys.TICKS_REMAINING).asImmutable());
 
         this.getValue(Keys.EXPLOSION_RADIUS).map(Value::asImmutable).ifPresent(values::add);

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/vehicle/MinecartTNTMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/vehicle/MinecartTNTMixin_API.java
@@ -46,6 +46,7 @@ public abstract class MinecartTNTMixin_API extends AbstractMinecartMixin_API imp
         final Set<Value.Immutable<?>> values = super.api$getVanillaValues();
 
         values.add(this.requireValue(Keys.FUSE_DURATION).asImmutable());
+        values.add(this.requireValue(Keys.IS_PRIMED).asImmutable());
         values.add(this.requireValue(Keys.TICKS_REMAINING).asImmutable());
 
         this.getValue(Keys.EXPLOSION_RADIUS).map(Value::asImmutable).ifPresent(values::add);

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/item/PrimedTntMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/item/PrimedTntMixin.java
@@ -85,6 +85,16 @@ public abstract class PrimedTntMixin extends EntityMixin implements PrimedTntBri
     }
 
     @Override
+    public boolean bridge$isPrimed() {
+        return true;
+    }
+
+    @Override
+    public boolean bridge$setPrimed(boolean primed) {
+        return false;
+    }
+
+    @Override
     public int bridge$getFuseDuration() {
         return this.bridge$fuseDuration;
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/item/PrimedTntMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/item/PrimedTntMixin.java
@@ -63,7 +63,6 @@ public abstract class PrimedTntMixin extends EntityMixin implements PrimedTntBri
     @Nullable private LivingEntity impl$detonator;
     private int bridge$explosionRadius = Constants.Entity.PrimedTNT.DEFAULT_EXPLOSION_RADIUS;
     private int bridge$fuseDuration = Constants.Entity.PrimedTNT.DEFAULT_FUSE_DURATION;
-    private boolean impl$postPrimeTriggered = false;
 
     @Override
     public void bridge$setDetonator(final LivingEntity detonator) {
@@ -97,8 +96,8 @@ public abstract class PrimedTntMixin extends EntityMixin implements PrimedTntBri
 
     @Override
     public void bridge$setFuseDuration(final int fuseTicks) {
+        this.shadow$setFuse(Math.max(this.shadow$getFuse() + fuseTicks - this.bridge$fuseDuration, 0));
         this.bridge$fuseDuration = fuseTicks;
-        this.shadow$setFuse(fuseTicks);
     }
 
     @Override
@@ -136,8 +135,7 @@ public abstract class PrimedTntMixin extends EntityMixin implements PrimedTntBri
 
     @Inject(method = "tick()V", at = @At("RETURN"))
     private void impl$updateTNTPushPrime(final CallbackInfo ci) {
-        if (!this.impl$postPrimeTriggered && !this.shadow$level().isClientSide) {
-            this.impl$postPrimeTriggered = true;
+        if (this.shadow$getFuse() == this.bridge$fuseDuration - 1 && !this.shadow$level().isClientSide) {
             try (final CauseStackManager.StackFrame frame = PhaseTracker.getCauseStackManager().pushCauseFrame()) {
                 if (this.impl$detonator != null) {
                     frame.pushCause(this.impl$detonator);

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/item/PrimedTntMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/item/PrimedTntMixin.java
@@ -63,6 +63,7 @@ public abstract class PrimedTntMixin extends EntityMixin implements PrimedTntBri
     @Nullable private LivingEntity impl$detonator;
     private int bridge$explosionRadius = Constants.Entity.PrimedTNT.DEFAULT_EXPLOSION_RADIUS;
     private int bridge$fuseDuration = Constants.Entity.PrimedTNT.DEFAULT_FUSE_DURATION;
+    private boolean impl$postPrimeTriggered = false;
 
     @Override
     public void bridge$setDetonator(final LivingEntity detonator) {
@@ -135,7 +136,8 @@ public abstract class PrimedTntMixin extends EntityMixin implements PrimedTntBri
 
     @Inject(method = "tick()V", at = @At("RETURN"))
     private void impl$updateTNTPushPrime(final CallbackInfo ci) {
-        if (this.shadow$getFuse() == this.bridge$fuseDuration - 1 && !this.shadow$level().isClientSide) {
+        if (!this.impl$postPrimeTriggered && !this.shadow$level().isClientSide) {
+            this.impl$postPrimeTriggered = true;
             try (final CauseStackManager.StackFrame frame = PhaseTracker.getCauseStackManager().pushCauseFrame()) {
                 if (this.impl$detonator != null) {
                     frame.pushCause(this.impl$detonator);

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/item/PrimedTntMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/item/PrimedTntMixin.java
@@ -63,6 +63,7 @@ public abstract class PrimedTntMixin extends EntityMixin implements PrimedTntBri
     @Nullable private LivingEntity impl$detonator;
     private int bridge$explosionRadius = Constants.Entity.PrimedTNT.DEFAULT_EXPLOSION_RADIUS;
     private int bridge$fuseDuration = Constants.Entity.PrimedTNT.DEFAULT_FUSE_DURATION;
+    private boolean impl$postPrimeTriggered = false;
 
     @Override
     public void bridge$setDetonator(final LivingEntity detonator) {
@@ -102,6 +103,7 @@ public abstract class PrimedTntMixin extends EntityMixin implements PrimedTntBri
     @Override
     public void bridge$setFuseDuration(final int fuseTicks) {
         this.bridge$fuseDuration = fuseTicks;
+        this.shadow$setFuse(fuseTicks);
     }
 
     @Override
@@ -139,7 +141,8 @@ public abstract class PrimedTntMixin extends EntityMixin implements PrimedTntBri
 
     @Inject(method = "tick()V", at = @At("RETURN"))
     private void impl$updateTNTPushPrime(final CallbackInfo ci) {
-        if (this.shadow$getFuse() == this.bridge$fuseDuration - 1 && !this.shadow$level().isClientSide) {
+        if (!impl$postPrimeTriggered && !this.shadow$level().isClientSide) {
+            impl$postPrimeTriggered = true;
             try (final CauseStackManager.StackFrame frame = PhaseTracker.getCauseStackManager().pushCauseFrame()) {
                 if (this.impl$detonator != null) {
                     frame.pushCause(this.impl$detonator);
@@ -149,5 +152,4 @@ public abstract class PrimedTntMixin extends EntityMixin implements PrimedTntBri
             }
         }
     }
-
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/item/PrimedTntMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/item/PrimedTntMixin.java
@@ -91,11 +91,6 @@ public abstract class PrimedTntMixin extends EntityMixin implements PrimedTntBri
     }
 
     @Override
-    public boolean bridge$setPrimed(boolean primed) {
-        return false;
-    }
-
-    @Override
     public int bridge$getFuseDuration() {
         return this.bridge$fuseDuration;
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/item/PrimedTntMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/item/PrimedTntMixin.java
@@ -136,8 +136,8 @@ public abstract class PrimedTntMixin extends EntityMixin implements PrimedTntBri
 
     @Inject(method = "tick()V", at = @At("RETURN"))
     private void impl$updateTNTPushPrime(final CallbackInfo ci) {
-        if (!impl$postPrimeTriggered && !this.shadow$level().isClientSide) {
-            impl$postPrimeTriggered = true;
+        if (!this.impl$postPrimeTriggered && !this.shadow$level().isClientSide) {
+            this.impl$postPrimeTriggered = true;
             try (final CauseStackManager.StackFrame frame = PhaseTracker.getCauseStackManager().pushCauseFrame()) {
                 if (this.impl$detonator != null) {
                     frame.pushCause(this.impl$detonator);

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/monster/CreeperMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/monster/CreeperMixin.java
@@ -57,10 +57,10 @@ public abstract class CreeperMixin extends MonsterMixin implements FusedExplosiv
     @Shadow private int explosionRadius;
 
     @Shadow public abstract void shadow$ignite();
+    @Shadow public abstract boolean shadow$isIgnited();
     @Shadow public abstract int shadow$getSwellDir();
     // @formatter:on
 
-    private int impl$fuseDuration = Constants.Entity.Creeper.FUSE_DURATION;
     private boolean impl$interactPrimeCancelled;
     private boolean impl$stateDirty;
     private boolean impl$detonationCancelled;
@@ -79,7 +79,7 @@ public abstract class CreeperMixin extends MonsterMixin implements FusedExplosiv
 
     @Override
     public boolean bridge$isPrimed() {
-        return shadow$getSwellDir() > 0;
+        return shadow$isIgnited() || shadow$getSwellDir() == Constants.Entity.Creeper.STATE_PRIMED;
     }
 
     @Override
@@ -95,12 +95,12 @@ public abstract class CreeperMixin extends MonsterMixin implements FusedExplosiv
 
     @Override
     public int bridge$getFuseDuration() {
-        return this.impl$fuseDuration;
+        return this.maxSwell;
     }
 
     @Override
     public void bridge$setFuseDuration(final int fuseTicks) {
-        this.impl$fuseDuration = fuseTicks;
+        this.maxSwell = fuseTicks;
     }
 
     @Override
@@ -123,9 +123,8 @@ public abstract class CreeperMixin extends MonsterMixin implements FusedExplosiv
         if (this.shadow$level().isClientSide) {
             return;
         }
-        this.bridge$setFuseDuration(this.impl$fuseDuration);
 
-        final boolean isPrimed = this.shadow$getSwellDir() == Constants.Entity.Creeper.STATE_PRIMED;
+        final boolean isPrimed = this.bridge$isPrimed();
 
         if (!isPrimed && state == Constants.Entity.Creeper.STATE_PRIMED && !this.bridge$shouldPrime()) {
             ci.cancel();

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/monster/CreeperMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/monster/CreeperMixin.java
@@ -83,17 +83,6 @@ public abstract class CreeperMixin extends MonsterMixin implements FusedExplosiv
     }
 
     @Override
-    public boolean bridge$setPrimed(boolean primed) {
-        if (primed) {
-            if (!bridge$isPrimed() && bridge$shouldPrime()) {
-                shadow$ignite();
-            }
-            return true;
-        }
-        return false;
-    }
-
-    @Override
     public int bridge$getFuseDuration() {
         return this.maxSwell;
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/monster/CreeperMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/monster/CreeperMixin.java
@@ -79,7 +79,7 @@ public abstract class CreeperMixin extends MonsterMixin implements FusedExplosiv
 
     @Override
     public boolean bridge$isPrimed() {
-        return shadow$isIgnited() || shadow$getSwellDir() == Constants.Entity.Creeper.STATE_PRIMED;
+        return this.shadow$isIgnited() || this.shadow$getSwellDir() == Constants.Entity.Creeper.STATE_PRIMED;
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/monster/CreeperMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/monster/CreeperMixin.java
@@ -78,6 +78,22 @@ public abstract class CreeperMixin extends MonsterMixin implements FusedExplosiv
     }
 
     @Override
+    public boolean bridge$isPrimed() {
+        return shadow$getSwellDir() > 0;
+    }
+
+    @Override
+    public boolean bridge$setPrimed(boolean primed) {
+        if (primed) {
+            if (!bridge$isPrimed() && bridge$shouldPrime()) {
+                shadow$ignite();
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
     public int bridge$getFuseDuration() {
         return this.impl$fuseDuration;
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/projectile/FireworkRocketEntityMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/projectile/FireworkRocketEntityMixin.java
@@ -57,6 +57,16 @@ public abstract class FireworkRocketEntityMixin extends ProjectileMixin implemen
     private int impl$explosionRadius = Constants.Entity.Firework.DEFAULT_EXPLOSION_RADIUS;
 
     @Override
+    public boolean bridge$isPrimed() {
+        return true;
+    }
+
+    @Override
+    public boolean bridge$setPrimed(boolean primed) {
+        return false;
+    }
+
+    @Override
     public int bridge$getFuseDuration() {
         return this.lifetime;
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/projectile/FireworkRocketEntityMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/projectile/FireworkRocketEntityMixin.java
@@ -62,11 +62,6 @@ public abstract class FireworkRocketEntityMixin extends ProjectileMixin implemen
     }
 
     @Override
-    public boolean bridge$setPrimed(boolean primed) {
-        return false;
-    }
-
-    @Override
     public int bridge$getFuseDuration() {
         return this.lifetime;
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/vehicle/MinecartTNTMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/vehicle/MinecartTNTMixin.java
@@ -86,15 +86,6 @@ public abstract class MinecartTNTMixin extends AbstractMinecartMixin implements 
     }
 
     @Override
-    public boolean bridge$setPrimed(boolean primed) {
-        if (primed) {
-            shadow$primeFuse();
-            return true;
-        }
-        return false;
-    }
-
-    @Override
     public int bridge$getFuseDuration() {
         return this.impl$fuseDuration;
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/vehicle/MinecartTNTMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/vehicle/MinecartTNTMixin.java
@@ -82,7 +82,7 @@ public abstract class MinecartTNTMixin extends AbstractMinecartMixin implements 
 
     @Override
     public boolean bridge$isPrimed() {
-        return shadow$isPrimed();
+        return this.shadow$isPrimed();
     }
 
     @Override
@@ -93,7 +93,7 @@ public abstract class MinecartTNTMixin extends AbstractMinecartMixin implements 
     @Override
     public void bridge$setFuseDuration(final int fuseTicks) {
         this.impl$fuseDuration = fuseTicks;
-        if (shadow$isPrimed()) {
+        if (this.shadow$isPrimed()) {
             this.fuse = fuseTicks;
         }
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/vehicle/MinecartTNTMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/vehicle/MinecartTNTMixin.java
@@ -61,6 +61,8 @@ public abstract class MinecartTNTMixin extends AbstractMinecartMixin implements 
 
     // @formatter:off
     @Shadow private int fuse;
+    @Shadow public abstract boolean shadow$isPrimed();
+    @Shadow public abstract void shadow$primeFuse();
     // @formatter:on
 
     @Nullable private Integer impl$explosionRadius = null;
@@ -76,6 +78,20 @@ public abstract class MinecartTNTMixin extends AbstractMinecartMixin implements 
     @Override
     public void bridge$setExplosionRadius(final @Nullable Integer radius) {
         this.impl$explosionRadius = radius;
+    }
+
+    @Override
+    public boolean bridge$isPrimed() {
+        return shadow$isPrimed();
+    }
+
+    @Override
+    public boolean bridge$setPrimed(boolean primed) {
+        if (primed) {
+            shadow$primeFuse();
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/vehicle/MinecartTNTMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/vehicle/MinecartTNTMixin.java
@@ -92,10 +92,10 @@ public abstract class MinecartTNTMixin extends AbstractMinecartMixin implements 
 
     @Override
     public void bridge$setFuseDuration(final int fuseTicks) {
-        this.impl$fuseDuration = fuseTicks;
         if (this.shadow$isPrimed()) {
-            this.fuse = fuseTicks;
+            this.fuse = Math.max(this.fuse + fuseTicks - this.impl$fuseDuration, 0);
         }
+        this.impl$fuseDuration = fuseTicks;
     }
 
     @Override

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/vehicle/MinecartTNTMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/entity/vehicle/MinecartTNTMixin.java
@@ -102,6 +102,9 @@ public abstract class MinecartTNTMixin extends AbstractMinecartMixin implements 
     @Override
     public void bridge$setFuseDuration(final int fuseTicks) {
         this.impl$fuseDuration = fuseTicks;
+        if (shadow$isPrimed()) {
+            this.fuse = fuseTicks;
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #4116 

- synchronizes firework entity data changes with client
- implements `IS_PRIMED` for all fused explosives
- fixes `TICKS_REMAINING` throwing an error for anything other than `PrimedTNT`
- fixes `FUSE_DURATION` always rejecting
- ~~`detonate` method of Creeper only igniting, not exploding it (other methods explode)~~
- allows to modify flight duration of a firework item with `FIREWORK_FLIGHT_MODIFIER` (not sure if this is wanted)