### PR TITLE
Remove bad supports() in key impl

### DIFF
--- a/src/main/java/org/spongepowered/common/data/provider/item/stack/BookItemStackData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/item/stack/BookItemStackData.java
@@ -29,7 +29,6 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.network.Filterable;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.WritableBookContent;
 import net.minecraft.world.item.component.WrittenBookContent;
 import org.spongepowered.api.data.Keys;
@@ -61,7 +60,6 @@ public final class BookItemStackData {
                             h.set(DataComponents.WRITTEN_BOOK_CONTENT,
                                     new WrittenBookContent(content.title(), author, content.generation(), content.pages(), content.resolved()));
                         })
-                        .supports(h -> h.getItem() == Items.WRITTEN_BOOK)
                     .create(Keys.GENERATION)
                         .get(h -> {
                             final WrittenBookContent content = h.get(DataComponents.WRITTEN_BOOK_CONTENT);
@@ -79,7 +77,6 @@ public final class BookItemStackData {
                                     new WrittenBookContent(content.title(), content.author(), v, content.pages(), content.resolved()));
                             return true;
                         })
-                        .supports(h -> h.getItem() == Items.WRITTEN_BOOK)
                     .create(Keys.PAGES)
                         .get(h -> {
                             final WrittenBookContent content = h.get(DataComponents.WRITTEN_BOOK_CONTENT);
@@ -99,7 +96,6 @@ public final class BookItemStackData {
                             h.set(DataComponents.WRITTEN_BOOK_CONTENT,
                                     new WrittenBookContent(content.title(), content.author(), content.generation(), Collections.emptyList(), content.resolved()));
                         })
-                        .supports(h -> h.getItem() == Items.WRITTEN_BOOK)
                     .create(Keys.PLAIN_PAGES)
                         .get(h -> {
                             final WritableBookContent content = h.get(DataComponents.WRITABLE_BOOK_CONTENT);
@@ -109,8 +105,7 @@ public final class BookItemStackData {
                             return content.pages().stream().map(Filterable::raw).toList();
                         })
                         .set((h, v) -> h.set(DataComponents.WRITABLE_BOOK_CONTENT, new WritableBookContent(v.stream().map(Filterable::passThrough).toList())))
-                        .delete(h -> h.set(DataComponents.WRITABLE_BOOK_CONTENT, new WritableBookContent(Collections.emptyList())))
-                        .supports(h -> h.getItem() == Items.WRITABLE_BOOK);
+                        .delete(h -> h.set(DataComponents.WRITABLE_BOOK_CONTENT, new WritableBookContent(Collections.emptyList())));
     }
     // @formatter:on
 

--- a/src/main/java/org/spongepowered/common/data/provider/item/stack/FireworkItemStackData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/item/stack/FireworkItemStackData.java
@@ -25,7 +25,6 @@
 package org.spongepowered.common.data.provider.item.stack;
 
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import org.spongepowered.api.data.Keys;
 import org.spongepowered.common.data.provider.DataProviderRegistrator;
 import org.spongepowered.common.util.FireworkUtil;
@@ -46,7 +45,6 @@ public final class FireworkItemStackData {
                         .get(h -> FireworkUtil.getFireworkEffects(h).orElse(null))
                         .setAnd(FireworkUtil::setFireworkEffects)
                         .deleteAnd(FireworkUtil::removeFireworkEffects)
-                        .supports(h -> h.getItem() == Items.FIREWORK_ROCKET || h.getItem() == Items.FIREWORK_STAR)
                     .create(Keys.FIREWORK_FLIGHT_MODIFIER)
                         .get(h -> {
                             final OptionalInt modifier = FireworkUtil.getFlightModifier(h);
@@ -61,8 +59,7 @@ public final class FireworkItemStackData {
                                 return false;
                             }
                             return FireworkUtil.setFlightModifier(h, ticks);
-                        })
-                        .supports(h -> h.getItem() == Items.FIREWORK_ROCKET);
+                        });
     }
     // @formatter:on
 }

--- a/src/main/java/org/spongepowered/common/data/provider/item/stack/ItemStackData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/item/stack/ItemStackData.java
@@ -32,7 +32,6 @@ import net.minecraft.util.Unit;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.component.ChargedProjectiles;
 import net.minecraft.world.item.component.CustomModelData;
