### PR TITLE
Allow including external projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ buildSrc/src/api
 testplugins.settings.gradle.kts
 spongeforge.settings.gradle.kts
 projects.properties
+# External plugin projects
+/userplugins/userPluginBuilds
+/userplugins/userPlugins

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -25,6 +25,7 @@ val bootstrapDevProject = commonProject.project(":bootstrap-dev")
 val transformersProject = commonProject.project(":modlauncher-transformers")
 val libraryManagerProject = commonProject.project(":library-manager")
 val testPluginsProject: Project? = rootProject.subprojects.find { "testplugins" == it.name }
+val userPluginsProject: Project? = rootProject.subprojects.find { "userplugins" == it.name }
 
 val apiVersion: String by project
 val minecraftVersion: String by project
@@ -213,6 +214,9 @@ dependencies {
 
     runtimeOnly(project(bootstrapDevProject.path))
     testPluginsProject?.also {
+        runtimeOnly(project(it.path))
+    }
+    userPluginsProject?.also {
         runtimeOnly(project(it.path))
     }
 }

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -21,6 +21,7 @@ val commonProject = parent!!
 val transformersProject = commonProject.project(":modlauncher-transformers")
 val libraryManagerProject = commonProject.project(":library-manager")
 val testPluginsProject: Project? = rootProject.subprojects.find { "testplugins" == it.name }
+val userPluginsProject: Project? = rootProject.subprojects.find { "userplugins" == it.name }
 
 val apiVersion: String by project
 val minecraftVersion: String by project
@@ -303,6 +304,9 @@ tasks {
                 dirs.addAll(testPluginsOutput.classesDirs)
                 environment["SPONGE_PLUGINS"] = dirs.joinToString("&")
 
+                dependsOn(it.tasks.classes)
+            }
+            userPluginsProject?.also {
                 dependsOn(it.tasks.classes)
             }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -110,6 +110,22 @@ if (projects.contains("neoforge")) {
     project(":SpongeNeo").projectDir = file("neoforge")
 }
 
+if (projects.contains("userplugins")) {
+    include(":userplugins")
+    val userPluginBuilds = file("userplugins/userPluginBuilds")
+    if (userPluginBuilds.exists()) {
+        userPluginBuilds.readLines().filter { !it.startsWith("#") && it.isNotBlank()}.forEach {
+            includeBuild(it)
+        }
+    } else {
+        userPluginBuilds.writeText("# Add paths to your plugin projects here")
+    }
+    val userPlugins = file("userplugins/userPlugins")
+    if (userPlugins.exists().not()) {
+        userPlugins.writeText("# Add dependencies to your plugins here")
+    }
+}
+
 if (projects.contains("testplugins")) {
     include(":testplugins")
 }

--- a/userplugins/build.gradle.kts
+++ b/userplugins/build.gradle.kts
@@ -1,0 +1,11 @@
+val apiVersion: String by project
+
+dependencies {
+    annotationProcessor(implementation("org.spongepowered:spongeapi:$apiVersion")!!)
+    val userPlugins = file("userPlugins")
+    if (userPlugins.exists()) {
+        userPlugins.readLines().filter { !it.startsWith("#") && it.isNotBlank() }.forEach {
+            implementation(it)
+        }
+    }
+}

--- a/vanilla/build.gradle.kts
+++ b/vanilla/build.gradle.kts
@@ -14,6 +14,7 @@ val bootstrapDevProject = commonProject.project(":bootstrap-dev")
 val transformersProject = commonProject.project(":modlauncher-transformers")
 val libraryManagerProject = commonProject.project(":library-manager")
 val testPluginsProject: Project? = rootProject.subprojects.find { "testplugins" == it.name }
+val userPluginsProject: Project? = rootProject.subprojects.find { "userplugins" == it.name }
 
 val apiVersion: String by project
 val apiJavaTarget: String by project
@@ -246,6 +247,9 @@ dependencies {
     testPluginsProject?.also {
         runtimeOnly(project(it.path))
     }
+        userPluginsProject?.also {
+            runtimeOnly(project(it.path))
+        }
 }
 
 minecraft {


### PR DESCRIPTION
Adding `userplugins=true` to `project.properties` enables 
`testplugins/userPluginBuilds` file to add paths to additional gradle projects
```
/path/to/my/plugin/project
```
`testplugins/userPlugins` file to add plugins as gradle dependencies
```
com.example.plugin:plugin1
com.example.plugin:plugin2
```

Sponge Plugins added this way are automatically loaded and can be hot-swapped.
