### PR TITLE
Fix multiple transaction related issues

### DIFF
--- a/src/main/java/org/spongepowered/common/data/holder/SpongeMutableDataHolder.java
+++ b/src/main/java/org/spongepowered/common/data/holder/SpongeMutableDataHolder.java
@@ -293,7 +293,7 @@ public interface SpongeMutableDataHolder extends SpongeDataHolder, DataHolder.Mu
         for (final Value<?> value : result.successfulData()) {
             builder.absorbResult(this.remove(value));
         }
-        return DataTransactionResult.failNoData();
+        return builder.build();
     }
 
     // Delegated

--- a/src/main/java/org/spongepowered/common/inventory/InventoryTransactionResultImpl.java
+++ b/src/main/java/org/spongepowered/common/inventory/InventoryTransactionResultImpl.java
@@ -58,17 +58,21 @@ public class InventoryTransactionResultImpl implements InventoryTransactionResul
 
     @Override
     public InventoryTransactionResult and(InventoryTransactionResult other) {
-        Type resultType = Type.SUCCESS;
+        final Type resultType;
         if (this.type == Type.ERROR || other.type() == Type.ERROR) {
             resultType = Type.ERROR;
-        }
-        if (this.type == Type.FAILURE || other.type() == Type.FAILURE) {
+        } else if (this.type == Type.FAILURE || other.type() == Type.FAILURE) {
             resultType = Type.FAILURE;
+        } else if (this.type == Type.NO_SLOT || other.type() == Type.NO_SLOT) {
+            resultType = Type.NO_SLOT;
+        } else {
+            resultType = Type.SUCCESS;
         }
         InventoryTransactionResult.Builder builder =
                 InventoryTransactionResult.builder().type(resultType).reject(this.rejected).reject(other.rejectedItems())
                         .transaction(this.slotTransactions).transaction(other.slotTransactions());
         this.polled.forEach(builder::poll);
+        other.polledItems().forEach(builder::poll);
         return builder.build();
     }
 
@@ -189,6 +193,7 @@ public class InventoryTransactionResultImpl implements InventoryTransactionResul
             this.resultType = Objects.requireNonNull(value.type(), "ResultType cannot be null!");
             this.slotTransactions = new ArrayList<>(value.slotTransactions());
             this.rejected = new ArrayList<>(value.rejectedItems());
+            this.polled = new ArrayList<>(value.polledItems());
             return this;
         }
 
@@ -197,6 +202,7 @@ public class InventoryTransactionResultImpl implements InventoryTransactionResul
             this.resultType = null;
             this.rejected = null;
             this.slotTransactions = null;
+            this.polled = null;
             return this;
         }
 


### PR DESCRIPTION
- SpongeMutableDataHolder#undo returned DataTransactionResult.failNoData() instead of the actual result.
- InventoryTransactionResultImpl#and discarded the polled items of the other transaction
- InventoryTransactionResultImpl#and returned a SUCCESS transaction when `type == NO_SLOT`
- InventoryTransactionResultImpl.Builder from & reset ignored polled items