### PR TITLE
Support reloadable registries

### DIFF
--- a/generator/src/main/java/org/spongepowered/vanilla/generator/GeneratorMain.java
+++ b/generator/src/main/java/org/spongepowered/vanilla/generator/GeneratorMain.java
@@ -175,7 +175,6 @@ public final class GeneratorMain {
         );
 
 
-        final RegistryAccess.Frozen compositeRegistries = withDimensions.getAccessForLoading(RegistryLayer.RELOADABLE);
         final var resourcesFuture = ReloadableServerResources.loadResources(
             resourceManager,
             withDimensions,
@@ -207,7 +206,7 @@ public final class GeneratorMain {
         Logger.info("Datapack load complete");
 
         return Pair.of(
-            compositeRegistries,
+            resources.fullRegistries().get(),
             resources
         );
     }

--- a/src/main/java/org/spongepowered/common/registry/RegistryHolderLogic.java
+++ b/src/main/java/org/spongepowered/common/registry/RegistryHolderLogic.java
@@ -220,4 +220,15 @@ public final class RegistryHolderLogic implements RegistryHolder {
     public void freezeSpongeDynamicRegistries() {
         this.roots.get(RegistryRoots.SPONGE).forEach(net.minecraft.core.Registry::freeze);
     }
+
+    public void reload(final RegistryAccess access) {
+        final WritableRegistry root = new MappedRegistry<>(
+            net.minecraft.resources.ResourceKey.createRegistryKey((ResourceLocation) (Object) RegistryRoots.MINECRAFT),
+            Lifecycle.experimental()
+        );
+
+        access.registries().forEach(entry -> root.register(entry.key(), entry.value(), RegistrationInfo.BUILT_IN));
+        root.freeze();
+        this.roots.put((ResourceKey) (Object) ResourceLocation.withDefaultNamespace("root"), root);
+    }
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/MinecraftServerMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/server/MinecraftServerMixin_API.java
@@ -170,7 +170,7 @@ public abstract class MinecraftServerMixin_API implements SpongeServer, SpongeRe
         this.api$playerDataHandler = new SpongePlayerDataManager(this);
         this.api$teleportHelper = new SpongeTeleportHelper();
         this.api$mapStorage = new SpongeMapStorage();
-        this.api$registryHolder = new RegistryHolderLogic($$3.registries().compositeAccess());
+        this.api$registryHolder = new RegistryHolderLogic($$3.dataPackResources().fullRegistries().get());
         this.api$userManager = new SpongeUserManager((MinecraftServer) (Object) this);
 
         this.api$dataPackManager = new SpongeDataPackManager((MinecraftServer) (Object) this, this.storageSource.getLevelPath(LevelResource.DATAPACK_DIR));

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/MinecraftServerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/MinecraftServerMixin.java
@@ -33,6 +33,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.obfuscate.DontObfuscate;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.ReloadableServerRegistries;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.server.players.GameProfileCache;
@@ -61,6 +62,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
@@ -81,6 +83,7 @@ import org.spongepowered.common.config.inheritable.InheritableConfigHandle;
 import org.spongepowered.common.config.inheritable.WorldConfig;
 import org.spongepowered.common.datapack.SpongeDataPackManager;
 import org.spongepowered.common.event.tracking.PhaseTracker;
+import org.spongepowered.common.registry.SpongeRegistryHolder;
 import org.spongepowered.common.service.server.SpongeServerScopedServiceProvider;
 
 import java.io.IOException;
@@ -114,6 +117,7 @@ public abstract class MinecraftServerMixin implements SpongeServer, MinecraftSer
     @Shadow public abstract WorldData shadow$getWorldData();
     @Shadow protected abstract void loadLevel(); // has overrides!
     @Shadow public abstract boolean shadow$haveTime();
+    @Shadow public abstract ReloadableServerRegistries.Holder shadow$reloadableRegistries();
     @Shadow private volatile boolean isSaving;
     // @formatter:on
 
@@ -385,6 +389,13 @@ public abstract class MinecraftServerMixin implements SpongeServer, MinecraftSer
         final List<String> reloadablePacks = ((SpongeDataPackManager) this.dataPackManager()).registerPacks();
         datapacksToLoad.addAll(reloadablePacks);
         this.shadow$getPackRepository().reload();
+    }
+
+    // Targets lambda where ReloadableResources is set to server because at
+    // this point reloaded resources become "valid" in terms of registries
+    @Inject(method = "lambda$reloadResources$29", at = @At(value = "TAIL"))
+    private void impl$handleRegistriesReload(final Collection<String> $$0x, final @Coerce Object reloadableResources, final CallbackInfo ci) {
+        ((SpongeRegistryHolder) this).registryHolder().reload(this.shadow$reloadableRegistries().get());
     }
 
     @Override


### PR DESCRIPTION
Changes `RegistryAccess` for server from default access to full access (from ReloadableResources, full access contains registries from default access plus few additional ones). The only additional registries are 3 related to loot tables registries.

Also added handler for registries on data pack reload. Currently we dont update registries even though they are actually changed (replaced with completely new registry) because of data packs add/removal. Reloadable registries include 3 loot registries and some registries from default access.

About `GeneratorMain`: I don't really know what deleted line is supposed to do, but I widened access here too, nothing broke and now it can generate loot tables which wasn't possible before.