### PR TITLE
Fix HandPreference#asComponent

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/HumanoidArmMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/entity/HumanoidArmMixin_API.java
@@ -35,11 +35,11 @@ import org.spongepowered.asm.mixin.Shadow;
 public abstract class HumanoidArmMixin_API implements HandPreference {
 
     // @formatter:off
-    @Shadow @Final private String name;
+    @Shadow @Final private String translationKey;
     // @formatter:on
 
     @Override
     public Component asComponent() {
-        return Component.translatable(this.name);
+        return Component.translatable(this.translationKey);
     }
 }


### PR DESCRIPTION
Component#translatable should use its translation key, not serializable name