### PR TITLE
Make BlockEntity a delegating DataHolder

### DIFF
--- a/src/mixins/java/org/spongepowered/common/mixin/api/data/DataHolderMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/data/DataHolderMixin_API.java
@@ -26,12 +26,11 @@ package org.spongepowered.common.mixin.api.data;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.common.data.holder.SpongeMutableDataHolder;
 
-@Mixin(value = {BlockEntity.class, Entity.class, ItemStack.class}, priority = 899)
+@Mixin(value = {Entity.class, ItemStack.class}, priority = 899)
 public abstract class DataHolderMixin_API implements DataHolder, SpongeMutableDataHolder {
 
 }

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/level/block/entity/BlockEntityMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/level/block/entity/BlockEntityMixin.java
@@ -32,6 +32,8 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.ResourceKey;
+import org.spongepowered.api.block.entity.BlockEntity;
+import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.world.server.ServerWorld;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -42,13 +44,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.bridge.data.DataCompoundHolder;
 import org.spongepowered.common.bridge.world.level.block.entity.BlockEntityBridge;
 import org.spongepowered.common.data.DataUtil;
+import org.spongepowered.common.data.holder.SpongeMutableDataHolder;
 import org.spongepowered.common.data.provider.nbt.NBTDataType;
 import org.spongepowered.common.data.provider.nbt.NBTDataTypes;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.StringJoiner;
 
 @Mixin(net.minecraft.world.level.block.entity.BlockEntity.class)
-public abstract class BlockEntityMixin implements BlockEntityBridge, DataCompoundHolder {
+public abstract class BlockEntityMixin implements BlockEntityBridge, DataCompoundHolder, SpongeMutableDataHolder {
 
     //@formatter:off
     @Shadow @Final private BlockEntityType<?> type;
@@ -118,5 +123,11 @@ public abstract class BlockEntityMixin implements BlockEntityBridge, DataCompoun
     @Override
     public String bridge$getPrettyPrinterString() {
         return this.getPrettyPrinterStringHelper().toString();
+    }
+
+    @Override
+    public List<DataHolder> impl$delegateDataHolder() {
+        final org.spongepowered.api.block.BlockState state = ((BlockEntity) this).block();
+        return Arrays.asList(this, state, state.type());
     }
 }


### PR DESCRIPTION
Makes BlockEntity delegate data holder stuff to its BlockState and BlockType.
Fixes issue mentioned [here](https://github.com/SpongePowered/SpongeAPI/pull/2504#discussion_r1758482974) and also just nice to have