### PR TITLE
Fix Keys.STORED_ENCHANTMENTS applying only to enchanted book

### DIFF
--- a/src/main/java/org/spongepowered/common/data/provider/item/stack/BookPagesItemStackData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/item/stack/BookPagesItemStackData.java
@@ -28,7 +28,6 @@ import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.item.enchantment.Enchantment;
@@ -58,8 +57,7 @@ public final class BookPagesItemStackData {
                     .create(Keys.STORED_ENCHANTMENTS)
                         .get(h -> BookPagesItemStackData.get(h, DataComponents.STORED_ENCHANTMENTS))
                         .set((h, v) -> BookPagesItemStackData.set(h, v, Collection::stream, DataComponents.STORED_ENCHANTMENTS))
-                        .delete(h -> BookPagesItemStackData.delete(h, DataComponents.STORED_ENCHANTMENTS))
-                        .supports(h -> h.getItem() == Items.ENCHANTED_BOOK);
+                        .delete(h -> BookPagesItemStackData.delete(h, DataComponents.STORED_ENCHANTMENTS));
     }
     // @formatter:on
 


### PR DESCRIPTION
There is no particular reason to limit this key specificially to enchanted book - it can be applied to any item and it will work fine (in anvil this component is mostly ignored so this is totally fine too). This limitation becomes real problem when you realize you can't interact with modded enchanted books (that's what happened to me)
![image](https://github.com/user-attachments/assets/65e15fb5-e4ba-4c69-9218-d7df178b6abe)
