### PR TITLE
Add Keys.TOOLTIP_STYLE

### DIFF
--- a/src/main/java/org/spongepowered/common/data/provider/item/stack/ItemStackData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/item/stack/ItemStackData.java
@@ -364,6 +364,10 @@ public final class ItemStackData {
                             return builder.build();
                         })
                         .deleteAndGet(ItemStackData::deleteAndTransactUseCooldown)
+                    .create(Keys.TOOLTIP_STYLE)
+                        .get(h -> (ResourceKey) (Object) h.get(DataComponents.TOOLTIP_STYLE))
+                        .set((h, v) -> h.set(DataComponents.TOOLTIP_STYLE, (ResourceLocation) (Object) v))
+                        .delete(h -> h.remove(DataComponents.TOOLTIP_STYLE))
         ;
     }
     // @formatter:on


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/2603) | **Sponge**

Exposes the [`minecraft:tooltip_style`](https://minecraft.wiki/w/Data_component_format#tooltip_style) data component.