### PR TITLE
#4269: Fix pardon command

### DIFF
--- a/src/main/java/org/spongepowered/common/service/server/ban/SpongeBanService.java
+++ b/src/main/java/org/spongepowered/common/service/server/ban/SpongeBanService.java
@@ -157,7 +157,7 @@ public final class SpongeBanService implements BanService {
                     .thenApplyAsync(user -> {
                         Sponge.eventManager().post(SpongeEventFactory.createPardonUserEvent(PhaseTracker.getInstance().currentCause(), (Ban.Profile) ban, user));
 
-                        UserListUtil.removeEntry(this.getUserBanList(), SpongeGameProfile.toMcProfile(((Ban.Profile) ban).profile()));
+                        UserListUtil.removeEntry(this.getUserBanList(), SpongeGameProfile.toNameAndId(((Ban.Profile) ban).profile()));
                         return true;
                     }, ((MinecraftServerBridge) SpongeCommon.server()).bridge$spongeMainThreadExecutor());
         } else if (ban.type().equals(BanTypes.IP.get())) {


### PR DESCRIPTION
Issue #4269: Unbanning a player does not work

`/pardon` command wasn't working due to a silent **ClassCastException**: the key element type of the list `SpongeUserBanList` is `NameAndId` but a `GameProfile` was given instead.

The fix just change the element type to be removed by a `NameAndId`.