@@ -143,15 +142,13 @@ public final class ItemStackData {
                             if (h.has(DataComponents.CUSTOM_NAME)) {
                                 return SpongeAdventure.asAdventure(h.getHoverName());
                             }
-                            if (h.getItem() == Items.WRITTEN_BOOK) {
-                                // When no custom name is set on a written book fallback to its title
-                                // The custom name has a higher priority than the title so no setter is needed.
-                                var bookContent = h.get(DataComponents.WRITTEN_BOOK_CONTENT);
-                                if (bookContent != null) {
-                                    final String rawTitle = bookContent.title().raw();
-                                    if (!StringUtil.isBlank(rawTitle)) {
-                                        return LegacyComponentSerializer.legacySection().deserialize(rawTitle);
-                                    }
+                            // When no custom name is set on a written book fallback to its title
+                            // The custom name has a higher priority than the title so no setter is needed.
+                            var bookContent = h.get(DataComponents.WRITTEN_BOOK_CONTENT);
+                            if (bookContent != null) {
+                                final String rawTitle = bookContent.title().raw();
+                                if (!StringUtil.isBlank(rawTitle)) {
+                                    return LegacyComponentSerializer.legacySection().deserialize(rawTitle);
                                 }
                             }
                             return null;

--- a/src/main/java/org/spongepowered/common/data/provider/item/stack/PotionItemStackData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/item/stack/PotionItemStackData.java
@@ -30,7 +30,6 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.alchemy.Potion;
 import net.minecraft.world.item.alchemy.PotionContents;
 import org.spongepowered.api.data.Keys;
@@ -58,7 +57,6 @@ public final class PotionItemStackData {
                         .get(h -> Color.ofRgb(h.getOrDefault(DataComponents.POTION_CONTENTS, PotionContents.EMPTY).getColor()))
                         .set((h, v) -> h.update(DataComponents.POTION_CONTENTS, PotionContents.EMPTY, contents -> new PotionContents(contents.potion(), Optional.of(v.rgb()), contents.customEffects())))
                         .delete(h -> h.update(DataComponents.POTION_CONTENTS, PotionContents.EMPTY, contents -> new PotionContents(contents.potion(), Optional.empty(), contents.customEffects())))
-                        .supports(h -> h.getItem() == Items.POTION || h.getItem() == Items.SPLASH_POTION || h.getItem() == Items.LINGERING_POTION || h.getItem() == Items.TIPPED_ARROW)
                     .create(Keys.CUSTOM_POTION_EFFECTS)
                         .get(h -> {
                             final List<MobEffectInstance> effects = h.getOrDefault(DataComponents.POTION_CONTENTS, PotionContents.EMPTY).customEffects();
@@ -69,7 +67,6 @@ public final class PotionItemStackData {
                             h.update(DataComponents.POTION_CONTENTS, PotionContents.EMPTY, contents -> new PotionContents(contents.potion(), contents.customColor(), mcList));
                         })
                         .delete(h -> h.update(DataComponents.POTION_CONTENTS, PotionContents.EMPTY, contents -> new PotionContents(contents.potion(), contents.customColor(), Collections.emptyList())))
-                        .supports(h -> h.getItem() == Items.POTION || h.getItem() == Items.SPLASH_POTION || h.getItem() == Items.LINGERING_POTION || h.getItem() == Items.TIPPED_ARROW)
                     .create(Keys.POTION_TYPE)
                         .get(h -> (PotionType) h.getOrDefault(DataComponents.POTION_CONTENTS, PotionContents.EMPTY).potion().map(Holder::value).orElse(null)) // TODO empty POTION gone?
                         .set((h, v) -> {
@@ -77,14 +74,11 @@ public final class PotionItemStackData {
                             h.update(DataComponents.POTION_CONTENTS, PotionContents.EMPTY, contents -> new PotionContents(potion, contents.customColor(), contents.customEffects()));
                         })
                         .delete(h -> h.update(DataComponents.POTION_CONTENTS, PotionContents.EMPTY, contents -> new PotionContents(Optional.empty(), contents.customColor(), contents.customEffects())))
-                        .supports(h -> h.getItem() == Items.POTION || h.getItem() == Items.SPLASH_POTION ||
-                                h.getItem() == Items.LINGERING_POTION || h.getItem() == Items.TIPPED_ARROW)
                     .create(Keys.POTION_EFFECTS)
                         .get(h -> {
                             final Iterable<MobEffectInstance> effects = h.getOrDefault(DataComponents.POTION_CONTENTS, PotionContents.EMPTY).getAllEffects();
                             return ImmutableList.copyOf((List<PotionEffect>) (Object) effects);
                         })
-                        .supports(h -> h.getItem() == Items.POTION || h.getItem() == Items.SPLASH_POTION || h.getItem() == Items.LINGERING_POTION || h.getItem() == Items.TIPPED_ARROW)
         ;
     }
     // @formatter:on

--- a/src/main/java/org/spongepowered/common/util/FireworkUtil.java
+++ b/src/main/java/org/spongepowered/common/util/FireworkUtil.java
@@ -58,14 +58,11 @@ public final class FireworkUtil {
 
         if (item.getItem() == Items.FIREWORK_STAR) {
             item.set(DataComponents.FIREWORK_EXPLOSION, (FireworkExplosion) (Object) effects.getFirst());
-            return true;
-        } else if (item.getItem() == Items.FIREWORK_ROCKET) {
+        } else {
             final List<FireworkExplosion> mcEffects = effects.stream().map(FireworkExplosion.class::cast).toList();
             item.update(DataComponents.FIREWORKS, new Fireworks(1, Collections.emptyList()), p -> new Fireworks(p.flightDuration(), mcEffects));
-            return true;
         }
-
-        return false;
+        return true;
     }
 
     public static Optional<List<FireworkEffect>> getFireworkEffects(final FireworkRocketEntity firework) {
@@ -77,20 +74,18 @@ public final class FireworkUtil {
             return Optional.empty();
         }
 
-        if (item.getItem() == Items.FIREWORK_ROCKET) {
-            final Fireworks fireworks = item.get(DataComponents.FIREWORKS);
-            if (fireworks == null || fireworks.explosions().isEmpty()) {
-                return Optional.empty();
+        if (item.getItem() == Items.FIREWORK_STAR) {
+            final FireworkExplosion fireworkExplosion = item.get(DataComponents.FIREWORK_EXPLOSION);
+            if (fireworkExplosion != null) {
+                return Optional.of(List.of((FireworkEffect) (Object) fireworkExplosion));
             }
-            return Optional.of(fireworks.explosions().stream().map(FireworkEffect.class::cast).toList());
         }
 
-        Preconditions.checkArgument(item.getItem() == Items.FIREWORK_STAR, "Item is not a firework star!");
-        final FireworkExplosion fireworkExplosion = item.get(DataComponents.FIREWORK_EXPLOSION);
-        if (fireworkExplosion == null) {
+        final Fireworks fireworks = item.get(DataComponents.FIREWORKS);
+        if (fireworks == null || fireworks.explosions().isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(List.of((FireworkEffect) (Object) fireworkExplosion));
+        return Optional.of(fireworks.explosions().stream().map(FireworkEffect.class::cast).toList());
     }
 
     public static boolean removeFireworkEffects(final FireworkRocketEntity firework) {
@@ -106,14 +101,12 @@ public final class FireworkUtil {
             item.remove(DataComponents.FIREWORK_EXPLOSION);
             return true;
         }
-        if (item.getItem() == Items.FIREWORK_ROCKET) {
-            if (item.has(DataComponents.FIREWORKS)) {
-                // keep flight duration
-                item.update(DataComponents.FIREWORKS, null, p -> new Fireworks(p.flightDuration(), Collections.emptyList()));
-            }
-            return true;
+
+        if (item.has(DataComponents.FIREWORKS)) {
+            // keep flight duration
+            item.update(DataComponents.FIREWORKS, null, p -> new Fireworks(p.flightDuration(), Collections.emptyList()));
         }
-        return false;
+        return true;
     }
 
     public static boolean setFlightModifier(final FireworkRocketEntity firework, final int modifier) {
@@ -127,11 +120,8 @@ public final class FireworkUtil {
             return false;
         }
 
-        if (item.getItem() == Items.FIREWORK_ROCKET) {
-            item.update(DataComponents.FIREWORKS, new Fireworks(1, Collections.emptyList()), p -> new Fireworks(modifier, p.explosions()));
-            return true;
-        }
-        return false;
+        item.update(DataComponents.FIREWORKS, new Fireworks(1, Collections.emptyList()), p -> new Fireworks(modifier, p.explosions()));
+        return true;
     }
 
     public static OptionalInt getFlightModifier(final FireworkRocketEntity firework) {


### PR DESCRIPTION
These `supports`  make no sense because these keys reflect components that can be applied to any stack.

For firework data the only remaining limitation is that FIREWORK_STAR assumed to be the only item that can have `FIREWORK_EXPLOSION` component. For other stacks `Keys.FIREWORK_EFFECTS` sets regular firework component (and will do the same whenever firework star component gets it's own key).