### PR TITLE
Fix multiple issues related to rounding / inBounds checks

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhaseUtil.java
@@ -227,8 +227,8 @@ public final class PacketPhaseUtil {
                         // Basically, we need to sanity check the nearby blocks because if they have
                         // any positional logic, we need to run captures
                         final AABB boundingBox = packetPlayer.getBoundingBox();
-                        final BlockPos min = new BlockPos((int) (boundingBox.minX + 0.001D), (int) (boundingBox.minY + 0.001D), (int) (boundingBox.minZ + 0.001D));
-                        final BlockPos max = new BlockPos((int) (boundingBox.maxX - 0.001D), (int) (boundingBox.maxY - 0.001D), (int) (boundingBox.maxZ - 0.001D));
+                        final BlockPos min = BlockPos.containing(boundingBox.minX + 0.001D, boundingBox.minY + 0.001D, boundingBox.minZ + 0.001D);
+                        final BlockPos max = BlockPos.containing(boundingBox.maxX - 0.001D, boundingBox.maxY - 0.001D, boundingBox.maxZ - 0.001D);
                         final BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos();
                         if (packetPlayer.level().hasChunksAt(min, max)) {
                             for(int x = min.getX(); x <= max.getX(); ++x) {

--- a/src/main/java/org/spongepowered/common/util/VecHelper.java
+++ b/src/main/java/org/spongepowered/common/util/VecHelper.java
@@ -182,6 +182,11 @@ public final class VecHelper {
         return VecHelper.inBounds(pos.getX(), pos.getY(), pos.getZ(), min, max);
     }
 
+    public static boolean inBounds(final org.spongepowered.math.vector.Vector3i pos, final org.spongepowered.math.vector.Vector3i min,
+                                   final org.spongepowered.math.vector.Vector3i max) {
+        return VecHelper.inBounds(pos.x(), pos.y(), pos.z(), min, max);
+    }
+
     public static boolean inBounds(final org.spongepowered.math.vector.Vector3d pos, final org.spongepowered.math.vector.Vector3i min,
                                    final org.spongepowered.math.vector.Vector3i max) {
         return VecHelper.inBounds(pos.x(), pos.y(), pos.z(), min, max);

--- a/src/main/java/org/spongepowered/common/world/level/chunk/storage/SpongeEntityChunk.java
+++ b/src/main/java/org/spongepowered/common/world/level/chunk/storage/SpongeEntityChunk.java
@@ -187,7 +187,7 @@ public final class SpongeEntityChunk implements EntityChunk {
     @Override
     public Optional<Entity> createEntity(final DataContainer container) {
         return Optional.ofNullable(((LevelBridge) this.level).bridge$createEntity(container, null,
-                position -> VecHelper.inBounds(position, this.min(), this.max())));
+                position -> VecHelper.inBounds(position.toInt(), this.min(), this.max())));
     }
 
     @Override
@@ -231,7 +231,7 @@ public final class SpongeEntityChunk implements EntityChunk {
     }
 
     private void checkPositionInChunk(final Vector3d position) {
-        if (!VecHelper.inBounds(position, this.min(), this.max())) {
+        if (!VecHelper.inBounds(position.toInt(), this.min(), this.max())) {
             throw new IllegalArgumentException("Supplied bounds are not within this chunk.");
         }
     }

--- a/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/chunk/LevelChunkMixin_API.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/api/minecraft/world/level/chunk/LevelChunkMixin_API.java
@@ -469,8 +469,7 @@ public abstract class LevelChunkMixin_API extends ChunkAccess implements WorldCh
 
     @Override
     public Optional<Entity> createEntity(final DataContainer container) {
-        return Optional.ofNullable(((LevelBridge) this.level).bridge$createEntity(container, null,
-                position -> VecHelper.inBounds(position, this.min(), this.max())));
+        return Optional.ofNullable(((LevelBridge) this.level).bridge$createEntity(container, null, this::api$isInBounds));
     }
 
     @Override
@@ -510,7 +509,7 @@ public abstract class LevelChunkMixin_API extends ChunkAccess implements WorldCh
     }
 
     private boolean api$isInBounds(final Vector3d position) {
-        return VecHelper.inBounds(position, this.min(), this.max());
+        return VecHelper.inBounds(position.toInt(), this.min(), this.max());
     }
 
 

--- a/src/mixins/java/org/spongepowered/common/mixin/core/item/EmptyMapItemMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/item/EmptyMapItemMixin.java
@@ -71,7 +71,7 @@ public abstract class EmptyMapItemMixin {
             frame.addContext(EventContextKeys.USED_ITEM, ItemStackUtil.snapshotOf(usedItem));
 
             final Set<Value<?>> mapValues = Sets.newHashSet(
-                Value.immutableOf(Keys.MAP_LOCATION, Vector2i.from((int) player.getX(), (int) player.getZ())),
+                Value.immutableOf(Keys.MAP_LOCATION, Vector2i.from(player.getBlockX(), player.getBlockZ())),
                 Value.immutableOf(Keys.MAP_WORLD, ((ServerWorld) level).key())
             );
 

--- a/src/mixins/java/org/spongepowered/common/mixin/core/server/commands/TeleportCommandMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/server/commands/TeleportCommandMixin.java
@@ -100,7 +100,7 @@ public abstract class TeleportCommandMixin {
 
                 if (entityIn instanceof ServerPlayer) {
 
-                    ChunkPos chunkpos = new ChunkPos(new BlockPos((int) actualX, (int) actualY, (int) actualZ));
+                    ChunkPos chunkpos = new ChunkPos(BlockPos.containing(actualX, actualY, actualZ));
                     worldIn.getChunkSource().addRegionTicket(TicketType.POST_TELEPORT, chunkpos, 1, entityIn.getId());
 
                     entityIn.stopRiding();

--- a/src/mixins/java/org/spongepowered/common/mixin/core/world/level/LevelMixin.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/core/world/level/LevelMixin.java
@@ -228,7 +228,7 @@ public abstract class LevelMixin implements LevelBridge, LevelAccessor {
 
         if (naturally && entity instanceof Mob) {
             // Adding the default equipment
-            final DifficultyInstance difficulty = this.shadow$getCurrentDifficultyAt(new BlockPos((int) x, (int) y, (int) z));
+            final DifficultyInstance difficulty = this.shadow$getCurrentDifficultyAt(BlockPos.containing(x, y, z));
             ((MobAccessor) entity).invoker$populateDefaultEquipmentSlots(this.random, difficulty);
         }
 

--- a/src/mixins/java/org/spongepowered/common/mixin/tracker/world/entity/item/FallingBlockEntityMixin_Tracker.java
+++ b/src/mixins/java/org/spongepowered/common/mixin/tracker/world/entity/item/FallingBlockEntityMixin_Tracker.java
@@ -83,7 +83,7 @@ public abstract class FallingBlockEntityMixin_Tracker extends EntityMixin_Tracke
 //            cancellable = true
 //    )
     private void tracker$handleBlockCapture(final CallbackInfo ci) {
-        final BlockPos pos = new BlockPos((int) this.shadow$getX(), (int) this.shadow$getY(), (int) this.shadow$getZ());
+        final BlockPos pos = BlockPos.containing(this.shadow$getX(), this.shadow$getY(), this.shadow$getZ());
         // So, there's two cases here: either the world is not cared for, or the
         // ChangeBlockEvent is not being listened to. If it's not being listened to,
         // we need to specifically just proceed as normal.


### PR DESCRIPTION
Cast to int rounds towards zero instead of negative infinity resulting in inconsistent behaviour. `BlockPos.containing(...)` floors the input values.

The inBounds check failed when, for example, spawning an entity near the border of a chunk.