### PR TITLE
Fix dimension query

### DIFF
--- a/src/main/java/org/spongepowered/common/entity/SpongeEntityArchetype.java
+++ b/src/main/java/org/spongepowered/common/entity/SpongeEntityArchetype.java
@@ -172,7 +172,7 @@ public final class SpongeEntityArchetype extends AbstractArchetype<EntityType, E
         final CompoundTag newCompound = this.compound.copy();
         final Vector3d pos = location.position();
         newCompound.put(Constants.Entity.ENTITY_POSITION, Constants.NBT.newDoubleNBTList(pos.x(), pos.y(), pos.z()));
-        newCompound.putString(Constants.Sponge.World.WORLD_KEY, location.worldKey().formatted());
+        newCompound.putString(Constants.Sponge.World.DIMENSION, location.worldKey().formatted());
         builder.compound = newCompound;
         builder.worldKey = location.world().properties().key();
         builder.position = pos;

--- a/src/main/java/org/spongepowered/common/entity/player/SpongeUserData.java
+++ b/src/main/java/org/spongepowered/common/entity/player/SpongeUserData.java
@@ -220,8 +220,8 @@ public final class SpongeUserData implements Identifiable, DataSerializable, Bed
         this.reset();
         this.compound = compound;
 
-        if (!compound.contains(Constants.Sponge.World.WORLD_KEY)) {
-            this.worldKey = ResourceKey.resolve(compound.getString(Constants.Sponge.World.WORLD_KEY));
+        if (!compound.contains(Constants.Sponge.World.DIMENSION)) {
+            this.worldKey = ResourceKey.resolve(compound.getString(Constants.Sponge.World.DIMENSION));
         }
         final ListTag position = compound.getList(Constants.Entity.ENTITY_POSITION, Constants.NBT.TAG_DOUBLE);
         final ListTag rotation = compound.getList(Constants.Entity.ENTITY_ROTATION, Constants.NBT.TAG_FLOAT);
@@ -238,7 +238,7 @@ public final class SpongeUserData implements Identifiable, DataSerializable, Bed
 
     public void writeCompound(final CompoundTag compound) {
 
-        compound.putString(Constants.Sponge.World.WORLD_KEY, this.worldKey.formatted());
+        compound.putString(Constants.Sponge.World.DIMENSION, this.worldKey.formatted());
 
         this.loadInventory();
         this.loadEnderInventory();

--- a/src/main/java/org/spongepowered/common/util/Constants.java
+++ b/src/main/java/org/spongepowered/common/util/Constants.java
@@ -287,7 +287,7 @@ public final class Constants {
             public static final String LEVEL_SPONGE_DAT_NEW = org.spongepowered.common.util.Constants.Sponge.World.LEVEL_SPONGE_DAT + "_new";
             public static final String UNIQUE_ID = "UUID";
             public static final String DIMENSIONS_DIRECTORY = "dimensions";
-            public static final String WORLD_KEY = "WorldKey";
+            public static final String DIMENSION = "Dimension";
         }
 
         public static final class Schematic {


### PR DESCRIPTION
This fixes getting an offline player's location via `User#worldKey()`

At some point, it was renamed to Dimension instead of WorldKey I suppose

`SpongeEntityArchetype` was changed but seemingly nothing is different in my testing?