### PR TITLE
Fix Human movement by restoring the body rotation tick

### DIFF
--- a/src/main/java/org/spongepowered/common/entity/living/human/HumanEntity.java
+++ b/src/main/java/org/spongepowered/common/entity/living/human/HumanEntity.java
@@ -304,6 +304,8 @@ public final class HumanEntity extends PathfinderMob implements TeamMember, Rang
 
     @Override
     protected void tickHeadTurn(final float p_110146_1_) {
+        // Must run first, it is the only thing that updates yBodyRot, which the look control clamps yHeadRot against
+        super.tickHeadTurn(p_110146_1_);
         // Make the body rotation follow head rotation
         this.setYRot(this.getYHeadRot());
     }


### PR DESCRIPTION
Human written part of the description:

We noticed weird movement with human entities during API-14 -> API-18 upgrade and this resolves the issue.

I also tried removing the `tickHeadTurn` override completely, but this in turn caused the human head <-> body rotation to desync. (the yaw rot of the two could differ 180°) 

---

The 25w02a update (ac2bbe5557) adapted HumanEntity to Mojang's new tickHeadTurn(float) signature but dropped the super call in the process. Mob.tickHeadTurn is solely bodyRotationControl.clientTick(), which is the only thing that ever writes yBodyRot, so the Human's yBodyRot was frozen at its spawn value.

Since LookControl clamps yHeadRot to within getMaxHeadYRot() of yBodyRot while navigating, and this override copies yHeadRot onto yRot (the vector moveRelative steers by), the movement direction was pinned to a cone around that stale angle and MoveControl's steering was overwritten every tick. Humans walked into walls, moved sideways, and oscillated between two blocks.