### PR TITLE
Fix "Unregistered holder" exception when applying an ArchetypeVolume to a world

### DIFF
--- a/src/main/java/org/spongepowered/common/world/volume/VolumeStreamUtils.java
+++ b/src/main/java/org/spongepowered/common/world/volume/VolumeStreamUtils.java
@@ -31,6 +31,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.core.SectionPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.Entity;
@@ -60,6 +61,7 @@ import org.spongepowered.api.world.volume.game.Region;
 import org.spongepowered.api.world.volume.stream.StreamOptions;
 import org.spongepowered.api.world.volume.stream.VolumeElement;
 import org.spongepowered.api.world.volume.stream.VolumeStream;
+import org.spongepowered.common.SpongeCommon;
 import org.spongepowered.common.accessor.client.multiplayer.ClientLevelAccessor;
 import org.spongepowered.common.accessor.server.level.ServerLevelAccessor;
 import org.spongepowered.common.accessor.world.level.block.entity.BlockEntityAccessor;
@@ -177,7 +179,11 @@ public final class VolumeStreamUtils {
         final int maskedX = x & 3;
         final int maskedY = y & 3;
         final int maskedZ = z & 3;
-        final var old = ((PalettedContainer<Holder<Biome>>) section.getBiomes()).getAndSet(maskedX, maskedY, maskedZ, Holder.direct((Biome) (Object) biome));
+        final Registry<Biome> biomeRegistry = SpongeCommon.vanillaRegistry(Registries.BIOME);
+        final ResourceKey<Biome> biomeResourceKey = biomeRegistry.getResourceKey((Biome) (Object) biome)
+            .orElseThrow(() -> new IllegalStateException("Missing resource in " + biomeRegistry.key() + ": " + biome));
+        final Holder.Reference<Biome> biomeHolder = biomeRegistry.getHolderOrThrow(biomeResourceKey);
+        final var old = ((PalettedContainer<Holder<Biome>>) section.getBiomes()).getAndSet(maskedX, maskedY, maskedZ, biomeHolder);
         if (old.value() == (Object) biome) {
             return false;
         }


### PR DESCRIPTION
Related to #4222

### Bug
When a biome is applied through **ArchetypeVolume**, the exception "**Unregistered holder in ResourceKey[minecraft:root / minecraft:worldgen/biome]: Direct{net.minecraft.world.level.biome.Biome@XXXXXXX};**" is thrown when the chunk is saved.

### Cause
The root error is the function `Registry#safeCastToReference` which check that the `Holder `is a `Reference`, which is not the case after an **ArchetypeVolume** is applied to a world as it sets biomes with a `Holder.Direct`.

### Fix
Change the `Holder.Direct` to a `Holder.Reference` when a biome is set to a LevelChunkSection.

### Reproduction
I used this code to create and apply an ArchetypeVolume:
```java
private ArchetypeVolume volume;

@Listener
public void rightClick(InteractBlockEvent.Secondary event) {
    if(event.context().get(EventContextKeys.USED_HAND).orElse(HandTypes.OFF_HAND.get()).equals(HandTypes.MAIN_HAND.get())) {
        Vector3i pos = event.interactionPoint().toInt();
        ServerWorld serverWorld = Sponge.server().worldManager().world(event.block().world()).get();
        if (volume == null) {
            volume = serverWorld.createArchetypeVolume(pos, pos.add(0, 1, 0), pos);
            logger.info("volume created");
        } else {
            volume.applyToWorld(serverWorld, pos, SpawnTypes.PLUGIN);
            logger.info("volume applied");
            volume = null;
        }
    }
}
```