### PR TITLE
Use a supplier to avoid costly String#format in PhaseStack#push

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/PhaseStack.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/PhaseStack.java
@@ -78,8 +78,8 @@ final class PhaseStack {
 
     PhaseStack push(IPhaseState<?> state, PhaseContext<?> context) {
         Objects.requireNonNull(context, "Tuple cannot be null!");
-        Preconditions.checkArgument(context.state == state, String.format("Illegal IPhaseState not matching PhaseContext: %s", context));
-        Preconditions.checkArgument(context.isComplete(), String.format("Phase context must be complete: %s", context));
+        Preconditions.checkArgument(context.state == state, () -> String.format("Illegal IPhaseState not matching PhaseContext: %s", context));
+        Preconditions.checkArgument(context.isComplete(), () -> String.format("Phase context must be complete: %s", context));
         this.phases.push(context);
         return this;
     }


### PR DESCRIPTION
This was showing up in spark as mentioned on Discord a while ago, so it's a nice little performance improvement.