### PR TITLE
Fix entities not spawning in structures on Forge

### DIFF
--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -176,6 +176,13 @@ configurations.configureEach {
     if (name != "minecraft") { // awful terrible hack sssh
         exclude(group = "com.mojang", module = "minecraft")
     }
+    // modlauncher 8.0.9 (bundled with Forge 36.2.5) directly calls the single-arg
+    // ManifestEntryVerifier(Manifest) constructor which was removed in Java 8u321+
+    // (and JDK 11/17 from 2021-10 onwards). 8.1.3 fixes this via reflection.
+    resolutionStrategy {
+        force("cpw.mods:modlauncher:8.1.3")
+        force("cpw.mods:modlauncher-api:8.1.3")
+    }
 }
 
 dependencies {

--- a/forge/src/main/java/org/spongepowered/forge/world/server/ForgeWorldManager.java
+++ b/forge/src/main/java/org/spongepowered/forge/world/server/ForgeWorldManager.java
@@ -25,11 +25,18 @@
 package org.spongepowered.forge.world.server;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.common.world.StructureSpawnManager;
 import org.spongepowered.common.world.server.SpongeWorldManager;
 
 public final class ForgeWorldManager extends SpongeWorldManager {
 
     public ForgeWorldManager(final MinecraftServer server) {
         super(server);
+    }
+
+    @Override
+    public void loadLevel() {
+        StructureSpawnManager.gatherEntitySpawns();
+        super.loadLevel();
     }
 }


### PR DESCRIPTION
Sponge replaces MinecraftServer#loadLevel with this world loading path, which never reaches MinecraftServer#prepareLevels.
Forge injects StructureSpawnManager.gatherEntitySpawns() at the very start of prepareLevels to populate its structure spawn registry (structuresWithSpawns, including the vanilla defaults pre-filled by the gather event).