### PR TITLE
Use LauncherInterceptor for JUnit tests

### DIFF
--- a/bootstrap/src/main/java/org/spongepowered/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/org/spongepowered/bootstrap/Bootstrap.java
@@ -26,6 +26,7 @@ package org.spongepowered.bootstrap;
 
 import org.spongepowered.bootstrap.dev.DevClasspath;
 
+import java.io.File;
 import java.lang.module.Configuration;
 import java.lang.module.ModuleFinder;
 import java.net.URL;
@@ -38,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public abstract class Bootstrap<Jar> {
     public static final boolean DEBUG = Boolean.getBoolean("sponge.bootstrap.debug");
@@ -117,7 +119,23 @@ public abstract class Bootstrap<Jar> {
 
         // Isolation
         final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
-        ClassLoader parentLoader = isolated ? ClassLoader.getPlatformClassLoader() : contextLoader;
+        ClassLoader parentLoader = ClassLoader.getPlatformClassLoader();
+        if (!isolated) {
+            // Make sure we don't leak classes that are supposed to be
+            // in the game layer from the boostrap layer.
+            final String resources = System.getProperty("sponge.resources");
+            if (resources != null) {
+                final List<Jar> spongeJars = new ArrayList<>();
+                for (final String entry : resources.split(File.pathSeparator)) {
+                    final Path[] paths = Stream.of(entry.split("&")).map(Path::of).toArray(Path[]::new);
+                    spongeJars.add(this.createJar(paths));
+                }
+                final List<String> spongeModules = spongeJars.stream().map(this::getModuleName).toList();
+                final ModuleFinder spongeFinder = this.createModuleFinder(spongeJars);
+                final Configuration spongeConfig = Configuration.resolveAndBind(spongeFinder, List.of(config), ModuleFinder.of(), spongeModules);
+                parentLoader = new FilteringPassthroughClassLoader(contextLoader, spongeConfig);
+            }
+        }
 
         // Intermediate classloader to include resources but not modules
         if (!resourceJars.isEmpty()) {

--- a/bootstrap/src/main/java/org/spongepowered/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/org/spongepowered/bootstrap/Bootstrap.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.lang.module.Configuration;
 import java.lang.module.ModuleFinder;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,7 +74,8 @@ public abstract class Bootstrap<Jar> {
 
         // Collect the jars
         final Set<String> moduleNames = new HashSet<>();
-        final List<Path> resourceJars = new ArrayList<>();
+        final List<Path> resourcePaths = new ArrayList<>();
+        final List<Jar> resourceJars = new ArrayList<>();
         final List<Jar> appJars = new ArrayList<>();
 
         for (final Path[] paths : classpath) {
@@ -94,7 +94,8 @@ public abstract class Bootstrap<Jar> {
                 if (Bootstrap.DEBUG) {
                     System.out.println("Filtered: " + name + " " + Bootstrap.formatUnion(paths));
                 }
-                resourceJars.addAll(Arrays.asList(paths));
+                resourceJars.add(jar);
+                resourcePaths.addAll(Arrays.asList(paths));
                 continue;
             }
 
@@ -102,7 +103,8 @@ public abstract class Bootstrap<Jar> {
                 if (Bootstrap.DEBUG) {
                     System.out.println("Duplicate: " + name + " " + Bootstrap.formatUnion(paths));
                 }
-                resourceJars.addAll(Arrays.asList(paths));
+                resourceJars.add(jar);
+                resourcePaths.addAll(Arrays.asList(paths));
                 continue;
             }
 
@@ -130,20 +132,20 @@ public abstract class Bootstrap<Jar> {
                     final Path[] paths = Stream.of(entry.split("&")).map(Path::of).toArray(Path[]::new);
                     spongeJars.add(this.createJar(paths));
                 }
-                final List<String> spongeModules = spongeJars.stream().map(this::getModuleName).toList();
                 final ModuleFinder spongeFinder = this.createModuleFinder(spongeJars);
-                final Configuration spongeConfig = Configuration.resolveAndBind(spongeFinder, List.of(config), ModuleFinder.of(), spongeModules);
-                parentLoader = new FilteringPassthroughClassLoader(contextLoader, spongeConfig);
+                final ModuleFinder resourceFinder = this.createModuleFinder(resourceJars);
+                parentLoader = new FilteringPassthroughClassLoader(contextLoader,
+                    Stream.concat(spongeFinder.findAll().stream(), resourceFinder.findAll().stream()));
             }
         }
 
         // Intermediate classloader to include resources but not modules
-        if (!resourceJars.isEmpty()) {
-            final URL[] urls = new URL[resourceJars.size()];
+        if (!resourcePaths.isEmpty()) {
+            final URL[] urls = new URL[resourcePaths.size()];
             for (int i = 0; i < urls.length; i++) {
-                urls[i] = resourceJars.get(i).toUri().toURL();
+                urls[i] = resourcePaths.get(i).toUri().toURL();
             }
-            parentLoader = new URLClassLoader("BOOTSTRAP-RESOURCES", urls, parentLoader);
+            parentLoader = new ResourceClassLoader("BOOTSTRAP-RESOURCES", urls, parentLoader);
         }
 
         // Create the application classloader

--- a/bootstrap/src/main/java/org/spongepowered/bootstrap/FilteringPassthroughClassLoader.java
+++ b/bootstrap/src/main/java/org/spongepowered/bootstrap/FilteringPassthroughClassLoader.java
@@ -22,21 +22,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.vanilla.boot;
+package org.spongepowered.bootstrap;
 
-import org.junit.platform.launcher.LauncherSession;
-import org.junit.platform.launcher.LauncherSessionListener;
+import java.lang.module.Configuration;
+import java.lang.module.ResolvedModule;
+import java.util.HashSet;
+import java.util.Set;
 
-public final class SpongeSessionListener implements LauncherSessionListener {
+public final class FilteringPassthroughClassLoader extends ClassLoader {
 
-    private final ClassLoader classLoader;
+    private final Set<String> filteredPackages = new HashSet<>();
 
-    public SpongeSessionListener() {
-        this.classLoader = Thread.currentThread().getContextClassLoader();
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+
+    FilteringPassthroughClassLoader(final ClassLoader parent, final Configuration config) {
+        super(parent);
+        for (final ResolvedModule module : config.modules()) {
+            this.filteredPackages.addAll(module.reference().descriptor().packages());
+        }
     }
 
     @Override
-    public void launcherSessionOpened(final LauncherSession session) {
-        Thread.currentThread().setContextClassLoader(this.classLoader);
+    protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+        if (!this.filteredPackages.contains(FilteringPassthroughClassLoader.nameToPackage(name))) {
+            return super.loadClass(name, resolve);
+        }
+        throw new ClassNotFoundException(name);
+    }
+
+    private static String nameToPackage(final String name) {
+        final int index = name.lastIndexOf('.');
+        if (index == -1 || index == name.length() - 1) {
+            return "";
+        }
+        return name.substring(0, index);
     }
 }

--- a/bootstrap/src/main/java/org/spongepowered/bootstrap/ResourceClassLoader.java
+++ b/bootstrap/src/main/java/org/spongepowered/bootstrap/ResourceClassLoader.java
@@ -24,37 +24,21 @@
  */
 package org.spongepowered.bootstrap;
 
-import java.lang.module.ModuleReference;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Stream;
+import java.net.URL;
+import java.net.URLClassLoader;
 
-public final class FilteringPassthroughClassLoader extends ClassLoader {
-
-    private final Set<String> filteredPackages = new HashSet<>();
+public final class ResourceClassLoader extends URLClassLoader {
 
     static {
         ClassLoader.registerAsParallelCapable();
     }
 
-    FilteringPassthroughClassLoader(final ClassLoader parent, final Stream<ModuleReference> modules) {
-        super(parent);
-        modules.forEach(m -> this.filteredPackages.addAll(m.descriptor().packages()));
+    public ResourceClassLoader(final String name, final URL[] urls, final ClassLoader parent) {
+        super(name, urls, parent);
     }
 
     @Override
-    protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
-        if (!this.filteredPackages.contains(FilteringPassthroughClassLoader.nameToPackage(name))) {
-            return super.loadClass(name, resolve);
-        }
+    protected Class<?> findClass(final String name) throws ClassNotFoundException {
         throw new ClassNotFoundException(name);
-    }
-
-    private static String nameToPackage(final String name) {
-        final int index = name.lastIndexOf('.');
-        if (index == -1 || index == name.length() - 1) {
-            return "";
-        }
-        return name.substring(0, index);
     }
 }

--- a/bootstrap/src/main/java/org/spongepowered/bootstrap/dev/DevClasspath.java
+++ b/bootstrap/src/main/java/org/spongepowered/bootstrap/dev/DevClasspath.java
@@ -125,14 +125,14 @@ public class DevClasspath {
 
             final String fileName = path.getFileName().toString();
 
-            if (fileName.startsWith("junit-") || fileName.startsWith("mockito-")) {
+            if (fileName.startsWith("junit-") || fileName.startsWith("byte-buddy-")) {
                 if (Bootstrap.DEBUG) {
                     System.out.println("Ignored: " + path);
                 }
                 continue;
             }
 
-            if (bootNames.contains(fileName) || fileName.startsWith("org.jacoco.core-")) {
+            if (bootNames.contains(fileName) || fileName.startsWith("org.jacoco.core-") || fileName.startsWith("mockito-") || fileName.startsWith("objenesis-")) {
                 if (Bootstrap.DEBUG) {
                     System.out.println("Boot: " + path);
                 }

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -435,6 +435,7 @@ tasks {
         jvmArgs(runServer.jvmArgs)
         jvmArgs("-Dsponge.test.args=" + runServer.args.joinToString(" "))
         jvmArgs("-Dsponge.jacoco.packages=org.spongepowered")
+        jvmArgs("-Djunit.platform.launcher.interceptors.enabled=true")
         workingDir = layout.buildDirectory.dir("test-run").get().asFile
 
         doFirst {

--- a/forge/src/test/java/org/spongepowered/forge/boot/SpongeLauncherInterceptor.java
+++ b/forge/src/test/java/org/spongepowered/forge/boot/SpongeLauncherInterceptor.java
@@ -22,21 +22,36 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.vanilla.boot;
+package org.spongepowered.forge.boot;
 
-import org.junit.platform.launcher.LauncherSession;
-import org.junit.platform.launcher.LauncherSessionListener;
+import org.junit.platform.launcher.LauncherInterceptor;
+import org.spongepowered.common.applaunch.test.TestGameAccess;
 
-public final class SpongeSessionListener implements LauncherSessionListener {
+public final class SpongeLauncherInterceptor implements LauncherInterceptor {
 
     private final ClassLoader classLoader;
 
-    public SpongeSessionListener() {
-        this.classLoader = Thread.currentThread().getContextClassLoader();
+    public SpongeLauncherInterceptor() {
+        try {
+            this.classLoader = SpongeTestBoot.getGameClassLoader();
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
-    public void launcherSessionOpened(final LauncherSession session) {
+    public <T> T intercept(final Invocation<T> invocation) {
+        final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(this.classLoader);
+        try {
+            return invocation.proceed();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Override
+    public void close() {
+        TestGameAccess.shutdownGame();
     }
 }

--- a/forge/src/test/java/org/spongepowered/forge/boot/SpongeSessionListener.java
+++ b/forge/src/test/java/org/spongepowered/forge/boot/SpongeSessionListener.java
@@ -26,25 +26,17 @@ package org.spongepowered.forge.boot;
 
 import org.junit.platform.launcher.LauncherSession;
 import org.junit.platform.launcher.LauncherSessionListener;
-import org.spongepowered.common.applaunch.test.TestGameAccess;
 
-public class SpongeSessionListener implements LauncherSessionListener {
-    private ClassLoader previousLoader;
+public final class SpongeSessionListener implements LauncherSessionListener {
 
-    @Override
-    public void launcherSessionOpened(final LauncherSession session) {
-        this.previousLoader = Thread.currentThread().getContextClassLoader();
+    private final ClassLoader classLoader;
 
-        try {
-            Thread.currentThread().setContextClassLoader(SpongeTestBoot.getGameClassLoader());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    public SpongeSessionListener() {
+        this.classLoader = Thread.currentThread().getContextClassLoader();
     }
 
     @Override
-    public void launcherSessionClosed(final LauncherSession session) {
-        TestGameAccess.shutdownGame();
-        Thread.currentThread().setContextClassLoader(this.previousLoader);
+    public void launcherSessionOpened(final LauncherSession session) {
+        Thread.currentThread().setContextClassLoader(this.classLoader);
     }
 }

--- a/forge/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherInterceptor
+++ b/forge/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherInterceptor
@@ -1,0 +1,1 @@
+org.spongepowered.forge.boot.SpongeLauncherInterceptor

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -410,6 +410,7 @@ tasks {
         jvmArgs(runServer.get().jvmArgs)
         jvmArgs("-Dsponge.test.args=" + runServer.get().args!!.joinToString(" "))
         jvmArgs("-Dsponge.jacoco.packages=org.spongepowered")
+        jvmArgs("-Djunit.platform.launcher.interceptors.enabled=true")
         workingDir = layout.buildDirectory.dir("test-run").get().asFile
 
         doFirst {

--- a/neoforge/src/test/java/org/spongepowered/neoforge/boot/SpongeLauncherInterceptor.java
+++ b/neoforge/src/test/java/org/spongepowered/neoforge/boot/SpongeLauncherInterceptor.java
@@ -22,21 +22,42 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.vanilla.boot;
+package org.spongepowered.neoforge.boot;
 
-import org.junit.platform.launcher.LauncherSession;
-import org.junit.platform.launcher.LauncherSessionListener;
+import org.junit.platform.launcher.LauncherInterceptor;
+import org.spongepowered.common.applaunch.test.TestGameAccess;
 
-public final class SpongeSessionListener implements LauncherSessionListener {
+public final class SpongeLauncherInterceptor implements LauncherInterceptor {
 
     private final ClassLoader classLoader;
 
-    public SpongeSessionListener() {
-        this.classLoader = Thread.currentThread().getContextClassLoader();
+    private long counter;
+
+    public SpongeLauncherInterceptor() {
+        try {
+            this.classLoader = SpongeTestBoot.getGameClassLoader();
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
-    public void launcherSessionOpened(final LauncherSession session) {
+    public <T> T intercept(final Invocation<T> invocation) {
+        // getResources broken on Neo
+        if (this.counter++ == 1) {
+            return invocation.proceed();
+        }
+        final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(this.classLoader);
+        try {
+            return invocation.proceed();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Override
+    public void close() {
+        TestGameAccess.shutdownGame();
     }
 }

--- a/neoforge/src/test/java/org/spongepowered/neoforge/boot/SpongeSessionListener.java
+++ b/neoforge/src/test/java/org/spongepowered/neoforge/boot/SpongeSessionListener.java
@@ -26,25 +26,17 @@ package org.spongepowered.neoforge.boot;
 
 import org.junit.platform.launcher.LauncherSession;
 import org.junit.platform.launcher.LauncherSessionListener;
-import org.spongepowered.common.applaunch.test.TestGameAccess;
 
-public class SpongeSessionListener implements LauncherSessionListener {
-    private ClassLoader previousLoader;
+public final class SpongeSessionListener implements LauncherSessionListener {
 
-    @Override
-    public void launcherSessionOpened(final LauncherSession session) {
-        this.previousLoader = Thread.currentThread().getContextClassLoader();
+    private final ClassLoader classLoader;
 
-        try {
-            Thread.currentThread().setContextClassLoader(SpongeTestBoot.getGameClassLoader());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    public SpongeSessionListener() {
+        this.classLoader = Thread.currentThread().getContextClassLoader();
     }
 
     @Override
-    public void launcherSessionClosed(final LauncherSession session) {
-        TestGameAccess.shutdownGame();
-        Thread.currentThread().setContextClassLoader(this.previousLoader);
+    public void launcherSessionOpened(final LauncherSession session) {
+        Thread.currentThread().setContextClassLoader(this.classLoader);
     }
 }

--- a/neoforge/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherInterceptor
+++ b/neoforge/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherInterceptor
@@ -1,0 +1,1 @@
+org.spongepowered.neoforge.boot.SpongeLauncherInterceptor

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-subclass

--- a/vanilla/build.gradle.kts
+++ b/vanilla/build.gradle.kts
@@ -516,6 +516,7 @@ tasks {
         jvmArgs(runServer.allJvmArguments())
         jvmArgs("-Dsponge.test.args=" + runServer.allArguments().joinToString(" "))
         jvmArgs("-Dsponge.jacoco.packages=org.spongepowered")
+        jvmArgs("-Djunit.platform.launcher.interceptors.enabled=true")
         workingDir = layout.buildDirectory.dir("test-run").get().asFile
 
         doFirst {

--- a/vanilla/src/installer/java/org/spongepowered/vanilla/installer/test/SpongeLauncherInterceptor.java
+++ b/vanilla/src/installer/java/org/spongepowered/vanilla/installer/test/SpongeLauncherInterceptor.java
@@ -24,19 +24,34 @@
  */
 package org.spongepowered.vanilla.installer.test;
 
-import org.junit.platform.launcher.LauncherSession;
-import org.junit.platform.launcher.LauncherSessionListener;
+import org.junit.platform.launcher.LauncherInterceptor;
+import org.spongepowered.common.applaunch.test.TestGameAccess;
 
-public final class SpongeSessionListener implements LauncherSessionListener {
+public final class SpongeLauncherInterceptor implements LauncherInterceptor {
 
     private final ClassLoader classLoader;
 
-    public SpongeSessionListener() {
-        this.classLoader = Thread.currentThread().getContextClassLoader();
+    public SpongeLauncherInterceptor() {
+        try {
+            this.classLoader = SpongeTestBoot.getGameClassLoader();
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
-    public void launcherSessionOpened(final LauncherSession session) {
+    public <T> T intercept(final Invocation<T> invocation) {
+        final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(this.classLoader);
+        try {
+            return invocation.proceed();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Override
+    public void close() {
+        TestGameAccess.shutdownGame();
     }
 }

--- a/vanilla/src/installer/resources/META-INF/services/org.junit.platform.launcher.LauncherInterceptor
+++ b/vanilla/src/installer/resources/META-INF/services/org.junit.platform.launcher.LauncherInterceptor
@@ -1,0 +1,1 @@
+org.spongepowered.vanilla.installer.test.SpongeLauncherInterceptor

--- a/vanilla/src/test/java/org/spongepowered/vanilla/boot/SpongeLauncherInterceptor.java
+++ b/vanilla/src/test/java/org/spongepowered/vanilla/boot/SpongeLauncherInterceptor.java
@@ -24,19 +24,34 @@
  */
 package org.spongepowered.vanilla.boot;
 
-import org.junit.platform.launcher.LauncherSession;
-import org.junit.platform.launcher.LauncherSessionListener;
+import org.junit.platform.launcher.LauncherInterceptor;
+import org.spongepowered.common.applaunch.test.TestGameAccess;
 
-public final class SpongeSessionListener implements LauncherSessionListener {
+public final class SpongeLauncherInterceptor implements LauncherInterceptor {
 
     private final ClassLoader classLoader;
 
-    public SpongeSessionListener() {
-        this.classLoader = Thread.currentThread().getContextClassLoader();
+    public SpongeLauncherInterceptor() {
+        try {
+            this.classLoader = SpongeTestBoot.getGameClassLoader();
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
-    public void launcherSessionOpened(final LauncherSession session) {
+    public <T> T intercept(final Invocation<T> invocation) {
+        final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(this.classLoader);
+        try {
+            return invocation.proceed();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Override
+    public void close() {
+        TestGameAccess.shutdownGame();
     }
 }

--- a/vanilla/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherInterceptor
+++ b/vanilla/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherInterceptor
@@ -1,0 +1,1 @@
+org.spongepowered.vanilla.boot.SpongeLauncherInterceptor


### PR DESCRIPTION
We are now guaranteed to be in the transforming class loader during unit test loading and their execution, ensuring class loading happens from the correct `ClassLoader`.
