### PR TITLE
Fixes for DataHolder & ItemStackSnapshot

### DIFF
--- a/src/main/java/org/spongepowered/common/data/holder/SpongeDataHolder.java
+++ b/src/main/java/org/spongepowered/common/data/holder/SpongeDataHolder.java
@@ -113,7 +113,8 @@ public interface SpongeDataHolder extends DataHolder {
     default Set<Key<?>> getKeys() {
         return this.impl$delegateDataHolder().stream()
                 .flatMap(dh -> this.impl$getAllProviders(dh).stream()
-                        .filter(provider -> provider.get(dh).isPresent()).map(DataProvider::key))
+                        .map(DataProvider::key))
+                        .filter(this::supports)
                 .collect(ImmutableSet.toImmutableSet());
     }
 

--- a/src/main/java/org/spongepowered/common/item/SpongeItemStackSnapshot.java
+++ b/src/main/java/org/spongepowered/common/item/SpongeItemStackSnapshot.java
@@ -73,8 +73,8 @@ public class SpongeItemStackSnapshot implements ItemStackSnapshot {
     private final int damageValue;
     private final ImmutableList<DataManipulator.Immutable> manipulators;
     private final transient ItemStack privateStack; // only for internal use since the processors have a huge say
-    private final ImmutableSet<Key<?>> keys;
-    private final ImmutableSet<org.spongepowered.api.data.value.Value.Immutable<?>> values;
+    private final Set<Key<?>> keys;
+    private final Set<org.spongepowered.api.data.value.Value.Immutable<?>> values;
     private final DataComponentPatch components;
     private @Nullable UUID creatorUniqueId;
 
@@ -95,17 +95,13 @@ public class SpongeItemStackSnapshot implements ItemStackSnapshot {
         this.itemType = itemStack.type();
         this.quantity = itemStack.quantity();
         final ImmutableList.Builder<DataManipulator.Immutable> builder = ImmutableList.builder();
-        final ImmutableSet.Builder<Key<?>> keyBuilder = ImmutableSet.builder();
-        final ImmutableSet.Builder<org.spongepowered.api.data.value.Value.Immutable<?>> valueBuilder = ImmutableSet.builder();
         final DataManipulator.Mutable customData = ((SpongeDataHolderBridge) itemStack).bridge$getManipulator();
         builder.add(customData.asImmutable());
-        keyBuilder.addAll(customData.getKeys());
-        valueBuilder.addAll(customData.getValues());
         this.damageValue = ItemStackUtil.toNative(itemStack).getDamageValue();
         this.manipulators = builder.build();
         this.privateStack = itemStack.copy();
-        this.keys = keyBuilder.build();
-        this.values = valueBuilder.build();
+        this.keys = itemStack.getKeys();
+        this.values = itemStack.getValues();
         this.components = ItemStackUtil.toNative(this.privateStack).getComponentsPatch();
     }
 


### PR DESCRIPTION
`ItemStackSnapshot` `getKeys()` & `getValues()` now return all values & supported keys instead of just custom
`DataHolder#getKeys` now returns all supported keys instead of just present