### PR TITLE
Clamp mod-provided progress for bossbars

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/BossEventMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/BossEventMixin.java
@@ -90,7 +90,7 @@ public abstract class BossEventMixin implements BossEventBridge {
 
     @Redirect(method = "setProgress", at = @At(value = "FIELD", target = "Lnet/minecraft/world/BossEvent;progress:F"))
     private void adventurePercent(final BossEvent $this, final float percent) {
-        this.bridge$asAdventure().progress(percent);
+        this.bridge$asAdventure().progress(Math.clamp(percent, 0, 1));
     }
 
     @Redirect(method = "setColor", at = @At(value = "FIELD", target = "Lnet/minecraft/world/BossEvent;color:Lnet/minecraft/world/BossEvent$BossBarColor;"))


### PR DESCRIPTION
Should solve #4200 

The progress restriction of [0, 1] is coming from Adventure. Minecraft doesn't have this restriction so mods don't really care about clamping the value they provide. So I think it would be better to just clamp all mod-provided progress