### PR TITLE
Missing event when middle mouse click on a block/entity

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/ClickMenuTransaction.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/context/transaction/inventory/ClickMenuTransaction.java
@@ -25,6 +25,8 @@
 package org.spongepowered.common.event.tracking.context.transaction.inventory;
 
 import net.minecraft.network.protocol.game.ServerboundContainerClickPacket;
+import net.minecraft.network.protocol.game.ServerboundPickItemFromBlockPacket;
+import net.minecraft.network.protocol.game.ServerboundPickItemFromEntityPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -106,10 +108,14 @@ public class ClickMenuTransaction extends ContainerBasedTransaction {
     boolean isContainerEventAllowed(
         final PhaseContext<@NonNull ?> context
     ) {
-        if (!(context instanceof InventoryPacketContext)) {
+        if (!(context instanceof InventoryPacketContext inventoryPacketContext)) {
             return false;
         }
-        final int containerId = ((InventoryPacketContext) context).<ServerboundContainerClickPacket>getPacket().getContainerId();
+        if(inventoryPacketContext.getPacket() instanceof ServerboundPickItemFromBlockPacket ||
+            inventoryPacketContext.getPacket() instanceof ServerboundPickItemFromEntityPacket) {
+            return true; //The item is always put in the player container menu
+        }
+        final int containerId = inventoryPacketContext.<ServerboundContainerClickPacket>getPacket().getContainerId();
         return containerId != this.player.containerMenu.containerId;
     }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhase.java
@@ -39,6 +39,8 @@ import net.minecraft.network.protocol.game.ServerboundContainerClickPacket;
 import net.minecraft.network.protocol.game.ServerboundContainerClosePacket;
 import net.minecraft.network.protocol.game.ServerboundInteractPacket;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
+import net.minecraft.network.protocol.game.ServerboundPickItemFromBlockPacket;
+import net.minecraft.network.protocol.game.ServerboundPickItemFromEntityPacket;
 import net.minecraft.network.protocol.game.ServerboundPlaceRecipePacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerAbilitiesPacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
@@ -316,6 +318,8 @@ public final class PacketPhase {
         this.packetTranslationMap.put(ServerboundPlayerInputPacket.class, packet -> PacketPhase.General.HANDLED_EXTERNALLY);
         this.packetTranslationMap.put(ServerboundContainerClosePacket.class, packet -> PacketPhase.General.CLOSE_WINDOW);
         this.packetTranslationMap.put(ServerboundContainerClickPacket.class, packet -> PacketPhase.fromWindowPacket((ServerboundContainerClickPacket) packet));
+        this.packetTranslationMap.put(ServerboundPickItemFromBlockPacket.class, packet -> Inventory.MIDDLE_INVENTORY_CLICK);
+        this.packetTranslationMap.put(ServerboundPickItemFromEntityPacket.class, packet -> Inventory.MIDDLE_INVENTORY_CLICK);
         this.packetTranslationMap.put(ServerboundSetCreativeModeSlotPacket.class, packet -> PacketPhase.General.CREATIVE_INVENTORY);
         this.packetTranslationMap.put(ServerboundContainerButtonClickPacket.class, packet -> PacketPhase.Inventory.ENCHANT_ITEM);
         this.packetTranslationMap.put(ServerboundSignUpdatePacket.class, packet -> PacketPhase.General.UPDATE_SIGN);

--- a/src/mixins/java/org/spongepowered/common/mixin/inventory/event/server/network/ServerGamePacketListenerImplMixin_Inventory.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/inventory/event/server/network/ServerGamePacketListenerImplMixin_Inventory.java
@@ -36,8 +36,10 @@ import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.AnvilMenu;
+import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.inventory.MerchantMenu;
 import net.minecraft.world.item.ItemStack;
@@ -51,6 +53,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import org.spongepowered.common.bridge.world.TrackedWorldBridge;
 import org.spongepowered.common.bridge.world.inventory.AbstractContainerMenu_InventoryBridge;
 import org.spongepowered.common.bridge.world.inventory.container.MenuBridge;
@@ -77,6 +80,16 @@ public class ServerGamePacketListenerImplMixin_Inventory {
         try (final EffectTransactor ignored = transactor.logCreativeClickContainer(packetIn.slotNum(), ItemStackUtil.snapshotOf(itemstack), this.player)) {
         }
         inventoryMenu.broadcastChanges();
+    }
+
+    @Inject(method = "tryPickItem",
+        at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/world/entity/player/Inventory;findSlotMatchingItem(Lnet/minecraft/world/item/ItemStack;)I"),
+        locals = LocalCapture.CAPTURE_FAILSOFT)
+    private void impl$onPickItem(final ItemStack stack, final CallbackInfo ci, Inventory inventory, int slotNum) {
+        final PhaseContext<@NonNull ?> context = PhaseTracker.getWorldInstance(this.player.serverLevel()).getPhaseContext();
+        final TransactionalCaptureSupplier transactor = context.getTransactor();
+        try(final EffectTransactor ignored = transactor.logClickContainer(player.containerMenu, slotNum, 0, ClickType.PICKUP, player)) {
+        }
     }
 
     @Redirect(method = "handleSetCreativeModeSlot",


### PR DESCRIPTION
Issue #4171 

### Bug
When performing a middle mouse click in creative mode on a block or an entity, the warning `Logged slot transactions without event! 1 net.minecraft.world.inventory.InventoryMenu` followed by an exception was printed in the console.

### Fix
Log a click container transaction when the player picks a block or an entity.

### Notes
_buttonNum_ is set to 0 because the packet doesn't contain this information, but the value is not used in **MiddleInventoryClickState**.
I wanted to add the mixin before the `broadcastChanges`  but the slot number was not available at that point (I don't know why), so I added it after `findSlotMatchingItem`.
I acknowledge that the instanceof in **ClickMenuTransaction** is not very clean but I wanted to minimize code changes.