### PR TITLE
Fix HumanEntity registration missed during udate

### DIFF
--- a/vanilla/src/mixins/java/org/spongepowered/vanilla/mixin/core/world/entity/EntityTypesMixin_Vanilla.java
+++ b/vanilla/src/mixins/java/org/spongepowered/vanilla/mixin/core/world/entity/EntityTypesMixin_Vanilla.java
@@ -25,15 +25,15 @@
 package org.spongepowered.vanilla.mixin.core.world.entity;
 
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntityTypes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.entity.SpongeEntityTypes;
 
-@Mixin(EntityType.class)
-public abstract class EntityTypeMixin_Vanilla {
+@Mixin(EntityTypes.class)
+public abstract class EntityTypesMixin_Vanilla {
 
     @Inject(method = "<clinit>", at = @At("TAIL"))
     private static void impl$registerSpongeTypes(CallbackInfo ci) {

--- a/vanilla/src/mixins/resources/mixins.spongevanilla.core.json
+++ b/vanilla/src/mixins/resources/mixins.spongevanilla.core.json
@@ -35,7 +35,7 @@
     "server.packs.repository.PackRepositoryMixin_Vanilla",
     "tags.TagLoaderMixin_Vanilla",
     "world.entity.EntityMixin_Vanilla",
-    "world.entity.EntityTypeMixin_Vanilla",
+    "world.entity.EntityTypesMixin_Vanilla",
     "world.entity.LivingEntityMixin_Vanilla",
     "world.entity.LivingEntityMixin_Vanilla_Damage",
     "world.entity.ai.attributes.DefaultAttributesMixin",


### PR DESCRIPTION
Previously, Minecraft registered the EntityTypes in the `EntityType` class, but the registration was moved to EntityTypes class.

As a result of this, I was getting disconnected due to a "Network Protocol Error" when trying to join the server.

EntityType class diff: https://mcsrc.dev/2/diff/26.1.2/26.2/net/minecraft/world/entity/EntityType