### PR TITLE
#4288: Fix incompatibility with Compact Machines

### DIFF
--- a/src/main/java/org/spongepowered/common/datapack/SpongeDataPackManager.java
+++ b/src/main/java/org/spongepowered/common/datapack/SpongeDataPackManager.java
@@ -109,16 +109,17 @@ public final class SpongeDataPackManager implements DataPackManager {
     }
 
     public List<String> registerPacks() {
+        final List<String> reloadablePacks = new ArrayList<>();
+
         // Ignore reload immediately after first call
         if (this.ignoreNext) {
             this.ignoreNext = false;
-            return List.of();
+            return reloadablePacks;
         }
 
         SpongeIngredient.clearCache();
         IngredientResultUtil.clearCache();
 
-        final List<String> reloadablePacks = new ArrayList<>();
         this.registerAndSerializePack(DataPackTypes.ADVANCEMENT, reloadablePacks);
         this.registerAndSerializePack(DataPackTypes.RECIPE, reloadablePacks);
         this.registerAndSerializePack(DataPackTypes.BLOCK_TAG, reloadablePacks);

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/MinecraftServerMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/MinecraftServerMixin.java
@@ -83,6 +83,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -503,11 +504,12 @@ public abstract class MinecraftServerMixin implements SpongeServer, MinecraftSer
         return this.impl$serviceProvider;
     }
 
-    @Inject(method = "reloadResources", at = @At(value = "HEAD"))
-    public void impl$reloadResources(final Collection<String> datapacksToLoad, final CallbackInfoReturnable<CompletableFuture<Void>> cir) {
+    @ModifyVariable(method = "reloadResources", at = @At(value = "HEAD"), argsOnly = true)
+    public Collection<String> impl$reloadResources(final Collection<String> datapacksToLoad) {
         final List<String> reloadablePacks = ((SpongeDataPackManager) this.dataPackManager()).registerPacks();
-        datapacksToLoad.addAll(reloadablePacks);
+        reloadablePacks.addAll(datapacksToLoad);
         this.shadow$getPackRepository().reload();
+        return reloadablePacks;
     }
 
     @Override


### PR DESCRIPTION
Fix #4288: Incompatibility in commands between CompactMachines and SpongeNeo

Compact Machines is reloading the packs with an immutable list but Sponge Common tried to add other packs to the list, which threw an UnsupportedOperationException.
https://github.com/CompactMods/CompactMachines/blob/21.1/main/neoforge-main/src/main/java/dev/compactmods/machines/command/EnableBasicTemplatesSubcommand.java#L36

The fix consists of adding the Compact Machines packs to the Sponge packs list since it's an ArrayList, and then replacing the initial list with the Sponge packs list.