### PR TITLE
[Issue #4216] Saving entity NBT error for pixelmon

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/world/SpawnEntityTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/world/SpawnEntityTransaction.java
@@ -91,7 +91,9 @@ public final class SpawnEntityTransaction extends WorldBasedTransaction<SpawnEnt
     @Override
     protected void captureState() {
         super.captureState();
-        this.entityTag = this.entityToSpawn.saveWithoutId(new CompoundTag());
+        if(this.entityToSpawn.getType().canSerialize()) {
+            this.entityTag = this.entityToSpawn.saveWithoutId(new CompoundTag());
+        }
     }
 
     @Override


### PR DESCRIPTION
Issue #4216 

### Bug
When throwing an empty pokeball, the transaction **SpawnEntityTransaction** will call `Entity#saveWithoutId` that will call `Entity#addAdditionalSaveData` overrided by **ThrowableItemProjectile** to save the **ItemStack** linked to the throwable. To retrieve this **ItemStack**, it will call `ThrowableItemProjectile#getItem` that is overrided by **PokeBallEntity**, but it will return an empty **ItemStack**, which is not serializable, hence the _Cannot encode empty ItemStack_ error.

### Fix
`Entity#saveWithoutId` is only call if the entity is made to be saved/serializable. It's something clearly set by the developer and so intended, and a way to tell that a call to the method may cause issues while remaining more permissive than `Entity#save`.

### Impact
In the game, 4 entities are marked as not serializable: leash knot, lightning bolt, player and fishing robber. We can also add some entities of other mods in the list. So the change has a significant impact because it will stop serialize a lot of entities for which it worked, but it seems that the `entityTag` field is not used in Sponge or even shared to mods, so I don't understand in what way it is important. Am I missing something here ?

### Discussion
#### Else clause
I didn't set a value in the case where the entity is not serializable because I didn't know what a good one could be. An another value can be an empty **CoumpoundTag**, which is a way to say that `captureState()` has been called but the state cannot be captured and allows to avoid NPE, but then you cannot differentiate between something that don't have something to save.

#### Condition
I though of another solutions but that I like less:
- Surround the method with a try/catch: reduce the impact to the minimum, only the problematic ones, but may hide potential bugs as the exception will not be logged anymore or difficult to see if logged at a lower level
- Do not call the method if the entity is a throwable item with an empty item: too specific to the bug, an exception may also happen with other type of entities or for other reasons, and so the condition will become bigger and bigger. This is less future-proof and increase cost maintenance.