### PR TITLE
Fixed modern forwarding support

### DIFF
--- a/src/main/java/org/spongepowered/common/ipforward/velocity/VelocityForwardingInfo.java
+++ b/src/main/java/org/spongepowered/common/ipforward/velocity/VelocityForwardingInfo.java
@@ -24,9 +24,11 @@
  */
 package org.spongepowered.common.ipforward.velocity;
 
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.net.InetAddresses;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
+import com.mojang.authlib.properties.PropertyMap;
 import io.netty.buffer.ByteBuf;
 import net.kyori.adventure.text.Component;
 import net.minecraft.network.Connection;
@@ -135,18 +137,20 @@ public class VelocityForwardingInfo {
     }
 
     public static GameProfile createProfile(final ChannelBuf buf) {
-        final GameProfile profile = new GameProfile(buf.readUniqueId(), ((FriendlyByteBuf) buf).readUtf(16)); // TODO: ChannelBuf length-limited strings
-        VelocityForwardingInfo.readProperties(buf, profile);
-        return profile;
+        // TODO: ChannelBuf length-limited strings
+        return new GameProfile(buf.readUniqueId(), ((FriendlyByteBuf) buf).readUtf(16), VelocityForwardingInfo.readProperties(buf));
     }
 
-    private static void readProperties(final ChannelBuf buf, final GameProfile profile) {
+    private static PropertyMap readProperties(final ChannelBuf buf) {
+        final ImmutableMultimap.Builder<String, Property> propertiesBuilder = ImmutableMultimap.builder();
         final int properties = buf.readVarInt();
         for (int i1 = 0; i1 < properties; i1++) {
             final String name = buf.readString();
             final String value = buf.readString();
             final String signature = buf.readBoolean() ? buf.readString() : null;
-            profile.properties().put(name, new Property(name, value, signature));
+            propertiesBuilder.put(name, new Property(name, value, signature));
         }
+        final ImmutableMultimap<String, Property> propertiesMap = propertiesBuilder.build();
+        return new PropertyMap(propertiesMap);
     }
 }

--- a/src/main/java/org/spongepowered/common/profile/SpongeGameProfile.java
+++ b/src/main/java/org/spongepowered/common/profile/SpongeGameProfile.java
@@ -25,8 +25,11 @@
 package org.spongepowered.common.profile;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.mojang.authlib.properties.Property;
+import com.mojang.authlib.properties.PropertyMap;
 import net.minecraft.server.players.NameAndId;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -148,11 +151,12 @@ public final class SpongeGameProfile implements GameProfile {
     public com.mojang.authlib.GameProfile toMcProfile() {
         final UUID uniqueId = this.uniqueId;
         final String name = (this.name == null) ? "" : this.name;
-        final com.mojang.authlib.GameProfile mcProfile = new com.mojang.authlib.GameProfile(uniqueId, name);
+        final ImmutableMultimap.Builder<String, Property> propertyBuilder = ImmutableMultimap.builder();
         for (final SpongeProfileProperty property : this.properties) {
-            mcProfile.properties().put(property.name(), property.asProperty());
+            propertyBuilder.put(property.name(), property.asProperty());
         }
-        return mcProfile;
+        final PropertyMap propertyMap = new PropertyMap(propertyBuilder.build());
+        return new com.mojang.authlib.GameProfile(uniqueId, name, propertyMap);
     }
 
     @Override


### PR DESCRIPTION
> Since 1.21.9, the multimap used in GameProfile is immutable, so attempting to add the properties sent by Velocity causes an UnsupportedOperationException

related pr: https://github.com/PaperMC/Paper/pull/13098 https://github.com/OKTW-Network/FabricProxy-Lite/pull/134

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/c245c517-ab22-4226-98fc-3784f97fd4f5" />
