### PR TITLE
introduce scoped registry holder using PhaseTracker

### DIFF
--- a/generator/src/main/java/org/spongepowered/vanilla/generator/RegistryScope.java
+++ b/generator/src/main/java/org/spongepowered/vanilla/generator/RegistryScope.java
@@ -63,7 +63,7 @@ public enum RegistryScope {
     SERVER {
         @Override
         protected CodeBlock registryKeyToReference() {
-            return CodeBlock.of("asDefaultedReference($T::server)", Types.SPONGE);
+            return CodeBlock.of("asScopedReference()", Types.SPONGE);
         }
 
         @Override

--- a/src/main/java/org/spongepowered/common/SpongeCommon.java
+++ b/src/main/java/org/spongepowered/common/SpongeCommon.java
@@ -37,7 +37,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.common.applaunch.config.core.SpongeConfigs;
+import org.spongepowered.common.event.tracking.PhaseTracker;
 import org.spongepowered.common.launch.Launch;
+import org.spongepowered.common.registry.SpongeRegistryHolder;
 import org.spongepowered.common.scheduler.AsyncScheduler;
 import org.spongepowered.common.scheduler.ServerScheduler;
 
@@ -100,8 +102,21 @@ public final class SpongeCommon {
         return SpongeCommon.server().registryAccess();
     }
 
+    public static SpongeRegistryHolder scopedHolder() {
+        var holder = PhaseTracker.getInstance().currentCause().first(SpongeRegistryHolder.class);
+        // If we have a holder in scope use it directly unless it is game
+        if (holder.isEmpty() || holder.get() == SpongeCommon.game()) {
+
+            if (SpongeCommon.game().isServerAvailable()) {
+                return (SpongeRegistryHolder) SpongeCommon.server();
+            }
+            return SpongeCommon.game();
+        }
+        return holder.get();
+    }
+
     public static <E> Registry<E> vanillaRegistry(ResourceKey<? extends Registry<? extends E>> key) {
-        return SpongeCommon.vanillaRegistryAccess().lookupOrThrow(key);
+        return (Registry<E>) SpongeCommon.scopedHolder().lookupOrThrow(key);
     }
 
     public static ServerScheduler serverScheduler() {

--- a/src/main/java/org/spongepowered/common/SpongeCommon.java
+++ b/src/main/java/org/spongepowered/common/SpongeCommon.java
@@ -103,16 +103,15 @@ public final class SpongeCommon {
     }
 
     public static SpongeRegistryHolder scopedHolder() {
-        var holder = PhaseTracker.getInstance().currentCause().first(SpongeRegistryHolder.class);
+        var holder = PhaseTracker.getInstance().startupRegistryHolder();
         // If we have a holder in scope use it directly unless it is game
-        if (holder.isEmpty() || holder.get() == SpongeCommon.game()) {
-
+        if (holder == null) {
             if (SpongeCommon.game().isServerAvailable()) {
                 return (SpongeRegistryHolder) SpongeCommon.server();
             }
             return SpongeCommon.game();
         }
-        return holder.get();
+        return holder;
     }
 
     public static <E> Registry<E> vanillaRegistry(ResourceKey<? extends Registry<? extends E>> key) {

--- a/src/main/java/org/spongepowered/common/SpongeLifecycle.java
+++ b/src/main/java/org/spongepowered/common/SpongeLifecycle.java
@@ -212,13 +212,16 @@ public final class SpongeLifecycle implements Lifecycle {
 
     @Override
     public void processServerRegistries(final RegistryHolder server, final Stream<? extends org.spongepowered.api.registry.Registry<?>> registries) {
-        final Map<RegistryType<?>, org.spongepowered.api.registry.Registry<?>> map =
-            registries.collect(Collectors.toMap(org.spongepowered.api.registry.Registry::type, Function.identity()));
-        if (!map.isEmpty()) {
-            map.values().forEach(r -> ((WritableRegistryBridge<?>) r).bridge$setRegistryHolder(server));
-            this.game.eventManager().post(AbstractRegisterRegistryValueEvent.EngineScopedImpl.server(Cause.of(EventContext.empty(), this.game), this.game, server, map));
-            map.values().forEach(r -> ((WritableRegistryBridge<?>) r).bridge$markEventCalled());
-            ((SpongeRegistryHolder) server).registryHolder().freezeSpongeDynamicRegistries(false);
+        try (var frame = PhaseTracker.getInstance().pushCauseFrame()) {
+            frame.pushCause(server);
+            final Map<RegistryType<?>, org.spongepowered.api.registry.Registry<?>> map =
+                    registries.collect(Collectors.toMap(org.spongepowered.api.registry.Registry::type, Function.identity()));
+            if (!map.isEmpty()) {
+                map.values().forEach(r -> ((WritableRegistryBridge<?>) r).bridge$setRegistryHolder(server));
+                this.game.eventManager().post(AbstractRegisterRegistryValueEvent.EngineScopedImpl.server(Cause.of(EventContext.empty(), this.game), this.game, server, map));
+                map.values().forEach(r -> ((WritableRegistryBridge<?>) r).bridge$markEventCalled());
+                ((SpongeRegistryHolder) server).registryHolder().freezeSpongeDynamicRegistries(false);
+            }
         }
     }
 

--- a/src/main/java/org/spongepowered/common/SpongeLifecycle.java
+++ b/src/main/java/org/spongepowered/common/SpongeLifecycle.java
@@ -212,8 +212,8 @@ public final class SpongeLifecycle implements Lifecycle {
 
     @Override
     public void processServerRegistries(final RegistryHolder server, final Stream<? extends org.spongepowered.api.registry.Registry<?>> registries) {
-        try (var frame = PhaseTracker.getInstance().pushCauseFrame()) {
-            frame.pushCause(server);
+        try {
+            PhaseTracker.getInstance().startupRegistryHolder(server);
             final Map<RegistryType<?>, org.spongepowered.api.registry.Registry<?>> map =
                     registries.collect(Collectors.toMap(org.spongepowered.api.registry.Registry::type, Function.identity()));
             if (!map.isEmpty()) {
@@ -222,6 +222,8 @@ public final class SpongeLifecycle implements Lifecycle {
                 map.values().forEach(r -> ((WritableRegistryBridge<?>) r).bridge$markEventCalled());
                 ((SpongeRegistryHolder) server).registryHolder().freezeSpongeDynamicRegistries(false);
             }
+        } finally {
+            PhaseTracker.getInstance().startupRegistryHolder(null);
         }
     }
 

--- a/src/main/java/org/spongepowered/common/data/provider/entity/PaintingData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/entity/PaintingData.java
@@ -53,7 +53,7 @@ public final class PaintingData {
                         .setAnd((h, v) -> {
                             if (!h.level().isClientSide) {
                                 final Holder<PaintingVariant> oldArt = h.getVariant();
-                                var newArt = SpongeCommon.server().registryAccess().lookupOrThrow(Registries.PAINTING_VARIANT).wrapAsHolder((PaintingVariant) (Object) v);
+                                var newArt = SpongeCommon.vanillaRegistry(Registries.PAINTING_VARIANT).wrapAsHolder((PaintingVariant) (Object) v);
                                 h.setVariant(newArt);
                                 ((HangingEntityAccessor) h).invoker$setDirection(h.getDirection());
                                 if (!h.survives()) {

--- a/src/main/java/org/spongepowered/common/data/provider/item/stack/BookPagesItemStackData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/item/stack/BookPagesItemStackData.java
@@ -71,7 +71,7 @@ public final class BookPagesItemStackData {
         if (value.isEmpty()) {
             return BookPagesItemStackData.delete(holder, component);
         }
-        final var registry = SpongeCommon.server().registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
+        final var registry = SpongeCommon.vanillaRegistry(Registries.ENCHANTMENT);
         holder.update(component, ItemEnchantments.EMPTY, ench -> {
             final ItemEnchantments.Mutable mutable = new ItemEnchantments.Mutable(ench);
             mutable.keySet().clear();

--- a/src/main/java/org/spongepowered/common/data/provider/item/stack/ItemStackData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/item/stack/ItemStackData.java
@@ -112,7 +112,13 @@ public final class ItemStackData {
         registrator
                 .asMutable(ItemStack.class)
                     .create(Keys.BURN_TIME)
-                        .get(h -> SpongeCommon.server().fuelValues().burnDuration(h))
+                        .get(h -> {
+                            if (SpongeCommon.game().isServerAvailable()) {
+                                return SpongeCommon.server().fuelValues().burnDuration(h);
+                            } else {
+                                return null;
+                            }
+                        })
                     .create(Keys.CONTAINER_ITEM)
                         .get(h -> (ItemType) h.getItem().getCraftingRemainder().getItem())
                     .create(Keys.DISPLAY_NAME)
@@ -395,12 +401,12 @@ public final class ItemStackData {
             return DataTransactionResult.successNoData();
         }
         return cooldown.cooldownGroup()
-            .map(group -> DataTransactionResult.successRemove(List.of(
-                Value.immutableOf(Keys.COOLDOWN, Ticks.of(cooldown.ticks())),
-                Value.immutableOf(Keys.COOLDOWN_GROUP, (ResourceKey) (Object) group)
-            ))).orElseGet(() -> DataTransactionResult.successRemove(List.of(
-                Value.immutableOf(Keys.COOLDOWN, Ticks.of(cooldown.ticks()))
-            )));
+                .map(group -> DataTransactionResult.successRemove(List.of(
+                        Value.immutableOf(Keys.COOLDOWN, Ticks.of(cooldown.ticks())),
+                        Value.immutableOf(Keys.COOLDOWN_GROUP, (ResourceKey) (Object) group)
+                ))).orElseGet(() -> DataTransactionResult.successRemove(List.of(
+                        Value.immutableOf(Keys.COOLDOWN, Ticks.of(cooldown.ticks()))
+                )));
     }
 
 }

--- a/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeDamageSourceBuilder.java
+++ b/src/main/java/org/spongepowered/common/event/cause/entity/damage/SpongeDamageSourceBuilder.java
@@ -63,7 +63,7 @@ public class SpongeDamageSourceBuilder implements DamageSource.Builder {
 
     @Override
     public DamageSource.Builder type(final DamageType damageType) {
-        final var registry = SpongeCommon.server().registryAccess().lookupOrThrow(Registries.DAMAGE_TYPE);
+        final var registry = SpongeCommon.vanillaRegistry(Registries.DAMAGE_TYPE);
         this.damageType = registry.wrapAsHolder((net.minecraft.world.damagesource.DamageType) (Object) damageType);
         return this;
     }

--- a/src/main/java/org/spongepowered/common/event/tracking/PhaseTracker.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/PhaseTracker.java
@@ -49,6 +49,7 @@ import org.spongepowered.api.event.CauseStackManager;
 import org.spongepowered.api.event.EventContext;
 import org.spongepowered.api.event.EventContextKey;
 import org.spongepowered.api.event.EventContextKeys;
+import org.spongepowered.api.registry.RegistryHolder;
 import org.spongepowered.api.scheduler.Task;
 import org.spongepowered.api.util.Ticks;
 import org.spongepowered.common.SpongeCommon;
@@ -59,6 +60,7 @@ import org.spongepowered.common.event.tracking.phase.general.GeneralPhase;
 import org.spongepowered.common.event.tracking.phase.plugin.PluginPhase;
 import org.spongepowered.common.event.tracking.phase.tick.TickPhase;
 import org.spongepowered.common.launch.Launch;
+import org.spongepowered.common.registry.SpongeRegistryHolder;
 import org.spongepowered.common.util.Constants;
 import org.spongepowered.common.util.Preconditions;
 import org.spongepowered.common.util.PrettyPrinter;
@@ -259,6 +261,7 @@ public final class PhaseTracker implements CauseStackManager {
     private final Deque<PhaseContext<?>> phaseContextProviders = new ArrayDeque<>();
     final PhaseStack stack = new PhaseStack();
     private final SpongeCauseStackManager api = new SpongeCauseStackManager();
+    private @Nullable SpongeRegistryHolder startupRegistryHolder;
 
     PhaseTracker() {
         for (int i = 0; i < PhaseTracker.INITIAL_POOL_SIZE; i++) {
@@ -866,6 +869,18 @@ public final class PhaseTracker implements CauseStackManager {
 
     public CauseStackManager apiAccess() {
         return this.api;
+    }
+
+    public void startupRegistryHolder(final RegistryHolder holder) {
+        if (holder instanceof SpongeRegistryHolder srh) {
+            this.startupRegistryHolder = srh;
+        } else {
+            this.startupRegistryHolder = null;
+        }
+    }
+
+    public @Nullable SpongeRegistryHolder startupRegistryHolder() {
+        return this.startupRegistryHolder;
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/item/enchantment/SpongeRandomEnchantmentListBuilder.java
+++ b/src/main/java/org/spongepowered/common/item/enchantment/SpongeRandomEnchantmentListBuilder.java
@@ -93,7 +93,7 @@ public final class SpongeRandomEnchantmentListBuilder implements Enchantment.Ran
         if (this.pool == null || this.pool.isEmpty()) {
             Objects.requireNonNull(this.item, "The item cannot be null");
             this.randomSource.setSeed(this.seed + this.option);
-            final var registry = SpongeCommon.server().registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
+            final var registry = SpongeCommon.vanillaRegistry(Registries.ENCHANTMENT);
             var stream = registry.listElements().map($$0x -> (Holder<net.minecraft.world.item.enchantment.Enchantment>)$$0x);
             enchantments = EnchantmentHelper.selectEnchantment(this.randomSource, ItemStackUtil.toNative(this.item), this.level, stream);
         } else {
@@ -139,7 +139,7 @@ public final class SpongeRandomEnchantmentListBuilder implements Enchantment.Ran
     }
 
     public static List<EnchantmentInstance> toNative(final List<Enchantment> list) {
-        final var registry = SpongeCommon.server().registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
+        final var registry = SpongeCommon.vanillaRegistry(Registries.ENCHANTMENT);
         return list.stream().map(ench -> {
                     var mcEnch = registry.wrapAsHolder((net.minecraft.world.item.enchantment.Enchantment) (Object) ench.type());
                     return new EnchantmentInstance(mcEnch, ench.level());

--- a/src/main/java/org/spongepowered/common/registry/SpongeRegistryKey.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeRegistryKey.java
@@ -30,6 +30,7 @@ import org.spongepowered.api.registry.RegistryHolder;
 import org.spongepowered.api.registry.RegistryKey;
 import org.spongepowered.api.registry.RegistryReference;
 import org.spongepowered.api.registry.RegistryType;
+import org.spongepowered.common.SpongeCommon;
 
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -63,6 +64,11 @@ public class SpongeRegistryKey<T> implements RegistryKey<T> {
     @Override
     public final <V extends T> DefaultedRegistryReference<V> asDefaultedReference(final Supplier<RegistryHolder> defaultHolder) {
         return new SpongeDefaultedRegistryReference<>((RegistryKey<V>) this, defaultHolder);
+    }
+
+    @Override
+    public final <V extends T> DefaultedRegistryReference<V> asScopedReference() {
+        return new SpongeDefaultedRegistryReference<>((RegistryKey<V>) this, SpongeCommon::scopedHolder);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/registry/SpongeRegistryType.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeRegistryType.java
@@ -28,6 +28,7 @@ import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.registry.DefaultedRegistryType;
 import org.spongepowered.api.registry.RegistryHolder;
 import org.spongepowered.api.registry.RegistryType;
+import org.spongepowered.common.SpongeCommon;
 
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -56,6 +57,11 @@ public class SpongeRegistryType<T> implements RegistryType<T> {
     @Override
     public final <V extends T> DefaultedRegistryType<V> asDefaultedType(final Supplier<RegistryHolder> defaultHolder) {
         return new SpongeDefaultedRegistryType<>(this.root, this.location, Objects.requireNonNull(defaultHolder, "defaultHolder"));
+    }
+
+    @Override
+    public <V> DefaultedRegistryType<V> asScopedType() {
+        return new SpongeDefaultedRegistryType<>(this.root, this.location, SpongeCommon::scopedHolder);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/schematic/SchematicTranslator.java
+++ b/src/main/java/org/spongepowered/common/world/schematic/SchematicTranslator.java
@@ -327,7 +327,7 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
             .orElseThrow(() -> new InvalidDataException("Missing BiomePalette as required by the schematic spec"));
 
         final Set<DataQuery> biomeKeys = biomeMap.keys(false);
-        final Registry<Biome> biomeRegistry = VolumeStreamUtils.nativeToSpongeRegistry(SpongeCommon.server().registryAccess().lookupOrThrow(Registries.BIOME));
+        final Registry<Biome> biomeRegistry = VolumeStreamUtils.nativeToSpongeRegistry(SpongeCommon.vanillaRegistry(Registries.BIOME));
         biomePalette = new MutableBimapPalette<>(
             PaletteTypes.BIOME_PALETTE.get(),
             biomeRegistry,
@@ -454,7 +454,7 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
 
 
             final Registry<BlockType> blockRegistry = VolumeStreamUtils.nativeToSpongeRegistry(
-                    SpongeCommon.server().registryAccess().lookupOrThrow(Registries.BLOCK));
+                    SpongeCommon.vanillaRegistry(Registries.BLOCK));
 
             SchematicTranslator.writePaletteToView(
                 blockData, palette, blockRegistry, Constants.Sponge.Schematic.BLOCK_PALETTE, BlockState::type,
@@ -506,7 +506,7 @@ public class SchematicTranslator implements DataTranslator<Schematic> {
                 // Should never reach here.
             }
 
-            final Registry<Biome> biomeRegistry = VolumeStreamUtils.nativeToSpongeRegistry(SpongeCommon.server().registryAccess().lookupOrThrow(Registries.BIOME));
+            final Registry<Biome> biomeRegistry = VolumeStreamUtils.nativeToSpongeRegistry(SpongeCommon.vanillaRegistry(Registries.BIOME));
 
             SchematicTranslator.writePaletteToView(
                 biomeContainer, biomePalette, biomeRegistry, Constants.Sponge.Schematic.BIOME_PALETTE,


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2584) | **Sponge**

Intruduces `SpongeCommon#scopedHolder` which attempts to find a `RegistryHolder` in the current cause.
`SpongeCommon#vanillaRegistry` now uses this.
Fallback to Server -> Game depending on availability.

During Startup `SpongeLifecycle#processerverRegistries` the current RegistryHolder is pushed on the stack allowing plugins during registration to access registries earlier.
Later when `DedicatedServer#initServer` is called the Server is pushed on the stack.

